### PR TITLE
Added convolution module for use in focal statistics.

### DIFF
--- a/xrspatial/convolution.py
+++ b/xrspatial/convolution.py
@@ -1,0 +1,117 @@
+import datashader.transfer_functions._cuda_utils as cu
+from numba import cuda, float32, int32, prange, jit
+from xrspatial.utils import ngjit
+import numpy as np
+
+def _cuda_present():
+    """Check for supported CUDA device. If none found, return False"""
+    try:
+        cuda.cudadrv.devices.gpus.current
+        local_cuda = True
+    except cuda.cudadrv.error.CudaSupportError:
+        local_cuda = False
+
+    return local_cuda
+
+
+def convolve_2d(image, kernel, pad=True, use_cuda=True):
+    """Function to call the 2D convolution via Numba.
+    The Numba convolution function does not account for an edge so
+    if we wish to take this into account, will pad the image array.
+    """
+    # Don't allow padding on (1, 1) kernel
+    if (kernel.shape[0] == 1 and kernel.shape[1] == 1):
+        pad = False
+
+    if pad:
+        pad_rows = kernel.shape[0] // 2
+        pad_cols = kernel.shape[1] // 2
+        pad_width = ((pad_rows, pad_rows),
+                     (pad_cols, pad_cols))
+    else:
+        # If padding is not desired, set pads to 0
+        pad_rows = 0
+        pad_cols = 0
+        pad_width = 0
+
+    padded_image = np.pad(image, pad_width=pad_width, mode="reflect")
+    result = np.empty_like(padded_image)
+
+    if _cuda_present() and use_cuda:
+        griddim, blockdim = cu.cuda_args(padded_image.shape)
+        _convolve_2d_cuda[griddim, blockdim](result, kernel, padded_image)
+    else:
+        result = _convolve_2d(kernel, padded_image)
+
+    if pad:
+        result = result[pad_rows:-pad_rows, pad_cols:-pad_cols]
+
+    if result.shape != image.shape:
+        raise ValueError("Output and input rasters are not the same shape.")
+
+    return result
+
+
+@jit(nopython=True, nogil=True, parallel=True)
+def _convolve_2d(kernel, image):
+    """Apply kernel to image."""
+
+    nx = image.shape[0]
+    ny = image.shape[1]
+    nkx = kernel.shape[0]
+    nky = kernel.shape[1]
+    wkx = nkx // 2
+    wky = nky // 2
+
+    result = np.zeros(image.shape, dtype=float32)
+
+    for i in prange(0, nx, 1):
+        iimin = max(i - wkx, 0)
+        iimax = min(i + wkx + 1, nx)
+        for j in prange(0, ny, 1):
+            jjmin = max(j - wky, 0)
+            jjmax = min(j + wky + 1, ny)
+            num = 0.0
+            for ii in range(iimin, iimax, 1):
+                iii = wkx + ii - i
+                for jj in range(jjmin, jjmax, 1):
+                    jjj = wky + jj - j
+                    num += kernel[iii, jjj] * image[ii, jj]
+            result[i, j] = num
+
+    return result
+
+
+# https://www.vincent-lunot.com/post/an-introduction-to-cuda-in-python-part-3/
+@cuda.jit
+def _convolve_2d_cuda(result, kernel, image):
+    # expects a 2D grid and 2D blocks,
+    # a kernel with odd numbers of rows and columns, (-1-)
+    # a grayscale image
+
+    # (-2-) 2D coordinates of the current thread:
+    i, j = cuda.grid(2)
+
+    # (-3-) if the thread coordinates are outside of the image, we ignore the thread:
+    image_rows, image_cols = image.shape
+    if (i >= image_rows) or (j >= image_cols):
+        return
+
+    # To compute the result at coordinates (i, j), we need to use delta_rows rows of the image
+    # before and after the i_th row,
+    # as well as delta_cols columns of the image before and after the j_th column:
+    delta_rows = kernel.shape[0] // 2
+    delta_cols = kernel.shape[1] // 2
+
+    # The result at coordinates (i, j) is equal to
+    # sum_{k, l} kernel[k, l] * image[i - k + delta_rows, j - l + delta_cols]
+    # with k and l going through the whole kernel array:
+    s = 0
+    for k in range(kernel.shape[0]):
+        for l in range(kernel.shape[1]):
+            i_k = i - k + delta_rows
+            j_l = j - l + delta_cols
+            # (-4-) Check if (i_k, j_k) coordinates are inside the image:
+            if (i_k >= 0) and (i_k < image_rows) and (j_l >= 0) and (j_l < image_cols):
+                s += kernel[k, l] * image[i_k, j_l]
+    result[i, j] = s

--- a/xrspatial/focal.py
+++ b/xrspatial/focal.py
@@ -7,6 +7,7 @@ import numpy as np
 from xarray import DataArray
 
 from xrspatial.utils import ngjit
+from xrspatial.convolution import convolve_2d
 
 warnings.simplefilter('default')
 
@@ -396,7 +397,7 @@ def hotspots(raster, kernel, x='x', y='y'):
                          "(%s, %s)".format(y, x))
 
     # apply kernel to raster values
-    mean_array = _apply(raster.values.astype(float), kernel, calc_mean)
+    mean_array = convolve_2d(raster.values, kernel / kernel.sum(), pad=True)
 
     # calculate z-scores
     global_mean = np.nanmean(raster.values)


### PR DESCRIPTION
Addresses #130 

A few things need to be addressed, as mentioned in #130 

- How to handle boundaries. This in an issue on non-symmetrical mean kernels, as their weighted averages can be affected. For my use cases, what is coded works for mean kernels: the values of the raster will be reflected across the boundary so the appropriate weightings are applied (given a symmetrical kernel). Sum kernels don't require padding so `pad=False` works just fine.
- After coding this, there could be some validity in making an easier kernel-creation function to include common functions like weighted means, but it's also very simple to just do `kernel / kernel.sum()` to get this.
- I am a little confused how the original `focal._apply()` behavior was supposed to work from the old `test_apply()`, in one test `np.nan == 0` (the sums) and in the other it was supposed to be `==1` (the means).
- There could be some way to deal with `np.nan` in the raster for the kernel creation, but I honestly always deal with them at the source so I'm not sure if there is a clean way to handle them, or if we _should_ allow that behavior. I personally like the amplification of `NaN`s to alert me to underlying data issues.