### PR TITLE
Add rtx gpu hillshade with shadows

### DIFF
--- a/xrspatial/gpu_rtx/hillshade.py
+++ b/xrspatial/gpu_rtx/hillshade.py
@@ -1,0 +1,197 @@
+# Only call functions in this file if has_rtx() returns True as this checks
+# that the required dependent libraries are installed.
+
+import cupy
+import numba as nb
+import numpy as np
+from rtxpy import RTX
+from scipy.spatial.transform import Rotation as R
+import xarray as xr
+
+from .cuda_utils import add, dot, invert, make_float3, mul
+from .mesh_utils import create_triangulation
+
+from ..utils import calc_cuda_dims
+
+
+@nb.cuda.jit
+def _generate_primary_rays_kernel(data, H, W):
+    """
+    A GPU kernel that given a set of x and y discrete coordinates on a raster
+    terrain generates in @data a list of parallel rays that represent camera
+    rays generated from an orthographic camera that is looking straight down
+    at the surface from an origin height 10000.
+    """
+    i, j = nb.cuda.grid(2)
+    if i >= 0 and i < H and j >= 0 and j < W:
+        if (j == W-1):
+            data[i, j, 0] = j - 1e-3
+        else:
+            data[i, j, 0] = j + 1e-3
+
+        if (i == H-1):
+            data[i, j, 1] = i - 1e-3
+        else:
+            data[i, j, 1] = i + 1e-3
+
+        data[i, j, 2] = 10000  # Location of the camera (height)
+        data[i, j, 3] = 1e-3
+        data[i, j, 4] = 0
+        data[i, j, 5] = 0
+        data[i, j, 6] = -1
+        data[i, j, 7] = np.inf
+
+
+def _generate_primary_rays(rays, H, W):
+    griddim, blockdim = calc_cuda_dims((H, W))
+    _generate_primary_rays_kernel[griddim, blockdim](rays, H, W)
+    return 0
+
+
+@nb.cuda.jit
+def _generate_shadow_rays_kernel(rays, hits, normals, H, W, sun_dir):
+    """
+    A GPU kernel that given a set rays and their respective intersection
+    points, generates in rays (overwriting the original content) a new set of
+    rays (shadow rays) that have their origins at the point of intersection of
+    their parent ray and the direction towards the sun.
+    The normals vectors at the point of intersection of the original rays are
+    cached in @normals, thus we can later use them to do lambertian shading,
+    after the shadow rays have been traced.
+    """
+    i, j = nb.cuda.grid(2)
+    if i >= 0 and i < H and j >= 0 and j < W:
+        dist = hits[i, j, 0]
+        norm = make_float3(hits[i, j], 1)
+        if (norm[2] < 0):
+            norm = invert(norm)
+        ray = rays[i, j]
+        ray_origin = make_float3(ray, 0)
+        ray_dir = make_float3(ray, 4)
+        p = add(ray_origin, mul(ray_dir, dist))
+
+        new_origin = add(p, mul(norm, 1e-3))
+        ray[0] = new_origin[0]
+        ray[1] = new_origin[1]
+        ray[2] = new_origin[2]
+        ray[3] = 1e-3
+        ray[4] = sun_dir[0]
+        ray[5] = sun_dir[1]
+        ray[6] = sun_dir[2]
+        ray[7] = np.inf if dist > 0 else 0
+
+        normals[i, j, 0] = norm[0]
+        normals[i, j, 1] = norm[1]
+        normals[i, j, 2] = norm[2]
+
+
+def _generate_shadow_rays(rays, hits, normals, H, W, sunDir):
+    griddim, blockdim = calc_cuda_dims((H, W))
+    _generate_shadow_rays_kernel[griddim, blockdim](
+        rays, hits, normals, H, W, sunDir)
+    return 0
+
+
+@nb.cuda.jit
+def _shade_lambert_kernel(hits, normals, output, H, W, sun_dir, cast_shadows):
+    """
+    This kernel does a simple Lambertian shading.
+    The hits array contains the results of tracing the shadow rays through the
+    scene. If the value in hits[x, y, 0] is > 0 then a valid intersection
+    occurred and that means that the point at location x, y is in shadow.
+    The normals array stores the normal at the intersecion point of each
+    camera ray. We then use the information for light visibility and normal to
+    apply Lambert's cosine law.
+    """
+    i, j = nb.cuda.grid(2)
+    if i >= 0 and i < H and j >= 0 and j < W:
+        # Normal at the intersection of camera ray (i,j) with the scene
+        norm = make_float3(normals[i, j], 0)
+
+        light_dir = make_float3(sun_dir, 0)
+        cos_theta = dot(light_dir, norm)  # light_dir and norm are normalised.
+
+        temp = (cos_theta + 1) / 2
+
+        if cast_shadows and hits[i, j, 0] >= 0:
+            temp = temp / 2
+
+        if temp > 1:
+            temp = 1
+        elif temp < 0:
+            temp = 0
+
+        output[i, j] = temp
+
+
+def _shade_lambert(hits, normals, output, H, W, sun_dir, cast_shadows):
+    griddim, blockdim = calc_cuda_dims((H, W))
+    _shade_lambert_kernel[griddim, blockdim](
+        hits, normals, output, H, W, sun_dir, cast_shadows)
+    return 0
+
+
+def _get_sun_dir(angle_altitude, azimuth):
+    """
+    Calculate the vector towards the sun based on sun altitude angle and
+    azimuth.
+    """
+    north = (0, 1, 0)
+    rx = R.from_euler('x', angle_altitude, degrees=True)
+    rz = R.from_euler('z', azimuth+180, degrees=True)
+    sun_dir = rx.apply(north)
+    sun_dir = rz.apply(sun_dir)
+    return sun_dir
+
+
+def _hillshade_rt(raster: xr.DataArray,
+                  optix: RTX,
+                  azimuth: int,
+                  angle_altitude: int,
+                  shadows: bool) -> xr.DataArray:
+    H, W = raster.shape
+    sun_dir = cupy.array(_get_sun_dir(angle_altitude, azimuth))
+
+    # Device buffers
+    d_rays = cupy.empty((H, W, 8), np.float32)
+    d_hits = cupy.empty((H, W, 4), np.float32)
+    d_aux = cupy.empty((H, W, 3), np.float32)
+    d_output = cupy.empty((H, W), np.float32)
+
+    _generate_primary_rays(d_rays, H, W)
+    device = cupy.cuda.Device(0)
+    device.synchronize()
+    res = optix.trace(d_rays, d_hits, W*H)
+    if res:
+        raise RuntimeError(f"Failed trace 1, error code: {res}")
+
+    _generate_shadow_rays(d_rays, d_hits, d_aux, H, W, sun_dir)
+    if shadows:
+        device.synchronize()
+        res = optix.trace(d_rays, d_hits, W*H)
+        if res:
+            raise RuntimeError(f"Failed trace 2, error code: {res}")
+
+    _shade_lambert(d_hits, d_aux, d_output, H, W, sun_dir, shadows)
+
+    d_output[0, :] = cupy.nan
+    d_output[-1, :] = cupy.nan
+    d_output[:, 0] = cupy.nan
+    d_output[:, -1] = cupy.nan
+
+    return d_output
+
+
+def hillshade_rtx(raster: xr.DataArray,
+                  azimuth: int,
+                  angle_altitude: int,
+                  shadows: bool) -> xr.DataArray:
+    if not isinstance(raster.data, cupy.ndarray):
+        raise TypeError("raster.data must be a cupy array")
+
+    optix = RTX()
+    create_triangulation(raster, optix)
+
+    return _hillshade_rt(
+        raster, optix, azimuth=azimuth, angle_altitude=angle_altitude,
+        shadows=shadows)

--- a/xrspatial/gpu_rtx/hillshade.py
+++ b/xrspatial/gpu_rtx/hillshade.py
@@ -114,7 +114,7 @@ def _shade_lambert_kernel(hits, normals, output, H, W, sun_dir, cast_shadows):
         temp = (cos_theta + 1) / 2
 
         if cast_shadows and hits[i, j, 0] >= 0:
-            temp = temp / 2.5
+            temp = temp / 2
 
         if temp > 1:
             temp = 1

--- a/xrspatial/gpu_rtx/hillshade.py
+++ b/xrspatial/gpu_rtx/hillshade.py
@@ -51,12 +51,12 @@ def _generate_primary_rays(rays, H, W):
 @nb.cuda.jit
 def _generate_shadow_rays_kernel(rays, hits, normals, H, W, sun_dir):
     """
-    A GPU kernel that given a set rays and their respective intersection
-    points, generates in rays (overwriting the original content) a new set of
-    rays (shadow rays) that have their origins at the point of intersection of
-    their parent ray and the direction towards the sun.
+    A GPU kernel that takes a set rays and their intersection points with the
+    triangulated surface, and calculates a set of shadow rays (overwriting the
+    original rays) that have their origins at the intersection points and
+    directions towards the sun.
     The normals vectors at the point of intersection of the original rays are
-    cached in @normals, thus we can later use them to do lambertian shading,
+    cached in normals, thus we can later use them to do Lambertian shading,
     after the shadow rays have been traced.
     """
     i, j = nb.cuda.grid(2)
@@ -114,7 +114,7 @@ def _shade_lambert_kernel(hits, normals, output, H, W, sun_dir, cast_shadows):
         temp = (cos_theta + 1) / 2
 
         if cast_shadows and hits[i, j, 0] >= 0:
-            temp = temp / 2
+            temp = temp / 2.5
 
         if temp > 1:
             temp = 1

--- a/xrspatial/gpu_rtx/viewshed.py
+++ b/xrspatial/gpu_rtx/viewshed.py
@@ -49,8 +49,10 @@ def _generate_primary_rays_kernel(data, x_coords, y_coords, H, W):
 
 def _generate_primary_rays(rays, x_coords, y_coords, H, W):
     griddim, blockdim = calc_cuda_dims((H, W))
+    d_y_coords = cupy.array(y_coords)
+    d_x_coords = cupy.array(x_coords)
     _generate_primary_rays_kernel[griddim, blockdim](
-        rays, x_coords, y_coords, H, W)
+        rays, d_x_coords, d_y_coords, H, W)
     return 0
 
 

--- a/xrspatial/gpu_rtx/viewshed.py
+++ b/xrspatial/gpu_rtx/viewshed.py
@@ -5,19 +5,53 @@ import cupy
 import math
 import numba as nb
 import numpy as np
-from typing import Union
 from rtxpy import RTX
+from typing import Union
 import xarray as xr
 
-from .cuda_utils import (
-    add, diff, dot, float3, invert, make_float3, mul)
-from .mesh_utils import triangulate_terrain
+from .cuda_utils import add, diff, dot, float3, invert, make_float3, mul
+from .mesh_utils import create_triangulation
 
 from ..utils import calc_cuda_dims
 
 
 # If a cell is invisible, its value is set to -1
 INVISIBLE = -1
+
+
+@nb.cuda.jit
+def _generate_primary_rays_kernel(data, x_coords, y_coords, H, W):
+    """
+    A GPU kernel that given a set of x and y discrete coordinates on a raster
+    terrain generates in @data a list of parallel rays that represent camera
+    rays generated from an orthographic camera that is looking straight down
+    at the surface from an origin height 10000.
+    """
+    i, j = nb.cuda.grid(2)
+    if i >= 0 and i < H and j >= 0 and j < W:
+        if (j == W-1):
+            data[i, j, 0] = x_coords[j] - 1e-3
+        else:
+            data[i, j, 0] = x_coords[j] + 1e-3
+
+        if (i == H-1):
+            data[i, j, 1] = y_coords[i] - 1e-3
+        else:
+            data[i, j, 1] = y_coords[i] + 1e-3
+
+        data[i, j, 2] = 10000  # Location of the camera (height)
+        data[i, j, 3] = 1e-3
+        data[i, j, 4] = 0
+        data[i, j, 5] = 0
+        data[i, j, 6] = -1
+        data[i, j, 7] = np.inf
+
+
+def _generate_primary_rays(rays, x_coords, y_coords, H, W):
+    griddim, blockdim = calc_cuda_dims((H, W))
+    _generate_primary_rays_kernel[griddim, blockdim](
+        rays, x_coords, y_coords, H, W)
+    return 0
 
 
 @nb.cuda.jit
@@ -36,37 +70,6 @@ def _calc_viewshed_kernel(hits, visibility_grid, H, W):
 def _calc_viewshed(hits, visibility_grid, H, W):
     griddim, blockdim = calc_cuda_dims((H, W))
     _calc_viewshed_kernel[griddim, blockdim](hits, visibility_grid, H, W)
-    return 0
-
-
-@nb.cuda.jit
-def _generate_primary_rays_kernel(data, x_coords, y_coords, H, W):
-    i, j = nb.cuda.grid(2)
-    if i >= 0 and i < H and j >= 0 and j < W:
-        if (j == W-1):
-            data[i, j, 0] = x_coords[j] - 1e-6
-        else:
-            data[i, j, 0] = x_coords[j] + 1e-6
-
-        if (i == H-1):
-            data[i, j, 1] = y_coords[i] - 1e-6
-        else:
-            data[i, j, 1] = y_coords[i] + 1e-6
-
-        data[i, j, 2] = 10000  # Location of the camera (height)
-        data[i, j, 3] = 1e-3
-        data[i, j, 4] = 0
-        data[i, j, 5] = 0
-        data[i, j, 6] = -1
-        data[i, j, 7] = np.inf
-
-
-def _generate_primary_rays(rays, x_coords, y_coords, H, W):
-    griddim, blockdim = calc_cuda_dims((H, W))
-    d_y_coords = cupy.array(y_coords)
-    d_x_coords = cupy.array(x_coords)
-    _generate_primary_rays_kernel[griddim, blockdim](
-        rays, d_x_coords, d_y_coords, H, W)
     return 0
 
 
@@ -185,12 +188,15 @@ def _viewshed_rt(
     d_vsrays = cupy.empty((H, W, 8), np.float32)
 
     _generate_primary_rays(d_rays, x_coords, y_coords, H, W)
+    device = cupy.cuda.Device(0)
+    device.synchronize()
     res = optix.trace(d_rays, d_hits, W*H)
     if res:
         raise RuntimeError(f"Failed trace 1, error code: {res}")
 
     _generate_viewshed_rays(d_rays, d_hits, d_vsrays, d_visgrid, H, W,
                             (x_view, y_view, observer_elev, target_elev))
+    device.synchronize()
     res = optix.trace(d_vsrays, d_hits, W*H)
     if res:
         raise RuntimeError(f"Failed trace 2, error code: {res}")
@@ -222,32 +228,7 @@ def viewshed_gpu(
     if not isinstance(raster.data, cupy.ndarray):
         raise TypeError("raster.data must be a cupy array")
 
-    H, W = raster.shape
     optix = RTX()
+    create_triangulation(raster, optix)
 
-    data_hash = np.uint64(hash(str(raster.data.get())))
-    optix_hash = np.uint64(optix.getHash())
-    if (optix_hash != data_hash):
-        num_tris = (H - 1) * (W - 1) * 2
-        verts = cupy.empty(H * W * 3, np.float32)
-        triangles = cupy.empty(num_tris * 3, np.int32)
-
-        # Generate a mesh from the terrain (buffers are on the GPU, so
-        # generation happens also on GPU)
-        res = triangulate_terrain(verts, triangles, raster)
-        if res:
-            raise RuntimeError(
-                f"Failed to generate mesh from terrain, error code: {res}")
-
-        res = optix.build(data_hash, verts, triangles)
-        if res:
-            raise RuntimeError(
-                f"OptiX failed to build GAS, error code: {res}")
-
-        # Clear some GPU memory that we no longer need
-        verts = None
-        triangles = None
-        cupy.get_default_memory_pool().free_all_blocks()
-
-    view = _viewshed_rt(raster, optix, x, y, observer_elev, target_elev)
-    return view
+    return _viewshed_rt(raster, optix, x, y, observer_elev, target_elev)

--- a/xrspatial/hillshade.py
+++ b/xrspatial/hillshade.py
@@ -1,24 +1,14 @@
-# std lib
-from typing import Optional
+import dask.array as da
 from functools import partial
 import math
-
-# 3rd-party
-try:
-    import cupy
-except ImportError:
-    class cupy(object):
-        ndarray = False
-
 from numba import cuda
-
 import numpy as np
+from typing import Optional
 import xarray as xr
 
-# local modules
-from xrspatial.utils import cuda_args
-from xrspatial.utils import ArrayTypeFunctionMapping
-from xrspatial.utils import not_implemented_func
+from .gpu_rtx import has_rtx
+from .utils import (
+    calc_cuda_dims, has_cuda, has_cupy, is_cupy_array, is_cupy_backed)
 
 
 def _run_numpy(data, azimuth=225, angle_altitude=25):
@@ -83,8 +73,9 @@ def _run_cupy(d_data, azimuth, angle_altitude):
     azimuthrad = (360.0 - azimuth) * np.pi / 180.
 
     # Allocate output buffer and launch kernel with appropriate dimensions
+    import cupy
     output = cupy.empty(d_data.shape, np.float32)
-    griddim, blockdim = cuda_args(d_data.shape)
+    griddim, blockdim = calc_cuda_dims(d_data.shape)
     _gpu_calc_numba[griddim, blockdim](
         d_data, output, sin_altituderad, cos_altituderad, azimuthrad
     )
@@ -101,7 +92,8 @@ def _run_cupy(d_data, azimuth, angle_altitude):
 def hillshade(agg: xr.DataArray,
               azimuth: int = 225,
               angle_altitude: int = 25,
-              name: Optional[str] = 'hillshade') -> xr.DataArray:
+              name: Optional[str] = 'hillshade',
+              shadows: bool = False) -> xr.DataArray:
     """
     Calculates, for all cells in the array, an illumination value of
     each cell based on illumination from a specific azimuth and
@@ -120,6 +112,10 @@ def hillshade(agg: xr.DataArray,
         specified in degrees.
     name : str, default='hillshade'
         Name of output DataArray.
+    shadows : bool, default=False
+        Whether to calculate shadows or not. Shadows are available
+        only for Cupy-backed Dask arrays and only if rtxpy is
+        installed and appropriate graphics hardware is available.
 
     Returns
     -------
@@ -166,15 +162,34 @@ def hillshade(agg: xr.DataArray,
           * y        (y) int32 4 3 2 1 0
           * x        (x) int32 0 1 2 3 4
     """
-    mapper = ArrayTypeFunctionMapping(
-        numpy_func=_run_numpy,
-        cupy_func=_run_cupy,
-        dask_func=_run_dask_numpy,
-        dask_cupy_func=lambda *args: not_implemented_func(
-            *args, messages='hillshade() does not support dask with cupy backed DataArray'  # noqa
-        ),
-    )
-    out = mapper(agg)(agg.data, azimuth, angle_altitude)
+
+    if shadows and not has_rtx():
+        raise RuntimeError(
+            "Can only calculate shadows if cupy and rtxpy are available")
+
+    # numpy case
+    if isinstance(agg.data, np.ndarray):
+        out = _run_numpy(agg.data, azimuth, angle_altitude)
+
+    # cupy/numba case
+    elif has_cuda() and has_cupy() and is_cupy_array(agg.data):
+        if shadows and has_rtx():
+            from .gpu_rtx.hillshade import hillshade_rtx
+            out = hillshade_rtx(agg, azimuth, angle_altitude, shadows=shadows)
+        else:
+            out = _run_cupy(agg.data, azimuth, angle_altitude)
+
+    # dask + cupy case
+    elif (has_cuda() and has_cupy() and isinstance(agg.data, da.Array) and
+            is_cupy_backed(agg)):
+        out = _run_dask_cupy(agg.data, azimuth, angle_altitude)
+
+    # dask + numpy case
+    elif isinstance(agg.data, da.Array):
+        out = _run_dask_numpy(agg.data, azimuth, angle_altitude)
+
+    else:
+        raise TypeError('Unsupported Array Type: {}'.format(type(agg.data)))
 
     return xr.DataArray(out,
                         name=name,

--- a/xrspatial/hillshade.py
+++ b/xrspatial/hillshade.py
@@ -182,7 +182,7 @@ def hillshade(agg: xr.DataArray,
     # dask + cupy case
     elif (has_cuda() and has_cupy() and isinstance(agg.data, da.Array) and
             is_cupy_backed(agg)):
-        out = _run_dask_cupy(agg.data, azimuth, angle_altitude)
+        raise NotImplementedError("Dask/CuPy hillshade not implemented")
 
     # dask + numpy case
     elif isinstance(agg.data, da.Array):


### PR DESCRIPTION
This PR adds an `rtxpy` implementation of `hillshade` with full shadows. Output looks like this for UK elevation (not very well clipped at sea level but it is only an example):

![out2](https://user-images.githubusercontent.com/580326/146969252-ca23c4fc-6fef-4721-a864-5e5f7105c13d.png)

To use, call `hillshade` with a `cupy`-backed `xarray` and the keyword argument `shadows=True`. The algorithm aims to produce very similar results to the CPU algorithm where there aren't shadows, so follows the usual simple maths of conventional hillshade algorithms.

There are a few improvements to the rtxpy `viewshed` function too, to make it more robust. There is some similar code for both algorithms relating to generation of primary rays; they will be combined later when when I correctly deal with the presence or absence of `x,y` coordinates.

Thanks to @a7az0th who did most of the heavy lifting here.