### PR TITLE
Allow all numpy float data types, not just numpy.float64

### DIFF
--- a/xrspatial/curvature.py
+++ b/xrspatial/curvature.py
@@ -40,7 +40,7 @@ def curvature(raster):
         raise ValueError("`raster` must be 2D")
 
     if not (issubclass(raster.values.dtype.type, np.integer) or
-            issubclass(raster.values.dtype.type, np.float)):
+            issubclass(raster.values.dtype.type, np.floating)):
         raise ValueError(
             "`raster` must be an array of integers or float")
 

--- a/xrspatial/focal.py
+++ b/xrspatial/focal.py
@@ -331,7 +331,7 @@ def apply(raster, kernel, func=calc_mean):
         raise ValueError("`raster` must be 2D")
 
     if not (issubclass(raster.values.dtype.type, np.integer) or
-            issubclass(raster.values.dtype.type, np.float)):
+            issubclass(raster.values.dtype.type, np.floating)):
         raise ValueError(
             "`raster` must be an array of integers or float")
 

--- a/xrspatial/tests/test_zonal.py
+++ b/xrspatial/tests/test_zonal.py
@@ -94,6 +94,16 @@ def test_stats_default():
     assert zone_double_sums == df['double sum'].tolist()
 
 
+def test_stats_dtypes():
+    zones, values = stats_create_zones_values()
+    values = values.astype(np.float16)
+
+    # default stat_funcs=['mean', 'max', 'min', 'std', 'var', 'count']
+    df = stats(zones=zones, values=values)
+
+    assert isinstance(df, pd.DataFrame)
+
+
 # TODO: get this test passing
 def _test_stats_invalid_custom_stat():
     zones, values = stats_create_zones_values()
@@ -290,6 +300,25 @@ def test_crosstab_2d():
     assert df['check_sum'][zone_idx[0]] == 1.0
 
 
+def test_crosstab_2d_dtypes():
+    values_val = np.asarray([[0, 0, 10, 20],
+                             [0, 0, 0, 10],
+                             [np.inf, 30, 20, 50],
+                             [10, 30, 40, 40],
+                             [10, np.nan, 50, 0]], dtype=np.float16)
+    values_agg = xa.DataArray(values_val, dims=['lat', 'lon'])
+    zones_val = np.asarray([[1, 1, 6, 6],
+                            [1, 1, 6, 6],
+                            [3, 5, 6, 6],
+                            [3, 5, 7, 7],
+                            [3, 7, 7, 0]])
+    zones_agg = xa.DataArray(zones_val, dims=['lat', 'lon'])
+
+    df = crosstab(zones_agg, values_agg)
+
+    assert isinstance(df, pd.DataFrame)
+
+
 def test_apply_invalid_input():
     def func(x):
         return 0
@@ -382,7 +411,7 @@ def test_suggest_zonal_canvas():
     assert height == 100
     assert width == 200
 
-    
+
 def create_test_arr(arr):
     n, m = arr.shape
     raster = xa.DataArray(arr, dims=['y', 'x'])

--- a/xrspatial/zonal.py
+++ b/xrspatial/zonal.py
@@ -89,7 +89,7 @@ def stats(zones, values, stat_funcs=['mean', 'max', 'min', 'std',
         raise ValueError("`zones` must be an array of integers")
 
     if not (issubclass(values.data.dtype.type, np.integer) or
-            issubclass(values.data.dtype.type, np.float)):
+            issubclass(values.data.dtype.type, np.floating)):
         raise ValueError(
             "`values` must be an array of integers or floats")
 
@@ -262,7 +262,7 @@ def crosstab(zones, values, layer=None):
         raise ValueError("`zones` must be an xarray of integers")
 
     if not issubclass(values.data.dtype.type, np.integer) and \
-            not issubclass(values.data.dtype.type, np.float):
+            not issubclass(values.data.dtype.type, np.floating):
         raise ValueError(
             "`values` must be an xarray of integers or floats")
 
@@ -329,7 +329,7 @@ def apply(zones, values, func):
         raise ValueError("`zones.values` must be an array of integers")
 
     if not (issubclass(values.values.dtype.type, np.integer) or
-            issubclass(values.values.dtype.type, np.float)):
+            issubclass(values.values.dtype.type, np.floating)):
         raise ValueError(
             "`values` must be an array of integers or float")
 
@@ -450,7 +450,7 @@ def suggest_zonal_canvas(smallest_area, x_range, y_range,
 
     return canvas_h, canvas_w
 
-  
+
 @ngjit
 def _area_connectivity(data, n=4):
     '''


### PR DESCRIPTION
Xarray-spatial checks if data array data types are a subclass
of numpy.float. However, numpy.float is an alias of
builtins.float, of which only numpy.float64 is subclassed.
Changing numpy.float to numpy.floating allows all numpy float
data types.