### PR TITLE
Add benchmark for CPU polygonize

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ conda install -c conda-forge xarray-spatial
 ```
 
 ### Downloading our starter examples and data
-Once you have xarray-spatial installed in your environment, you can use one of the following in your terminal (with the environment active) to download our examples and/or sample data into your local directory. 
+Once you have xarray-spatial installed in your environment, you can use one of the following in your terminal (with the environment active) to download our examples and/or sample data into your local directory.
 
-```xrspatial examples``` : Download the examples notebooks and the data used.  
+```xrspatial examples``` : Download the examples notebooks and the data used.
 
-```xrspatial copy-examples``` : Download the examples notebooks but not the data. Note: you won't be able to run many of the examples.  
+```xrspatial copy-examples``` : Download the examples notebooks but not the data. Note: you won't be able to run many of the examples.
 
 ```xrspatial fetch-data``` : Download just the data and not the notebooks.
 
@@ -136,6 +136,14 @@ In the GIS world, rasters are used for representing continuous phenomena (e.g. e
 
 --------
 
+### **Raster to vector**
+
+| Name | NumPy xr.DataArray | Dask xr.DataArray | CuPy GPU xr.DataArray | Dask GPU xr.DataArray |
+|:-----|:------------------:|:-----------------:|:---------------------:|:---------------------:|
+| [Polygonize](xrspatial/experimental/polygonize.py) | ✅️ | | | |
+
+--------
+
 ### **Surface**
 
 | Name | NumPy xr.DataArray | Dask xr.DataArray | CuPy GPU xr.DataArray | Dask GPU xr.DataArray |
@@ -198,7 +206,7 @@ Check out the user guide [here](/examples/user_guide/).
 
 #### Dependencies
 
-`xarray-spatial` currently depends on Datashader, but will soon be updated to depend only on `xarray` and `numba`, while still being able to make use of Datashader output when available. 
+`xarray-spatial` currently depends on Datashader, but will soon be updated to depend only on `xarray` and `numba`, while still being able to make use of Datashader output when available.
 
 ![title](img/dependencies.svg)
 

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -72,8 +72,14 @@
     //
     "matrix": {
         "pyct": [],
+        // Optional for cupy support; use correct cuda version.
         //"cupy-cuda101": [],
+        // Optional for ray-tracing support, need cupy too.
         //"rtxpy": [],
+        // Optional for polygonize.
+        //"geopandas": [],
+        //"rasterio": [],
+        //"spatialpandas": [],
     },
 
     // Combinations of libraries/python versions can be excluded/included

--- a/benchmarks/benchmarks/polygonize.py
+++ b/benchmarks/benchmarks/polygonize.py
@@ -1,0 +1,41 @@
+import numpy as np
+import xarray as xr
+from xrspatial.experimental import polygonize
+
+
+class Polygonize:
+    params = (
+        [100, 300, 1000],
+        ["numpy", "geopandas", "spatialpandas", "rasterio",
+            "rasterio-geopandas"],
+    )
+    param_names = ("nx", "ret")
+
+    def setup(self, nx, ret):
+        # Raster and mask with many small regions.
+        ny = nx // 2
+        rng = np.random.default_rng(9461713)
+        raster = rng.integers(low=0, high=4, size=(ny, nx), dtype=np.int32)
+        mask = rng.uniform(0, 1, size=(ny, nx)) < 0.9
+        self.raster = xr.DataArray(raster)
+        self.mask = xr.DataArray(mask)
+
+    def time_polygonize(self, nx, ret):
+        if ret.startswith("rasterio"):
+            import rasterio.features
+            if ret == "rasterio":
+                # Cast to list to ensure generator is run.
+                list(rasterio.features.shapes(
+                    self.raster.data, self.mask.data))
+            else:
+                import geopandas as gpd
+                from shapely.geometry import shape
+                values = []
+                shapes = []
+                for shape_dict, value in rasterio.features.shapes(
+                        self.raster.data, self.mask.data):
+                    shapes.append(shape(shape_dict))
+                    values.append(value)
+                gpd.GeoDataFrame({"DN": values, "geometry": shapes})
+        else:
+            polygonize(self.raster, mask=self.mask, return_type=ret)


### PR DESCRIPTION
This PR adds a benchmark for the new CPU `polygonize` function, and a table in the `README` showing that that algorithm only supports `numpy` arrays so far.

The benchmark compares our algorithm against `rasterio`'s, which uses `GDAL`.

Timings on my dev machine:

![polygonize](https://user-images.githubusercontent.com/580326/146552550-5a163947-7a26-433a-a2e2-3b8e2822ce0b.png)
```
  ====== ============= ============ =============== ============ ====================
  --                                         ret                                     
  ------ ----------------------------------------------------------------------------
    nx       numpy      geopandas    spatialpandas    rasterio    rasterio-geopandas 
  ====== ============= ============ =============== ============ ====================
   100    2.23±0.01ms   40.8±0.6ms    9.22±0.07ms    9.97±0.1ms       40.9±0.4ms     
   300     21.6±0.2ms    355±4ms       81.3±0.1ms     99.4±4ms        370±0.7ms      
   1000     264±1ms     3.95±0.01s      918±1ms       1.16±0s         4.16±0.02s     
  ====== ============= ============ =============== ============ ====================
```
### Summary
Algorithm timings depend greatly on the format of the data that is returned (the `return_type` argument to `polygonize`). The fastest, returning `numpy` arrays (blue line), is about 4 times faster than `rasterio`'s fastest (grey line). If we want to return a `geopandas` `GeoDataFrame` then our algorithm is only slightly faster than `rasterio`'s (red and yellow lines respectively). Here the timings are dominated by the conversion to `geopandas` as the conversion takes about 14 times as long as calculating the polygons!