### PR TITLE
chore: Remove numpy pin, pin datashader, drop Python 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python: [3.7, 3.8, 3.9, '3.10', 3.11]
+        python: [3.8, 3.9, '3.10', 3.11]
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,10 +19,10 @@ url = https://github.com/makepath/xarray-spatial
 [options]
 include_package_data = True
 install_requires =
-    datashader
+    datashader >= 0.15.0
     numba
     xarray
-    numpy <= 1.23.4
+    numpy
 packages = find:
 python_requires = >=3.7
 setup_requires = setuptools_scm

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ install_requires =
     xarray
     numpy
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 setup_requires = setuptools_scm
 zip_safe = False
 


### PR DESCRIPTION
## Proposed Changes

  - Pin datashader version to 0.15.0 and remove numpy version pin.
  - Require Python >=3.8.

Xarray-spatial tests were failing due to datashader calling `numpy.warnings`, which is removed in numpy >=1.24.0 ( https://github.com/makepath/xarray-spatial/issues/779 ). Datashader 0.15.0 removes calls to `numpy.warnings` (pr: https://github.com/holoviz/datashader/pull/1176 , changelog: https://github.com/holoviz/datashader/releases/tag/v0.15.0). This pull requests removes the numpy <= 1.23.4 pin in favour of a datashader >= 1.15.0 pin.

Datashader requires Python >=3.8, so this also drops support for Python 3.7.