### PR TITLE
Fix rtx viewshed rendering blank image

### DIFF
--- a/xrspatial/gpu_rtx/mesh_utils.py
+++ b/xrspatial/gpu_rtx/mesh_utils.py
@@ -41,6 +41,7 @@ def create_triangulation(raster, optix):
         cupy.get_default_memory_pool().free_all_blocks()
     return scale
 
+
 @nb.cuda.jit
 def _triangulate_terrain_kernel(verts, triangles, data, H, W, scale, stride):
     global_id = stride + nb.cuda.grid(1)

--- a/xrspatial/gpu_rtx/mesh_utils.py
+++ b/xrspatial/gpu_rtx/mesh_utils.py
@@ -7,12 +7,12 @@ def create_triangulation(raster, optix):
     datahash = np.uint64(hash(str(raster.data.get())))
     optixhash = np.uint64(optix.getHash())
 
-    #Calculate a scale factor for the height that maintains the ratio
-    #width/height
+    # Calculate a scale factor for the height that maintains the ratio
+    # width/height
     x_coords = raster.indexes.get('x').values
     x_range = x_coords.max() - x_coords.min()
     H, W = raster.shape
-    #Get the scale factor of the terrain height vs terrain size
+    # Get the scale factor of the terrain height vs terrain size
     scaleFactor = x_range / raster.res[1]
     scale = scaleFactor * W / raster.res[1]
 

--- a/xrspatial/gpu_rtx/mesh_utils.py
+++ b/xrspatial/gpu_rtx/mesh_utils.py
@@ -6,15 +6,23 @@ import numpy as np
 def create_triangulation(raster, optix):
     datahash = np.uint64(hash(str(raster.data.get())))
     optixhash = np.uint64(optix.getHash())
+
+    #Calculate a scale factor for the height that maintains the ratio
+    #width/height
+    x_coords = raster.indexes.get('x').values
+    x_range = x_coords.max() - x_coords.min()
+    H, W = raster.shape
+    #Get the scale factor of the terrain height vs terrain size
+    scaleFactor = x_range / raster.res[1]
+    scale = scaleFactor * W / raster.res[1]
+
     if optixhash != datahash:
-        H, W = raster.shape
         num_tris = (H - 1) * (W - 1) * 2
         verts = cupy.empty(H * W * 3, np.float32)
         triangles = cupy.empty(num_tris * 3, np.int32)
-
         # Generate a mesh from the terrain (buffers are on the GPU, so
         # generation happens also on GPU)
-        res = _triangulate_terrain(verts, triangles, raster)
+        res = _triangulate_terrain(verts, triangles, raster, scale)
         if res:
             raise RuntimeError(
                 f"Failed to generate mesh from terrain, error code: {res}")
@@ -24,11 +32,14 @@ def create_triangulation(raster, optix):
             raise RuntimeError(
                 f"OptiX failed to build GAS, error code: {res}")
 
+        # Enable for debug purposes
+        if False:
+            write("mesh.stl", verts, triangles)
         # Clear some GPU memory that we no longer need
         verts = None
         triangles = None
         cupy.get_default_memory_pool().free_all_blocks()
-
+    return scale
 
 @nb.cuda.jit
 def _triangulate_terrain_kernel(verts, triangles, data, H, W, scale, stride):

--- a/xrspatial/gpu_rtx/viewshed.py
+++ b/xrspatial/gpu_rtx/viewshed.py
@@ -19,6 +19,7 @@ INVISIBLE = -1
 
 CAMERA_HEIGHT = 10000
 
+
 @nb.cuda.jit
 def _generate_primary_rays_kernel(data, H, W):
     """


### PR DESCRIPTION
Fix for wrong camera ray generation in viewshed. 

While debugging the above issue I noticed that the raster had some sort of scaling applied to the latitude and longitude, but not to the height. I took that scale factor into account while triangulating the terrain and now Hillshade and Viewshed
produce almost identical results compared to their numpy counterparts.

![image](https://user-images.githubusercontent.com/15478599/170093678-6e0590d9-ddc6-4f25-a30e-bec0b2165933.png)
On the first row you have:
the original terrain | numpy viewshed | cupy rtx viewshed
On the second row you have:
the original terrain | numpy hillshade | cupy rtx viewshed with shadows