### PR TITLE
Correct examples in docstrings

### DIFF
--- a/xrspatial/curvature.py
+++ b/xrspatial/curvature.py
@@ -121,6 +121,7 @@ def curvature(agg: xr.DataArray,
     .. sourcecode:: python
 
         >>> import numpy as np
+        >>> import dask.array as da
         >>> import xarray as xr
         >>> from xrspatial import curvature
         >>> flat_data = np.zeros((5, 5), dtype=np.float32)
@@ -187,7 +188,7 @@ def curvature(agg: xr.DataArray,
             cupy.asarray(concave_data),
             attrs={'res': (10, 10)}, name='concave_cupy_raster')
         >>> concave_curv = curvature(concave_raster)
-        >>> print(type(concave_curv))
+        >>> print(type(concave_curv.data))
         <class 'cupy.core.core.ndarray'>
         >>> print(concave_curv)
         <xarray.DataArray 'curvature' (dim_0: 5, dim_1: 5)>

--- a/xrspatial/focal.py
+++ b/xrspatial/focal.py
@@ -193,11 +193,11 @@ def mean(agg, passes=1, excludes=[np.nan], name='mean'):
         <class 'cupy.core.core.ndarray'>
         >>> print(mean_cupy)
         <xarray.DataArray 'mean' (dim_0: 5, dim_1: 5)>
-        array([[0.47928994, 0.47928994, 0.47928994, 0.47928994, 0.47928994],
-               [0.47928994, 0.47928994, 0.47928994, 0.47928994, 0.47928994],
-               [0.47928994, 0.47928994, 0.47928994, 0.47928994, 0.47928994],
-               [0.47928994, 0.47928994, 0.47928994, 0.47928994, 0.47928994],
-               [0.47928994, 0.47928994, 0.47928994, 0.47928994, 0.47928994]])
+        array([[0.47928995, 0.47928995, 0.47928995, 0.47928995, 0.47928995],
+               [0.47928995, 0.47928995, 0.47928995, 0.47928995, 0.47928995],
+               [0.47928995, 0.47928995, 0.47928995, 0.47928995, 0.47928995],
+               [0.47928995, 0.47928995, 0.47928995, 0.47928995, 0.47928995],
+               [0.47928995, 0.47928995, 0.47928995, 0.47928995, 0.47928995]])
         Dimensions without coordinates: dim_0, dim_1
     """
 
@@ -358,6 +358,7 @@ def apply(raster, kernel, func=_calc_mean, name='focal_apply'):
                [0., 1., 0.]])
         >>> # apply kernel mean by default
         >>> apply_mean_agg = apply(raster, kernel)
+        >>> apply_mean_agg
         <xarray.DataArray 'focal_apply' (y: 4, x: 5)>
         array([[ 2.        ,  2.25   ,  3.25      ,  4.25      ,  5.33333333],
                [ 5.25      ,  6.     ,  7.        ,  8.        ,  8.75      ],
@@ -387,13 +388,14 @@ def apply(raster, kernel, func=_calc_mean, name='focal_apply'):
     ])
     >>> @ngjit
     >>> def func(kernel_data):
-    >>>     weight = np.array([
-                [0, 0.5, 0],
-                [0, 1, 0.5],
-                [0, 0.5, 0],
-            ])
-    >>>    return np.nansum(kernel_data * weight)
+    ...     weight = np.array([
+    ...         [0, 0.5, 0],
+    ...         [0, 1, 0.5],
+    ...         [0, 0.5, 0],
+    ...     ])
+    ...     return np.nansum(kernel_data * weight)
 
+    >>> import dask.array as da
     >>> data_da = da.from_array(np.ones((6, 4), dtype=np.float64), chunks=(3, 2))
     >>> raster_da = xr.DataArray(data_da, dims=['y', 'x'], name='raster_da')
     >>> print(raster_da)
@@ -713,7 +715,7 @@ def hotspots(raster, kernel):
         >>> import numpy as np
         >>> import xarray as xr
         >>> from xrspatial.convolution import custom_kernel
-        >>> kernel = custom_kernel(np.array([1, 1, 0]))
+        >>> kernel = custom_kernel(np.array([[1, 1, 0]]))
         >>> data = np.array([
         ...    [0, 1000, 1000, 0, 0, 0],
         ...    [0, 0, 0, -1000, -1000, 0],

--- a/xrspatial/proximity.py
+++ b/xrspatial/proximity.py
@@ -112,14 +112,14 @@ def manhattan_distance(x1: float, x2: float, y1: float, y2: float) -> float:
         >>> from xrspatial import manhattan_distance
         >>> point_a = (142.32, 23.23)
         >>> point_b = (312.54, 432.01)
-        >>> # Calculate Euclidean Distance
+        >>> # Calculate Manhattan Distance
         >>> dist = manhattan_distance(
         ...     point_a[0],
         ...     point_b[0],
         ...     point_a[1],
         ...     point_b[1])
         >>> print(dist)
-        196075.9368
+        579.0
     """
 
     x = x1 - x2
@@ -165,7 +165,7 @@ def great_circle_distance(
         >>> from xrspatial import great_circle_distance
         >>> point_a = (123.2, 82.32)
         >>> point_b = (178.0, 65.09)
-        >>> # Calculate Euclidean Distance
+        >>> # Calculate Great Circle Distance
         >>> dist = great_circle_distance(
         ...     point_a[0],
         ...     point_b[0],

--- a/xrspatial/viewshed.py
+++ b/xrspatial/viewshed.py
@@ -1637,7 +1637,7 @@ def viewshed(raster: xarray.DataArray,
         array([[ 0,  0,  1,  0,  0],
                [ 1,  3,  0,  0,  0],
                [10,  2,  5,  2, -1],
-               [20,  1,  2,  9,  0]])
+               [11,  1,  2,  9,  0]])
         Coordinates:
           * y        (y) float64 1.0 2.0 3.0 4.0
           * x        (x) float64 1.0 2.0 3.0 4.0 5.0


### PR DESCRIPTION
In some examples in functions' docstrings, there are some missing imports and typos. Issue https://github.com/makepath/xarray-spatial/issues/701 is an example. This PR fixes the examples in following modules: 
- curvature
- focal
- proximity
- viewshed
- zonal