### PR TITLE
Optimize natural_break on large inputs

### DIFF
--- a/xrspatial/classify.py
+++ b/xrspatial/classify.py
@@ -526,7 +526,9 @@ def _run_numpy_natural_break(data, num_sample, k):
         # randomly select sample from the whole dataset
         # create a pseudo random number generator
         generator = RandomState(1234567890)
-        idx = np.linspace(0, data.size, data.size, endpoint=False, dtype=np.uint32)
+        idx = np.linspace(
+            0, data.size, data.size, endpoint=False, dtype=np.uint32
+        )
         generator.shuffle(idx)
         sample_idx = idx[:num_sample]
         sample_data = data.flatten()[sample_idx]

--- a/xrspatial/classify.py
+++ b/xrspatial/classify.py
@@ -563,7 +563,7 @@ def _run_numpy_natural_break(data, num_sample, k):
         uv.sort()
         bins = uv
     else:
-        centroids = _run_numpy_jenks(sample_data, k)
+        centroids = _run_numpy_jenks(uv, k)
         bins = np.array(centroids[1:])
 
     out = _bin(data, bins, np.arange(uvk))


### PR DESCRIPTION
Optimized natural break on CPU.
* Removed slow random sample generation with a much faster one.
* Removed a slow and unnecessary nan removal
* Optimized the _run_numpy_jenks_matrices by making it multithreaded.

Initial performance I benchmarked took 11.27s to calculate
New version takes 3.2s