### PR TITLE
Fix doc build failure due to Jinja2 version

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -19,7 +19,7 @@ jobs:
           python -m pip install --upgrade pip
       - name: Install xarray-spatial
         run: |
-          pip install .[docs]
+          pip install .[docs,tests]
           pip list
       - name: Build
         run: |

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ extras_require = {
     ],
     'docs': [
         'geopandas',
+        'Jinja2 >=2.11',
         'ipykernel',
         'matplotlib',
         'nbsphinx',


### PR DESCRIPTION
This fixes the recent failure when building the docs in CI. Error was
```
Exception occurred:
  File "/usr/lib/python3/dist-packages/jinja2/loaders.py", line 163, in __init__
    self.searchpath = list(searchpath)
TypeError: 'PosixPath' object is not iterable
```
which can apparently be fixed by pinning the `Jinja2` version to `>=2.11`.