### PR TITLE
zonal stats: speed up dask case

### DIFF
--- a/xrspatial/tests/test_zonal.py
+++ b/xrspatial/tests/test_zonal.py
@@ -62,13 +62,8 @@ def check_results(df_np, df_da, expected_results_dict):
         df_da = df_da.compute()
         assert isinstance(df_da, pd.DataFrame)
 
-        # numpy results equal dask results
-        # zone column
-        assert (df_np['zone'] == df_da['zone']).all()
-
-        assert (df_np.columns == df_da.columns).all()
-        for col in df_np.columns[1:]:
-            assert np.isclose(df_np[col], df_da[col], equal_nan=True).all()
+        # numpy results equal dask results, ignoring their indexes
+        assert np.array_equal(df_np.values, df_da.values, equal_nan=True)
 
 
 def test_stats():
@@ -94,7 +89,27 @@ def test_stats():
     df_da = stats(zones=zones_da, values=values_da)
     check_results(df_np, df_da, default_stats_results)
 
-    # ---- custom stats ----
+    # expected results
+    stats_results_zone_0_3 = {
+        'zone':  [0, 3],
+        'mean':  [0, 2.4],
+        'max':   [0, 3],
+        'min':   [0, 0],
+        'sum':   [0, 12],
+        'std':   [0, 1.2],
+        'var':   [0, 1.44],
+        'count': [5, 5]
+    }
+
+    # numpy case
+    df_np_zone_0_3 = stats(zones=zones_np, values=values_np, zone_ids=[0, 3])
+
+    # dask case
+    df_da_zone_0_3 = stats(zones=zones_da, values=values_da, zone_ids=[0, 3])
+
+    check_results(df_np_zone_0_3, df_da_zone_0_3, stats_results_zone_0_3)
+
+    # ---- custom stats (NumPy only) ----
     # expected results
     custom_stats_results = {
         'zone':       [1, 2],

--- a/xrspatial/tests/test_zonal.py
+++ b/xrspatial/tests/test_zonal.py
@@ -115,12 +115,12 @@ def test_stats():
     # numpy case
     df_np = stats(
         zones=zones_np, values=values_np, stats_funcs=custom_stats,
-        zone_ids=[1, 2], nodata_zones=0, nodata_values=0
+        zone_ids=[1, 2], nodata_values=0
     )
     # dask case
     df_da = stats(
         zones=zones_da, values=values_da, stats_funcs=custom_stats,
-        zone_ids=[1, 2], nodata_zones=0, nodata_values=0
+        zone_ids=[1, 2], nodata_values=0
     )
     check_results(df_np, df_da, custom_stats_results)
 

--- a/xrspatial/tests/test_zonal.py
+++ b/xrspatial/tests/test_zonal.py
@@ -56,18 +56,19 @@ def check_results(df_np, df_da, expected_results_dict):
             df_np[col], expected_results_dict[col], equal_nan=True
         ).all()
 
-    # dask case
-    assert isinstance(df_da, dd.DataFrame)
-    df_da = df_da.compute()
-    assert isinstance(df_da, pd.DataFrame)
+    if df_da is not None:
+        # dask case
+        assert isinstance(df_da, dd.DataFrame)
+        df_da = df_da.compute()
+        assert isinstance(df_da, pd.DataFrame)
 
-    # numpy results equal dask results
-    # zone column
-    assert (df_np['zone'] == df_da['zone']).all()
+        # numpy results equal dask results
+        # zone column
+        assert (df_np['zone'] == df_da['zone']).all()
 
-    assert (df_np.columns == df_da.columns).all()
-    for col in df_np.columns[1:]:
-        assert np.isclose(df_np[col], df_da[col], equal_nan=True).all()
+        assert (df_np.columns == df_da.columns).all()
+        for col in df_np.columns[1:]:
+            assert np.isclose(df_np[col], df_da[col], equal_nan=True).all()
 
 
 def test_stats():
@@ -118,10 +119,7 @@ def test_stats():
         zone_ids=[1, 2], nodata_values=0
     )
     # dask case
-    df_da = stats(
-        zones=zones_da, values=values_da, stats_funcs=custom_stats,
-        zone_ids=[1, 2], nodata_values=0
-    )
+    df_da = None
     check_results(df_np, df_da, custom_stats_results)
 
 

--- a/xrspatial/zonal.py
+++ b/xrspatial/zonal.py
@@ -149,13 +149,13 @@ def _stats_func_dask_numpy(
     values_block: np.array,
     unique_zones: np.array,
     zone_ids: np.array,
-    func: callable,
+    func: Callable,
     nodata_values: Union[int, float] = None,
 ) -> pd.DataFrame:
 
     sorted_zones = np.sort(zones_block.flatten())
-    sored_indices = np.argsort(zones_block.flatten())
-    values_by_zones = values_block.flatten()[sored_indices]
+    sorted_indices = np.argsort(zones_block.flatten())
+    values_by_zones = values_block.flatten()[sorted_indices]
 
     # exclude nans from calculation
     # flatten_zones is already sorted, NaN elements (if any) are at the end
@@ -164,11 +164,11 @@ def _stats_func_dask_numpy(
     zone_breaks = _strides(sorted_zones, unique_zones)
 
     start = 0
-    results = np.zeros(unique_zones.shape) * np.nan
+    results = np.full(unique_zones.shape, np.nan)
     for i in range(len(unique_zones)):
         end = zone_breaks[i]
         if unique_zones[i] in zone_ids:
-            zone_values = values_by_zones[start: end]
+            zone_values = values_by_zones[start:end]
             # filter out non-finite and nodata_values
             zone_values = zone_values[
                 np.isfinite(zone_values) & (zone_values != nodata_values)]

--- a/xrspatial/zonal.py
+++ b/xrspatial/zonal.py
@@ -145,17 +145,17 @@ def _strides(flatten_zones, unique_zones):
 
 @delayed
 def _stats_func_dask_numpy(
-    zones: np.array,
-    values: np.array,
+    zones_block: np.array,
+    values_block: np.array,
     unique_zones: np.array,
     zone_ids: np.array,
     func: callable,
     nodata_values: Union[int, float] = None,
 ) -> pd.DataFrame:
 
-    sorted_zones = np.sort(zones.flatten())
-    sored_indices = np.argsort(zones.flatten())
-    values_by_zones = values.flatten()[sored_indices]
+    sorted_zones = np.sort(zones_block.flatten())
+    sored_indices = np.argsort(zones_block.flatten())
+    values_by_zones = values_block.flatten()[sored_indices]
 
     # exclude nans from calculation
     # flatten_zones is already sorted, NaN elements (if any) are at the end
@@ -180,11 +180,11 @@ def _stats_func_dask_numpy(
 
 
 def _stats_dask_numpy(
-        zones: da.Array,
-        values: da.Array,
-        zone_ids: List[Union[int, float]],
-        stats_funcs: Dict,
-        nodata_values: Union[int, float],
+    zones: da.Array,
+    values: da.Array,
+    zone_ids: List[Union[int, float]],
+    stats_funcs: Dict,
+    nodata_values: Union[int, float],
 ) -> pd.DataFrame:
 
     # find ids for all zones


### PR DESCRIPTION
This PR uses the same approach as https://github.com/makepath/xarray-spatial/pull/568 to improve performance for zonal stats when input data arrays are dask-backed. It computes stats chunk by chunk and then summarizes all the results and return output as a dask DataFrame. 

This also limits stats that supported in dask case to a subset of default stats, which is safer since a custom statistics would not be always element-wise thus can produce unexpected results.

`nodata_zones` is removed as we already support `zone_ids`, and exclude invalid values (nan, inf) from our calculations.