### PR TITLE
Add isort to pytest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,7 @@ optional =
     rtxpy
 tests =
     flake8
+    isort
     noise >= 1.2.2
     pytest
     pytest-cov

--- a/xrspatial/tests/test_codebase.py
+++ b/xrspatial/tests/test_codebase.py
@@ -5,3 +5,9 @@ def test_flake8():
     cmd = ["flake8"]
     proc = run(cmd, capture_output=True)
     assert proc.returncode == 0, f"Flake8 issues:\n{proc.stdout.decode('utf-8')}"
+
+
+def test_isort():
+    cmd = ["isort", "--diff", "--check", "."]
+    proc = run(cmd, capture_output=True)
+    assert proc.returncode == 0, f"isort issues:\n{proc.stdout.decode('utf-8')}"


### PR DESCRIPTION
This PR adds the running of `isort` within `pytest`.

PR #697 removed the linting github action which unintentionally removed the running of `isort` in CI. Here it is added to `test_codebase.py` so that it always runs whenever `pytest` is run. This ensures that `isort` errors are caught before PRs are submitted (assuming PR submitters run `pytest` of course!)