### PR TITLE
Codecov: disable Numba; ignore tests, experimental, and gpu_rtx

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -29,7 +29,7 @@ jobs:
         pip install -e .[tests]
     - name: Generate coverage report
       run: |
-        NUMBA_DISABLE_JIT=1 pytest --cov=./ --cov-report=xml
+        NUMBA_DISABLE_JIT=1 pytest --cov=./ --cov-report=xml --ignore ./xrspatial/tests/test_polygonize.py
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2
       with:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,5 +1,12 @@
 name: Codecov
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+    - '*'
+
 jobs:
   run:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -22,7 +22,7 @@ jobs:
         pip install -e .[tests]
     - name: Generate coverage report
       run: |
-        pytest --cov=./ --cov-report=xml
+        NUMBA_DISABLE_JIT=1 pytest --cov=./ --cov-report=xml
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2
       with:

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,6 +10,9 @@ comment:
   require_changes: yes
 
 ignore:
-  - "xrspatial/tests/test_polygonize.py"
+  - "setup.py"
+  - "xrspatial/__init__.py"
+  - "xrspatial/__main__.py"
   - "xrspatial/experimental/*"
   - "xrspatial/gpu_rtx/*"
+  - "xrspatial/tests/*"

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,6 +8,3 @@ coverage:
 
 comment:
   require_changes: yes
-
-ignore:
-  - "xrspatial/tests/test_polygonize.py"

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,9 +10,9 @@ comment:
   require_changes: yes
 
 ignore:
-  - "setup.py"
   - "xrspatial/__init__.py"
   - "xrspatial/__main__.py"
   - "xrspatial/experimental/*"
   - "xrspatial/gpu_rtx/*"
   - "xrspatial/tests/*"
+  - "./setup.py"

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,9 +10,7 @@ comment:
   require_changes: yes
 
 ignore:
-  - "xrspatial/__init__.py"
-  - "xrspatial/__main__.py"
+  - "xrspatial/tests/test_polygonize.py"
   - "xrspatial/experimental/*"
   - "xrspatial/gpu_rtx/*"
   - "xrspatial/tests/*"
-  - "./setup.py"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,10 +1,13 @@
 coverage:
-   status:
-     patch: off
-     project:
-       default:
-         target: auto
-         threshold: 1%
+  status:
+    patch: off
+    project:
+      default:
+        target: auto
+        threshold: 0.5%
 
- comment:
-   require_changes: yes
+comment:
+  require_changes: yes
+
+ignore:
+  - "xrspatial/tests/test_polygonize.py"

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,3 +8,8 @@ coverage:
 
 comment:
   require_changes: yes
+
+ignore:
+  - "xrspatial/tests/test_polygonize.py"
+  - "xrspatial/experimental/*"
+  - "xrspatial/gpu_rtx/*"

--- a/xrspatial/convolution.py
+++ b/xrspatial/convolution.py
@@ -294,7 +294,7 @@ def _convolve_2d_numpy(data, kernel):
     wkx = nkx // 2
     wky = nky // 2
 
-    out = np.zeros(data.shape, dtype=float32)
+    out = np.zeros(data.shape, dtype=np.float32)
     out[:] = np.nan
     for i in prange(wkx, nx-wkx):
         iimin = max(i - wkx, 0)

--- a/xrspatial/convolution.py
+++ b/xrspatial/convolution.py
@@ -3,7 +3,7 @@ from functools import partial
 
 import numpy as np
 import xarray as xr
-from numba import cuda, float32, jit, prange
+from numba import cuda, jit, prange
 
 from xrspatial.utils import (ArrayTypeFunctionMapping, cuda_args, get_dataarray_resolution,
                              not_implemented_func)

--- a/xrspatial/terrain.py
+++ b/xrspatial/terrain.py
@@ -41,7 +41,7 @@ def _gen_terrain(height_map, seed, x_range=(0, 1), y_range=(0, 1)):
         y_range[0], y_range[1], height, endpoint=False, dtype=np.float32
     )
     x, y = np.meshgrid(linx, liny)
-    nrange = np.arange(2**20, dtype=int)
+    nrange = np.arange(2**20, dtype=np.int32)
     for i, (m, (xfreq, yfreq)) in enumerate(NOISE_LAYERS):
         np.random.seed(seed+i)
         p = np.random.permutation(nrange)
@@ -93,7 +93,7 @@ def _terrain_dask_numpy(data: da.Array,
     )
     x, y = da.meshgrid(linx, liny)
 
-    nrange = np.arange(2 ** 20, dtype=int)
+    nrange = np.arange(2 ** 20, dtype=np.int32)
 
     # multiplier, (xfreq, yfreq)
     NOISE_LAYERS = ((1 / 2 ** i, (2 ** i, 2 ** i)) for i in range(16))

--- a/xrspatial/tests/test_analytics.py
+++ b/xrspatial/tests/test_analytics.py
@@ -6,6 +6,14 @@ from xrspatial.analytics import summarize_terrain
 from xrspatial.tests.general_checks import create_test_raster
 
 
+def test_summarize_terrain_no_name():
+    data = np.zeros((10, 20))
+    test_terrain = create_test_raster(data, name=None)
+    msg = "Requires xr.DataArray.name property to be set"
+    with pytest.raises(NameError, match=msg):
+        summarize_terrain(test_terrain)
+
+
 @pytest.mark.parametrize("size", [(2, 4), (100, 150)])
 @pytest.mark.parametrize(
     "dtype", [np.int32, np.int64, np.uint32, np.uint64, np.float32, np.float64]

--- a/xrspatial/tests/test_zonal.py
+++ b/xrspatial/tests/test_zonal.py
@@ -250,7 +250,7 @@ def test_apply():
     def func(x):
         return 0
 
-    zones_val = np.zeros((3, 3), dtype=int)
+    zones_val = np.zeros((3, 3), dtype=np.int32)
     # define some zones
     zones_val[1] = 1
     zones_val[2] = 2


### PR DESCRIPTION
At the moment Codecov does not capture Numba-jited functions, and GitHub action does not handle cupy/GPU related stuffs. 
- Disable Numba when reporting code coverage, and fix some related issue
- Ignore `xrspatial/experimental` as some tests with `polygonize()` failed when Numba is turned off
- Ignore `xrspatial/gpu_rtx`