### PR TITLE
Add annulus focal kernel

### DIFF
--- a/xrspatial/focal.py
+++ b/xrspatial/focal.py
@@ -332,12 +332,12 @@ def _hotspots(z_array):
     return out
 
 
-def hotspots(raster, x='x', y='y', kernel_shape='circle', kernel_radius=10000, zscore=False, r2=None):
+def hotspots(raster, kernel, x='x', y='y'):
     """Identify statistically significant hot spots and cold spots in an input
     raster. To be a statistically significant hot spot, a feature will have a
     high value and be surrounded by other features with high values as well.
     Neighborhood of a feature defined by the input kernel, which currently
-    support a shape of circle and a radius in meters.
+    support a shape of circle, annulus, or custom kernel.
 
     The result should be a raster with the following 7 values:
     90 for 90% confidence high value cluster
@@ -353,7 +353,6 @@ def hotspots(raster, x='x', y='y', kernel_shape='circle', kernel_radius=10000, z
     raster: xarray.DataArray
         Input raster image with shape=(height, width)
     kernel: Kernel
-    zscore: If True, return z-scores instead of hotspots
 
     Returns
     -------
@@ -394,12 +393,7 @@ def hotspots(raster, x='x', y='y', kernel_shape='circle', kernel_radius=10000, z
                                 "of the input raster values is 0.")
     z_array = (mean_array - global_mean) / global_std
 
-    # Return z-scores if desired, otherwise return hotspots
-    # hotspots is default
-    if zscore:
-        out = z_array
-    else:
-        out = _hotspots(z_array)
+    out = _hotspots(z_array)
 
     result = DataArray(out,
                        coords=raster.coords,

--- a/xrspatial/focal.py
+++ b/xrspatial/focal.py
@@ -139,15 +139,9 @@ def annulus_kernel(cellsize_x, cellsize_y, outer_radius, inner_radius):
         warnings.warn('Annulus radii are closer than cellsize distance.',
                       Warning)
 
-    kernel_half_w_outer = int(r_outer / cellsize_x)
-    kernel_half_h_outer = int(r_outer / cellsize_y)
-    kernel_outer = _gen_ellipse_kernel(kernel_half_w_outer,
-                                       kernel_half_h_outer)
-
-    kernel_half_w_inner = int(r_inner / cellsize_x)
-    kernel_half_h_inner = int(r_inner / cellsize_y)
-    kernel_inner = _gen_ellipse_kernel(kernel_half_w_inner,
-                                       kernel_half_h_inner)
+    # Get the two circular kernels for the annulus
+    kernel_outer = circular_kernel(cellsize_x, cellsize_y, outer_radius)
+    kernel_inner = circular_kernel(cellsize_x, cellsize_y, inner_radius)
 
     # Need to pad kernel_inner to get it the same shape and centered
     # in kernel_outer

--- a/xrspatial/focal.py
+++ b/xrspatial/focal.py
@@ -333,7 +333,7 @@ def _hotspots(z_array):
     return out
 
 
-def hotspots(raster, x='x', y='y', kernel_shape='circle', kernel_radius=10000):
+def hotspots(raster, x='x', y='y', kernel_shape='circle', kernel_radius=10000, zscore=False, r2=None):
     """Identify statistically significant hot spots and cold spots in an input
     raster. To be a statistically significant hot spot, a feature will have a
     high value and be surrounded by other features with high values as well.
@@ -354,6 +354,7 @@ def hotspots(raster, x='x', y='y', kernel_shape='circle', kernel_radius=10000):
     raster: xarray.DataArray
         Input raster image with shape=(height, width)
     kernel: Kernel
+    zscore: If True, return z-scores instead of hotspots
 
     Returns
     -------
@@ -394,7 +395,13 @@ def hotspots(raster, x='x', y='y', kernel_shape='circle', kernel_radius=10000):
                                 "of the input raster values is 0.")
     z_array = (mean_array - global_mean) / global_std
 
-    out = _hotspots(z_array)
+    # Return z-scores if desired, otherwise return hotspots
+    # hotspots is default
+    if zscore:
+        out = z_array
+    else:
+        out = _hotspots(z_array)
+
     result = DataArray(out,
                        coords=raster.coords,
                        dims=raster.dims,

--- a/xrspatial/focal.py
+++ b/xrspatial/focal.py
@@ -94,7 +94,8 @@ def _calc_cellsize(raster, x='x', y='y'):
     cellsize_x = _to_meters(cellsize_x, unit)
     cellsize_y = _to_meters(cellsize_y, unit)
 
-    return cellsize_x, cellsize_y
+    # When converting from lnglat_to_meters, could have negative cellsize in y
+    return cellsize_x, np.abs(cellsize_y)
 
 
 def _gen_ellipse_kernel(half_w, half_h):

--- a/xrspatial/focal.py
+++ b/xrspatial/focal.py
@@ -159,8 +159,6 @@ def _get_kernel(cellsize_x, cellsize_y, shape='circle', radius=10000, r2=None):
                             constant_values=0)
         # Get annulus by subtracting inner from outer
         kernel = kernel_outer - pad_kernel
-        # Add focal point back to kernel
-        kernel[kernel.shape[0] // 2, kernel.shape[1] // 2] = 1
 
     return kernel
 

--- a/xrspatial/focal.py
+++ b/xrspatial/focal.py
@@ -79,7 +79,7 @@ def _get_distance(distance_str):
     return meters
 
 
-def _calc_cellsize(raster, x='x', y='y'):
+def calc_cellsize(raster, x='x', y='y'):
     if 'unit' in raster.attrs:
         unit = raster.attrs['unit']
     else:
@@ -110,56 +110,57 @@ def _gen_ellipse_kernel(half_w, half_h):
     return ellipse.astype(float)
 
 
-def _get_kernel(cellsize_x, cellsize_y, shape='circle', radius=10000, r2=None):
-    # validate shape
-    if shape not in ['circle', 'annulus']:
-        raise ValueError(
-            "Kernel shape must be \'circle\' or \'annulus\'")
-
+def circular_kernel(cellsize_x, cellsize_y, radius):
     # validate radius, convert radius to meters
     r = _get_distance(str(radius))
-    if shape == 'circle':
-        # convert radius (meter) to pixel
-        kernel_half_w = int(r / cellsize_x)
-        kernel_half_h = int(r / cellsize_y)
-        kernel = _gen_ellipse_kernel(kernel_half_w, kernel_half_h)
-    elif shape == 'annulus':
-        r2 = _get_distance(str(r2))
 
-        if r2 > r:
-            r_outer = r2
-            r_inner = r
-        else:
-            r_outer = r
-            r_inner = r2
+    kernel_half_w = int(r / cellsize_x)
+    kernel_half_h = int(r / cellsize_y)
 
-        if r_outer - r_inner < np.sqrt((cellsize_x / 2)**2 + \
-                                       (cellsize_y / 2)**2):
-            warnings.warn('Annulus radii are closer than cellsize distance.',
-                          Warning)
+    kernel = _gen_ellipse_kernel(kernel_half_w, kernel_half_h)
+    return kernel
 
-        kernel_half_w_outer = int(r_outer / cellsize_x)
-        kernel_half_h_outer = int(r_outer / cellsize_y)
-        kernel_outer = _gen_ellipse_kernel(kernel_half_w_outer,
-                                           kernel_half_h_outer)
+def annulus_kernel(cellsize_x, cellsize_y, outer_radius, inner_radius):
 
-        kernel_half_w_inner = int(r_inner / cellsize_x)
-        kernel_half_h_inner = int(r_inner / cellsize_y)
-        kernel_inner = _gen_ellipse_kernel(kernel_half_w_inner,
-                                           kernel_half_h_inner)
+    # validate radii, convert to meters
+    r2 = _get_distance(str(outer_radius))
+    r1 = _get_distance(str(inner_radius))
 
-        # Pad kernel_inner to the same shape and centered in kernel_outer
-        pad_vals = np.array(kernel_outer.shape) - np.array(kernel_inner.shape)
-        pad_kernel = np.pad(kernel_inner,
-                            # Pad ((before_rows, after_rows),
-                            #      (before_cols, after_cols))
-                            pad_width=((pad_vals[0] // 2, pad_vals[0] // 2),
-                                       (pad_vals[1] // 2, pad_vals[1] // 2)),
-                            mode='constant',
-                            constant_values=0)
-        # Get annulus by subtracting inner from outer
-        kernel = kernel_outer - pad_kernel
+    # Validate that outer radius is indeed outer radius
+    if r2 > r1:
+        r_outer = r2
+        r_inner = r1
+    else:
+        r_outer = r1
+        r_inner = r2
 
+    if r_outer - r_inner < np.sqrt((cellsize_x / 2)**2 + \
+                                   (cellsize_y / 2)**2):
+        warnings.warn('Annulus radii are closer than cellsize distance.',
+                      Warning)
+
+    kernel_half_w_outer = int(r_outer / cellsize_x)
+    kernel_half_h_outer = int(r_outer / cellsize_y)
+    kernel_outer = _gen_ellipse_kernel(kernel_half_w_outer,
+                                       kernel_half_h_outer)
+
+    kernel_half_w_inner = int(r_inner / cellsize_x)
+    kernel_half_h_inner = int(r_inner / cellsize_y)
+    kernel_inner = _gen_ellipse_kernel(kernel_half_w_inner,
+                                       kernel_half_h_inner)
+
+    # Need to pad kernel_inner to get it the same shape and centered
+    # in kernel_outer
+    pad_vals = np.array(kernel_outer.shape) - np.array(kernel_inner.shape)
+    pad_kernel = np.pad(kernel_inner,
+                        # Pad ((before_rows, after_rows),
+                        #      (before_cols, after_cols))
+                        pad_width=((pad_vals[0] // 2, pad_vals[0] // 2),
+                                   (pad_vals[1] // 2, pad_vals[1] // 2)),
+                        mode='constant',
+                        constant_values=0)
+    # Get annulus by subtracting inner from outer
+    kernel = kernel_outer - pad_kernel
     return kernel
 
 
@@ -283,8 +284,81 @@ def _apply(data, kernel_array, func):
     return out
 
 
-def apply(raster, x='x', y='y', kernel_shape='circle', kernel_radius=10000,
-          func=calc_mean):
+def _validate_kernel_shape(custom_kernel=None, shape=None, radius=None,
+                           outer_radius=None, inner_radius=None):
+
+
+    if (shape == 'circle' and isinstance(_get_distance(str(radius)), float)):
+        if (custom_kernel is not None or
+            outer_radius is not None or
+            inner_radius is not None):
+             raise ValueError(
+                 "Received additional arguments for kernel creation",
+                 """Circular kernel must be specified by `shape='circle'` and a
+                    valid `radius`.
+                 """
+             )
+    elif (shape == 'annulus' and
+        isinstance(_get_distance(str(outer_radius)), float) and
+        isinstance(_get_distance(str(inner_radius)), float)
+    ):
+        if (custom_kernel is not None or radius is not None):
+             raise ValueError(
+                 "Received additional arguments for kernel creation",
+                 """Annulus kernel must be specified by `shape='annulus'` and a
+                    valid `outer_radius` and `inner_radius`.
+                 """
+             )
+    elif custom_kernel is not None:
+        rows, cols = custom_kernel.shape
+        if (rows % 2 == 0 or cols % 2 == 0):
+            raise ValueError(
+                "Received custom kernel with improper dimensions.",
+                """A custom kernel needs to have an odd shape, the
+                   supplied kernel has {} rows and {} columns.
+                """.format(rows, cols)
+            )
+        if (shape is not None or
+            radius is not None or
+            outer_radius is not None or
+            inner_radius is not None
+        ):
+            raise ValueError(
+                "Received additional arguments for kernel creation.",
+                """A custom kernel needs to be supplied by itself."""
+            )
+    else:
+        raise ValueError(
+            "Did not receive an appropriate kernel declaration",
+            """Valid kernel types are:
+               `shape` \in ('circle', 'annulus')
+               `shape='circle'` with `radius`
+               `shape='annulus'` with `outer_radius` and `inner_radius`
+               `custom_kernel`: a 2D kernel with odd dimensions
+            """
+        )
+
+
+def create_kernel(cellsize_x=None, cellsize_y=None, custom_kernel=None,
+                  shape=None, radius=None,
+                  outer_radius=None, inner_radius=None):
+    # Validate the passed kernel arguments
+    _validate_kernel_shape(custom_kernel, shape, radius,
+                             outer_radius, inner_radius)
+
+    if shape == 'circle':
+        kernel = circular_kernel(cellsize_x, cellsize_y, radius)
+    elif shape == 'annulus':
+        kernel = annulus_kernel(cellsize_x, cellsize_y,
+                                outer_radius, inner_radius)
+    # Ensure that custome kernel is numpy array
+    elif isinstance(custom_kernel, np.ndarray):
+        kernel = custom_kernel
+
+    return kernel
+
+
+def apply(raster, kernel, x='x', y='y', func=calc_mean):
     """
     """
 
@@ -304,12 +378,6 @@ def apply(raster, x='x', y='y', kernel_shape='circle', kernel_radius=10000,
     if raster_dims != (y, x):
         raise ValueError("raster.coords should be named as coordinates:"
                          "(%s, %s)".format(y, x))
-
-    # calculate cellsize along the x and y axis
-    cellsize_x, cellsize_y = _calc_cellsize(raster, x=x, y=y)
-    # create kernel mask array
-    kernel = _get_kernel(cellsize_x, cellsize_y,
-                         shape=kernel_shape, radius=kernel_radius)
 
     # apply kernel to raster values
     out = _apply(raster.values.astype(float), kernel, func)
@@ -375,12 +443,6 @@ def hotspots(raster, kernel, x='x', y='y'):
     if raster_dims != (y, x):
         raise ValueError("raster.coords should be named as coordinates:"
                          "(%s, %s)".format(y, x))
-
-    # calculate cellsize along the x and y axis
-    cellsize_x, cellsize_y = _calc_cellsize(raster, x=x, y=y)
-    # create kernel mask array
-    kernel = _get_kernel(cellsize_x, cellsize_y,
-                         shape=kernel_shape, radius=kernel_radius, r2=r2)
 
     # apply kernel to raster values
     mean_array = _apply(raster.values.astype(float), kernel, calc_mean)

--- a/xrspatial/focal.py
+++ b/xrspatial/focal.py
@@ -370,7 +370,7 @@ def hotspots(raster, x='x', y='y', kernel_shape='circle', kernel_radius=10000, z
         raise ValueError("`raster` must be 2D")
 
     if not (issubclass(raster.values.dtype.type, np.integer) or
-            issubclass(raster.values.dtype.type, np.float)):
+            issubclass(raster.values.dtype.type, np.floating)):
         raise ValueError(
             "`raster` must be an array of integers or float")
 


### PR DESCRIPTION
Addresses #125, #124

Using the circle kernel to extend to an annulus kernel. Implementation excludes the cells on the bound of the inner radius of the annulus.

Also implements the ability to return the raw z-scores from `hotspots`. 