### PR TITLE
Allow Negative Target Height in Viewshed Analysis (viewshed.py)

### DIFF
--- a/xrspatial/viewshed.py
+++ b/xrspatial/viewshed.py
@@ -1538,7 +1538,7 @@ def _viewshed_cpu(
     viewpoint_col = x_view
     viewpoint_elev = raster.values[y_view, x_view] + observer_elev
     viewpoint_target = 0.0
-    if target_elev > 0:
+    if abs(target_elev) > 0:
         viewpoint_target = target_elev
 
     # int getgrdhead(FILE * fd, struct Cell_head *cellhd)


### PR DESCRIPTION
**Description:**

This pull request introduces support for negative target heights in the viewshed function. The modification ensures that target points can have a decreased z-value, which is particularly useful for cases where visibility analysis needs to account for building facades rather than rooftops.

**Reason for Change:**

When using the library for viewshed analysis from an observer in a tall building, the function primarily returns visible points on rooftops rather than building facades. Allowing negative target heights makes it possible to adjust the z-value of the target point while keeping all other points treated normally, improving accuracy in urban visibility studies.

Fixes #

## Proposed Changes
Modified the conditional check in _viewshed_cpu from:
`if target_elev > 0:` to `if abs(target_elev) > 0`
  - This change ensures that the viewshed function correctly considers negative target heights while maintaining the existing behavior for positive values. 