### PR TITLE
Add hillshade benchmarking for numpy, cupy and rtxpy

### DIFF
--- a/benchmarks/benchmarks/hillshade.py
+++ b/benchmarks/benchmarks/hillshade.py
@@ -1,0 +1,18 @@
+from xrspatial import hillshade
+from .common import get_xr_dataarray
+
+
+class Hillshade:
+    # Note that rtxpy hillshade includes shadow calculations so timings are
+    # not comparable with numpy and cupy hillshade.
+    params = ([100, 300, 1000, 3000], ["numpy", "cupy", "rtxpy"])
+    param_names = ("nx", "type")
+
+    def setup(self, nx, type):
+        ny = nx // 2
+        self.xr = get_xr_dataarray(
+            (ny, nx), type, different_each_call=(type == "rtxpy"))
+
+    def time_hillshade(self, nx, type):
+        shadows = (type == "rtxpy")
+        hillshade(self.xr, shadows=shadows)


### PR DESCRIPTION
This PR adds a benchmark for `hillshade` for `numpy` arrays (calculated on CPU) and `cupy` arrays (calculated on GPU). Also the `rtxpy` version of hillshade that calculates full shadows, so the timings of this are not directly comparable with the two other implementations as it is performing many more calculations.

![hillshade_benchmark](https://user-images.githubusercontent.com/580326/148535610-55189a68-cfac-49fe-aa7e-68a5eae54480.png)

Timings on my dev machine (Quadro T1000 graphics card) show that GPU algorithm is ~1.5 orders of magnitude faster than CPU algorithm for rasters of dimension ~1000 and over 2 orders of magnitude faster for dimension ~3000.