### PR TITLE
code refactor: use array function mapper, add messages param to not_implemented_func()

### DIFF
--- a/xrspatial/classify.py
+++ b/xrspatial/classify.py
@@ -672,10 +672,10 @@ def natural_breaks(agg: xr.DataArray,
     mapper = ArrayTypeFunctionMapping(
         numpy_func=lambda *args: _run_natural_break(*args, module=np),
         dask_func=lambda *args: not_implemented_func(
-            *args, messages='natural_breaks() does not support dask with numpy backed DataArray.'),
+            *args, messages='natural_breaks() does not support dask with numpy backed DataArray.'),  # noqa
         cupy_func=lambda *args: _run_natural_break(*args, module=cupy),
         dask_cupy_func=lambda *args: not_implemented_func(
-            *args, messages='natural_breaks() does not support dask with cupy backed DataArray.'),
+            *args, messages='natural_breaks() does not support dask with cupy backed DataArray.'),  # noqa
     )
     out = mapper(agg)(agg, num_sample, k)
     return xr.DataArray(out,
@@ -779,7 +779,7 @@ def equal_interval(agg: xr.DataArray,
         dask_func=lambda *args: _run_equal_interval(*args, module=da),
         cupy_func=lambda *args: _run_equal_interval(*args, module=cupy),
         dask_cupy_func=lambda *args: not_implemented_func(
-            *args, messages='equal_interval() does support dask with cupy backed DataArray.'),
+            *args, messages='equal_interval() does support dask with cupy backed DataArray.'),  # noqa
     )
     out = mapper(agg)(agg, k)
     return xr.DataArray(out,

--- a/xrspatial/convolution.py
+++ b/xrspatial/convolution.py
@@ -323,7 +323,7 @@ def custom_kernel(kernel):
     return kernel
 
 
-@jit(nopython=True, nogil=True, parallel=True)
+@jit(nopython=True, nogil=True)
 def _convolve_2d_numpy(data, kernel):
     """
     Apply kernel to data image.

--- a/xrspatial/curvature.py
+++ b/xrspatial/curvature.py
@@ -209,7 +209,7 @@ def curvature(agg: xr.DataArray,
         cupy_func=_run_cupy,
         dask_func=_run_dask_numpy,
         dask_cupy_func=lambda *args: not_implemented_func(
-            *args, messages='curvature() does not support dask with cupy backed DataArray.'),
+            *args, messages='curvature() does not support dask with cupy backed DataArray.'),  # noqa
     )
     out = mapper(agg)(agg.data, cellsize)
     return xr.DataArray(out,

--- a/xrspatial/curvature.py
+++ b/xrspatial/curvature.py
@@ -208,7 +208,8 @@ def curvature(agg: xr.DataArray,
         numpy_func=_run_numpy,
         cupy_func=_run_cupy,
         dask_func=_run_dask_numpy,
-        dask_cupy_func=not_implemented_func,
+        dask_cupy_func=lambda *args: not_implemented_func(
+            *args, messages='curvature() does not support dask with cupy backed DataArray.'),
     )
     out = mapper(agg)(agg.data, cellsize)
     return xr.DataArray(out,

--- a/xrspatial/focal.py
+++ b/xrspatial/focal.py
@@ -109,7 +109,7 @@ def _mean(data, excludes):
         cupy_func=_mean_cupy,
         dask_func=_mean_dask_numpy,
         dask_cupy_func=lambda *args: not_implemented_func(
-            *args, messages='mean() does not support dask with cupy backed DataArray.'),
+            *args, messages='mean() does not support dask with cupy backed DataArray.'),  # noqa
     )
     out = mapper(agg)(agg.data, excludes)
     return out
@@ -430,7 +430,7 @@ def apply(raster, kernel, func=_calc_mean, name='focal_apply'):
         cupy_func=_apply_cupy,
         dask_func=_apply_dask_numpy,
         dask_cupy_func=lambda *args: not_implemented_func(
-            *args, messages='apply() does not support dask with cupy backed DataArray.'),
+            *args, messages='apply() does not support dask with cupy backed DataArray.'),  # noqa
     )
     out = mapper(raster)(raster.data.astype(float), kernel, func)
     result = DataArray(out,
@@ -768,7 +768,7 @@ def hotspots(raster, kernel):
         cupy_func=_hotspots_cupy,
         dask_func=_hotspots_dask_numpy,
         dask_cupy_func=lambda *args: not_implemented_func(
-            *args, messages='hotspots() does not support dask with cupy backed DataArray.'),
+            *args, messages='hotspots() does not support dask with cupy backed DataArray.'),  # noqa
     )
     out = mapper(raster)(raster, kernel)
 

--- a/xrspatial/focal.py
+++ b/xrspatial/focal.py
@@ -108,7 +108,8 @@ def _mean(data, excludes):
         numpy_func=_mean_numpy,
         cupy_func=_mean_cupy,
         dask_func=_mean_dask_numpy,
-        dask_cupy_func=not_implemented_func
+        dask_cupy_func=lambda *args: not_implemented_func(
+            *args, messages='mean() does not support dask with cupy backed DataArray.'),
     )
     out = mapper(agg)(agg.data, excludes)
     return out
@@ -428,7 +429,8 @@ def apply(raster, kernel, func=_calc_mean, name='focal_apply'):
         numpy_func=_apply_numpy,
         cupy_func=_apply_cupy,
         dask_func=_apply_dask_numpy,
-        dask_cupy_func=not_implemented_func,
+        dask_cupy_func=lambda *args: not_implemented_func(
+            *args, messages='apply() does not support dask with cupy backed DataArray.'),
     )
     out = mapper(raster)(raster.data.astype(float), kernel, func)
     result = DataArray(out,
@@ -765,7 +767,8 @@ def hotspots(raster, kernel):
         numpy_func=_hotspots_numpy,
         cupy_func=_hotspots_cupy,
         dask_func=_hotspots_dask_numpy,
-        dask_cupy_func=not_implemented_func,
+        dask_cupy_func=lambda *args: not_implemented_func(
+            *args, messages='hotspots() does not support dask with cupy backed DataArray.'),
     )
     out = mapper(raster)(raster, kernel)
 

--- a/xrspatial/perlin.py
+++ b/xrspatial/perlin.py
@@ -21,17 +21,17 @@ from xrspatial.utils import ArrayTypeFunctionMapping
 from xrspatial.utils import not_implemented_func
 
 
-@jit(nopython=True, nogil=True, parallel=True, cache=True)
+@jit(nopython=True, nogil=True)
 def _lerp(a, b, x):
     return a + x * (b - a)
 
 
-@jit(nopython=True, nogil=True, parallel=True, cache=True)
+@jit(nopython=True, nogil=True)
 def _fade(t):
     return 6 * t ** 5 - 15 * t ** 4 + 10 * t ** 3
 
 
-@jit(nopython=True, nogil=True, parallel=True, cache=True)
+@jit(nopython=True, nogil=True)
 def _gradient(h, x, y):
     # assert(len(h.shape) == 2)
     vectors = np.array([[0, 1], [0, -1], [1, 0], [-1, 0]])

--- a/xrspatial/utils.py
+++ b/xrspatial/utils.py
@@ -98,8 +98,8 @@ def is_dask_cupy(agg: xr.DataArray):
     return isinstance(agg.data, da.Array) and is_cupy_backed(agg)
 
 
-def not_implemented_func(agg, *args):
-    raise NotImplementedError('Not yet implemented.')
+def not_implemented_func(agg, *args, messages='Not yet implemented.'):
+    raise NotImplementedError(messages)
 
 
 class ArrayTypeFunctionMapping(object):


### PR DESCRIPTION
This PR:
 - adds a `messages` param to `not_implemented_func()` in order to provide clearer messages in case an array type is not supported for some function.
 - refactors code to use ArrayFunctionMapping in following modules/functions: hillshade, true_color, perlin, slope, terrain, zonal