### PR TITLE
classify.binary: handle NaNs and infinite values

### DIFF
--- a/xrspatial/classify.py
+++ b/xrspatial/classify.py
@@ -76,6 +76,7 @@ def binary(agg, values, name='binary'):
     """
     Binarize a data array based on a set of values. Data that equals to a value in the set will be
     set to 1. In contrast, data that does not equal to any value in the set will be set to 0.
+    Note that NaNs and infinite values will be set to NaNs.
 
     Parameters
     ----------
@@ -114,10 +115,10 @@ def binary(agg, values, name='binary'):
         >>> agg_binary = binary(agg, values)
         >>> print(agg_binary)
         <xarray.DataArray 'binary' (dim_0: 4, dim_1: 5)>
-        array([[0.,  1.,  1.,  1.,  0.],
+        array([[np.nan,  1.,  1.,  1.,  0.],
                [0.,  0.,  0.,  0.,  0.],
                [0.,  0.,  0.,  0.,  0.],
-               [0.,  0.,  0.,  0.,  0.]], dtype=float32)
+               [0.,  0.,  0.,  0.,  np.nan]], dtype=float32)
         Dimensions without coordinates: dim_0, dim_1
     """
 

--- a/xrspatial/classify.py
+++ b/xrspatial/classify.py
@@ -20,12 +20,13 @@ from xrspatial.utils import ArrayTypeFunctionMapping, cuda_args, ngjit, not_impl
 @ngjit
 def _cpu_binary(data, values):
     out = np.zeros_like(data)
+    out[:] = np.nan
     rows, cols = data.shape
     for y in range(0, rows):
         for x in range(0, cols):
             if np.any(values == data[y, x]):
                 out[y, x] = 1
-            else:
+            elif np.isfinite(data[y, x]):
                 out[y, x] = 0
     return out
 

--- a/xrspatial/classify.py
+++ b/xrspatial/classify.py
@@ -56,7 +56,8 @@ def _gpu_binary(data, values):
 def _run_gpu_binary(data, values, out):
     i, j = nb.cuda.grid(2)
     if i >= 0 and i < out.shape[0] and j >= 0 and j < out.shape[1]:
-        out[i, j] = _gpu_binary(data[i:i+1, j:j+1], values)
+        if cupy.isfinite(data[i:i+1, j:j+1]):
+            out[i, j] = _gpu_binary(data[i:i+1, j:j+1], values)
 
 
 def _run_cupy_binary(data, values):

--- a/xrspatial/classify.py
+++ b/xrspatial/classify.py
@@ -56,8 +56,7 @@ def _gpu_binary(data, values):
 def _run_gpu_binary(data, values, out):
     i, j = nb.cuda.grid(2)
     if i >= 0 and i < out.shape[0] and j >= 0 and j < out.shape[1]:
-        if cupy.isfinite(data[i:i+1, j:j+1]):
-            out[i, j] = _gpu_binary(data[i:i+1, j:j+1], values)
+        out[i, j] = _gpu_binary(data[i:i+1, j:j+1], values)
 
 
 def _run_cupy_binary(data, values):

--- a/xrspatial/tests/test_classify.py
+++ b/xrspatial/tests/test_classify.py
@@ -22,10 +22,10 @@ def input_data(backend='numpy'):
 def result_binary():
     values = [1, 2, 3]
     expected_result = np.asarray([
-        [0, 1, 1, 0, 0],
+        [np.nan, 1, 1, 0, np.nan],
         [0, 0, 0, 0, 0],
         [0, 0, 0, 0, 0],
-        [0, 0, 0, 0, 0]
+        [0, 0, 0, 0, np.nan]
     ], dtype=np.float32)
     return values, expected_result
 


### PR DESCRIPTION
Fixes #757

To be consistent with all other tools in classify module, this PR changes the way classify.binary() treats NaNs and infinite values. It now considers those values as outliers and classify them as NaNs instead of 0s as of previously.

- [x] numpy case
- [x] cupy case