### PR TITLE
Fix typo in readthedocs config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -23,4 +23,4 @@ python:
     - method: pip
       path: .
       extra_requirements:
-        - [docs, tests]
+        - [doc, tests]


### PR DESCRIPTION
Extra requirements need to be `[doc, tests]`, not `[docs, tests]`.

Follow-up to https://github.com/makepath/xarray-spatial/pull/797