### PR TITLE
More robust cuda and cupy identification

### DIFF
--- a/benchmarks/benchmarks/common.py
+++ b/benchmarks/benchmarks/common.py
@@ -2,7 +2,7 @@ import numpy as np
 import xarray as xr
 
 from xrspatial.gpu_rtx import has_rtx
-from xrspatial.utils import has_cuda, has_cupy
+from xrspatial.utils import has_cuda_and_cupy
 
 
 def get_xr_dataarray(
@@ -46,7 +46,7 @@ def get_xr_dataarray(
     if type == "numpy":
         pass
     elif type == "cupy":
-        if not (has_cuda() and has_cupy()):
+        if not has_cuda_and_cupy:
             raise NotImplementedError()
         import cupy
         z = cupy.asarray(z)

--- a/benchmarks/benchmarks/zonal.py
+++ b/benchmarks/benchmarks/zonal.py
@@ -2,7 +2,7 @@ import numpy as np
 import xarray as xr
 
 from xrspatial import zonal
-from xrspatial.utils import has_cuda
+from xrspatial.utils import has_cuda_and_cupy
 
 from .common import get_xr_dataarray
 
@@ -13,7 +13,7 @@ def create_arr(data=None, H=10, W=10, backend='numpy'):
         data = np.zeros((H, W), dtype=np.float32)
     raster = xr.DataArray(data, dims=['y', 'x'])
 
-    if has_cuda() and 'cupy' in backend:
+    if has_cuda_and_cupy() and 'cupy' in backend:
         import cupy
         raster.data = cupy.asarray(raster.data)
 

--- a/xrspatial/gpu_rtx/__init__.py
+++ b/xrspatial/gpu_rtx/__init__.py
@@ -1,4 +1,4 @@
-from ..utils import has_cuda, has_cupy
+from ..utils import has_cuda_and_cupy
 
 try:
     from rtxpy import RTX
@@ -7,4 +7,4 @@ except ImportError:
 
 
 def has_rtx():
-    return has_cupy() and has_cuda() and RTX is not None
+    return has_cuda_and_cupy and RTX is not None

--- a/xrspatial/hillshade.py
+++ b/xrspatial/hillshade.py
@@ -8,7 +8,7 @@ import xarray as xr
 from numba import cuda
 
 from .gpu_rtx import has_rtx
-from .utils import calc_cuda_dims, has_cuda, has_cupy, is_cupy_array, is_cupy_backed
+from .utils import calc_cuda_dims, has_cuda_and_cupy, is_cupy_array, is_cupy_backed
 
 
 def _run_numpy(data, azimuth=225, angle_altitude=25):
@@ -170,7 +170,7 @@ def hillshade(agg: xr.DataArray,
         out = _run_numpy(agg.data, azimuth, angle_altitude)
 
     # cupy/numba case
-    elif has_cuda() and has_cupy() and is_cupy_array(agg.data):
+    elif has_cuda_and_cupy() and is_cupy_array(agg.data):
         if shadows and has_rtx():
             from .gpu_rtx.hillshade import hillshade_rtx
             out = hillshade_rtx(agg, azimuth, angle_altitude, shadows=shadows)
@@ -178,7 +178,7 @@ def hillshade(agg: xr.DataArray,
             out = _run_cupy(agg.data, azimuth, angle_altitude)
 
     # dask + cupy case
-    elif (has_cuda() and has_cupy() and isinstance(agg.data, da.Array) and
+    elif (has_cuda_and_cupy() and isinstance(agg.data, da.Array) and
             is_cupy_backed(agg)):
         raise NotImplementedError("Dask/CuPy hillshade not implemented")
 

--- a/xrspatial/tests/general_checks.py
+++ b/xrspatial/tests/general_checks.py
@@ -1,9 +1,9 @@
 import dask.array as da
 import numpy as np
+import pytest
 import xarray as xr
 
 from xrspatial.utils import ArrayTypeFunctionMapping, has_cuda_and_cupy
-
 
 # Use this as a decorator to skip tests if do not have both CUDA and CuPy available.
 cuda_and_cupy_available = pytest.mark.skipif(

--- a/xrspatial/tests/general_checks.py
+++ b/xrspatial/tests/general_checks.py
@@ -2,7 +2,12 @@ import dask.array as da
 import numpy as np
 import xarray as xr
 
-from xrspatial.utils import ArrayTypeFunctionMapping, has_cuda
+from xrspatial.utils import ArrayTypeFunctionMapping, has_cuda_and_cupy
+
+
+# Use this as a decorator to skip tests if do not have both CUDA and CuPy available.
+cuda_and_cupy_available = pytest.mark.skipif(
+    not has_cuda_and_cupy(), reason="Requires CUDA and CuPy")
 
 
 def create_test_raster(
@@ -13,7 +18,7 @@ def create_test_raster(
     for i, dim in enumerate(dims):
         raster[dim] = np.linspace(0, data.shape[i] - 1, data.shape[i])
 
-    if has_cuda() and 'cupy' in backend:
+    if has_cuda_and_cupy() and 'cupy' in backend:
         import cupy
         raster.data = cupy.asarray(raster.data)
 

--- a/xrspatial/tests/test_aspect.py
+++ b/xrspatial/tests/test_aspect.py
@@ -4,8 +4,7 @@ import pytest
 from xrspatial import aspect
 from xrspatial.tests.general_checks import (assert_nan_edges_effect, assert_numpy_equals_cupy,
                                             assert_numpy_equals_dask_numpy, create_test_raster,
-                                            general_output_checks)
-from xrspatial.utils import doesnt_have_cuda
+                                            cuda_and_cupy_available, general_output_checks)
 
 
 def input_data(backend='numpy'):
@@ -70,7 +69,7 @@ def test_numpy_equals_dask_random_data(random_data):
     assert_numpy_equals_dask_numpy(numpy_agg, dask_agg, aspect)
 
 
-@pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
+@cuda_and_cupy_available
 def test_numpy_equals_cupy_qgis_data():
     # compare using the data run through QGIS
     numpy_agg = input_data()
@@ -78,7 +77,7 @@ def test_numpy_equals_cupy_qgis_data():
     assert_numpy_equals_cupy(numpy_agg, cupy_agg, aspect)
 
 
-@pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
+@cuda_and_cupy_available
 @pytest.mark.parametrize("size", [(2, 4), (10, 15)])
 @pytest.mark.parametrize(
     "dtype", [np.int32, np.int64, np.uint32, np.uint64, np.float32, np.float64])

--- a/xrspatial/tests/test_classify.py
+++ b/xrspatial/tests/test_classify.py
@@ -5,7 +5,6 @@ import xarray as xr
 from xrspatial import binary, equal_interval, natural_breaks, quantile, reclassify
 from xrspatial.tests.general_checks import (create_test_raster, cuda_and_cupy_available,
                                             general_output_checks)
-from xrspatial.utils import doesnt_have_cuda
 
 
 def input_data(backend='numpy'):
@@ -45,15 +44,15 @@ def test_binary_dask_numpy(result_binary):
     general_output_checks(dask_agg, dask_result, expected_result)
 
 
-@pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
-def test_binary_cupy(result_reclassify):
+@cuda_and_cupy_available
+def test_binary_cupy(result_binary):
     values, expected_result = result_binary
     cupy_agg = input_data(backend='cupy')
     cupy_result = binary(cupy_agg, values)
     general_output_checks(cupy_agg, cupy_result, expected_result)
 
 
-@pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
+@cuda_and_cupy_available
 def test_binary_dask_cupy(result_binary):
     values, expected_result = result_binary
     dask_cupy_agg = input_data(backend='dask+cupy')

--- a/xrspatial/tests/test_classify.py
+++ b/xrspatial/tests/test_classify.py
@@ -3,7 +3,8 @@ import pytest
 import xarray as xr
 
 from xrspatial import binary, equal_interval, natural_breaks, quantile, reclassify
-from xrspatial.tests.general_checks import create_test_raster, general_output_checks
+from xrspatial.tests.general_checks import (create_test_raster, cuda_and_cupy_available,
+                                            general_output_checks)
 from xrspatial.utils import doesnt_have_cuda
 
 
@@ -96,7 +97,7 @@ def test_reclassify_dask_numpy(result_reclassify):
     general_output_checks(dask_agg, dask_result, expected_result, verify_dtype=True)
 
 
-@pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
+@cuda_and_cupy_available
 def test_reclassify_cupy(result_reclassify):
     bins, new_values, expected_result = result_reclassify
     cupy_agg = input_data(backend='cupy')
@@ -104,7 +105,7 @@ def test_reclassify_cupy(result_reclassify):
     general_output_checks(cupy_agg, cupy_result, expected_result, verify_dtype=True)
 
 
-@pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
+@cuda_and_cupy_available
 def test_reclassify_dask_cupy(result_reclassify):
     bins, new_values, expected_result = result_reclassify
     dask_cupy_agg = input_data(backend='dask+cupy')
@@ -159,7 +160,7 @@ def test_quantile_dask_numpy(result_quantile):
     assert len(unique_elements) == k
 
 
-@pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
+@cuda_and_cupy_available
 def test_quantile_cupy(result_quantile):
     k, expected_result = result_quantile
     cupy_agg = input_data('cupy')
@@ -239,7 +240,7 @@ def test_natural_breaks_cpu_deterministic():
         )
 
 
-@pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
+@cuda_and_cupy_available
 def test_natural_breaks_cupy(result_natural_breaks):
     cupy_agg = input_data('cupy')
     k, expected_result = result_natural_breaks
@@ -247,7 +248,7 @@ def test_natural_breaks_cupy(result_natural_breaks):
     general_output_checks(cupy_agg, cupy_natural_breaks, expected_result, verify_dtype=True)
 
 
-@pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
+@cuda_and_cupy_available
 def test_natural_breaks_cupy_num_sample(result_natural_breaks_num_sample):
     cupy_agg = input_data('cupy')
     k, num_sample, expected_result = result_natural_breaks_num_sample
@@ -281,7 +282,7 @@ def test_equal_interval_dask_numpy(result_equal_interval):
     general_output_checks(dask_agg, dask_numpy_result, expected_result, verify_dtype=True)
 
 
-@pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
+@cuda_and_cupy_available
 def test_equal_interval_cupy(result_equal_interval):
     k, expected_result = result_equal_interval
     cupy_agg = input_data(backend='cupy')

--- a/xrspatial/tests/test_curvature.py
+++ b/xrspatial/tests/test_curvature.py
@@ -4,8 +4,7 @@ import pytest
 from xrspatial import curvature
 from xrspatial.tests.general_checks import (assert_numpy_equals_cupy,
                                             assert_numpy_equals_dask_numpy, create_test_raster,
-                                            general_output_checks)
-from xrspatial.utils import doesnt_have_cuda
+                                            cuda_and_cupy_available, general_output_checks)
 
 
 @pytest.fixture
@@ -80,7 +79,7 @@ def test_curvature_on_concave_surface(concave_surface):
     general_output_checks(numpy_agg, numpy_result, expected_result, verify_dtype=True)
 
 
-@pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
+@cuda_and_cupy_available
 @pytest.mark.parametrize("size", [(2, 4), (10, 15)])
 @pytest.mark.parametrize(
     "dtype", [np.int32, np.int64, np.uint32, np.uint64, np.float32, np.float64])

--- a/xrspatial/tests/test_focal.py
+++ b/xrspatial/tests/test_focal.py
@@ -7,8 +7,9 @@ from xrspatial import mean
 from xrspatial.convolution import (annulus_kernel, calc_cellsize, circle_kernel, convolution_2d,
                                    convolve_2d, custom_kernel)
 from xrspatial.focal import apply, focal_stats, hotspots
-from xrspatial.tests.general_checks import create_test_raster, general_output_checks
-from xrspatial.utils import doesnt_have_cuda, ngjit
+from xrspatial.tests.general_checks import (create_test_raster, cuda_and_cupy_available,
+                                            general_output_checks)
+from xrspatial.utils import ngjit
 
 
 def _do_sparse_array(data_array):
@@ -57,7 +58,7 @@ def test_mean_transfer_function_cpu():
     )
 
 
-@pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
+@cuda_and_cupy_available
 def test_mean_transfer_function_gpu_equals_cpu():
 
     import cupy
@@ -209,7 +210,7 @@ def test_convolution_dask_numpy(
     )
 
 
-@pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
+@cuda_and_cupy_available
 def test_2d_convolution_gpu(
     convolve_2d_data,
     kernel_circle_1_1_1,
@@ -297,7 +298,7 @@ def test_apply_dask_numpy(data_apply):
     general_output_checks(dask_numpy_agg, dask_numpy_apply, expected_result)
 
 
-@pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
+@cuda_and_cupy_available
 def test_apply_gpu(data_apply):
     data, kernel, expected_result = data_apply
     # cupy case
@@ -430,7 +431,7 @@ def test_hotspots_dask_numpy(data_hotspots):
     general_output_checks(dask_numpy_agg, dask_numpy_hotspots, expected_result)
 
 
-@pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
+@cuda_and_cupy_available
 def test_hotspot_gpu(data_hotspots):
     data, kernel, expected_result = data_hotspots
     cupy_agg = create_test_raster(data, backend='cupy')

--- a/xrspatial/tests/test_hillshade.py
+++ b/xrspatial/tests/test_hillshade.py
@@ -6,7 +6,7 @@ from numpy.testing import assert_allclose, assert_array_less
 from xrspatial import hillshade
 from xrspatial.tests.general_checks import (assert_numpy_equals_cupy,
                                             assert_numpy_equals_dask_numpy, create_test_raster,
-                                            general_output_checks)
+                                            cuda_and_cupy_available, general_output_checks)
 from xrspatial.utils import doesnt_have_cuda
 
 from ..gpu_rtx import has_rtx
@@ -46,7 +46,7 @@ def test_hillshade_numpy_equals_dask_numpy(random_data):
     assert_numpy_equals_dask_numpy(numpy_agg, dask_agg, hillshade)
 
 
-@pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
+@cuda_and_cupy_available
 @pytest.mark.parametrize("size", [(2, 4), (10, 15)])
 @pytest.mark.parametrize(
     "dtype", [np.int32, np.int64, np.float32, np.float64])

--- a/xrspatial/tests/test_hillshade.py
+++ b/xrspatial/tests/test_hillshade.py
@@ -7,7 +7,6 @@ from xrspatial import hillshade
 from xrspatial.tests.general_checks import (assert_numpy_equals_cupy,
                                             assert_numpy_equals_dask_numpy, create_test_raster,
                                             cuda_and_cupy_available, general_output_checks)
-from xrspatial.utils import doesnt_have_cuda
 
 from ..gpu_rtx import has_rtx
 

--- a/xrspatial/tests/test_multispectral.py
+++ b/xrspatial/tests/test_multispectral.py
@@ -4,8 +4,8 @@ import xarray as xr
 
 from xrspatial.multispectral import (arvi, ebbi, evi, gci, nbr, nbr2, ndmi, ndvi, savi, sipi,
                                      true_color)
-from xrspatial.tests.general_checks import create_test_raster, general_output_checks
-from xrspatial.utils import doesnt_have_cuda
+from xrspatial.tests.general_checks import (create_test_raster, cuda_and_cupy_available,
+                                            general_output_checks)
 
 
 @pytest.fixture
@@ -275,7 +275,7 @@ def test_ndvi_cpu(nir_data, red_data, result_ndvi):
     general_output_checks(nir_data, result, result_ndvi, verify_dtype=True)
 
 
-@pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
+@cuda_and_cupy_available
 @pytest.mark.parametrize("backend", ["cupy", "dask+cupy"])
 def test_ndvi_gpu(nir_data, red_data, result_ndvi):
     result = ndvi(nir_data, red_data)
@@ -304,7 +304,7 @@ def test_savi_cpu(nir_data, red_data, result_savi):
     general_output_checks(nir_data, result, result_savi)
 
 
-@pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
+@cuda_and_cupy_available
 @pytest.mark.parametrize("backend", ["cupy", "dask+cupy"])
 def test_savi_gpu(nir_data, red_data, result_savi):
     # test default savi where soil_factor = 1.0
@@ -319,7 +319,7 @@ def test_arvi_cpu(nir_data, red_data, blue_data, result_arvi):
     general_output_checks(nir_data, result, result_arvi)
 
 
-@pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
+@cuda_and_cupy_available
 @pytest.mark.parametrize("backend", ["cupy", "dask+cupy"])
 def test_arvi_gpu(nir_data, red_data, blue_data, result_arvi):
     result = arvi(nir_data, red_data, blue_data)
@@ -333,7 +333,7 @@ def test_evi_cpu(nir_data, red_data, blue_data, result_evi):
     general_output_checks(nir_data, result, result_evi)
 
 
-@pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
+@cuda_and_cupy_available
 @pytest.mark.parametrize("backend", ["cupy", "dask+cupy"])
 def test_evi_gpu(nir_data, red_data, blue_data, result_evi):
     result = evi(nir_data, red_data, blue_data)
@@ -347,7 +347,7 @@ def test_gci_cpu(nir_data, green_data, result_gci):
     general_output_checks(nir_data, result, result_gci)
 
 
-@pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
+@cuda_and_cupy_available
 @pytest.mark.parametrize("backend", ["cupy", "dask+cupy"])
 def test_gci_gpu(nir_data, green_data, result_gci):
     result = gci(nir_data, green_data)
@@ -361,7 +361,7 @@ def test_sipi_cpu(nir_data, red_data, blue_data, result_sipi):
     general_output_checks(nir_data, result, result_sipi)
 
 
-@pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
+@cuda_and_cupy_available
 @pytest.mark.parametrize("backend", ["cupy", "dask+cupy"])
 def test_sipi_gpu(nir_data, red_data, blue_data, result_sipi):
     result = sipi(nir_data, red_data, blue_data)
@@ -375,7 +375,7 @@ def test_nbr_cpu(nir_data, swir2_data, result_nbr):
     general_output_checks(nir_data, result, result_nbr)
 
 
-@pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
+@cuda_and_cupy_available
 @pytest.mark.parametrize("backend", ["cupy", "dask+cupy"])
 def test_nbr_gpu(nir_data, swir2_data, result_nbr):
     result = nbr(nir_data, swir2_data)
@@ -389,7 +389,7 @@ def test_nbr2_cpu(swir1_data, swir2_data, result_nbr2):
     general_output_checks(swir1_data, result, result_nbr2)
 
 
-@pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
+@cuda_and_cupy_available
 @pytest.mark.parametrize("backend", ["cupy", "dask+cupy"])
 def test_nbr2_gpu(swir1_data, swir2_data, result_nbr2):
     result = nbr2(swir1_data, swir2_data)
@@ -403,7 +403,7 @@ def test_ndmi_cpu(nir_data, swir1_data, result_ndmi):
     general_output_checks(nir_data, result, result_ndmi)
 
 
-@pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
+@cuda_and_cupy_available
 @pytest.mark.parametrize("backend", ["cupy", "dask+cupy"])
 def test_ndmi_gpu(nir_data, swir1_data, result_ndmi):
     result = ndmi(nir_data, swir1_data)
@@ -417,7 +417,7 @@ def test_ebbi_cpu(red_data, swir1_data, tir_data, result_ebbi):
     general_output_checks(red_data, result, result_ebbi)
 
 
-@pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
+@cuda_and_cupy_available
 @pytest.mark.parametrize("backend", ["cupy", "dask+cupy"])
 def test_ebbi_gpu(red_data, swir1_data, tir_data, result_ebbi):
     result = ebbi(red_data, swir1_data, tir_data)

--- a/xrspatial/tests/test_perlin.py
+++ b/xrspatial/tests/test_perlin.py
@@ -1,11 +1,10 @@
 import dask.array as da
 import numpy as np
-import pytest
 import xarray as xr
 
 from xrspatial import perlin
-from xrspatial.tests.general_checks import general_output_checks
-from xrspatial.utils import doesnt_have_cuda, has_cuda
+from xrspatial.tests.general_checks import cuda_and_cupy_available, general_output_checks
+from xrspatial.utils import has_cuda_and_cupy
 
 
 def create_test_arr(backend='numpy'):
@@ -14,7 +13,7 @@ def create_test_arr(backend='numpy'):
     data = np.zeros((H, W), dtype=np.float32)
     raster = xr.DataArray(data, dims=['y', 'x'])
 
-    if has_cuda() and 'cupy' in backend:
+    if has_cuda_and_cupy() and 'cupy' in backend:
         import cupy
         raster.data = cupy.asarray(raster.data)
 
@@ -41,7 +40,7 @@ def test_perlin_cpu():
     )
 
 
-@pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
+@cuda_and_cupy_available
 def test_perlin_gpu():
     # vanilla numpy version
     data_numpy = create_test_arr()

--- a/xrspatial/tests/test_slope.py
+++ b/xrspatial/tests/test_slope.py
@@ -4,8 +4,7 @@ import pytest
 from xrspatial import slope
 from xrspatial.tests.general_checks import (assert_nan_edges_effect, assert_numpy_equals_cupy,
                                             assert_numpy_equals_dask_numpy, create_test_raster,
-                                            general_output_checks)
-from xrspatial.utils import doesnt_have_cuda
+                                            cuda_and_cupy_available, general_output_checks)
 
 
 def input_data(backend):
@@ -65,7 +64,7 @@ def test_numpy_equals_dask_qgis_data():
     assert_numpy_equals_dask_numpy(numpy_agg, dask_agg, slope)
 
 
-@pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
+@cuda_and_cupy_available
 def test_numpy_equals_cupy_qgis_data():
     # compare using the data run through QGIS
     numpy_agg = input_data('numpy')

--- a/xrspatial/tests/test_terrain.py
+++ b/xrspatial/tests/test_terrain.py
@@ -1,3 +1,4 @@
+import dask.array as da
 import numpy as np
 import xarray as xr
 

--- a/xrspatial/tests/test_terrain.py
+++ b/xrspatial/tests/test_terrain.py
@@ -1,10 +1,9 @@
-import dask.array as da
 import numpy as np
-import pytest
 import xarray as xr
 
 from xrspatial import generate_terrain
-from xrspatial.utils import doesnt_have_cuda, has_cuda
+from xrspatial.tests.general_checks import cuda_and_cupy_available
+from xrspatial.utils import has_cuda_and_cupy
 
 
 def create_test_arr(backend='numpy'):
@@ -13,7 +12,7 @@ def create_test_arr(backend='numpy'):
     data = np.zeros((H, W), dtype=np.float32)
     raster = xr.DataArray(data, dims=['y', 'x'])
 
-    if has_cuda() and 'cupy' in backend:
+    if has_cuda_and_cupy() and 'cupy' in backend:
         import cupy
         raster.data = cupy.asarray(raster.data)
 
@@ -37,7 +36,7 @@ def test_terrain_cpu():
     np.testing.assert_allclose(terrain_numpy.data, terrain_dask.data, rtol=1e-05, atol=1e-07)
 
 
-@pytest.mark.skipif(doesnt_have_cuda(), reason="CUDA Device not Available")
+@cuda_and_cupy_available
 def test_terrain_gpu():
     # vanilla numpy version
     data_numpy = create_test_arr()

--- a/xrspatial/tests/test_zonal.py
+++ b/xrspatial/tests/test_zonal.py
@@ -10,6 +10,7 @@ from xrspatial import zonal_apply as apply
 from xrspatial import zonal_crosstab as crosstab
 from xrspatial import zonal_stats as stats
 from xrspatial.zonal import regions
+
 from .general_checks import create_test_raster, has_cuda_and_cupy
 
 

--- a/xrspatial/tests/test_zonal.py
+++ b/xrspatial/tests/test_zonal.py
@@ -9,9 +9,8 @@ from xrspatial import crop, suggest_zonal_canvas, trim
 from xrspatial import zonal_apply as apply
 from xrspatial import zonal_crosstab as crosstab
 from xrspatial import zonal_stats as stats
-from xrspatial.tests.general_checks import create_test_raster
-from xrspatial.utils import doesnt_have_cuda
 from xrspatial.zonal import regions
+from .general_checks import create_test_raster, has_cuda_and_cupy
 
 
 @pytest.fixture
@@ -168,16 +167,16 @@ def check_results(backend, df_result, expected_results_dict):
 
 @pytest.mark.parametrize("backend", ['numpy', 'dask+numpy', 'cupy'])
 def test_default_stats(backend, data_zones, data_values_2d, result_default_stats):
-    if backend == 'cupy' and doesnt_have_cuda():
-        pytest.skip("CUDA Device not Available")
+    if backend == 'cupy' and not has_cuda_and_cupy():
+        pytest.skip("Requires CUDA and CuPy")
     df_result = stats(zones=data_zones, values=data_values_2d)
     check_results(backend, df_result, result_default_stats)
 
 
 @pytest.mark.parametrize("backend", ['numpy', 'dask+numpy', 'cupy'])
 def test_zone_ids_stats(backend, data_zones, data_values_2d, result_zone_ids_stats):
-    if backend == 'cupy' and doesnt_have_cuda():
-        pytest.skip("CUDA Device not Available")
+    if backend == 'cupy' and not has_cuda_and_cupy():
+        pytest.skip("Requires CUDA and CuPy")
     zone_ids, expected_result = result_zone_ids_stats
     df_result = stats(zones=data_zones, values=data_values_2d,
                       zone_ids=zone_ids)
@@ -187,8 +186,8 @@ def test_zone_ids_stats(backend, data_zones, data_values_2d, result_zone_ids_sta
 @pytest.mark.parametrize("backend", ['numpy', 'cupy'])
 def test_custom_stats(backend, data_zones, data_values_2d, result_custom_stats):
     # ---- custom stats (NumPy and CuPy only) ----
-    if backend == 'cupy' and doesnt_have_cuda():
-        pytest.skip("CUDA Device not Available")
+    if backend == 'cupy' and not has_cuda_and_cupy():
+        pytest.skip("Requires CUDA and CuPy")
 
     custom_stats = {
         'double_sum': _double_sum,

--- a/xrspatial/utils.py
+++ b/xrspatial/utils.py
@@ -27,15 +27,19 @@ except ImportError:
 ngjit = jit(nopython=True, nogil=True)
 
 
-def has_cupy():
+def has_cuda_and_cupy():
+    return _has_cuda() and _has_cupy()
+
+
+def _has_cupy():
     return cupy is not None
 
 
 def is_cupy_array(arr):
-    return has_cupy() and isinstance(arr, cupy.ndarray)
+    return _has_cupy() and isinstance(arr, cupy.ndarray)
 
 
-def has_cuda():
+def _has_cuda():
     """Check for supported CUDA device. If none found, return False"""
     local_cuda = False
     try:
@@ -45,10 +49,6 @@ def has_cuda():
         local_cuda = False
 
     return local_cuda
-
-
-def doesnt_have_cuda():
-    return not has_cuda()
 
 
 def cuda_args(shape):
@@ -116,15 +116,11 @@ class ArrayTypeFunctionMapping(object):
             return self.numpy_func
 
         # cupy case
-        elif (
-            has_cuda()
-            and cupy is not None
-            and isinstance(arr.data, cupy.ndarray)
-        ):
+        elif has_cuda_and_cupy() and is_cupy_array(arr.data):
             return self.cupy_func
 
         # dask + cupy case
-        elif has_cuda() and is_dask_cupy(arr):
+        elif has_cuda_and_cupy() and is_dask_cupy(arr):
             return self.dask_cupy_func
 
         # dask + numpy case

--- a/xrspatial/viewshed.py
+++ b/xrspatial/viewshed.py
@@ -1,13 +1,12 @@
 from math import atan, fabs
 from math import pi as PI
 from math import sqrt
-from typing import Union
-
 import numpy as np
+from typing import Union
 import xarray
 
+from .utils import has_cuda_and_cupy, is_cupy_array, ngjit
 from .gpu_rtx import has_rtx
-from .utils import has_cupy, is_cupy_array, ngjit
 
 E_ROW_ID = 0
 E_COL_ID = 1
@@ -1656,7 +1655,7 @@ def viewshed(raster: xarray.DataArray,
     if isinstance(raster.data, np.ndarray):
         return _viewshed_cpu(raster, x, y, observer_elev, target_elev)
 
-    elif has_cupy() and is_cupy_array(raster.data):
+    elif has_cuda_and_cupy() and is_cupy_array(raster.data):
         if has_rtx():
             # Run on gpu
             from .gpu_rtx.viewshed import viewshed_gpu

--- a/xrspatial/viewshed.py
+++ b/xrspatial/viewshed.py
@@ -1,12 +1,13 @@
 from math import atan, fabs
 from math import pi as PI
 from math import sqrt
-import numpy as np
 from typing import Union
+
+import numpy as np
 import xarray
 
-from .utils import has_cuda_and_cupy, is_cupy_array, ngjit
 from .gpu_rtx import has_rtx
+from .utils import has_cuda_and_cupy, is_cupy_array, ngjit
 
 E_ROW_ID = 0
 E_COL_ID = 1


### PR DESCRIPTION
This PR makes the identification of cuda and cupy more robust. Previously it was possible to have cuda present but not have cupy installed, and some branches of code would view this as sufficient for running cupy code and hence fail.

The change is to add a new function `has_cuda_and_cupy` that combines the individual `has_cuda` and `has_cupy` functions, which are now made private with underscores. Existing code has been modified to use the new `has_cuda_and_cupy()`, and all new code should use this too.

Also added a `pytest.mark.skipif` decorator called `cuda_and_cupy_available` so we don't have to repeat the `reason` string throughout the code.

I have confirmed that tests run and pass on a cuda-enabled system in the following configurations:
  1. No cupy
  2. With cupy
  3. With cupy and rtxpy