### PR TITLE
Host Xarray-spatial documentation on Azure Storage

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -1,0 +1,27 @@
+name: Upload Docs To Azure Blob Storage
+on:
+  push:
+    branches:
+      - master
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.0.100'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel sphinx sphinx_rtd_theme
+      - name: Build
+        run: |
+          pip install .
+          make -C docs html
+      - uses: lauchacarro/Azure-Storage-Action@v1.0
+        with:
+          enabled-static-website: 'true'
+          folder: 'docs/build/html'
+          index-document: 'index.html'
+          connection-string: ${{ secrets.CONNECTION_STRING }}

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = sphinx-build
+SPHINXBUILD   = python -m sphinx
 SOURCEDIR     = source
 BUILDDIR      = build
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,8 +14,6 @@
 #
 import os
 import sys
-import xrspatial
-
 sys.path.insert(0, os.path.abspath('../..'))
 
 # -- Project information -----------------------------------------------------
@@ -24,6 +22,7 @@ project = u'xarray_spatial'
 copyright = u'2020, Brendan Collins'
 author = u'Brendan Collins'
 
+import xrspatial
 version = release = xrspatial.__version__
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
This PR solve the issue `Host the Xarray-spatial documentation on Azure Storage`  #262. It's mandatory to add a GitHub secret `CONNECTION_STRING` with the Azure Storage connection string.