### PR TITLE
Convert to float32 if input raster is in int dtype

### DIFF
--- a/xrspatial/convolution.py
+++ b/xrspatial/convolution.py
@@ -289,7 +289,7 @@ def custom_kernel(kernel):
 def _convolve_2d_numpy(data, kernel):
     # apply kernel to data image.
     # TODO: handle nan
-
+    data = data.astype(np.float32)
     nx = data.shape[0]
     ny = data.shape[1]
     nkx = kernel.shape[0]
@@ -317,6 +317,7 @@ def _convolve_2d_numpy(data, kernel):
 
 
 def _convolve_2d_dask_numpy(data, kernel):
+    data = data.astype(np.float32)
     pad_h = kernel.shape[0] // 2
     pad_w = kernel.shape[1] // 2
     _func = partial(_convolve_2d_numpy, kernel=kernel)
@@ -368,6 +369,7 @@ def _convolve_2d_cuda(data, kernel, out):
 
 
 def _convolve_2d_cupy(data, kernel):
+    data = data.astype(cupy.float32)
     out = cupy.empty(data.shape, dtype='f4')
     out[:, :] = cupy.nan
     griddim, blockdim = cuda_args(data.shape)

--- a/xrspatial/curvature.py
+++ b/xrspatial/curvature.py
@@ -41,12 +41,14 @@ def _cpu(data, cellsize):
 def _run_numpy(data: np.ndarray,
                cellsize: Union[int, float]) -> np.ndarray:
     # TODO: handle border edge effect
+    data = data.astype(np.float32)
     out = _cpu(data, cellsize)
     return out
 
 
 def _run_dask_numpy(data: da.Array,
                     cellsize: Union[int, float]) -> da.Array:
+    data = data.astype(np.float32)
     _func = partial(_cpu, cellsize=cellsize)
     out = data.map_overlap(_func,
                            depth=(1, 1),
@@ -76,6 +78,7 @@ def _run_gpu(arr, cellsize, out):
 def _run_cupy(data: cupy.ndarray,
               cellsize: Union[int, float]) -> cupy.ndarray:
 
+    data = data.astype(cupy.float32)
     cellsize_arr = cupy.array([float(cellsize)], dtype='f4')
 
     # TODO: add padding

--- a/xrspatial/focal.py
+++ b/xrspatial/focal.py
@@ -250,6 +250,8 @@ def _calc_var(array):
 
 @ngjit
 def _apply_numpy(data, kernel, func):
+    data = data.astype(np.float32)
+
     out = np.zeros_like(data)
     rows, cols = data.shape
     krows, kcols = kernel.shape
@@ -271,6 +273,7 @@ def _apply_numpy(data, kernel, func):
 
 
 def _apply_dask_numpy(data, kernel, func):
+    data = data.astype(np.float32)
     _func = partial(_apply_numpy, kernel=kernel, func=func)
 
     pad_h = kernel.shape[0] // 2
@@ -284,6 +287,7 @@ def _apply_dask_numpy(data, kernel, func):
 
 
 def _apply_cupy(data, kernel, func):
+    data = data.astype(cupy.float32)
     kernel = cupy.asarray(kernel)
 
     out = cupy.zeros(data.shape, dtype=data.dtype)
@@ -427,7 +431,7 @@ def apply(raster, kernel, func=_calc_mean, name='focal_apply'):
         dask_cupy_func=lambda *args: not_implemented_func(
             *args, messages='apply() does not support dask with cupy backed DataArray.'),  # noqa
     )
-    out = mapper(raster)(raster.data.astype(float), kernel, func)
+    out = mapper(raster)(raster.data, kernel, func)
     result = DataArray(out,
                        name=name,
                        coords=raster.coords,

--- a/xrspatial/focal.py
+++ b/xrspatial/focal.py
@@ -561,12 +561,13 @@ def _hotspots_numpy(raster, kernel):
             issubclass(raster.data.dtype.type, np.floating)):
         raise ValueError("data type must be integer or float")
 
+    data = raster.data.astype(np.float32)
     # apply kernel to raster values
-    mean_array = convolve_2d(raster.data, kernel / kernel.sum())
+    mean_array = convolve_2d(data, kernel / kernel.sum())
 
     # calculate z-scores
-    global_mean = np.nanmean(raster.data)
-    global_std = np.nanstd(raster.data)
+    global_mean = np.nanmean(data)
+    global_std = np.nanstd(data)
     if global_std == 0:
         raise ZeroDivisionError(
             "Standard deviation of the input raster values is 0."
@@ -578,13 +579,14 @@ def _hotspots_numpy(raster, kernel):
 
 
 def _hotspots_dask_numpy(raster, kernel):
+    data = raster.data.astype(np.float32)
 
     # apply kernel to raster values
-    mean_array = convolve_2d(raster.data, kernel / kernel.sum())
+    mean_array = convolve_2d(data, kernel / kernel.sum())
 
     # calculate z-scores
-    global_mean = da.nanmean(raster.data)
-    global_std = da.nanstd(raster.data)
+    global_mean = da.nanmean(data)
+    global_std = da.nanstd(data)
 
     # commented out to avoid early compute to check if global_std is zero
     # if global_std == 0:
@@ -646,12 +648,14 @@ def _hotspots_cupy(raster, kernel):
             issubclass(raster.data.dtype.type, cupy.floating)):
         raise ValueError("data type must be integer or float")
 
+    data = raster.data.astype(cupy.float32)
+
     # apply kernel to raster values
-    mean_array = convolve_2d(raster.data, kernel / kernel.sum())
+    mean_array = convolve_2d(data, kernel / kernel.sum())
 
     # calculate z-scores
-    global_mean = cupy.nanmean(raster.data)
-    global_std = cupy.nanstd(raster.data)
+    global_mean = cupy.nanmean(data)
+    global_std = cupy.nanstd(data)
     if global_std == 0:
         raise ZeroDivisionError(
             "Standard deviation of the input raster values is 0."

--- a/xrspatial/hillshade.py
+++ b/xrspatial/hillshade.py
@@ -12,6 +12,8 @@ from .utils import (
 
 
 def _run_numpy(data, azimuth=225, angle_altitude=25):
+    data = data.astype(np.float32)
+
     azimuth = 360.0 - azimuth
     x, y = np.gradient(data)
     slope = np.pi/2. - np.arctan(np.sqrt(x*x + y*y))
@@ -28,6 +30,8 @@ def _run_numpy(data, azimuth=225, angle_altitude=25):
 
 
 def _run_dask_numpy(data, azimuth, angle_altitude):
+    data = data.astype(np.float32)
+
     _func = partial(_run_numpy, azimuth=azimuth, angle_altitude=angle_altitude)
     out = data.map_overlap(_func,
                            depth=(1, 1),
@@ -74,6 +78,7 @@ def _run_cupy(d_data, azimuth, angle_altitude):
 
     # Allocate output buffer and launch kernel with appropriate dimensions
     import cupy
+    d_data = d_data.astype(cupy.float32)
     output = cupy.empty(d_data.shape, np.float32)
     griddim, blockdim = calc_cuda_dims(d_data.shape)
     _gpu_calc_numba[griddim, blockdim](

--- a/xrspatial/slope.py
+++ b/xrspatial/slope.py
@@ -27,6 +27,7 @@ from xrspatial.utils import not_implemented_func
 
 @ngjit
 def _cpu(data, cellsize_x, cellsize_y):
+    data = data.astype(np.float32)
     out = np.zeros_like(data, dtype=np.float32)
     out[:] = np.nan
     rows, cols = data.shape
@@ -57,6 +58,7 @@ def _run_numpy(data: np.ndarray,
 def _run_dask_numpy(data: da.Array,
                     cellsize_x: Union[int, float],
                     cellsize_y: Union[int, float]) -> da.Array:
+    data = data.astype(np.float32)
     _func = partial(_cpu,
                     cellsize_x=cellsize_x,
                     cellsize_y=cellsize_y)
@@ -102,6 +104,7 @@ def _run_cupy(data: cupy.ndarray,
               cellsize_y: Union[int, float]) -> cupy.ndarray:
     cellsize_x_arr = cupy.array([float(cellsize_x)], dtype='f4')
     cellsize_y_arr = cupy.array([float(cellsize_y)], dtype='f4')
+    data = data.astype(cupy.float32)
 
     griddim, blockdim = cuda_args(data.shape)
     out = cupy.empty(data.shape, dtype='f4')


### PR DESCRIPTION
This PR ensures that an input raster is converted to `float32` if it is originally an integer raster. All functions in `xrspatial` have been run with test data of `int` dtype and the following modules need to be changed:
- convolution.convolution_2d
- curvature
- focal.apply, focal.hotspots
- hillshade
- slope