### PR TITLE
Fixed ubuntu version in pypi publish

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -5,7 +5,7 @@ on:
        - '*'
 jobs:
   publish:
-    runs-on: ubuntu-20-04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@master
       - name: Set up Python 3.9


### PR DESCRIPTION
This PR fixed the typo in ubuntu version specified in the yaml file that caused issue in publishing the package to pypi. 