### PR TITLE
Remove numpy version pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 bokeh>2
 datashader
 noise >=1.2.2
-numpy>=1.7,<=1.20
+numba
 xarray

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ install_requires = [
     'dask',
     'datashader',
     'numba',
-    'numpy>=1.7,<=1.20',
     'pandas',
     'pillow',
     'requests',


### PR DESCRIPTION
Now that numba 0.55 has been released with support for numpy 1.21 and python 3.10, we no longer need to pin to a max numpy version ourselves.

Fixes issue #565.