### PR TITLE
Fixes #734: make noise a lazy import in datasets module

### DIFF
--- a/xrspatial/datasets/__init__.py
+++ b/xrspatial/datasets/__init__.py
@@ -6,7 +6,6 @@ except ImportError:
     da = None
 
 import datashader as ds
-import noise
 import numpy as np
 import pandas as pd
 import xarray as xr
@@ -80,6 +79,13 @@ def make_terrain(
     terrain : xarray.DataArray
         2D array of generated terrain values.
     """
+
+    try:
+        import noise
+    except ImportError:
+        raise ImportError(
+            "make_terrain requires the 'noise' package: pip install noise"
+        )
 
     if da is None:
         raise Exception("make terrain requires dask.Array (pip install dask)")


### PR DESCRIPTION
## Summary
- Move `import noise` from top-level in `xrspatial/datasets/__init__.py` to inside `make_terrain()`, guarded by try/except
- Previously, `from xrspatial.datasets import get_data` would fail with `ModuleNotFoundError: No module named 'noise'` on a fresh `pip install xarray-spatial` since `noise` is only in `[options.extras_require] tests`
- Now the module imports cleanly without `noise`, and `make_terrain()` raises a clear `ImportError` with install instructions

## Test plan
- [x] Verified `xrspatial.datasets` imports successfully without `noise` installed
- [x] Verified `make_terrain()` works when `noise` is installed
- [x] Verified `make_terrain()` gives a clear error when `noise` is missing: `ImportError: make_terrain requires the 'noise' package: pip install noise`