### PR TITLE
Error in zonal_stas when zone_values is empty

### DIFF
--- a/xrspatial/zonal.py
+++ b/xrspatial/zonal.py
@@ -322,10 +322,10 @@ def _stats_numpy(
             # filter out non-finite and nodata_values
             zone_values = zone_values[
                 np.isfinite(zone_values) & (zone_values != nodata_values)]
-            if len(zone_values) == 0:
-                stats_dict[stats].append(np.nan)
-            else:
-                for stats in stats_funcs:
+            for stats in stats_funcs:
+                if len(zone_values) == 0:
+                    stats_dict[stats].append(np.nan)
+                else:
                     stats_func = stats_funcs.get(stats)
                     if not callable(stats_func):
                         raise ValueError(stats)


### PR DESCRIPTION
# Fixes 
stats_dict is not properly populated when zone_values is empty

## Proposed Changes

  - moved check of empty zone_values inside the for loop
