### PR TITLE
Fix classify bug with dask array

### DIFF
--- a/xrspatial/classify.py
+++ b/xrspatial/classify.py
@@ -809,8 +809,9 @@ def _run_numpy_equal_interval(data, k):
 
 
 def _run_dask_numpy_equal_interval(data, k):
-    max_data = da.nanmax(data[da.isfinite(data)])
-    min_data = da.nanmin(data[da.isfinite(data)])
+    data = da.where(data == np.inf, np.nan, data)
+    max_data = da.nanmax(data)
+    min_data = da.nanmin(data)
     width = (max_data - min_data) / k
     cuts = da.arange(min_data + width, max_data + width, width)
     l_cuts = cuts.shape[0]


### PR DESCRIPTION
Fixes #598.

Bug is caused by code like
```python
max_data = da.nanmax(data[da.isfinite(data)])
```
as lazy evaluation of `data[da.isfinite(data)]` has an unknown `shape`.

The exception that is raised points to a possible solution which is to use `compute_chunk_sizes()` to determine the shape. However, this would be a dask-specific solution.

The solution here keeps the shape of the modified `data` array the same as it was. The same improvement could be applied to the `numpy` and `cupy` implementations, but I have left them for a future PR.