### PR TITLE
add Dask support for zonal_stats and zonal_crosstab

### DIFF
--- a/xrspatial/tests/test_zonal.py
+++ b/xrspatial/tests/test_zonal.py
@@ -236,7 +236,7 @@ def test_crosstab_no_values():
     zones_arr = np.arange(6, dtype=np.int).reshape(2, 3)
     zones_agg = xr.DataArray(zones_arr)
 
-    df = crosstab(zones_agg, values_agg, layer)
+    df = crosstab(zones_agg, values_agg, layer, nodata_values=0)
 
     num_cats = len(values_agg.dims[-1])
     # number of columns = number of categories + 1
@@ -247,11 +247,10 @@ def test_crosstab_no_values():
     # number of rows = number of zones
     assert len(df.index) == num_zones
 
-    # # values_agg are all 0s, so all 0 over categories
-    # for col in df.columns:
-    #     if col != 'zone':
-    #         print(col, df[col].unique())
-    #         assert np.isclose(df[col].unique(), [0])
+    # values_agg are all 0s, so all 0 over categories
+    for col in df.columns:
+        if col != 'zone':
+            assert np.isclose(df[col].unique(), [0])
 
 
 def test_crosstab_3d():

--- a/xrspatial/tests/test_zonal.py
+++ b/xrspatial/tests/test_zonal.py
@@ -311,8 +311,8 @@ def test_crosstab_2d():
     assert isinstance(df, pd.DataFrame)
 
     num_cats = 6  # 0, 10, 20, 30, 40, 50
-    # number of columns = number of categories
-    assert len(df.columns) == num_cats
+    # number of columns = number of categories + 1 (zone column)
+    assert len(df.columns) == num_cats + 1
 
     zone_idx = np.unique(zones_agg.data)
     num_zones = len(zone_idx)

--- a/xrspatial/tests/test_zonal.py
+++ b/xrspatial/tests/test_zonal.py
@@ -1,4 +1,3 @@
-import pytest
 import numpy as np
 import pandas as pd
 import xarray as xr

--- a/xrspatial/tests/test_zonal.py
+++ b/xrspatial/tests/test_zonal.py
@@ -38,11 +38,36 @@ def test_stats_default():
     zone_vals_2 = np.ma.masked_where(zones != 2, masked_values)
     zone_vals_3 = np.ma.masked_where(zones != 4, masked_values)
 
-    zone_means = [zone_vals_0.mean(), zone_vals_1.mean(), zone_vals_2.mean(), zone_vals_3.mean()]
-    zone_maxes = [zone_vals_0.max(), zone_vals_1.max(), zone_vals_2.max(), zone_vals_3.max()]
-    zone_mins = [zone_vals_0.min(), zone_vals_1.min(), zone_vals_2.min(), zone_vals_3.min()]
-    zone_stds = [zone_vals_0.std(), zone_vals_1.std(), zone_vals_2.std(), zone_vals_3.std()]
-    zone_vars = [zone_vals_0.var(), zone_vals_1.var(), zone_vals_2.var(), zone_vals_3.var()]
+    zone_means = [
+        zone_vals_0.mean(),
+        zone_vals_1.mean(),
+        zone_vals_2.mean(),
+        zone_vals_3.mean()
+    ]
+    zone_maxes = [
+        zone_vals_0.max(),
+        zone_vals_1.max(),
+        zone_vals_2.max(),
+        zone_vals_3.max()
+    ]
+    zone_mins = [
+        zone_vals_0.min(),
+        zone_vals_1.min(),
+        zone_vals_2.min(),
+        zone_vals_3.min()
+    ]
+    zone_stds = [
+        zone_vals_0.std(),
+        zone_vals_1.std(),
+        zone_vals_2.std(),
+        zone_vals_3.std()
+    ]
+    zone_vars = [
+        zone_vals_0.var(),
+        zone_vals_1.var(),
+        zone_vals_2.var(),
+        zone_vals_3.var()
+    ]
 
     zone_counts = [
         np.ma.count(zone_vals_0),
@@ -322,8 +347,8 @@ def test_apply():
 
     zones_val = np.zeros((3, 3), dtype=np.int)
     # define some zones
-    zones_val[0, ...] = 1
-    zones_val[1, ...] = 2
+    zones_val[1] = 1
+    zones_val[2] = 2
     zones = xa.DataArray(zones_val)
 
     values_val = np.array([[0, 1, 2],
@@ -332,7 +357,7 @@ def test_apply():
     values = xa.DataArray(values_val)
 
     values_copy = values.copy()
-    apply(zones, values, func)
+    apply(zones, values, func, nodata=2)
 
     # agg.shape remains the same
     assert values.shape == values_copy.shape
@@ -342,9 +367,7 @@ def test_apply():
     assert (values_val[0] == [0, 0, 0]).all()
     assert (values_val[1] == [0, 0, 0]).all()
     # values outside zones remain
-    assert (values_val[2, :2] == values_copy.values[2, :2]).all()
-    # last element of the last row is nan
-    assert np.isnan(values_val[2, 2])
+    assert np.isclose(values_val[2], values_copy.values[2], equal_nan=True).all()
 
 
 def test_suggest_zonal_canvas():

--- a/xrspatial/tests/test_zonal.py
+++ b/xrspatial/tests/test_zonal.py
@@ -235,25 +235,28 @@ def test_crosstab_no_values():
     values_agg = xa.DataArray(np.zeros(24).reshape(2, 3, 4),
                               dims=['lat', 'lon', 'race'])
     values_agg['race'] = ['cat1', 'cat2', 'cat3', 'cat4']
+    layer = -1
 
     # create a valid `zones_agg` with compatiable shape
     zones_arr = np.arange(6, dtype=np.int).reshape(2, 3)
     zones_agg = xa.DataArray(zones_arr)
 
-    df = crosstab(zones_agg, values_agg)
+    df = crosstab(zones_agg, values_agg, layer)
 
     num_cats = len(values_agg.dims[-1])
-    # number of columns = number of categories
-    assert len(df.columns) == num_cats
+    # number of columns = number of categories + 1
+    assert len(df.columns) == num_cats + 1
 
     zone_idx = np.unique(zones_arr)
     num_zones = len(zone_idx)
     # number of rows = number of zones
     assert len(df.index) == num_zones
 
-    num_zeros = (df == 0).sum().sum()
-    # all are 0s
-    assert num_zeros == num_zones * num_cats
+    # # values_agg are all 0s, so all 0 over categories
+    # for col in df.columns:
+    #     if col != 'zone':
+    #         print(col, df[col].unique())
+    #         assert np.isclose(df[col].unique(), [0])
 
 
 def test_crosstab_3d():
@@ -301,7 +304,7 @@ def test_crosstab_3d():
     # no NaN
     assert num_nans == 0
 
-    # values_agg are all 1s, so all categories have same percentage over zones
+    # values_agg are all 1s
     for col in df.columns:
         if col != 'zone':
             assert len(df[col].unique()) == 1
@@ -345,9 +348,6 @@ def test_crosstab_2d():
     num_zones = len(zone_idx)
     # number of rows = number of zones
     assert len(df.index) == num_zones
-    df.loc[:, 'check_sum'] = df.sum(axis=1)
-    # sum of a row is 1.0
-    assert df['check_sum'][zone_idx[0]] == 1.0
 
 
 def test_apply_invalid_input():

--- a/xrspatial/tests/test_zonal.py
+++ b/xrspatial/tests/test_zonal.py
@@ -258,20 +258,39 @@ def test_crosstab_no_values():
 
 def test_crosstab_3d():
     # create valid `values_agg` of np.nan and np.inf
-    values_agg = xa.DataArray(np.ones(24).reshape(2, 3, 4),
+    values_agg = xa.DataArray(np.ones(4*5*6).reshape(5, 6, 4),
                               dims=['lat', 'lon', 'race'])
     values_agg['race'] = ['cat1', 'cat2', 'cat3', 'cat4']
+    layer = -1
 
     # create a valid `zones_agg` with compatiable shape
-    zones_arr = np.arange(6, dtype=np.int).reshape(2, 3)
+    zones_arr = np.arange(5*6, dtype=np.int).reshape(5, 6)
     zones_agg = xa.DataArray(zones_arr)
 
-    df = crosstab(zones_agg, values_agg)
+    # numpy case
+    df = crosstab(zones_agg, values_agg, layer)
     assert isinstance(df, pd.DataFrame)
+
+    # dask case
+    values_agg_dask = xa.DataArray(
+        da.from_array(values_agg.data, chunks=(3, 3, 1)),
+        dims=['lat', 'lon', 'race']
+    )
+    values_agg_dask['race'] = ['cat1', 'cat2', 'cat3', 'cat4']
+    zones_agg_dask = xa.DataArray(da.from_array(zones_agg.data, chunks=(3, 3)))
+    dask_df = crosstab(zones_agg_dask, values_agg_dask, layer)
+    assert isinstance(dask_df, dd.DataFrame)
+
+    dask_df = dask_df.compute()
+    assert isinstance(dask_df, pd.DataFrame)
+
+    assert (df.columns == dask_df.columns).all()
+    for col in df.columns:
+        assert np.isclose(df[col], dask_df[col], equal_nan=True).all()
 
     num_cats = len(values_agg.dims[-1])
     # number of columns = number of categories
-    assert len(df.columns) == num_cats
+    assert len(df.columns) == num_cats + 1
 
     zone_idx = np.unique(zones_arr)
     num_zones = len(zone_idx)
@@ -284,12 +303,8 @@ def test_crosstab_3d():
 
     # values_agg are all 1s, so all categories have same percentage over zones
     for col in df.columns:
-        assert len(df[col].unique()) == 1
-
-    df['check_sum'] = df.apply(
-        lambda r: r['cat1'] + r['cat2'] + r['cat3'] + r['cat4'], axis=1)
-    # sum of a row is 1.0
-    assert df['check_sum'][zone_idx[0]] == 1.0
+        if col != 'zone':
+            assert len(df[col].unique()) == 1
 
 
 def test_crosstab_2d():

--- a/xrspatial/tests/test_zonal.py
+++ b/xrspatial/tests/test_zonal.py
@@ -56,6 +56,12 @@ def test_stats_default():
         zone_vals_2.min(),
         zone_vals_3.min()
     ]
+    zone_sums = [
+        zone_vals_0.sum(),
+        zone_vals_1.sum(),
+        zone_vals_2.sum(),
+        zone_vals_3.sum(),
+    ]
     zone_stds = [
         zone_vals_0.std(),
         zone_vals_1.std(),
@@ -68,7 +74,6 @@ def test_stats_default():
         zone_vals_2.var(),
         zone_vals_3.var()
     ]
-
     zone_counts = [
         np.ma.count(zone_vals_0),
         np.ma.count(zone_vals_1),
@@ -76,7 +81,7 @@ def test_stats_default():
         np.ma.count(zone_vals_3)
     ]
 
-    # default stat_funcs=['mean', 'max', 'min', 'std', 'var', 'count']
+    # default stats_funcs=['mean', 'max', 'min', 'sum', 'std', 'var', 'count']
     df = stats(zones=zones, values=values)
     assert isinstance(df, pd.DataFrame)
 
@@ -85,12 +90,13 @@ def test_stats_default():
     assert idx == unique_values
 
     num_cols = len(df.columns)
-    # there are 6 statistics in default settings
-    assert num_cols == 6
+    # there are 7 statistics in default settings
+    assert num_cols == 7
 
     assert zone_means == df['mean'].tolist()
     assert zone_maxes == df['max'].tolist()
     assert zone_mins == df['min'].tolist()
+    assert zone_sums == df['sum'].tolist()
     assert zone_stds == df['std'].tolist()
     assert zone_vars == df['var'].tolist()
     assert zone_counts == df['count'].tolist()
@@ -116,7 +122,7 @@ def test_stats_default():
     ]
 
     custom_stats = {'sum': cal_sum, 'double sum': cal_double_sum}
-    df = stats(zones=zones, values=values, stat_funcs=custom_stats)
+    df = stats(zones=zones, values=values, stats_funcs=custom_stats)
 
     assert isinstance(df, pd.DataFrame)
     # indices of the output DataFrame matches the unique values in `zones`
@@ -140,7 +146,7 @@ def _test_stats_invalid_custom_stat():
 
     # custom stat only takes 1 argument. Thus, raise error
     with pytest.raises(Exception) as e_info:  # noqa
-        stats(zones=zones, values=values, stat_funcs=custom_stats)
+        stats(zones=zones, values=values, stats_funcs=custom_stats)
 
 
 def test_stats_invalid_stat_input():
@@ -149,7 +155,7 @@ def test_stats_invalid_stat_input():
     # invalid stats
     custom_stats = ['some_stat']
     with pytest.raises(Exception) as e_info:  # noqa
-        stats(zones=zones, values=values, stat_funcs=custom_stats)
+        stats(zones=zones, values=values, stats_funcs=custom_stats)
 
     # invalid values:
     zones = xa.DataArray(np.array([1, 2, 0], dtype=np.int))

--- a/xrspatial/tests/test_zonal.py
+++ b/xrspatial/tests/test_zonal.py
@@ -261,13 +261,12 @@ def test_crosstab_3d():
     values_agg = xa.DataArray(np.ones(24).reshape(2, 3, 4),
                               dims=['lat', 'lon', 'race'])
     values_agg['race'] = ['cat1', 'cat2', 'cat3', 'cat4']
-    layer = 'race'
 
     # create a valid `zones_agg` with compatiable shape
     zones_arr = np.arange(6, dtype=np.int).reshape(2, 3)
     zones_agg = xa.DataArray(zones_arr)
 
-    df = crosstab(zones_agg, values_agg, layer)
+    df = crosstab(zones_agg, values_agg)
     assert isinstance(df, pd.DataFrame)
 
     num_cats = len(values_agg.dims[-1])

--- a/xrspatial/tests/test_zonal.py
+++ b/xrspatial/tests/test_zonal.py
@@ -367,7 +367,9 @@ def test_apply():
     assert (values_val[0] == [0, 0, 0]).all()
     assert (values_val[1] == [0, 0, 0]).all()
     # values outside zones remain
-    assert np.isclose(values_val[2], values_copy.values[2], equal_nan=True).all()
+    assert np.isclose(
+        values_val[2], values_copy.values[2], equal_nan=True
+    ).all()
 
 
 def test_suggest_zonal_canvas():

--- a/xrspatial/tests/test_zonal.py
+++ b/xrspatial/tests/test_zonal.py
@@ -197,11 +197,6 @@ def test_crosstab_invalid_input():
     with pytest.raises(Exception) as e_info:
         crosstab(zones_agg=zones, values_agg=values)
 
-    # invalid zones dtype (must be int)
-    zones = xa.DataArray(np.array([[1, 2, 0.5]]))
-    with pytest.raises(Exception) as e_info:  # noqa
-        crosstab(zones_agg=zones, values_agg=values)
-
     # invalid values
     zones = xa.DataArray(np.array([[1, 2, 0]], dtype=np.int))
     # values must be either int or float

--- a/xrspatial/tests/test_zonal.py
+++ b/xrspatial/tests/test_zonal.py
@@ -163,12 +163,6 @@ def test_stats_invalid_stat_input():
     with pytest.raises(Exception) as e_info:  # noqa
         stats(zones=zones, values=values)
 
-    # invalid zones
-    zones = xa.DataArray(np.array([1, 2, 0.5]))
-    values = xa.DataArray(np.array([1, 2, 0.5]))
-    with pytest.raises(Exception) as e_info:  # noqa
-        stats(zones=zones, values=values)
-
     # mismatch shape between zones and values:
     zones = xa.DataArray(np.array([1, 2, 0]))
     values = xa.DataArray(np.array([1, 2, 0, np.nan]))

--- a/xrspatial/tests/test_zonal.py
+++ b/xrspatial/tests/test_zonal.py
@@ -16,213 +16,110 @@ from xrspatial import crop
 from xrspatial.zonal import regions
 
 
-def stats_create_zones_values(backend='numpy'):
-    # create valid "zones" and "values" for testing stats()
-    zones_val = np.array([[0, 1, 1, 2, 4, 0, 0],
-                          [0, 0, 1, 1, 2, 1, 4],
-                          [4, 2, 2, 4, 4, 4, 0]])
+def create_zones_values(backend):
+    zones_val = np.array([[0, 0, 1, 1, 2, 2, 3, 3],
+                          [0, 0, 1, 1, 2, 2, 3, 3],
+                          [0, 0, 1, 1, 2, np.nan, 3, 3]])
     zones = xr.DataArray(zones_val)
 
-    values_val = np.array([[0, 12, 10, 2, 3.25, np.nan, np.nan],
-                           [0, 0, -11, 4, -2.5, np.nan, 7],
-                           [np.nan, 3.5, -9, 4, 2, 0, np.inf]])
-    values = xr.DataArray(values_val)
+    values_val_2d = np.asarray([
+        [0, 0, 1, 1, 2, 2, 3, np.inf],
+        [0, 0, 1, 1, 2, np.nan, 3, 0],
+        [np.inf, 0, 1, 1, 2, 2, 3, 3]
+    ])
+    values_2d = xr.DataArray(values_val_2d)
+
+    values_val_3d = np.ones(4 * 3 * 6).reshape(3, 6, 4)
+    values_3d = xr.DataArray(
+        values_val_3d,
+        dims=['lat', 'lon', 'race']
+    )
+    values_3d['race'] = ['cat1', 'cat2', 'cat3', 'cat4']
 
     if 'dask' in backend:
         zones.data = da.from_array(zones.data, chunks=(3, 3))
-        values.data = da.from_array(values.data, chunks=(3, 3))
+        values_2d.data = da.from_array(values_2d.data, chunks=(3, 3))
+        values_3d.data = da.from_array(values_3d.data, chunks=(3, 3, 1))
 
-    return zones, values
+    return zones, values_2d, values_3d
 
 
-def test_stats_default():
-    zones, values = stats_create_zones_values(backend='numpy')
-    dask_zones, dask_values = stats_create_zones_values(backend='dask')
+def test_stats():
+    # expected results
+    default_stats_results = {
+        'zone':  [0, 1, 2, 3],
+        'mean':  [0, 1, 2, 2.4],
+        'max':   [0, 1, 2, 3],
+        'min':   [0, 1, 2, 0],
+        'sum':   [0, 6, 8, 12],
+        'std':   [0, 0, 0, 1.2],
+        'var':   [0, 0, 0, 1.44],
+        'count': [5, 6, 4, 5]
+    }
 
-    unique_values = [0, 1, 2, 4]
-    masked_values = np.ma.masked_invalid(values.values)
-    zone_vals_0 = np.ma.masked_where(zones != 0, masked_values)
-    zone_vals_1 = np.ma.masked_where(zones != 1, masked_values)
-    zone_vals_2 = np.ma.masked_where(zones != 2, masked_values)
-    zone_vals_3 = np.ma.masked_where(zones != 4, masked_values)
+    # numpy case
+    zones_np, values_np, _ = create_zones_values(backend='numpy')
+    # default stats_funcs
+    df_np = stats(zones=zones_np, values=values_np)
+    assert isinstance(df_np, pd.DataFrame)
+    assert len(df_np.columns) == len(default_stats_results)
+    for col in df_np.columns:
+        assert np.isclose(
+            df_np[col], default_stats_results[col], equal_nan=True
+        ).all()
 
-    zone_means = [
-        zone_vals_0.mean(),
-        zone_vals_1.mean(),
-        zone_vals_2.mean(),
-        zone_vals_3.mean()
-    ]
-    zone_maxes = [
-        zone_vals_0.max(),
-        zone_vals_1.max(),
-        zone_vals_2.max(),
-        zone_vals_3.max()
-    ]
-    zone_mins = [
-        zone_vals_0.min(),
-        zone_vals_1.min(),
-        zone_vals_2.min(),
-        zone_vals_3.min()
-    ]
-    zone_sums = [
-        zone_vals_0.sum(),
-        zone_vals_1.sum(),
-        zone_vals_2.sum(),
-        zone_vals_3.sum(),
-    ]
-    zone_stds = [
-        zone_vals_0.std(),
-        zone_vals_1.std(),
-        zone_vals_2.std(),
-        zone_vals_3.std()
-    ]
-    zone_vars = [
-        zone_vals_0.var(),
-        zone_vals_1.var(),
-        zone_vals_2.var(),
-        zone_vals_3.var()
-    ]
-    zone_counts = [
-        np.ma.count(zone_vals_0),
-        np.ma.count(zone_vals_1),
-        np.ma.count(zone_vals_2),
-        np.ma.count(zone_vals_3)
-    ]
+    # dask case
+    zones_da, values_da, _ = create_zones_values(backend='dask')
+    df_da = stats(zones=zones_da, values=values_da)
+    assert isinstance(df_da, dd.DataFrame)
+    df_da = df_da.compute()
+    assert isinstance(df_da, pd.DataFrame)
+    assert (df_da.columns == df_np.columns).all()
+    for col in df_da.columns:
+        assert np.isclose(df_da[col], df_np[col], equal_nan=True).all()
 
-    # default stats_funcs=['mean', 'max', 'min', 'sum', 'std', 'var', 'count']
-    df = stats(zones=zones, values=values)
-    assert isinstance(df, pd.DataFrame)
+    # ---- custom stats ----
+    # expected results
+    custom_stats_results = {
+        'zone':       [1,   2,  3],
+        'double_sum': [12, 16, 24],
+        'range':      [0,   0,  0],
+    }
 
-    dask_df = stats(zones=dask_zones, values=dask_values)
-    assert isinstance(dask_df, dd.DataFrame)
-
-    dask_df = dask_df.compute()
-    assert isinstance(dask_df, pd.DataFrame)
-
-    assert (df.columns == dask_df.columns).all()
-    for col in df.columns:
-        assert np.isclose(df[col], dask_df[col], equal_nan=True).all()
-
-    # indices of the output DataFrame matches the unique values in `zones`
-    idx = df['zone']
-    assert np.isclose(idx, unique_values).all()
-
-    num_cols = len(df.columns)
-    # 8 columns: 1 for zone id, and 7 statistics in default settings
-    assert num_cols == 8
-
-    assert zone_means == df['mean'].tolist()
-    assert zone_maxes == df['max'].tolist()
-    assert zone_mins == df['min'].tolist()
-    assert zone_sums == df['sum'].tolist()
-    assert zone_stds == df['std'].tolist()
-    assert zone_vars == df['var'].tolist()
-    assert zone_counts == df['count'].tolist()
-
-    # custom stats
-    def cal_sum(values):
-        return values.sum()
-
-    def cal_double_sum(values):
+    def _double_sum(values):
         return values.sum() * 2
 
-    zone_sums = [
-        cal_sum(zone_vals_0),
-        cal_sum(zone_vals_1),
-        cal_sum(zone_vals_2),
-        cal_sum(zone_vals_3)
-    ]
-    zone_double_sums = [
-        cal_double_sum(zone_vals_0),
-        cal_double_sum(zone_vals_1),
-        cal_double_sum(zone_vals_2),
-        cal_double_sum(zone_vals_3)
-    ]
+    def _range(values):
+        return values.max() - values.min()
 
-    custom_stats = {'sum': cal_sum, 'double sum': cal_double_sum}
-    df = stats(zones=zones, values=values, stats_funcs=custom_stats)
+    custom_stats = {
+        'double_sum': _double_sum,
+        'range': _range,
+    }
 
-    assert isinstance(df, pd.DataFrame)
-    # indices of the output DataFrame matches the unique values in `zones`
-    idx = df['zone']
-    assert np.isclose(idx, unique_values).all()
-    num_cols = len(df.columns)
-    # 3 columns: 1 zone, 2 statistics
-    assert num_cols == 3
-    assert zone_sums == df['sum'].tolist()
-    assert zone_double_sums == df['double sum'].tolist()
+    # numpy case
+    df_np = stats(
+        zones=zones_np, values=values_np, stats_funcs=custom_stats,
+        nodata_zones=0, nodata_values=0
+    )
+    assert isinstance(df_np, pd.DataFrame)
+    assert len(df_np.columns) == len(custom_stats_results)
+    for col in df_np.columns:
+        assert np.isclose(
+            df_np[col], custom_stats_results[col], equal_nan=True
+        ).all()
 
-
-# TODO: get this test passing
-def _test_stats_invalid_custom_stat():
-    zones, values = stats_create_zones_values()
-
-    def cal_sum(values):
-        return values.sum()
-
-    custom_stats = {'sum': cal_sum}
-
-    # custom stat only takes 1 argument. Thus, raise error
-    with pytest.raises(Exception) as e_info:  # noqa
-        stats(zones=zones, values=values, stats_funcs=custom_stats)
-
-
-def test_stats_invalid_stat_input():
-    zones, values = stats_create_zones_values()
-
-    # invalid stats
-    custom_stats = ['some_stat']
-    with pytest.raises(Exception) as e_info:  # noqa
-        stats(zones=zones, values=values, stats_funcs=custom_stats)
-
-    # invalid values:
-    zones = xr.DataArray(np.array([1, 2, 0], dtype=np.int))
-    values = xr.DataArray(np.array(['apples', 'foobar', 'cowboy']))
-    with pytest.raises(Exception) as e_info:  # noqa
-        stats(zones=zones, values=values)
-
-    # mismatch shape between zones and values:
-    zones = xr.DataArray(np.array([1, 2, 0]))
-    values = xr.DataArray(np.array([1, 2, 0, np.nan]))
-    with pytest.raises(Exception) as e_info:  # noqa
-        stats(zones=zones, values=values)
-
-
-def test_crosstab_invalid_input():
-    # invalid zones dims (must be 2d)
-    zones = xr.DataArray(np.array([1, 2, 0]))
-    values = xr.DataArray(np.array([[[1, 2, 0.5]]]),
-                          dims=['lat', 'lon', 'race'])
-    values['race'] = ['cat1', 'cat2', 'cat3']
-    with pytest.raises(Exception) as e_info:
-        crosstab(zones_agg=zones, values_agg=values)
-
-    # invalid values
-    zones = xr.DataArray(np.array([[1, 2, 0]], dtype=np.int))
-    # values must be either int or float
-    values = xr.DataArray(np.array([[['apples', 'foobar', 'cowboy']]]),
-                          dims=['lat', 'lon', 'race'])
-    values['race'] = ['cat1', 'cat2', 'cat3']
-    with pytest.raises(Exception) as e_info:  # noqa
-        crosstab(zones_agg=zones, values_agg=values)
-
-    # mismatch shape zones and values
-    zones = xr.DataArray(np.array([[1, 2]]))
-    values = xr.DataArray(np.array([[[1, 2, np.nan]]]),
-                          dims=['lat', 'lon', 'race'])
-    values['race'] = ['cat1', 'cat2', 'cat3']
-    with pytest.raises(Exception) as e_info:  # noqa
-        crosstab(zones_agg=zones, values_agg=values)
-
-    # invalid layer
-    zones = xr.DataArray(np.array([[1, 2]]))
-    values = xr.DataArray(np.array([[[1, 2, np.nan]]]),
-                          dims=['lat', 'lon', 'race'])
-    values['race'] = ['cat1', 'cat2', 'cat3']
-    # this layer does not exist in values agg
-    layer = 'cat'
-    with pytest.raises(Exception) as e_info:  # noqa
-        crosstab(zones_agg=zones, values_agg=values, layer=layer)
+    # dask case
+    df_da = stats(
+        zones=zones_da, values=values_da, stats_funcs=custom_stats,
+        nodata_zones=0, nodata_values=0
+    )
+    assert isinstance(df_da, dd.DataFrame)
+    df_da = df_da.compute()
+    assert isinstance(df_da, pd.DataFrame)
+    assert (df_da.columns == df_np.columns).all()
+    for col in df_da.columns:
+        assert np.isclose(df_da[col], df_np[col], equal_nan=True).all()
 
 
 def test_crosstab_no_values():
@@ -342,41 +239,6 @@ def test_crosstab_2d():
     num_zones = len(zone_idx)
     # number of rows = number of zones
     assert len(df.index) == num_zones
-
-
-def test_apply_invalid_input():
-    def func(x):
-        return 0
-
-    # invalid dims (must be 2d)
-    zones = xr.DataArray(np.array([1, 2, 0]))
-    values = xr.DataArray(np.array([[[1, 2, 0.5]]]))
-    with pytest.raises(Exception) as e_info:
-        apply(zones, values, func)
-
-    # invalid zones data dtype (must be int)
-    zones = xr.DataArray(np.array([[1, 2, 0.5]]))
-    values = xr.DataArray(np.array([[[1, 2, 0.5]]]))
-    with pytest.raises(Exception) as e_info:
-        apply(zones, values, func)
-
-    # invalid values data dtype (must be int or float)
-    values = xr.DataArray(np.array([['apples', 'foobar', 'cowboy']]))
-    zones = xr.DataArray(np.array([[1, 2, 0]]))
-    with pytest.raises(Exception) as e_info:
-        apply(zones, values, func)
-
-    # invalid values dim (must be 2d or 3d)
-    values = xr.DataArray(np.array([1, 2, 0.5]))
-    zones = xr.DataArray(np.array([[1, 2, 0]]))
-    with pytest.raises(Exception) as e_info:
-        apply(zones, values, func)
-
-    zones = xr.DataArray(np.array([[1, 2, 0], [1, 2, 3]]))
-    values = xr.DataArray(np.array([[1, 2, 0.5]]))
-    # mis-match zones.shape and values.shape
-    with pytest.raises(Exception) as e_info:  # noqa
-        apply(zones, values, func)
 
 
 def test_apply():

--- a/xrspatial/zonal.py
+++ b/xrspatial/zonal.py
@@ -535,8 +535,9 @@ def crosstab(zones: xr.DataArray,
     if zones.ndim != 2:
         raise ValueError("zones must be 2D")
 
-    if not issubclass(zones.data.dtype.type, np.integer):
-        raise ValueError("`zones` must be an xarray of integers")
+    if not (issubclass(zones.data.dtype.type, np.integer) or
+            issubclass(zones.data.dtype.type, np.integer)):
+        raise ValueError("`zones` must be an xarray of integers or floats")
 
     if not issubclass(values.data.dtype.type, np.integer) and \
             not issubclass(values.data.dtype.type, np.floating):

--- a/xrspatial/zonal.py
+++ b/xrspatial/zonal.py
@@ -93,6 +93,8 @@ def _stats_numpy(zones: xr.DataArray,
     )
     stats_df = pd.DataFrame(stats_dict)
     stats_df.set_index('zone')
+    # set dtype for zone column the be the same as of `zones` raster
+    stats_df = stats_df.astype({'zone': zones.data.dtype})
     return stats_df
 
 

--- a/xrspatial/zonal.py
+++ b/xrspatial/zonal.py
@@ -150,11 +150,8 @@ def stats(zones: xr.DataArray,
         raise ValueError(
             "`values` must be an array of integers or floats")
 
-    if nodata is not None:
-        # do not consider zone with nodata values
-        unique_zones = np.unique(zones.data[np.where(zones.data != nodata)])
-    else:
-        unique_zones = np.unique(zones.data)
+    # do not consider zone with nodata values
+    unique_zones = np.unique(zones.data[np.where(zones.data != nodata)])
 
     # mask out all invalid values such as: nan, inf
     masked_values = np.ma.masked_invalid(values.data)
@@ -204,11 +201,8 @@ def stats(zones: xr.DataArray,
 
 def _crosstab_2d(zones, values, nodata):
 
-    if nodata is not None:
-        # do not consider zone with nodata values
-        unique_zones = np.unique(zones.data[np.where(zones.data != nodata)])
-    else:
-        unique_zones = np.unique(zones.data)
+    # do not consider zone with nodata values
+    unique_zones = np.unique(zones.data[np.where(zones.data != nodata)])
 
     # mask out all invalid values such as: nan, inf
     masked_values = np.ma.masked_invalid(values.data)
@@ -244,11 +238,8 @@ def _crosstab_3d(zones, values, layer, nodata):
 
     num_cats = len(cats)
 
-    if nodata is not None:
-        # do not consider zone with nodata values
-        unique_zones = np.unique(zones.data[np.where(zones.data != nodata)])
-    else:
-        unique_zones = np.unique(zones.data)
+    # do not consider zone with nodata values
+    unique_zones = np.unique(zones.data[np.where(zones.data != nodata)])
 
     # mask out all invalid values such as: nan, inf
     masked_values = np.ma.masked_invalid(values.data)
@@ -465,7 +456,7 @@ def apply(zones: xr.DataArray,
     agg : xr.DataArray
         agg.values is either a 2D or 3D array of integers or floats.
         The input value raster.
-        
+
     func : callable function to apply.
 
     nodata: int, default=None

--- a/xrspatial/zonal.py
+++ b/xrspatial/zonal.py
@@ -439,7 +439,8 @@ def crosstab(zones: xr.DataArray,
 
 def apply(zones: xr.DataArray,
           values: xr.DataArray,
-          func: Callable):
+          func: Callable,
+          nodata: Optional[int] = 0):
     """
     Apply a function to the `values` agg within zones in `zones` agg.
     Change the agg content.
@@ -497,11 +498,11 @@ def apply(zones: xr.DataArray,
         raise ValueError(
             "`values` must be an array of integers or float")
 
-    # entries of zone 0 remain the same
-    remain_entries = zones.data == 0
+    # entries of nodata remain the same
+    remain_entries = zones.data == nodata
 
-    # entries with a non-zero zone value
-    zones_entries = zones.data != 0
+    # entries with to be included in calculation
+    zones_entries = zones.data != nodata
 
     if len(values.shape) == 3:
         z = values.shape[-1]

--- a/xrspatial/zonal.py
+++ b/xrspatial/zonal.py
@@ -254,16 +254,15 @@ def stats(zones: xr.DataArray,
         4  4.793242e+06
     """
     if zones.shape != values.shape:
-        raise ValueError(
-            "`zones` and `values` must have same shape")
+        raise ValueError("`zones` and `values` must have same shape.")
 
-    if not issubclass(zones.data.dtype.type, np.integer):
-        raise ValueError("`zones` must be an array of integers")
+    if not (issubclass(zones.data.dtype.type, np.integer) or
+            issubclass(zones.data.dtype.type, np.floating)):
+        raise ValueError("`zones` must be an array of integers.")
 
     if not (issubclass(values.data.dtype.type, np.integer) or
             issubclass(values.data.dtype.type, np.floating)):
-        raise ValueError(
-            "`values` must be an array of integers or floats")
+        raise ValueError("`values` must be an array of integers or floats.")
 
     if isinstance(stats_funcs, list):
         # create a dict of stats

--- a/xrspatial/zonal.py
+++ b/xrspatial/zonal.py
@@ -53,14 +53,14 @@ def _stats(zones: xr.DataArray,
     for stats in stats_funcs:
         stats_dict[stats] = []
 
-    # mask out all invalid values such as: nan, inf
-    masked_data = array_module.ma.masked_invalid(values.data)
-
     for zone_id in unique_zones:
         # get zone values
         zone_values = array_module.ma.masked_where(
-            ((zones.data != zone_id) | (values.data == nodata_values)),
-            masked_data
+            ((zones.data != zone_id) |
+             (values.data == nodata_values) |
+             ~np.isfinite(values.data)  # mask out nan, inf
+             ),
+            values.data
         )
         for stats in stats_funcs:
             stats_func = stats_funcs.get(stats)
@@ -523,7 +523,7 @@ def crosstab(zones: xr.DataArray,
         raise ValueError("zones must be 2D")
 
     if not (issubclass(zones.data.dtype.type, np.integer) or
-            issubclass(zones.data.dtype.type, np.integer)):
+            issubclass(zones.data.dtype.type, np.floating)):
         raise ValueError("`zones` must be an xarray of integers or floats")
 
     if not issubclass(values.data.dtype.type, np.integer) and \

--- a/xrspatial/zonal.py
+++ b/xrspatial/zonal.py
@@ -182,8 +182,9 @@ def stats(zones: xr.DataArray,
     .. plot::
        :include-source:
 
-        from xrspatial.zonal import stats
         import numpy as np
+        import xarray as xr
+        from xrspatial.zonal import stats
 
         height, width = 10, 10
         # values raster
@@ -216,7 +217,33 @@ def stats(zones: xr.DataArray,
         1  10     1350
         2  20     3600
         3  30     3850
+
+        >>> # Calculate Stats with dask backed xarray DataArrays
+        >>> dask_stats_df = stats(zones=dask_zones, values=dask_values)
+        >>> print(type(dask_stats_df))
+        <class 'dask.dataframe.core.DataFrame'>
+        >>> print(dask_stats_df.compute())
+            zone  mean  max  min   sum       std    var  count
+        0     0  22.0   44    0   550  14.21267  202.0     25
+        1    10  27.0   49    5   675  14.21267  202.0     25
+        2    20  72.0   94   50  1800  14.21267  202.0     25
+        3    30  77.0   99   55  1925  14.21267  202.0     25
+
+        >>> # Custom Stats with dask backed xarray DataArrays
+        >>> dask_custom_stats ={'double_sum': lambda val: val.sum()*2}
+        >>> dask_custom_stats_df = stats(zones=dask_zones,
+                                    values=dask_values,
+                                    stats_funcs=custom_stats)
+        >>> print(type(dask_custom_stats_df))
+        <class 'dask.dataframe.core.DataFrame'>
+        >>> print(dask_custom_stats_df.compute())
+            zone  double_sum
+        0     0        1100
+        1    10        1350
+        2    20        3600
+        3    30        3850
     """
+
     if zones.shape != values.shape:
         raise ValueError("`zones` and `values` must have same shape.")
 

--- a/xrspatial/zonal.py
+++ b/xrspatial/zonal.py
@@ -45,7 +45,8 @@ def stats(zones: xr.DataArray,
 
     nodata: int, default=None
         Nodata value in `zones` raster.
-        Cells with `nodata` does not belong to any zone.
+        Cells with `nodata` does not belong to any zone,
+        and thus excluded from calculation.
 
     Returns
     -------
@@ -298,13 +299,20 @@ def crosstab(zones: xr.DataArray,
         whether or not they are contiguous. The input zone layer defines
         the shape, values, and locations of the zones. An integer field
         in the zone input is specified to define the zones.
+
     values : xr.DataArray
         values.values is a 3d array of integers or floats.
         The input value raster contains the input values used in
         calculating the categorical statistic for each zone.
+
     layer: str, default=None
         name of the layer inside the `values` DataArray for getting
         the values.
+
+    nodata: int, default=None
+        Nodata value in `zones` raster.
+        Cells with `nodata` does not belong to any zone,
+        and thus excluded from calculation.
 
     Returns
     -------
@@ -453,10 +461,17 @@ def apply(zones: xr.DataArray,
         contiguous. The input zone layer defines the shape, values, and
         locations of the zones. An integer field in the zone input is
         specified to define the zones.
+
     agg : xr.DataArray
         agg.values is either a 2D or 3D array of integers or floats.
         The input value raster.
+        
     func : callable function to apply.
+
+    nodata: int, default=None
+        Nodata value in `zones` raster.
+        Cells with `nodata` does not belong to any zone,
+        and thus excluded from calculation.
 
     Examples
     --------

--- a/xrspatial/zonal.py
+++ b/xrspatial/zonal.py
@@ -365,10 +365,8 @@ def _crosstab_dask(zones, values, nodata_zones, nodata_values):
         cats = values.indexes[values.dims[0]].values
     else:
         # 2D case
-        # mask out all invalid values: nan, inf
-        masked_data = da.ma.masked_invalid(values.data)
         # precompute categories
-        cats = da.unique(da.ma.getdata(masked_data)).compute()
+        cats = da.unique(values.data[da.isfinite(values.data)]).compute()
         cats = sorted(list(set(cats) - set([nodata_values])))
 
     # precompute unique zones

--- a/xrspatial/zonal.py
+++ b/xrspatial/zonal.py
@@ -123,7 +123,8 @@ def _stats_dask(zones: xr.DataArray,
     # name columns
     stats_df.columns = stats_dict.keys()
     stats_df.set_index('zone')
-
+    # set dtype for zone column the be the same as of `zones` raster
+    stats_df = stats_df.astype({'zone': zones.data.dtype})
     return stats_df
 
 

--- a/xrspatial/zonal.py
+++ b/xrspatial/zonal.py
@@ -323,7 +323,7 @@ def _crosstab_2d_numpy(zones, values, nodata):
     masked_values = np.ma.masked_invalid(values.data)
 
     # categories
-    cats = np.unique(masked_values[masked_values.mask == False]).data
+    cats = np.unique(masked_values[masked_values.mask == False]).data # noqa
 
     crosstab_dict = _crosstab_dict_2d(
         zones, values, masked_values, unique_zones, cats

--- a/xrspatial/zonal.py
+++ b/xrspatial/zonal.py
@@ -12,7 +12,7 @@ from typing import Optional, Callable, Union, Dict, List
 
 def stats(zones: xr.DataArray,
           values: xr.DataArray,
-          stat_funcs: Union[Dict, List] = ['mean', 'max', 'min', 'std', 'var', 'count'], #noqa
+          stat_funcs: Union[Dict, List] = ['mean', 'max', 'min', 'std', 'var', 'count'], # noqa
           nodata: Optional[int] = None):
     """
     Calculate summary statistics for each zone defined by a zone

--- a/xrspatial/zonal.py
+++ b/xrspatial/zonal.py
@@ -318,7 +318,7 @@ def _crosstab_dict(zones, values, unique_zones, cats, masked_data):
     return crosstab_dict
 
 
-def _crosstab_numpy(zones, values, nodata):
+def _crosstab_numpy(zones, values, nodata_zones):
 
     # mask out all invalid values such as: nan, inf
     masked_data = np.ma.masked_invalid(values.data)
@@ -332,7 +332,7 @@ def _crosstab_numpy(zones, values, nodata):
 
     # do not consider zone with nodata values
     unique_zones = np.unique(zones.data[np.isfinite(zones.data)])
-    unique_zones = [z for z in unique_zones if z != nodata]
+    unique_zones = [z for z in unique_zones if z != nodata_zones]
 
     crosstab_dict = _crosstab_dict(
         zones, values, unique_zones, cats, masked_data
@@ -348,7 +348,7 @@ def _crosstab_numpy(zones, values, nodata):
     return crosstab_df
 
 
-def _crosstab_dask(zones, values, nodata):
+def _crosstab_dask(zones, values, nodata_zones):
 
     # mask out all invalid values such as: nan, inf
     masked_data = da.ma.masked_invalid(values.data)
@@ -364,7 +364,7 @@ def _crosstab_dask(zones, values, nodata):
     # precompute unique zones
     unique_zones = da.unique(zones.data[da.isfinite(zones.data)]).compute()
     # do not consider zone with nodata values
-    unique_zones = [z for z in unique_zones if z != nodata]
+    unique_zones = [z for z in unique_zones if z != nodata_zones]
 
     crosstab_dict = _crosstab_dict(
         zones, values, unique_zones, cats, masked_data
@@ -390,7 +390,7 @@ def _crosstab_dask(zones, values, nodata):
 def crosstab(zones: xr.DataArray,
              values: xr.DataArray,
              layer: Optional[int] = None,
-             nodata: Optional[int] = None) -> pd.DataFrame:
+             nodata_zones: Optional[int] = None) -> pd.DataFrame:
     """
     Calculate cross-tabulated (categorical stats) areas
     between two datasets: a zone dataset, a value dataset (a value
@@ -569,10 +569,10 @@ def crosstab(zones: xr.DataArray,
 
     if isinstance(values.data, np.ndarray):
         # numpy case
-        crosstab_df = _crosstab_numpy(zones, values, nodata)
+        crosstab_df = _crosstab_numpy(zones, values, nodata_zones)
     else:
         # dask case
-        crosstab_df = _crosstab_dask(zones, values, nodata)
+        crosstab_df = _crosstab_dask(zones, values, nodata_zones)
 
     return crosstab_df
 

--- a/xrspatial/zonal.py
+++ b/xrspatial/zonal.py
@@ -7,7 +7,7 @@ from xrspatial.utils import ngjit
 
 from math import sqrt
 
-from typing import Optional, Callable, Union
+from typing import Optional, Callable, Union, Dict, List
 
 
 def stats(zones: xr.DataArray,
@@ -23,22 +23,24 @@ def stats(zones: xr.DataArray,
     Parameters
     ----------
     zones : xr.DataArray
-        zones.values is a 2d array of integers.
+        zones is a 2D xarray DataArray of integers.
         A zone is all the cells in a raster that have the same value,
-        whether or not they are contiguous. The input zone layer defines
+        whether or not they are contiguous. The input `zones` raster defines
         the shape, values, and locations of the zones. An integer field
-        in the zone input is specified to define the zones.
+        in the input `zones` DataArray defines a zone.
+
     values : xr.DataArray
-        values.values is a 2d array of integers or floats.
-        The input value raster contains the input values used in
+        values is a 2D xarray DataArray of numeric values (integers or floats).
+        The input `values` raster contains the input values used in
         calculating the output statistic for each zone.
-    stat_funcs : list of string or dict, default=['mean', 'max', 'min',
+
+    stat_funcs : Dict, or List of strings, default=['mean', 'max', 'min',
         'std', 'var', 'count'])
-        Which statistics to calculate for each zone. If a list, possible
-        choices are subsets of ['mean', 'max', 'min', 'std', 'var',
-        'count']. In the dictionary case, all of its values must be
-        callable. Function takes only one argument that is the zone
-        values. The key become the column name in the output DataFrame.
+        The statistics to calculate for each zone. If a list, possible
+        choices are subsets of `['mean', 'max', 'min', 'std', 'var',
+        'count']`. In the dictionary case, all of its values must be
+        callable. Function takes only one argument that is the `values` raster.
+        The key become the column name in the output DataFrame.
 
     Returns
     -------
@@ -142,8 +144,7 @@ def stats(zones: xr.DataArray,
         raise ValueError(
             "`values` must be an array of integers or floats")
 
-    # do not consider zone with 0s
-    unique_zones = np.unique(zones.data[np.where(zones.data != 0)])
+    unique_zones = np.unique(zones.data)
 
     # mask out all invalid values such as: nan, inf
     masked_values = np.ma.masked_invalid(values.data)
@@ -192,8 +193,7 @@ def stats(zones: xr.DataArray,
 
 
 def _crosstab_2d(zones, values):
-    # do not consider zone with 0s
-    unique_zones = np.unique(zones.data[np.where(zones.data != 0)])
+    unique_zones = np.unique(zones.data)
 
     # mask out all invalid values such as: nan, inf
     masked_values = np.ma.masked_invalid(values.data)
@@ -229,8 +229,7 @@ def _crosstab_3d(zones, values, layer):
 
     num_cats = len(cats)
 
-    # do not consider zone with 0s
-    unique_zones = np.unique(zones.data[np.where(zones.data != 0)])
+    unique_zones = np.unique(zones.data)
 
     # mask out all invalid values such as: nan, inf
     masked_values = np.ma.masked_invalid(values.data)

--- a/xrspatial/zonal.py
+++ b/xrspatial/zonal.py
@@ -281,7 +281,7 @@ def stats(zones: xr.DataArray,
 
 
 def _crosstab_dict(zones, values, unique_zones, cats, masked_data):
-    
+
     def _zone_cat_data(cat, zone_id, cat_id):
         if len(values.shape) == 2:
             # 2D case
@@ -309,7 +309,7 @@ def _crosstab_dict(zones, values, unique_zones, cats, masked_data):
         crosstab_dict[i] = []
 
     for c, cat in enumerate(cats):
-        for zone_id in unique_zones:            
+        for zone_id in unique_zones:
             # get category cat values in the selected zone
             zone_cat_data = _zone_cat_data(cat, zone_id, c)
             zone_cat_count = _stats_count(zone_cat_data)


### PR DESCRIPTION
- [x] add Dask support for zonal stats
- [x] add Dask support for zonal crosstab 2d
- [x] add Dask support for zonal crosstab 3d
- [x] allow floating point agg for zones
- [x] allow zone with id 0 (current behavior considers zone 0 as nodata region of the image so it is excluded from calculation)
- [x] add param `nodata_zones` with a default of `None` (or `nan`?) to specify value that will be excluded from `zones` raster
- [x] add param `nodata_values` with a default of `None` to specify value that will be excluded from `values` raster
- [x] update tests
- [x] update docstrings