### PR TITLE
Moved kernel creation to name-specific functions.

### DIFF
--- a/xrspatial/focal.py
+++ b/xrspatial/focal.py
@@ -110,6 +110,27 @@ def _gen_ellipse_kernel(half_w, half_h):
     return ellipse.astype(float)
 
 
+def _validate_kernel(kernel):
+    """Validatetes that the kernel is a numpy array and has odd dimensions."""
+
+    if not isinstance(kernel, np.ndarray):
+        raise ValueError(
+            "Received a custom kernel that is not a Numpy array.",
+            """The kernel received was of type {} and needs to be of type `ndarray`
+            """.format(type(kernel))
+        )
+    else:
+        rows, cols = kernel.shape
+
+    if (rows % 2 == 0 or cols % 2 == 0):
+        raise ValueError(
+            "Received custom kernel with improper dimensions.",
+            """A custom kernel needs to have an odd shape, the
+            supplied kernel has {} rows and {} columns.
+            """.format(rows, cols)
+        )
+
+
 def circle_kernel(cellsize_x, cellsize_y, radius):
     # validate radius, convert radius to meters
     r = _get_distance(str(radius))
@@ -159,25 +180,9 @@ def annulus_kernel(cellsize_x, cellsize_y, outer_radius, inner_radius):
     return kernel
 
 
-def validate_kernel(kernel):
-    """Validatetes that the custom kernle is a numpy array and has odd dimensions."""
-
-    if not isinstance(kernel, np.ndarray):
-        raise ValueError(
-            "Received a custom kernel that is not a Numpy array.",
-            """The kernel received was of type {} and needs to be of type `ndarray`"""
-        )
-    else:
-        rows, cols = kernel.shape
-
-    if (rows % 2 == 0 or cols % 2 == 0):
-        raise ValueError(
-            "Received custom kernel with improper dimensions.",
-            """A custom kernel needs to have an odd shape, the
-            supplied kernel has {} rows and {} columns.
-            """.format(rows, cols)
-        )
-
+def custom_kernel(kernel):
+    """Validates a custom kernel. If the kernel is valid, returns itself."""
+    _validate_kernel(kernel)
     return kernel
 
 
@@ -322,7 +327,8 @@ def apply(raster, kernel, x='x', y='y', func=calc_mean):
         raise ValueError("raster.coords should be named as coordinates:"
                          "(%s, %s)".format(y, x))
 
-    kernel = validate_kernel(kernel)
+    # Validate the kernel
+    _validate_kernel(kernel)
 
     # apply kernel to raster values
     out = _apply(raster.values.astype(float), kernel, func)

--- a/xrspatial/tests/test_focal.py
+++ b/xrspatial/tests/test_focal.py
@@ -4,11 +4,13 @@ import numpy as np
 from xrspatial import mean
 from xrspatial.focal import (
     apply,
-    create_kernel,
+    calc_cellsize,
     calc_mean,
     calc_sum,
     hotspots,
-    calc_cellsize,
+    circle_kernel,
+    annulus_kernel,
+    validate_kernel,
 )
 import pytest
 
@@ -68,34 +70,24 @@ def test_kernel():
     raster['y'] = np.linspace(0, m, m)
 
     cellsize_x, cellsize_y = calc_cellsize(raster)
-
-    # Passing extra kernel arguments for `circle`
+    # Passing invalid radius units for `circle`
     with pytest.raises(Exception) as e_info:
-        create_kernel(cellsize_x, cellsize_y,
-                      shape='circle', radius=2, outer_radius=4)
+        circle_kernel(cellsize_x, cellsize_y, "10 furlongs")
         assert e_info
 
-    # Passing extra kernel arguments for `annulus`
+    # Passing invalid radius for `annulus`
     with pytest.raises(Exception) as e_info:
-        create_kernel(cellsize_x, cellsize_y,
-                      shape='annulus', radius=2, inner_radisu=2, outer_radius=4)
+        annulus_kernel(cellsize_x, cellsize_y, 4, "2 leagues")
         assert e_info
 
     # Passing custom kernel with even dimensions
     with pytest.raises(Exception) as e_info:
-        create_kernel(cellsize_x, cellsize_y,
-                      custom_kernel=np.ones((2, 2)))
+        validate_kernel(np.ones((2, 2)))
         assert e_info
 
-    # Invalid kernel shape
+    # Passing custom kernel of wrong type
     with pytest.raises(Exception) as e_info:
-        create_kernel(cellsize_x, cellsize_y, shape='line')
-        assert e_info
-
-    # invalid radius distance unit
-    with pytest.raises(Exception) as e_info:
-        create_kernel(cellsize_x, cellsize_y,
-                      shape='circle', radius='10 inch')
+        validate_kernel([[1, 1, 1]])
         assert e_info
 
 
@@ -113,7 +105,7 @@ def test_apply():
         raster[cell[0], cell[1]] = np.nan
 
     # kernel array = [[1]]
-    kernel = create_kernel(custom_kernel=np.ones((1, 1)))
+    kernel = np.ones((1, 1))
     sum_output_1 = apply(raster, kernel, func=calc_sum)
     # np.nansum(np.array([np.nan])) = 0.0
     expected_out_sum_1 = np.array([[0., 1., 1., 1., 1., 1.],
@@ -137,8 +129,7 @@ def test_apply():
     # kernel array: [[0, 1, 0],
     #                [1, 1, 1],
     #                [0, 1, 0]]
-    kernel = create_kernel(cellsize_x=cellsize_x, cellsize_y=cellsize_y,
-                           shape='circle', radius=2.0)
+    kernel = circle_kernel(cellsize_x, cellsize_y, 2)
     sum_output_2 = apply(raster, kernel, func=calc_sum)
     expected_out_sum_2 = np.array([[2., 2., 4., 4., 4., 3.],
                                    [2., 4., 3., 5., 5., 4.],
@@ -156,8 +147,7 @@ def test_apply():
     # kernel array: [[0, 1, 0],
     #                [1, 0, 1],
     #                [0, 1, 0]]
-    kernel = create_kernel(cellsize_x=cellsize_x, cellsize_y=cellsize_y,
-                           shape='annulus', outer_radius=2.0, inner_radius=0.5)
+    kernel = annulus_kernel(cellsize_x, cellsize_y, 2.0, 0.5)
     sum_output_3 = apply(raster, kernel, func=calc_sum)
     expected_out_sum_3 = np.array([[2., 1., 3., 3., 3., 2.],
                                    [1., 4., 2., 4., 4., 3.],
@@ -180,8 +170,7 @@ def test_hotspot():
     raster['y'] = np.linspace(0, m, m)
     cellsize_x, cellsize_y = calc_cellsize(raster)
 
-    kernel = create_kernel(cellsize_x=cellsize_x, cellsize_y=cellsize_y,
-                           shape="circle", radius=2)
+    kernel = circle_kernel(cellsize_x, cellsize_y, 2.0)
 
     all_idx = zip(*np.where(raster.values == 0))
 

--- a/xrspatial/tests/test_focal.py
+++ b/xrspatial/tests/test_focal.py
@@ -10,7 +10,7 @@ from xrspatial.focal import (
     hotspots,
     circle_kernel,
     annulus_kernel,
-    validate_kernel,
+    _validate_kernel,
 )
 import pytest
 
@@ -82,12 +82,12 @@ def test_kernel():
 
     # Passing custom kernel with even dimensions
     with pytest.raises(Exception) as e_info:
-        validate_kernel(np.ones((2, 2)))
+        _validate_kernel(np.ones((2, 2)))
         assert e_info
 
     # Passing custom kernel of wrong type
     with pytest.raises(Exception) as e_info:
-        validate_kernel([[1, 1, 1]])
+        _validate_kernel([[1, 1, 1]])
         assert e_info
 
 


### PR DESCRIPTION
Per @thuydotm , simplified some kernel creation.

- Removed `create_kernel()`, now kernels are created by calling their name-specific functions. These are only `circle_kernel()` and `annulus_kernel()` at the moment. Custom kernels are any numpy array and therefore don't have a function, e.g., `kernel = np.ones((3, 3))`.
- Removed `_validate_kernel_shape()` and replaced with `validate_kernel()`, which checks that the kernel is a numpy array and has odd dimensions. This isn't a strict requirement, but I think it makes sense to have the focal point be at the center of a kernel. Perhaps in the future we can accept custom kernels where the focal point is not centered and then pad the kernel in order to center it.
- Updated tests to reflect these changes.