### PR TITLE
Use explicit cupy to numpy conversion in tests

### DIFF
--- a/xrspatial/focal.py
+++ b/xrspatial/focal.py
@@ -113,7 +113,7 @@ def _mean_dask_cupy(data, excludes):
 def _mean(data, excludes):
     # numpy case
     if isinstance(data, np.ndarray):
-        out = _mean_numpy(data.astype(np.float), excludes)
+        out = _mean_numpy(data.astype(float), excludes)
 
     # cupy case
     elif has_cuda() and isinstance(data, cupy.ndarray):
@@ -122,11 +122,11 @@ def _mean(data, excludes):
     # dask + cupy case
     elif has_cuda() and isinstance(data, da.Array) and \
             type(data._meta).__module__.split('.')[0] == 'cupy':
-        out = _mean_dask_cupy(data.astype(cupy.float), excludes)
+        out = _mean_dask_cupy(data.astype(float), excludes)
 
     # dask + numpy case
     elif isinstance(data, da.Array):
-        out = _mean_dask_numpy(data.astype(np.float), excludes)
+        out = _mean_dask_numpy(data.astype(float), excludes)
 
     else:
         raise TypeError('Unsupported Array Type: {}'.format(type(data)))

--- a/xrspatial/tests/test_aspect.py
+++ b/xrspatial/tests/test_aspect.py
@@ -89,7 +89,7 @@ def test_numpy_equals_cupy():
     gpu = aspect(small_da_cupy, name='aspect_agg')
 
     assert isinstance(gpu.data, cupy.ndarray)
-    assert np.isclose(cpu, gpu, equal_nan=True).all()
+    assert np.isclose(cpu, gpu.data.get(), equal_nan=True).all()
 
 
 @pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
@@ -113,7 +113,7 @@ def test_cupy_equals_qgis():
     # TODO: We shouldn't ignore edges!
     # validate output values
     # ignore border edges
-    xrspatial_vals = xrspatial_aspect.values[1:-1, 1:-1]
+    xrspatial_vals = xrspatial_aspect.data[1:-1, 1:-1].get()
     qgis_vals = QGIS_OUTPUT[1:-1, 1:-1]
     assert np.isclose(xrspatial_vals, qgis_vals, equal_nan=True).all()
 

--- a/xrspatial/tests/test_classify.py
+++ b/xrspatial/tests/test_classify.py
@@ -67,7 +67,7 @@ def test_reclassify_cpu_equals_gpu():
                      bins=bins,
                      new_values=new_values)
     assert isinstance(gpu.data, cupy.ndarray)
-    assert np.isclose(cpu, gpu, equal_nan=True).all()
+    assert np.isclose(cpu, gpu.data.get(), equal_nan=True).all()
 
     # dask + cupy
     dask_cupy_agg = xr.DataArray(cupy.asarray(elevation),
@@ -78,7 +78,7 @@ def test_reclassify_cpu_equals_gpu():
     assert isinstance(dask_gpu.data, da.Array) and is_cupy_backed(dask_gpu)
 
     dask_gpu.data = dask_gpu.data.compute()
-    assert np.isclose(cpu, dask_gpu, equal_nan=True).all()
+    assert np.isclose(cpu, dask_gpu.data.get(), equal_nan=True).all()
 
 
 def test_quantile_cpu():
@@ -123,7 +123,7 @@ def test_quantile_cpu_equals_gpu():
     gpu = quantile(cupy_agg, k=k, name='cupy_result')
 
     assert isinstance(gpu.data, cupy.ndarray)
-    assert np.isclose(cpu, gpu, equal_nan=True).all()
+    assert np.isclose(cpu, gpu.data.get(), equal_nan=True).all()
 
 
 def test_natural_breaks_cpu():
@@ -188,7 +188,7 @@ def test_natural_breaks_cpu_equals_gpu():
     gpu = natural_breaks(cupy_agg, k=k, name='cupy_result')
 
     assert isinstance(gpu.data, cupy.ndarray)
-    assert np.isclose(cpu, gpu, equal_nan=True).all()
+    assert np.isclose(cpu, gpu.data.get(), equal_nan=True).all()
 
 
 def test_equal_interval_cpu():
@@ -224,4 +224,4 @@ def test_equal_interval_cpu_equals_gpu():
     gpu = equal_interval(cupy_agg, k=k)
     assert isinstance(gpu.data, cupy.ndarray)
 
-    assert np.isclose(cpu, gpu, equal_nan=True).all()
+    assert np.isclose(cpu, gpu.data.get(), equal_nan=True).all()

--- a/xrspatial/tests/test_curvature.py
+++ b/xrspatial/tests/test_curvature.py
@@ -166,7 +166,7 @@ def test_curvature_gpu_equals_cpu():
 
     assert isinstance(gpu.data, cupy.ndarray)
 
-    assert np.isclose(cpu, gpu, equal_nan=True).all()
+    assert np.isclose(cpu, gpu.data.get(), equal_nan=True).all()
 
 
 def test_curvature_numpy_equals_dask():

--- a/xrspatial/tests/test_hillshade.py
+++ b/xrspatial/tests/test_hillshade.py
@@ -93,4 +93,4 @@ def test_hillshade_gpu_equals_cpu():
 
     assert isinstance(gpu.data, cupy.ndarray)
 
-    assert np.isclose(cpu, gpu, equal_nan=True).all()
+    assert np.isclose(cpu, gpu.data.get(), equal_nan=True).all()

--- a/xrspatial/tests/test_multispectral.py
+++ b/xrspatial/tests/test_multispectral.py
@@ -139,7 +139,7 @@ def test_ndvi_cupy_equals_numpy():
     test_result = ndvi(nir_cupy, red_cupy)
 
     assert isinstance(test_result.data, cupy.ndarray)
-    assert np.isclose(numpy_result, test_result, equal_nan=True).all()
+    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 @pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
@@ -158,7 +158,7 @@ def test_ndvi_dask_cupy_equals_numpy():
     assert is_dask_cupy(test_result)
 
     test_result.data = test_result.data.compute()
-    assert np.isclose(numpy_result, test_result, equal_nan=True).all()
+    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 # SAVI -------------
@@ -210,7 +210,7 @@ def test_savi_cupy_equals_numpy():
     test_result = savi(nir_cupy, red_cupy)
 
     assert isinstance(test_result.data, cupy.ndarray)
-    assert np.isclose(numpy_result, test_result, equal_nan=True).all()
+    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 @pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
@@ -227,7 +227,7 @@ def test_savi_dask_cupy_equals_numpy():
 
     assert is_dask_cupy(test_result)
     test_result.data = test_result.data.compute()
-    assert np.isclose(numpy_result, test_result, equal_nan=True).all()
+    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 # arvi -------------
@@ -280,7 +280,7 @@ def test_arvi_cupy_equals_numpy():
     test_result = arvi(nir_cupy, red_cupy, blue_cupy)
 
     assert isinstance(test_result.data, cupy.ndarray)
-    assert np.isclose(numpy_result, test_result, equal_nan=True).all()
+    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 @pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
@@ -300,7 +300,7 @@ def test_arvi_dask_cupy_equals_numpy():
     assert is_dask_cupy(test_result)
 
     test_result.data = test_result.data.compute()
-    assert np.isclose(numpy_result, test_result, equal_nan=True).all()
+    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 # EVI -------------
@@ -357,7 +357,7 @@ def test_evi_cupy_equals_numpy():
     test_result = evi(nir_cupy, red_cupy, blue_cupy)
 
     assert isinstance(test_result.data, cupy.ndarray)
-    assert np.isclose(numpy_result, test_result, equal_nan=True).all()
+    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 @pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
@@ -377,7 +377,7 @@ def test_evi_dask_cupy_equals_numpy():
     assert is_dask_cupy(test_result)
 
     test_result.data = test_result.data.compute()
-    assert np.isclose(numpy_result, test_result, equal_nan=True).all()
+    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 # GCI -------------
@@ -424,7 +424,7 @@ def test_gci_cupy_equals_numpy():
     test_result = gci(nir_cupy, green_cupy)
 
     assert isinstance(test_result.data, cupy.ndarray)
-    assert np.isclose(numpy_result, test_result, equal_nan=True).all()
+    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 @pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Dgcice not Available")
@@ -442,7 +442,7 @@ def test_gci_dask_cupy_equals_numpy():
     assert is_dask_cupy(test_result)
 
     test_result.data = test_result.data.compute()
-    assert np.isclose(numpy_result, test_result, equal_nan=True).all()
+    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 # SIPI -------------
@@ -495,7 +495,7 @@ def test_sipi_cupy_equals_numpy():
     test_result = sipi(nir_dask, red_dask, blue_dask)
 
     assert isinstance(test_result.data, cupy.ndarray)
-    assert np.isclose(numpy_result, test_result, equal_nan=True).all()
+    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 @pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
@@ -514,7 +514,7 @@ def test_sipi_dask_cupy_equals_numpy():
 
     assert is_dask_cupy(test_result)
     test_result.data = test_result.data.compute()
-    assert np.isclose(numpy_result, test_result, equal_nan=True).all()
+    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 # NBR -------------
@@ -561,7 +561,7 @@ def test_nbr_cupy_equals_numpy():
     test_result = nbr(nir_cupy, swir_cupy)
 
     assert isinstance(test_result.data, cupy.ndarray)
-    assert np.isclose(numpy_result, test_result, equal_nan=True).all()
+    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 @pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
@@ -579,7 +579,7 @@ def test_nbr_dask_cupy_equals_numpy():
     assert is_dask_cupy(test_result)
 
     test_result.data = test_result.data.compute()
-    assert np.isclose(numpy_result, test_result, equal_nan=True).all()
+    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 # NBR2 -------------
@@ -627,7 +627,7 @@ def test_nbr2_cupy_equals_numpy():
     test_result = nbr2(swir1_cupy, swir2_cupy)
 
     assert isinstance(test_result.data, cupy.ndarray)
-    assert np.isclose(numpy_result, test_result, equal_nan=True).all()
+    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 @pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Dnbr2ce not Available")
@@ -644,7 +644,7 @@ def test_nbr2_dask_cupy_equals_numpy():
 
     assert is_dask_cupy(test_result)
     test_result.data = test_result.data.compute()
-    assert np.isclose(numpy_result, test_result, equal_nan=True).all()
+    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 # NDMI -------------
@@ -692,7 +692,7 @@ def test_ndmi_cupy_equals_numpy():
     test_result = ndmi(nir_cupy, swir1_cupy)
 
     assert isinstance(test_result.data, cupy.ndarray)
-    assert np.isclose(numpy_result, test_result, equal_nan=True).all()
+    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 @pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
@@ -709,7 +709,7 @@ def test_ndmi_dask_cupy_equals_numpy():
 
     assert is_dask_cupy(test_result)
     test_result.data = test_result.data.compute()
-    assert np.isclose(numpy_result, test_result, equal_nan=True).all()
+    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 # EBBI -------------
@@ -761,7 +761,7 @@ def test_ebbi_cupy_equals_numpy():
     test_result = ebbi(red_dask, swir_dask, tir_dask)
 
     assert isinstance(test_result.data, cupy.ndarray)
-    assert np.isclose(numpy_result, test_result, equal_nan=True).all()
+    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 @pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
@@ -780,7 +780,7 @@ def test_ebbi_dask_cupy_equals_numpy():
 
     assert is_dask_cupy(test_result)
     test_result.data = test_result.data.compute()
-    assert np.isclose(numpy_result, test_result, equal_nan=True).all()
+    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 def test_true_color_cpu():

--- a/xrspatial/tests/test_multispectral.py
+++ b/xrspatial/tests/test_multispectral.py
@@ -139,7 +139,8 @@ def test_ndvi_cupy_equals_numpy():
     test_result = ndvi(nir_cupy, red_cupy)
 
     assert isinstance(test_result.data, cupy.ndarray)
-    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
+    assert np.isclose(
+        numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 @pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
@@ -158,7 +159,8 @@ def test_ndvi_dask_cupy_equals_numpy():
     assert is_dask_cupy(test_result)
 
     test_result.data = test_result.data.compute()
-    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
+    assert np.isclose(
+        numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 # SAVI -------------
@@ -210,7 +212,8 @@ def test_savi_cupy_equals_numpy():
     test_result = savi(nir_cupy, red_cupy)
 
     assert isinstance(test_result.data, cupy.ndarray)
-    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
+    assert np.isclose(
+        numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 @pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
@@ -227,7 +230,8 @@ def test_savi_dask_cupy_equals_numpy():
 
     assert is_dask_cupy(test_result)
     test_result.data = test_result.data.compute()
-    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
+    assert np.isclose(
+        numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 # arvi -------------
@@ -280,7 +284,8 @@ def test_arvi_cupy_equals_numpy():
     test_result = arvi(nir_cupy, red_cupy, blue_cupy)
 
     assert isinstance(test_result.data, cupy.ndarray)
-    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
+    assert np.isclose(
+        numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 @pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
@@ -300,7 +305,8 @@ def test_arvi_dask_cupy_equals_numpy():
     assert is_dask_cupy(test_result)
 
     test_result.data = test_result.data.compute()
-    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
+    assert np.isclose(
+        numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 # EVI -------------
@@ -357,7 +363,8 @@ def test_evi_cupy_equals_numpy():
     test_result = evi(nir_cupy, red_cupy, blue_cupy)
 
     assert isinstance(test_result.data, cupy.ndarray)
-    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
+    assert np.isclose(
+        numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 @pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
@@ -377,7 +384,8 @@ def test_evi_dask_cupy_equals_numpy():
     assert is_dask_cupy(test_result)
 
     test_result.data = test_result.data.compute()
-    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
+    assert np.isclose(
+        numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 # GCI -------------
@@ -424,7 +432,8 @@ def test_gci_cupy_equals_numpy():
     test_result = gci(nir_cupy, green_cupy)
 
     assert isinstance(test_result.data, cupy.ndarray)
-    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
+    assert np.isclose(
+        numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 @pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Dgcice not Available")
@@ -442,7 +451,8 @@ def test_gci_dask_cupy_equals_numpy():
     assert is_dask_cupy(test_result)
 
     test_result.data = test_result.data.compute()
-    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
+    assert np.isclose(
+        numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 # SIPI -------------
@@ -495,7 +505,8 @@ def test_sipi_cupy_equals_numpy():
     test_result = sipi(nir_dask, red_dask, blue_dask)
 
     assert isinstance(test_result.data, cupy.ndarray)
-    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
+    assert np.isclose(
+        numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 @pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
@@ -514,7 +525,8 @@ def test_sipi_dask_cupy_equals_numpy():
 
     assert is_dask_cupy(test_result)
     test_result.data = test_result.data.compute()
-    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
+    assert np.isclose(
+        numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 # NBR -------------
@@ -561,7 +573,8 @@ def test_nbr_cupy_equals_numpy():
     test_result = nbr(nir_cupy, swir_cupy)
 
     assert isinstance(test_result.data, cupy.ndarray)
-    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
+    assert np.isclose(
+        numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 @pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
@@ -579,7 +592,8 @@ def test_nbr_dask_cupy_equals_numpy():
     assert is_dask_cupy(test_result)
 
     test_result.data = test_result.data.compute()
-    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
+    assert np.isclose(
+        numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 # NBR2 -------------
@@ -627,7 +641,8 @@ def test_nbr2_cupy_equals_numpy():
     test_result = nbr2(swir1_cupy, swir2_cupy)
 
     assert isinstance(test_result.data, cupy.ndarray)
-    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
+    assert np.isclose(
+        numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 @pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Dnbr2ce not Available")
@@ -644,7 +659,8 @@ def test_nbr2_dask_cupy_equals_numpy():
 
     assert is_dask_cupy(test_result)
     test_result.data = test_result.data.compute()
-    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
+    assert np.isclose(
+        numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 # NDMI -------------
@@ -692,7 +708,8 @@ def test_ndmi_cupy_equals_numpy():
     test_result = ndmi(nir_cupy, swir1_cupy)
 
     assert isinstance(test_result.data, cupy.ndarray)
-    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
+    assert np.isclose(
+        numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 @pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
@@ -709,7 +726,8 @@ def test_ndmi_dask_cupy_equals_numpy():
 
     assert is_dask_cupy(test_result)
     test_result.data = test_result.data.compute()
-    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
+    assert np.isclose(
+        numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 # EBBI -------------
@@ -761,7 +779,8 @@ def test_ebbi_cupy_equals_numpy():
     test_result = ebbi(red_dask, swir_dask, tir_dask)
 
     assert isinstance(test_result.data, cupy.ndarray)
-    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
+    assert np.isclose(
+        numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 @pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
@@ -780,7 +799,8 @@ def test_ebbi_dask_cupy_equals_numpy():
 
     assert is_dask_cupy(test_result)
     test_result.data = test_result.data.compute()
-    assert np.isclose(numpy_result, test_result.data.get(), equal_nan=True).all()
+    assert np.isclose(
+        numpy_result, test_result.data.get(), equal_nan=True).all()
 
 
 def test_true_color_cpu():

--- a/xrspatial/tests/test_slope.py
+++ b/xrspatial/tests/test_slope.py
@@ -94,7 +94,7 @@ def test_slope_against_qgis_gpu():
 
     # validate output values
     # ignore border edges
-    xrspatial_vals = xrspatial_slope.values[1:-1, 1:-1]
+    xrspatial_vals = xrspatial_slope.data[1:-1, 1:-1].get()
     qgis_vals = qgis_slope[1:-1, 1:-1]
     assert (np.isclose(xrspatial_vals, qgis_vals, equal_nan=True).all() | (
                 np.isnan(xrspatial_vals) & np.isnan(qgis_vals))).all()
@@ -114,7 +114,7 @@ def test_slope_gpu_equals_cpu():
     gpu = slope(small_da_cupy, name='cupy_result')
     assert isinstance(gpu.data, cupy.ndarray)
 
-    assert np.isclose(cpu, gpu, equal_nan=True).all()
+    assert np.isclose(cpu, gpu.data.get(), equal_nan=True).all()
 
 
 @pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")

--- a/xrspatial/tests/test_zonal.py
+++ b/xrspatial/tests/test_zonal.py
@@ -219,7 +219,7 @@ def test_apply():
     def func(x):
         return 0
 
-    zones_val = np.zeros((3, 3), dtype=np.int)
+    zones_val = np.zeros((3, 3), dtype=int)
     # define some zones
     zones_val[1] = 1
     zones_val[2] = 2


### PR DESCRIPTION
Implicit conversion of cupy arrays to numpy, as we do here in test, is no longer allowed. This PR fixes this, and also removes some deprecated uses of `np.float` and `np.int`.