### PR TITLE
Increase allowed max line length to 100

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,10 @@
 [metadata]
 long_description = file: README.md
 long_description_content_type = text/markdown
+
+[flake8]
+exclude =
+    .git,
+    .asv,
+    __pycache__,
+max-line-length = 100

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ extras_require = {
         'geopandas',
         'shapely',
         'spatialpandas',
-        # Optional for gpu_rtx functions.
+        # Optional for gpu_rtx functions. Also requires cupy.
         "rtxpy",
     ],
 }


### PR DESCRIPTION
This PR increases the maximum line length allowed by `flake8` from 79 to 100 characters. It fixes the 6th item of issue #626.

Rather than reformatting the whole codebase in one go to take advantage of this, we will instead improve existing code only when we are changing it, or nearby code, in other PRs.