### PR TITLE
focal apply: drop gpu support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ In the GIS world, rasters are used for representing continuous phenomena (e.g. e
 
 | Name | NumPy xr.DataArray | Dask xr.DataArray | CuPy GPU xr.DataArray | Dask GPU xr.DataArray |
 |:----------:|:----------------------:|:--------------------:|:-------------------:|:------:|
-| [Apply](xrspatial/focal.py) | ✅️ | ✅️ | ✅️ |  |
+| [Apply](xrspatial/focal.py) | ✅️ | ✅️ |  |  |
 | [Hotspots](xrspatial/focal.py) | ✅️ | ✅️ | ✅️ |  |
 | [Mean](xrspatial/focal.py) | ✅️ | ✅️ | ✅️ | |
 | [Focal Statistics](xrspatial/focal.py) | ✅️ | ✅️ | ✅️ | |

--- a/benchmarks/benchmarks/focal.py
+++ b/benchmarks/benchmarks/focal.py
@@ -19,6 +19,7 @@ class Focal:
 
 class FocalApply(Focal):
     params = ([100, 300, 1000, 3000], [(5, 5), (25, 25)], ["numpy"])
+
     def time_apply(self, nx, kernelsize, type):
         apply(self.agg, self.kernel)
 

--- a/benchmarks/benchmarks/focal.py
+++ b/benchmarks/benchmarks/focal.py
@@ -18,6 +18,7 @@ class Focal:
 
 
 class FocalApply(Focal):
+    params = ([100, 300, 1000, 3000], [(5, 5), (25, 25)], ["numpy"])
     def time_apply(self, nx, kernelsize, type):
         apply(self.agg, self.kernel)
 

--- a/xrspatial/classify.py
+++ b/xrspatial/classify.py
@@ -630,8 +630,7 @@ def natural_breaks(agg: xr.DataArray,
     Parameters
     ----------
     agg : xarray.DataArray
-        2D NumPy, CuPy, NumPy-backed Dask, or Cupy-backed Dask array
-        of values to be reclassified.
+        2D NumPy DataArray of values to be reclassified.
     num_sample : int, default=20000
         Number of sample data points used to fit the model.
         Natural Breaks (Jenks) classification is indeed O(n²) complexity,

--- a/xrspatial/tests/test_focal.py
+++ b/xrspatial/tests/test_focal.py
@@ -319,21 +319,6 @@ def test_apply_dask_numpy(data_apply):
     general_output_checks(dask_numpy_agg, dask_numpy_apply, expected_result)
 
 
-@cuda_and_cupy_available
-def test_apply_gpu(data_apply):
-    data, kernel, expected_result = data_apply
-    # cupy case
-    cupy_agg = create_test_raster(data, backend='cupy')
-    cupy_apply = apply(cupy_agg, kernel, func_zero)
-    general_output_checks(cupy_agg, cupy_apply, expected_result)
-
-    # dask + cupy case not implemented
-    dask_cupy_agg = create_test_raster(data, backend='dask+cupy')
-    with pytest.raises(NotImplementedError) as e_info:
-        apply(dask_cupy_agg, kernel, func_zero)
-        assert e_info
-
-
 @pytest.fixture
 def data_focal_stats():
     data = np.arange(16).reshape(4, 4)


### PR DESCRIPTION
Focal apply receives a function as an argument, which seems not supported by numba cuda. On the other hand, it takes in a kernel of size `m*n`. To benefit from the GPU we need to be able to process data cells in parallel, each cell being the center of an `m*n` array. If we want enough flexibility, focal apply needs to allow calculations on an array created from the original data and the kernel, which requires array allocation, which is not supported by numba either. 

For those reasons, we cannot use numba for the cupy case at the moment. The GPU support should be dropped for now.