### PR TITLE
Modernise build system

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,9 +10,7 @@ environment:
 build: off
 
 install:
-  - "%PYTHON%\\python.exe -m pip install wheel"
-  - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
-  - "%PYTHON%\\python.exe -m pip install -r requirements-dev.txt"
+  - "%PYTHON%\\python.exe -m pip install .[tests]"
 
 test_script:
   - "%PYTHON%\\python.exe -m pytest"

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           pip install .[docs,tests]
           pip list
-      - name: Build
+      - name: Build docs
         run: |
           make -C docs html
       - uses: lauchacarro/Azure-Storage-Action@v1.0

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -5,13 +5,13 @@ on:
        - '*'
 jobs:
   publish:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20-04
     steps:
       - uses: actions/checkout@master
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Get release version
         run: |
           echo "CHANGELOG_VERSION=$(cat CHANGELOG.md | grep -oP '(?<=###\s)(.*)(?=\s\-)' | head -n 1 | sed 's/Version\s/v/')" >> $GITHUB_ENV
@@ -24,14 +24,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pyct \
-                      wheel \
-                      setuptools
+          pip install build
       - name: Get all git tags
         run: git fetch --tags -f
       - name: Build package
         run: |
-          python setup.py sdist bdist_wheel
+          python -m build --sdist --wheel
       - name: Get package size
         run: echo "PKG_SIZE=$(find dist -maxdepth 1 -regex '.*gz' | xargs stat --format='%s')" >> $GITHUB_ENV
       - name: Check package size

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,11 @@
 [build-system]
 requires = [
-    'param >=1.6.1',
-    'pyct >= 0.4.8',
+    'build',
+    'param',
+    'pyct',
     'setuptools >= 54.1.2',
-    'wheel >= 0.36.2',
 ]
+
 [tool.check-manifest]
 ignore = [
     '.appveyor.yml',

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,5 +2,3 @@ check-manifest
 pytest
 setuptools_scm
 tox
-twine
-wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bokeh>2
+bokeh >2
 datashader
 noise >=1.2.2
 numba

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,61 @@
 [metadata]
+author = makepath
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    Intended Audience :: Science/Research
+    License :: OSI Approved :: MIT License
+    Operating System :: OS Independent
+    Programming Language :: Python :: 3
+description = xarray-based spatial analysis tools
+license = MIT
+license_file = LICENSE.txt
 long_description = file: README.md
 long_description_content_type = text/markdown
+name = xarray-spatial
+platforms = any
+url = https://github.com/makepath/xarray-spatial
+
+[options]
+include_package_data = True
+install_requires =
+    datashader
+    numba
+    xarray
+packages = find:
+python_requires = >=3.6
+zip_safe = False
+
+[options.entry_points]
+console_scripts =
+    xrspatial = xrspatial.__main__:main
+
+[options.extras_require]
+doc =
+    geopandas
+    Jinja2 >=2.11
+    ipykernel
+    matplotlib
+    nbsphinx
+    numpydoc
+    pandoc
+    pydata_sphinx_theme
+    sphinx
+    sphinx-multiversion
+    sphinx-panels
+    sphinx_rtd_theme
+examples =
+optional =
+    # Optional for polygonize return types.
+    awkward>=1.4
+    geopandas
+    shapely
+    spatialpandas
+    # Optional for gpu_rtx functions. Also requires cupy.
+    rtxpy
+tests =
+    noise >= 1.2.2
+    pytest
 
 [flake8]
 exclude =

--- a/setup.py
+++ b/setup.py
@@ -1,72 +1,17 @@
 import os
+import param
+import pyct.build
 import sys
 import shutil
 from setuptools import setup
 
 
-# build dependencies
-import pyct.build
-import param
-
-# dependencies
-
-# datashader first, then pyct unless pyct version compatible with ds
-# is specified
-# spatialpandas may not be required in final pharmacy_desert version
-# pyct may not be required after pyctdev is released
-install_requires = [
-    'dask',
-    'datashader',
-    'numba',
-    'pandas',
-    'pillow',
-    'requests',
-    'xarray',
-    'pyct <=0.4.6',
-    'param >=1.6.1',
-    'distributed >=2021.03.0',
-]
-
-examples = [
-]
-
-# Additional tests dependencies and examples_extra may be needed in the future
-extras_require = {
-    'tests': [
-        'pytest',
-        'noise >=1.2.2',
-    ],
-    'examples': examples,
-    'optional': [
-        # Optional for polygonize return types.
-        'awkward>=1.4',
-        'geopandas',
-        'shapely',
-        'spatialpandas',
-        # Optional for gpu_rtx functions. Also requires cupy.
-        "rtxpy",
-    ],
-    'docs': [
-        'geopandas',
-        'Jinja2 >=2.11',
-        'ipykernel',
-        'matplotlib',
-        'nbsphinx',
-        'numpydoc',
-        'pandoc',
-        'pydata_sphinx_theme',
-        'sphinx',
-        'sphinx-multiversion',
-        'sphinx-panels',
-        'sphinx_rtd_theme',
-    ],
-}
-
-extras_require['all'] = sorted(set(sum(extras_require.values(), [])))
-
-version = param.version.get_setup_version(__file__, 'xarray-spatial',
-                                          pkgname='xrspatial',
-                                          archive_commit="$Format:%h$")
+version = param.version.get_setup_version(
+    __file__,
+    'xarray-spatial',
+    pkgname='xrspatial',
+    archive_commit="$Format:%h$",
+)
 
 if 'sdist' in sys.argv and 'bdist_wheel' in sys.argv:
     try:
@@ -78,37 +23,12 @@ if 'sdist' in sys.argv and 'bdist_wheel' in sys.argv:
         sys.exit('invalid version')
 
 
-# metadata for setuptools
-
-setup_args = dict(
-    name='xarray-spatial',
-    version=version,
-    description='xarray-based spatial analysis tools',
-    install_requires=install_requires,
-    extras_require=extras_require,
-    tests_require=extras_require['tests'],
-    zip_safe=False,
-    classifiers=['Programming Language :: Python :: 3',
-                 'License :: OSI Approved :: MIT License',
-                 'Operating System :: OS Independent'],
-    packages=['xrspatial',
-              'xrspatial.tests'
-              ],
-    include_package_data=True,
-    entry_points={
-        'console_scripts': [
-            'xrspatial = xrspatial.__main__:main'
-        ]
-    },
-)
-
-
 if __name__ == '__main__':
     example_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                 'xrspatial', 'examples')
     if 'develop' not in sys.argv:
         pyct.build.examples(example_path, __file__, force=True)
-    setup(**setup_args)
+    setup(version=version)
 
     if os.path.isdir(example_path):
         shutil.rmtree(example_path)


### PR DESCRIPTION
Fixes #633.

This PR modernises the build system in line with PEP517/518. There is a migration of config data from `setup.py` to `setup.cfg`. I have not been able to remove the two `requirements` files as they are still used by CI. I will deal with these are part of the migration of all of our CI to github actions.

This will most likely break something in the build/release/docs process. Now that we are making regular releases we shall just have to be really careful with the next release.