### PR TITLE
Fixes #845: add configurable boundary mode to kernel-based spatial ops

### DIFF
--- a/xrspatial/aspect.py
+++ b/xrspatial/aspect.py
@@ -16,7 +16,10 @@ from numba import cuda
 
 from xrspatial.utils import ArrayTypeFunctionMapping
 from xrspatial.utils import Z_UNITS
+from xrspatial.utils import _boundary_to_dask
 from xrspatial.utils import _extract_latlon_coords
+from xrspatial.utils import _pad_array
+from xrspatial.utils import _validate_boundary
 from xrspatial.utils import cuda_args
 from xrspatial.utils import ngjit
 from xrspatial.dataset_support import supports_dataset
@@ -54,7 +57,7 @@ RADIAN = 180 / np.pi
 # =====================================================================
 
 @ngjit
-def _run_numpy(data: np.ndarray):
+def _cpu(data: np.ndarray):
     data = data.astype(np.float32)
     out = np.zeros_like(data, dtype=np.float32)
     out[:] = np.nan
@@ -88,6 +91,14 @@ def _run_numpy(data: np.ndarray):
                     out[y, x] = 90.0 - _aspect
 
     return out
+
+
+def _run_numpy(data: np.ndarray, boundary: str = 'nan') -> np.ndarray:
+    if boundary == 'nan':
+        return _cpu(data)
+    padded = _pad_array(data, 1, boundary)
+    result = _cpu(padded)
+    return result[1:-1, 1:-1]
 
 
 @cuda.jit(device=True)
@@ -136,7 +147,12 @@ def _run_gpu(arr, out):
         out[i, j] = _gpu(arr[i-di:i+di+1, j-dj:j+dj+1])
 
 
-def _run_cupy(data: cupy.ndarray) -> cupy.ndarray:
+def _run_cupy(data: cupy.ndarray, boundary: str = 'nan') -> cupy.ndarray:
+    if boundary != 'nan':
+        padded = _pad_array(data, 1, boundary)
+        result = _run_cupy(padded)
+        return result[1:-1, 1:-1]
+
     data = data.astype(cupy.float32)
     griddim, blockdim = cuda_args(data.shape)
     out = cupy.empty(data.shape, dtype='f4')
@@ -145,22 +161,22 @@ def _run_cupy(data: cupy.ndarray) -> cupy.ndarray:
     return out
 
 
-def _run_dask_numpy(data: da.Array) -> da.Array:
+def _run_dask_numpy(data: da.Array, boundary: str = 'nan') -> da.Array:
     data = data.astype(np.float32)
-    _func = partial(_run_numpy)
+    _func = partial(_cpu)
     out = data.map_overlap(_func,
                            depth=(1, 1),
-                           boundary=np.nan,
+                           boundary=_boundary_to_dask(boundary),
                            meta=np.array(()))
     return out
 
 
-def _run_dask_cupy(data: da.Array) -> da.Array:
+def _run_dask_cupy(data: da.Array, boundary: str = 'nan') -> da.Array:
     data = data.astype(cupy.float32)
     _func = partial(_run_cupy)
     out = data.map_overlap(_func,
                            depth=(1, 1),
-                           boundary=cupy.nan,
+                           boundary=_boundary_to_dask(boundary, is_cupy=True),
                            meta=cupy.array(()))
     return out
 
@@ -169,7 +185,14 @@ def _run_dask_cupy(data: da.Array) -> da.Array:
 # Geodesic backend functions
 # =====================================================================
 
-def _run_numpy_geodesic(data, lat_2d, lon_2d, a2, b2, z_factor):
+def _run_numpy_geodesic(data, lat_2d, lon_2d, a2, b2, z_factor, boundary='nan'):
+    if boundary != 'nan':
+        data_p = _pad_array(data.astype(np.float64), 1, boundary)
+        lat_p = _pad_array(lat_2d, 1, boundary)
+        lon_p = _pad_array(lon_2d, 1, boundary)
+        stacked = np.stack([data_p, lat_p, lon_p], axis=0)
+        result = _cpu_geodesic_aspect(stacked, a2, b2, z_factor)
+        return result[1:-1, 1:-1]
     stacked = np.stack([
         data.astype(np.float64),
         lat_2d,
@@ -178,7 +201,22 @@ def _run_numpy_geodesic(data, lat_2d, lon_2d, a2, b2, z_factor):
     return _cpu_geodesic_aspect(stacked, a2, b2, z_factor)
 
 
-def _run_cupy_geodesic(data, lat_2d, lon_2d, a2, b2, z_factor):
+def _run_cupy_geodesic(data, lat_2d, lon_2d, a2, b2, z_factor, boundary='nan'):
+    if boundary != 'nan':
+        data_p = _pad_array(data.astype(cupy.float64), 1, boundary)
+        lat_p = _pad_array(cupy.asarray(lat_2d, dtype=cupy.float64), 1, boundary)
+        lon_p = _pad_array(cupy.asarray(lon_2d, dtype=cupy.float64), 1, boundary)
+        stacked = cupy.stack([data_p, lat_p, lon_p], axis=0)
+        H, W = data_p.shape
+        out = cupy.full((H, W), cupy.nan, dtype=cupy.float32)
+        a2_arr = cupy.array([a2], dtype=cupy.float64)
+        b2_arr = cupy.array([b2], dtype=cupy.float64)
+        zf_arr = cupy.array([z_factor], dtype=cupy.float64)
+        inv_2r_arr = cupy.array([INV_2R], dtype=cupy.float64)
+        griddim, blockdim = _geodesic_cuda_dims((H, W))
+        _run_gpu_geodesic_aspect[griddim, blockdim](stacked, a2_arr, b2_arr, zf_arr, inv_2r_arr, out)
+        return out[1:-1, 1:-1]
+
     lat_2d_gpu = cupy.asarray(lat_2d, dtype=cupy.float64)
     lon_2d_gpu = cupy.asarray(lon_2d, dtype=cupy.float64)
     stacked = cupy.stack([
@@ -227,7 +265,7 @@ def _dask_geodesic_aspect_chunk_cupy(stacked_chunk, a2, b2, z_factor):
     return out
 
 
-def _run_dask_numpy_geodesic(data, lat_2d, lon_2d, a2, b2, z_factor):
+def _run_dask_numpy_geodesic(data, lat_2d, lon_2d, a2, b2, z_factor, boundary='nan'):
     lat_dask = da.from_array(lat_2d, chunks=data.chunksize)
     lon_dask = da.from_array(lon_2d, chunks=data.chunksize)
     stacked = da.stack([
@@ -237,16 +275,17 @@ def _run_dask_numpy_geodesic(data, lat_2d, lon_2d, a2, b2, z_factor):
     ], axis=0).rechunk({0: 3})
 
     _func = partial(_dask_geodesic_aspect_chunk, a2=a2, b2=b2, z_factor=z_factor)
+    dask_bnd = _boundary_to_dask(boundary)
     out = stacked.map_overlap(
         _func,
         depth=(0, 1, 1),
-        boundary=np.nan,
+        boundary={0: np.nan, 1: dask_bnd, 2: dask_bnd},
         meta=np.array((), dtype=np.float32),
     )
     return out[0]
 
 
-def _run_dask_cupy_geodesic(data, lat_2d, lon_2d, a2, b2, z_factor):
+def _run_dask_cupy_geodesic(data, lat_2d, lon_2d, a2, b2, z_factor, boundary='nan'):
     lat_dask = da.from_array(cupy.asarray(lat_2d, dtype=cupy.float64),
                              chunks=data.chunksize)
     lon_dask = da.from_array(cupy.asarray(lon_2d, dtype=cupy.float64),
@@ -258,10 +297,11 @@ def _run_dask_cupy_geodesic(data, lat_2d, lon_2d, a2, b2, z_factor):
     ], axis=0).rechunk({0: 3})
 
     _func = partial(_dask_geodesic_aspect_chunk_cupy, a2=a2, b2=b2, z_factor=z_factor)
+    dask_bnd = _boundary_to_dask(boundary, is_cupy=True)
     out = stacked.map_overlap(
         _func,
         depth=(0, 1, 1),
-        boundary=cupy.nan,
+        boundary={0: cupy.nan, 1: dask_bnd, 2: dask_bnd},
         meta=cupy.array((), dtype=cupy.float32),
     )
     return out[0]
@@ -275,7 +315,8 @@ def _run_dask_cupy_geodesic(data, lat_2d, lon_2d, a2, b2, z_factor):
 def aspect(agg: xr.DataArray,
            name: Optional[str] = 'aspect',
            method: str = 'planar',
-           z_unit: str = 'meter') -> xr.DataArray:
+           z_unit: str = 'meter',
+           boundary: str = 'nan') -> xr.DataArray:
     """
     Calculates the aspect value of an elevation aggregate.
 
@@ -314,6 +355,12 @@ def aspect(agg: xr.DataArray,
         Unit of the elevation values.  Only used when ``method='geodesic'``.
         Accepted values: ``'meter'``, ``'foot'``, ``'kilometer'``, ``'mile'``
         (and common aliases).
+    boundary : str, default='nan'
+        How to handle edges where the kernel extends beyond the raster.
+        ``'nan'``     — fill missing neighbours with NaN (default).
+        ``'nearest'`` — repeat edge values.
+        ``'reflect'`` — mirror at boundary.
+        ``'wrap'``    — periodic / toroidal.
 
     Returns
     -------
@@ -353,6 +400,7 @@ def aspect(agg: xr.DataArray,
         raise ValueError(
             f"method must be 'planar' or 'geodesic', got {method!r}"
         )
+    _validate_boundary(boundary)
 
     if method == 'planar':
         mapper = ArrayTypeFunctionMapping(
@@ -361,7 +409,7 @@ def aspect(agg: xr.DataArray,
             cupy_func=_run_cupy,
             dask_cupy_func=_run_dask_cupy,
         )
-        out = mapper(agg)(agg.data)
+        out = mapper(agg)(agg.data, boundary=boundary)
 
     else:  # geodesic
         if z_unit not in Z_UNITS:
@@ -379,7 +427,7 @@ def aspect(agg: xr.DataArray,
             dask_func=_run_dask_numpy_geodesic,
             dask_cupy_func=_run_dask_cupy_geodesic,
         )
-        out = mapper(agg)(agg.data, lat_2d, lon_2d, WGS84_A2, WGS84_B2, z_factor)
+        out = mapper(agg)(agg.data, lat_2d, lon_2d, WGS84_A2, WGS84_B2, z_factor, boundary)
 
     return xr.DataArray(out,
                         name=name,

--- a/xrspatial/convolution.py
+++ b/xrspatial/convolution.py
@@ -5,7 +5,8 @@ import numpy as np
 import xarray as xr
 from numba import cuda, jit, prange
 
-from xrspatial.utils import (ArrayTypeFunctionMapping, cuda_args, get_dataarray_resolution,
+from xrspatial.utils import (ArrayTypeFunctionMapping, _boundary_to_dask, _pad_array,
+                             _validate_boundary, cuda_args, get_dataarray_resolution,
                              not_implemented_func)
 
 # 3rd-party
@@ -313,14 +314,28 @@ def _convolve_2d_numpy(data, kernel):
     return out
 
 
-def _convolve_2d_dask_numpy(data, kernel):
+def _convolve_2d_numpy_boundary(data, kernel, boundary='nan'):
+    if boundary == 'nan':
+        return _convolve_2d_numpy(data, kernel)
+    pad_h = kernel.shape[0] // 2
+    pad_w = kernel.shape[1] // 2
+    padded = _pad_array(data, (pad_h, pad_w), boundary)
+    result = _convolve_2d_numpy(padded, kernel)
+    r0 = pad_h if pad_h else None
+    r1 = -pad_h if pad_h else None
+    c0 = pad_w if pad_w else None
+    c1 = -pad_w if pad_w else None
+    return result[r0:r1, c0:c1]
+
+
+def _convolve_2d_dask_numpy(data, kernel, boundary='nan'):
     data = data.astype(np.float32)
     pad_h = kernel.shape[0] // 2
     pad_w = kernel.shape[1] // 2
     _func = partial(_convolve_2d_numpy, kernel=kernel)
     out = data.map_overlap(_func,
                            depth=(pad_h, pad_w),
-                           boundary=np.nan,
+                           boundary=_boundary_to_dask(boundary),
                            meta=np.array(()))
     return out
 
@@ -365,7 +380,18 @@ def _convolve_2d_cuda(data, kernel, out):
     out[i, j] = s
 
 
-def _convolve_2d_cupy(data, kernel):
+def _convolve_2d_cupy(data, kernel, boundary='nan'):
+    if boundary != 'nan':
+        pad_h = kernel.shape[0] // 2
+        pad_w = kernel.shape[1] // 2
+        padded = _pad_array(data, (pad_h, pad_w), boundary)
+        result = _convolve_2d_cupy(padded, kernel)
+        r0 = pad_h if pad_h else None
+        r1 = -pad_h if pad_h else None
+        c0 = pad_w if pad_w else None
+        c1 = -pad_w if pad_w else None
+        return result[r0:r1, c0:c1]
+
     data = data.astype(cupy.float32)
     out = cupy.empty(data.shape, dtype='f4')
     out[:, :] = cupy.nan
@@ -374,30 +400,31 @@ def _convolve_2d_cupy(data, kernel):
     return out
 
 
-def _convolve_2d_dask_cupy(data, kernel):
+def _convolve_2d_dask_cupy(data, kernel, boundary='nan'):
     data = data.astype(cupy.float32)
     pad_h = kernel.shape[0] // 2
     pad_w = kernel.shape[1] // 2
     _func = partial(_convolve_2d_cupy, kernel=kernel)
     out = data.map_overlap(_func,
                            depth=(pad_h, pad_w),
-                           boundary=cupy.nan,
+                           boundary=_boundary_to_dask(boundary, is_cupy=True),
                            meta=cupy.array(()))
     return out
 
 
-def convolve_2d(data, kernel):
+def convolve_2d(data, kernel, boundary='nan'):
+    _validate_boundary(boundary)
     mapper = ArrayTypeFunctionMapping(
-        numpy_func=_convolve_2d_numpy,
+        numpy_func=_convolve_2d_numpy_boundary,
         cupy_func=_convolve_2d_cupy,
         dask_func=_convolve_2d_dask_numpy,
         dask_cupy_func=_convolve_2d_dask_cupy
     )
-    out = mapper(xr.DataArray(data))(data, kernel)
+    out = mapper(xr.DataArray(data))(data, kernel, boundary)
     return out
 
 
-def convolution_2d(agg, kernel, name='convolution_2d'):
+def convolution_2d(agg, kernel, name='convolution_2d', boundary='nan'):
     """
     Calculates, for all inner cells of an array, the 2D convolution of
     each cell. Convolution is frequently used for image
@@ -413,6 +440,12 @@ def convolution_2d(agg, kernel, name='convolution_2d'):
     kernel : array-like object
         Impulse kernel, determines area to apply impulse function for
         each cell.
+    boundary : str, default='nan'
+        How to handle edges where the kernel extends beyond the raster.
+        ``'nan'``     -- fill missing neighbours with NaN (default).
+        ``'nearest'`` -- repeat edge values.
+        ``'reflect'`` -- mirror at boundary.
+        ``'wrap'``    -- periodic / toroidal.
 
     Returns
     -------
@@ -513,7 +546,7 @@ def convolution_2d(agg, kernel, name='convolution_2d'):
     """
 
     # wrapper of convolve_2d
-    out = convolve_2d(agg.data, kernel)
+    out = convolve_2d(agg.data, kernel, boundary)
     return xr.DataArray(out,
                         name=name,
                         coords=agg.coords,

--- a/xrspatial/curvature.py
+++ b/xrspatial/curvature.py
@@ -22,6 +22,9 @@ from numba import cuda
 
 # local modules
 from xrspatial.utils import ArrayTypeFunctionMapping
+from xrspatial.utils import _boundary_to_dask
+from xrspatial.utils import _pad_array
+from xrspatial.utils import _validate_boundary
 from xrspatial.utils import cuda_args
 from xrspatial.utils import get_dataarray_resolution
 from xrspatial.utils import ngjit
@@ -42,20 +45,24 @@ def _cpu(data, cellsize):
 
 
 def _run_numpy(data: np.ndarray,
-               cellsize: Union[int, float]) -> np.ndarray:
-    # TODO: handle border edge effect
+               cellsize: Union[int, float],
+               boundary: str = 'nan') -> np.ndarray:
     data = data.astype(np.float32)
-    out = _cpu(data, cellsize)
-    return out
+    if boundary == 'nan':
+        return _cpu(data, cellsize)
+    padded = _pad_array(data, 1, boundary)
+    result = _cpu(padded, cellsize)
+    return result[1:-1, 1:-1]
 
 
 def _run_dask_numpy(data: da.Array,
-                    cellsize: Union[int, float]) -> da.Array:
+                    cellsize: Union[int, float],
+                    boundary: str = 'nan') -> da.Array:
     data = data.astype(np.float32)
     _func = partial(_cpu, cellsize=cellsize)
     out = data.map_overlap(_func,
                            depth=(1, 1),
-                           boundary=np.nan,
+                           boundary=_boundary_to_dask(boundary),
                            meta=np.array(()))
     return out
 
@@ -79,12 +86,16 @@ def _run_gpu(arr, cellsize, out):
 
 
 def _run_cupy(data: cupy.ndarray,
-              cellsize: Union[int, float]) -> cupy.ndarray:
+              cellsize: Union[int, float],
+              boundary: str = 'nan') -> cupy.ndarray:
+    if boundary != 'nan':
+        padded = _pad_array(data, 1, boundary)
+        result = _run_cupy(padded, cellsize)
+        return result[1:-1, 1:-1]
 
     data = data.astype(cupy.float32)
     cellsize_arr = cupy.array([float(cellsize)], dtype='f4')
 
-    # TODO: add padding
     griddim, blockdim = cuda_args(data.shape)
     out = cupy.empty(data.shape, dtype='f4')
     out[:] = cupy.nan
@@ -95,7 +106,8 @@ def _run_cupy(data: cupy.ndarray,
 
 
 def _run_dask_cupy(data: da.Array,
-                   cellsize: Union[int, float]) -> da.Array:
+                   cellsize: Union[int, float],
+                   boundary: str = 'nan') -> da.Array:
     data = data.astype(cupy.float32)
     cellsize_arr = cupy.array([float(cellsize)], dtype='f4')
 
@@ -103,14 +115,15 @@ def _run_dask_cupy(data: da.Array,
 
     out = data.map_overlap(_func,
                            depth=(1, 1),
-                           boundary=cupy.nan,
+                           boundary=_boundary_to_dask(boundary, is_cupy=True),
                            meta=cupy.array(()))
     return out
 
 
 @supports_dataset
 def curvature(agg: xr.DataArray,
-              name: Optional[str] = 'curvature') -> xr.DataArray:
+              name: Optional[str] = 'curvature',
+              boundary: str = 'nan') -> xr.DataArray:
     """
     Calculates, for all cells in the array, the curvature (second
     derivative) of each cell based on the elevation of its neighbors
@@ -130,6 +143,12 @@ def curvature(agg: xr.DataArray,
         data variable independently.
     name : str, default='curvature'
         Name of output DataArray.
+    boundary : str, default='nan'
+        How to handle edges where the kernel extends beyond the raster.
+        ``'nan'``     — fill missing neighbours with NaN (default).
+        ``'nearest'`` — repeat edge values.
+        ``'reflect'`` — mirror at boundary.
+        ``'wrap'``    — periodic / toroidal.
 
     Returns
     -------
@@ -233,13 +252,15 @@ def curvature(agg: xr.DataArray,
     cellsize_x, cellsize_y = get_dataarray_resolution(agg)
     cellsize = (cellsize_x + cellsize_y) / 2
 
+    _validate_boundary(boundary)
+
     mapper = ArrayTypeFunctionMapping(
         numpy_func=_run_numpy,
         cupy_func=_run_cupy,
         dask_func=_run_dask_numpy,
         dask_cupy_func=_run_dask_cupy
     )
-    out = mapper(agg)(agg.data, cellsize)
+    out = mapper(agg)(agg.data, cellsize, boundary)
     return xr.DataArray(out,
                         name=name,
                         coords=agg.coords,

--- a/xrspatial/focal.py
+++ b/xrspatial/focal.py
@@ -28,7 +28,8 @@ except ImportError:
         ndarray = False
 
 from xrspatial.convolution import convolve_2d, custom_kernel, _convolve_2d_numpy
-from xrspatial.utils import ArrayTypeFunctionMapping, cuda_args, ngjit, not_implemented_func
+from xrspatial.utils import (ArrayTypeFunctionMapping, _boundary_to_dask, _pad_array,
+                             _validate_boundary, cuda_args, ngjit, not_implemented_func)
 from xrspatial.dataset_support import supports_dataset
 
 # TODO: Make convolution more generic with numba first-class functions.
@@ -67,11 +68,11 @@ def _mean_numpy(data, excludes):
     return out
 
 
-def _mean_dask_numpy(data, excludes):
+def _mean_dask_numpy(data, excludes, boundary='nan'):
     _func = partial(_mean_numpy, excludes=excludes)
     out = data.map_overlap(_func,
                            depth=(1, 1),
-                           boundary=np.nan,
+                           boundary=_boundary_to_dask(boundary),
                            meta=np.array(()))
     return out
 
@@ -146,12 +147,20 @@ def _mean_cupy(data, excludes):
     return out
 
 
-def _mean(data, excludes):
+def _mean_numpy_boundary(data, excludes, boundary='nan'):
+    if boundary == 'nan':
+        return _mean_numpy(data, excludes)
+    padded = _pad_array(data, 1, boundary)
+    result = _mean_numpy(padded, excludes)
+    return result[1:-1, 1:-1]
+
+
+def _mean(data, excludes, boundary='nan'):
     agg = xr.DataArray(data)
     mapper = ArrayTypeFunctionMapping(
-        numpy_func=_mean_numpy,
+        numpy_func=partial(_mean_numpy_boundary, boundary=boundary),
         cupy_func=_mean_cupy,
-        dask_func=_mean_dask_numpy,
+        dask_func=partial(_mean_dask_numpy, boundary=boundary),
         dask_cupy_func=lambda *args: not_implemented_func(
             *args, messages='mean() does not support dask with cupy backed DataArray.'),  # noqa
     )
@@ -160,7 +169,7 @@ def _mean(data, excludes):
 
 
 @supports_dataset
-def mean(agg, passes=1, excludes=[np.nan], name='mean'):
+def mean(agg, passes=1, excludes=[np.nan], name='mean', boundary='nan'):
     """
     Returns Mean filtered array using a 3x3 window.
     Default behaviour to 'mean' is to exclude NaNs from calculations.
@@ -175,6 +184,12 @@ def mean(agg, passes=1, excludes=[np.nan], name='mean'):
         Number of times to run mean.
     name : str, default='mean'
         Output xr.DataArray.name property.
+    boundary : str, default='nan'
+        How to handle edges where the kernel extends beyond the raster.
+        ``'nan'``     -- fill missing neighbours with NaN (default).
+        ``'nearest'`` -- repeat edge values.
+        ``'reflect'`` -- mirror at boundary.
+        ``'wrap'``    -- periodic / toroidal.
 
     Returns
     -------
@@ -254,9 +269,10 @@ def mean(agg, passes=1, excludes=[np.nan], name='mean'):
         Dimensions without coordinates: dim_0, dim_1
     """
 
+    _validate_boundary(boundary)
     out = agg.data.astype(float)
     for i in range(passes):
-        out = _mean(out, tuple(excludes))
+        out = _mean(out, tuple(excludes), boundary)
 
     return DataArray(out,
                      name=name,
@@ -326,7 +342,21 @@ def _apply_numpy(data, kernel, func):
     return out
 
 
-def _apply_dask_numpy(data, kernel, func):
+def _apply_numpy_boundary(data, kernel, func, boundary='nan'):
+    if boundary == 'nan':
+        return _apply_numpy(data, kernel, func)
+    pad_h = kernel.shape[0] // 2
+    pad_w = kernel.shape[1] // 2
+    padded = _pad_array(data, (pad_h, pad_w), boundary)
+    result = _apply_numpy(padded, kernel, func)
+    r0 = pad_h if pad_h else None
+    r1 = -pad_h if pad_h else None
+    c0 = pad_w if pad_w else None
+    c1 = -pad_w if pad_w else None
+    return result[r0:r1, c0:c1]
+
+
+def _apply_dask_numpy(data, kernel, func, boundary='nan'):
     data = data.astype(np.float32)
     _func = partial(_apply_numpy, kernel=kernel, func=func)
 
@@ -335,12 +365,12 @@ def _apply_dask_numpy(data, kernel, func):
 
     out = data.map_overlap(_func,
                            depth=(pad_h, pad_w),
-                           boundary=np.nan,
+                           boundary=_boundary_to_dask(boundary),
                            meta=np.array(()))
     return out
 
 
-def apply(raster, kernel, func=_calc_mean, name='focal_apply'):
+def apply(raster, kernel, func=_calc_mean, name='focal_apply', boundary='nan'):
     """
     Returns custom function applied array using a user-created window.
 
@@ -353,6 +383,12 @@ def apply(raster, kernel, func=_calc_mean, name='focal_apply'):
         2D array where values of 1 indicate the kernel.
     func : callable, default=xrspatial.focal._calc_mean
         Function which takes an input array and returns an array.
+    boundary : str, default='nan'
+        How to handle edges where the kernel extends beyond the raster.
+        ``'nan'``     -- fill missing neighbours with NaN (default).
+        ``'nearest'`` -- repeat edge values.
+        ``'reflect'`` -- mirror at boundary.
+        ``'wrap'``    -- periodic / toroidal.
 
     Returns
     -------
@@ -453,14 +489,16 @@ def apply(raster, kernel, func=_calc_mean, name='focal_apply'):
     # Validate the kernel
     kernel = custom_kernel(kernel)
 
+    _validate_boundary(boundary)
+
     # apply kernel to raster values
     # if raster is a numpy or dask with numpy backed data array,
     # the function func must be a @ngjit
     mapper = ArrayTypeFunctionMapping(
-        numpy_func=_apply_numpy,
+        numpy_func=partial(_apply_numpy_boundary, boundary=boundary),
         cupy_func=lambda *args: not_implemented_func(
             *args, messages='apply() does not support cupy backed DataArray.'),
-        dask_func=_apply_dask_numpy,
+        dask_func=partial(_apply_dask_numpy, boundary=boundary),
         dask_cupy_func=lambda *args: not_implemented_func(
             *args, messages='apply() does not support dask with cupy backed DataArray.'),
     )
@@ -779,7 +817,7 @@ def _focal_stats_cupy(agg, kernel, stats_funcs):
     return stats
 
 
-def _focal_stats_cpu(agg, kernel, stats_funcs):
+def _focal_stats_cpu(agg, kernel, stats_funcs, boundary='nan'):
     _function_mapping = {
         'mean': _calc_mean,
         'max': _calc_max,
@@ -791,7 +829,8 @@ def _focal_stats_cpu(agg, kernel, stats_funcs):
     }
     stats_aggs = []
     for stats in stats_funcs:
-        stats_agg = apply(agg, kernel, func=_function_mapping[stats])
+        stats_agg = apply(agg, kernel, func=_function_mapping[stats],
+                          boundary=boundary)
         stats_aggs.append(stats_agg)
     stats = xr.concat(stats_aggs, pd.Index(stats_funcs, name='stats', dtype=object))
     return stats
@@ -801,7 +840,8 @@ def focal_stats(agg,
                 kernel,
                 stats_funcs=[
                     'mean', 'max', 'min', 'range', 'std', 'var', 'sum'
-                ]):
+                ],
+                boundary='nan'):
     """
     Calculates statistics of the values within a specified focal neighborhood
     for each pixel in an input raster. The statistics types are Mean, Maximum,
@@ -817,6 +857,12 @@ def focal_stats(agg,
     stats_funcs: list of string
         List of statistics types to be calculated.
         Default set to ['mean', 'max', 'min', 'range', 'std', 'var', 'sum'].
+    boundary : str, default='nan'
+        How to handle edges where the kernel extends beyond the raster.
+        ``'nan'``     -- fill missing neighbours with NaN (default).
+        ``'nearest'`` -- repeat edge values.
+        ``'reflect'`` -- mirror at boundary.
+        ``'wrap'``    -- periodic / toroidal.
 
     Returns
     -------
@@ -867,10 +913,12 @@ def focal_stats(agg,
     # Validate the kernel
     kernel = custom_kernel(kernel)
 
+    _validate_boundary(boundary)
+
     mapper = ArrayTypeFunctionMapping(
-        numpy_func=_focal_stats_cpu,
+        numpy_func=partial(_focal_stats_cpu, boundary=boundary),
         cupy_func=_focal_stats_cupy,
-        dask_func=_focal_stats_cpu,
+        dask_func=partial(_focal_stats_cpu, boundary=boundary),
         dask_cupy_func=lambda *args: not_implemented_func(
             *args, messages='focal_stats() does not support dask with cupy backed DataArray.'),
     )
@@ -915,14 +963,14 @@ def _calc_hotspots_numpy(z_array):
     return out
 
 
-def _hotspots_numpy(raster, kernel):
+def _hotspots_numpy(raster, kernel, boundary='nan'):
     if not (issubclass(raster.data.dtype.type, np.integer) or
             issubclass(raster.data.dtype.type, np.floating)):
         raise ValueError("data type must be integer or float")
 
     data = raster.data.astype(np.float32)
     # apply kernel to raster values
-    mean_array = convolve_2d(data, kernel / kernel.sum())
+    mean_array = convolve_2d(data, kernel / kernel.sum(), boundary)
 
     # calculate z-scores
     global_mean = np.nanmean(data)
@@ -937,7 +985,7 @@ def _hotspots_numpy(raster, kernel):
     return out
 
 
-def _hotspots_dask_numpy(raster, kernel):
+def _hotspots_dask_numpy(raster, kernel, boundary='nan'):
     data = raster.data
     if not np.issubdtype(data.dtype, np.floating):
         data = data.astype(np.float32)
@@ -971,7 +1019,7 @@ def _hotspots_dask_numpy(raster, kernel):
     out = data.map_overlap(
         _func,
         depth=(pad_h, pad_w),
-        boundary=np.nan,
+        boundary=_boundary_to_dask(boundary),
         meta=np.array((), dtype=np.int8),
     )
     return out
@@ -1022,7 +1070,7 @@ def _run_gpu_hotspots(data, out):
         out[i, j] = _gpu_hotspots(data[i:i + 1, j:j + 1])
 
 
-def _hotspots_cupy(raster, kernel):
+def _hotspots_cupy(raster, kernel, boundary='nan'):
     if not (issubclass(raster.data.dtype.type, cupy.integer) or
             issubclass(raster.data.dtype.type, cupy.floating)):
         raise ValueError("data type must be integer or float")
@@ -1030,7 +1078,7 @@ def _hotspots_cupy(raster, kernel):
     data = raster.data.astype(cupy.float32)
 
     # apply kernel to raster values
-    mean_array = convolve_2d(data, kernel / kernel.sum())
+    mean_array = convolve_2d(data, kernel / kernel.sum(), boundary)
 
     # calculate z-scores
     global_mean = cupy.nanmean(data)
@@ -1047,7 +1095,7 @@ def _hotspots_cupy(raster, kernel):
     return out
 
 
-def hotspots(raster, kernel):
+def hotspots(raster, kernel, boundary='nan'):
     """
     Identify statistically significant hot spots and cold spots in an
     input raster. To be a statistically significant hot spot, a feature
@@ -1072,6 +1120,12 @@ def hotspots(raster, kernel):
         Can be a NumPy backed, CuPy backed, or Dask with NumPy backed DataArray
     kernel : Numpy Array
         2D array where values of 1 indicate the kernel.
+    boundary : str, default='nan'
+        How to handle edges where the kernel extends beyond the raster.
+        ``'nan'``     -- fill missing neighbours with NaN (default).
+        ``'nearest'`` -- repeat edge values.
+        ``'reflect'`` -- mirror at boundary.
+        ``'wrap'``    -- periodic / toroidal.
 
     Returns
     -------
@@ -1107,10 +1161,12 @@ def hotspots(raster, kernel):
     if raster.ndim != 2:
         raise ValueError("`raster` must be 2D")
 
+    _validate_boundary(boundary)
+
     mapper = ArrayTypeFunctionMapping(
-        numpy_func=_hotspots_numpy,
-        cupy_func=_hotspots_cupy,
-        dask_func=_hotspots_dask_numpy,
+        numpy_func=partial(_hotspots_numpy, boundary=boundary),
+        cupy_func=partial(_hotspots_cupy, boundary=boundary),
+        dask_func=partial(_hotspots_dask_numpy, boundary=boundary),
         dask_cupy_func=lambda *args: not_implemented_func(
             *args, messages='hotspots() does not support dask with cupy backed DataArray.'),  # noqa
     )

--- a/xrspatial/hillshade.py
+++ b/xrspatial/hillshade.py
@@ -13,13 +13,20 @@ import xarray as xr
 from numba import cuda
 
 from .gpu_rtx import has_rtx
-from .utils import (calc_cuda_dims, get_dataarray_resolution,
+from .utils import (_boundary_to_dask, _pad_array, _validate_boundary,
+                    calc_cuda_dims, get_dataarray_resolution,
                     has_cuda_and_cupy, is_cupy_array, is_cupy_backed)
 from .dataset_support import supports_dataset
 
 
 def _run_numpy(data, azimuth=225, angle_altitude=25,
-               cellsize_x=1.0, cellsize_y=1.0):
+               cellsize_x=1.0, cellsize_y=1.0, boundary='nan'):
+    if boundary != 'nan':
+        padded = _pad_array(data.astype(np.float32), 1, boundary)
+        result = _run_numpy(padded, azimuth, angle_altitude,
+                            cellsize_x, cellsize_y)
+        return result[1:-1, 1:-1]
+
     data = data.astype(np.float32)
 
     az_rad = azimuth * np.pi / 180.
@@ -51,7 +58,7 @@ def _run_numpy(data, azimuth=225, angle_altitude=25,
 
 
 def _run_dask_numpy(data, azimuth, angle_altitude,
-                    cellsize_x=1.0, cellsize_y=1.0):
+                    cellsize_x=1.0, cellsize_y=1.0, boundary='nan'):
     data = data.astype(np.float32)
 
     _func = partial(_run_numpy, azimuth=azimuth,
@@ -59,7 +66,7 @@ def _run_dask_numpy(data, azimuth, angle_altitude,
                     cellsize_x=cellsize_x, cellsize_y=cellsize_y)
     out = data.map_overlap(_func,
                            depth=(1, 1),
-                           boundary=np.nan,
+                           boundary=_boundary_to_dask(boundary),
                            meta=np.array(()))
     return out
 
@@ -91,7 +98,7 @@ def _gpu_calc_numba(
 
 
 def _run_dask_cupy(data, azimuth, angle_altitude,
-                   cellsize_x=1.0, cellsize_y=1.0):
+                   cellsize_x=1.0, cellsize_y=1.0, boundary='nan'):
     import cupy
     data = data.astype(cupy.float32)
 
@@ -100,13 +107,20 @@ def _run_dask_cupy(data, azimuth, angle_altitude,
                     cellsize_x=cellsize_x, cellsize_y=cellsize_y)
     out = data.map_overlap(_func,
                            depth=(1, 1),
-                           boundary=cupy.nan,
+                           boundary=_boundary_to_dask(boundary, is_cupy=True),
                            meta=cupy.array(()))
     return out
 
 
 def _run_cupy(d_data, azimuth, angle_altitude,
-              cellsize_x=1.0, cellsize_y=1.0):
+              cellsize_x=1.0, cellsize_y=1.0, boundary='nan'):
+    if boundary != 'nan':
+        import cupy
+        padded = _pad_array(d_data.astype(cupy.float32), 1, boundary)
+        result = _run_cupy(padded, azimuth, angle_altitude,
+                           cellsize_x, cellsize_y)
+        return result[1:-1, 1:-1]
+
     altituderad = angle_altitude * np.pi / 180.
     azimuthrad = azimuth * np.pi / 180.
     sin_alt = np.sin(altituderad)
@@ -137,7 +151,8 @@ def hillshade(agg: xr.DataArray,
               azimuth: int = 225,
               angle_altitude: int = 25,
               name: Optional[str] = 'hillshade',
-              shadows: bool = False) -> xr.DataArray:
+              shadows: bool = False,
+              boundary: str = 'nan') -> xr.DataArray:
     """
     Calculates, for all cells in the array, an illumination value of
     each cell based on illumination from a specific azimuth and
@@ -162,6 +177,12 @@ def hillshade(agg: xr.DataArray,
         Whether to calculate shadows or not. Shadows are available
         only for Cupy-backed Dask arrays and only if rtxpy is
         installed and appropriate graphics hardware is available.
+    boundary : str, default='nan'
+        How to handle edges where the kernel extends beyond the raster.
+        ``'nan'``     — fill missing neighbours with NaN (default).
+        ``'nearest'`` — repeat edge values.
+        ``'reflect'`` — mirror at boundary.
+        ``'wrap'``    — periodic / toroidal.
 
     Returns
     -------
@@ -200,12 +221,14 @@ def hillshade(agg: xr.DataArray,
         raise RuntimeError(
             "Can only calculate shadows if cupy and rtxpy are available")
 
+    _validate_boundary(boundary)
+
     cellsize_x, cellsize_y = get_dataarray_resolution(agg)
 
     # numpy case
     if isinstance(agg.data, np.ndarray):
         out = _run_numpy(agg.data, azimuth, angle_altitude,
-                         cellsize_x, cellsize_y)
+                         cellsize_x, cellsize_y, boundary)
 
     # cupy/numba case
     elif has_cuda_and_cupy() and is_cupy_array(agg.data):
@@ -214,18 +237,18 @@ def hillshade(agg: xr.DataArray,
             out = hillshade_rtx(agg, azimuth, angle_altitude, shadows=shadows)
         else:
             out = _run_cupy(agg.data, azimuth, angle_altitude,
-                            cellsize_x, cellsize_y)
+                            cellsize_x, cellsize_y, boundary)
 
     # dask + cupy case
     elif (has_cuda_and_cupy() and da is not None and isinstance(agg.data, da.Array) and
             is_cupy_backed(agg)):
         out = _run_dask_cupy(agg.data, azimuth, angle_altitude,
-                             cellsize_x, cellsize_y)
+                             cellsize_x, cellsize_y, boundary)
 
     # dask + numpy case
     elif da is not None and isinstance(agg.data, da.Array):
         out = _run_dask_numpy(agg.data, azimuth, angle_altitude,
-                              cellsize_x, cellsize_y)
+                              cellsize_x, cellsize_y, boundary)
 
     else:
         raise TypeError('Unsupported Array Type: {}'.format(type(agg.data)))

--- a/xrspatial/slope.py
+++ b/xrspatial/slope.py
@@ -23,8 +23,12 @@ from numba import cuda
 
 # local modules
 from xrspatial.utils import ArrayTypeFunctionMapping
+from xrspatial.utils import VALID_BOUNDARY_MODES
 from xrspatial.utils import Z_UNITS
+from xrspatial.utils import _boundary_to_dask
 from xrspatial.utils import _extract_latlon_coords
+from xrspatial.utils import _pad_array
+from xrspatial.utils import _validate_boundary
 from xrspatial.utils import cuda_args
 from xrspatial.utils import get_dataarray_resolution
 from xrspatial.utils import ngjit
@@ -78,14 +82,19 @@ def _cpu(data, cellsize_x, cellsize_y):
 
 def _run_numpy(data: np.ndarray,
                cellsize_x: Union[int, float],
-               cellsize_y: Union[int, float]) -> np.ndarray:
-    out = _cpu(data, cellsize_x, cellsize_y)
-    return out
+               cellsize_y: Union[int, float],
+               boundary: str = 'nan') -> np.ndarray:
+    if boundary == 'nan':
+        return _cpu(data, cellsize_x, cellsize_y)
+    padded = _pad_array(data, 1, boundary)
+    result = _cpu(padded, cellsize_x, cellsize_y)
+    return result[1:-1, 1:-1]
 
 
 def _run_dask_numpy(data: da.Array,
                     cellsize_x: Union[int, float],
-                    cellsize_y: Union[int, float]) -> da.Array:
+                    cellsize_y: Union[int, float],
+                    boundary: str = 'nan') -> da.Array:
     data = data.astype(np.float32)
     _func = partial(_cpu,
                     cellsize_x=cellsize_x,
@@ -93,14 +102,15 @@ def _run_dask_numpy(data: da.Array,
 
     out = data.map_overlap(_func,
                            depth=(1, 1),
-                           boundary=np.nan,
+                           boundary=_boundary_to_dask(boundary),
                            meta=np.array(()))
     return out
 
 
 def _run_dask_cupy(data: da.Array,
                    cellsize_x: Union[int, float],
-                   cellsize_y: Union[int, float]) -> da.Array:
+                   cellsize_y: Union[int, float],
+                   boundary: str = 'nan') -> da.Array:
     data = data.astype(cupy.float32)
     _func = partial(_run_cupy,
                     cellsize_x=cellsize_x,
@@ -108,7 +118,7 @@ def _run_dask_cupy(data: da.Array,
 
     out = data.map_overlap(_func,
                            depth=(1, 1),
-                           boundary=cupy.nan,
+                           boundary=_boundary_to_dask(boundary, is_cupy=True),
                            meta=cupy.array(()))
     return out
 
@@ -144,7 +154,13 @@ def _run_gpu(arr, cellsize_x_arr, cellsize_y_arr, out):
 
 def _run_cupy(data: cupy.ndarray,
               cellsize_x: Union[int, float],
-              cellsize_y: Union[int, float]) -> cupy.ndarray:
+              cellsize_y: Union[int, float],
+              boundary: str = 'nan') -> cupy.ndarray:
+    if boundary != 'nan':
+        padded = _pad_array(data, 1, boundary)
+        result = _run_cupy(padded, cellsize_x, cellsize_y)
+        return result[1:-1, 1:-1]
+
     cellsize_x_arr = cupy.array([float(cellsize_x)], dtype='f4')
     cellsize_y_arr = cupy.array([float(cellsize_y)], dtype='f4')
     data = data.astype(cupy.float32)
@@ -164,7 +180,14 @@ def _run_cupy(data: cupy.ndarray,
 # Geodesic backend functions
 # =====================================================================
 
-def _run_numpy_geodesic(data, lat_2d, lon_2d, a2, b2, z_factor):
+def _run_numpy_geodesic(data, lat_2d, lon_2d, a2, b2, z_factor, boundary='nan'):
+    if boundary != 'nan':
+        data_p = _pad_array(data.astype(np.float64), 1, boundary)
+        lat_p = _pad_array(lat_2d, 1, boundary)
+        lon_p = _pad_array(lon_2d, 1, boundary)
+        stacked = np.stack([data_p, lat_p, lon_p], axis=0)
+        result = _cpu_geodesic_slope(stacked, a2, b2, z_factor)
+        return result[1:-1, 1:-1]
     stacked = np.stack([
         data.astype(np.float64),
         lat_2d,
@@ -173,7 +196,22 @@ def _run_numpy_geodesic(data, lat_2d, lon_2d, a2, b2, z_factor):
     return _cpu_geodesic_slope(stacked, a2, b2, z_factor)
 
 
-def _run_cupy_geodesic(data, lat_2d, lon_2d, a2, b2, z_factor):
+def _run_cupy_geodesic(data, lat_2d, lon_2d, a2, b2, z_factor, boundary='nan'):
+    if boundary != 'nan':
+        data_p = _pad_array(data.astype(cupy.float64), 1, boundary)
+        lat_p = _pad_array(cupy.asarray(lat_2d, dtype=cupy.float64), 1, boundary)
+        lon_p = _pad_array(cupy.asarray(lon_2d, dtype=cupy.float64), 1, boundary)
+        stacked = cupy.stack([data_p, lat_p, lon_p], axis=0)
+        H, W = data_p.shape
+        out = cupy.full((H, W), cupy.nan, dtype=cupy.float32)
+        a2_arr = cupy.array([a2], dtype=cupy.float64)
+        b2_arr = cupy.array([b2], dtype=cupy.float64)
+        zf_arr = cupy.array([z_factor], dtype=cupy.float64)
+        inv_2r_arr = cupy.array([INV_2R], dtype=cupy.float64)
+        griddim, blockdim = _geodesic_cuda_dims((H, W))
+        _run_gpu_geodesic_slope[griddim, blockdim](stacked, a2_arr, b2_arr, zf_arr, inv_2r_arr, out)
+        return out[1:-1, 1:-1]
+
     lat_2d_gpu = cupy.asarray(lat_2d, dtype=cupy.float64)
     lon_2d_gpu = cupy.asarray(lon_2d, dtype=cupy.float64)
     stacked = cupy.stack([
@@ -224,7 +262,7 @@ def _dask_geodesic_slope_chunk_cupy(stacked_chunk, a2, b2, z_factor):
     return out
 
 
-def _run_dask_numpy_geodesic(data, lat_2d, lon_2d, a2, b2, z_factor):
+def _run_dask_numpy_geodesic(data, lat_2d, lon_2d, a2, b2, z_factor, boundary='nan'):
     lat_dask = da.from_array(lat_2d, chunks=data.chunksize)
     lon_dask = da.from_array(lon_2d, chunks=data.chunksize)
     stacked = da.stack([
@@ -234,16 +272,17 @@ def _run_dask_numpy_geodesic(data, lat_2d, lon_2d, a2, b2, z_factor):
     ], axis=0).rechunk({0: 3})  # all 3 channels in one chunk
 
     _func = partial(_dask_geodesic_slope_chunk, a2=a2, b2=b2, z_factor=z_factor)
+    dask_bnd = _boundary_to_dask(boundary)
     out = stacked.map_overlap(
         _func,
         depth=(0, 1, 1),
-        boundary=np.nan,
+        boundary={0: np.nan, 1: dask_bnd, 2: dask_bnd},
         meta=np.array((), dtype=np.float32),
     )
     return out[0]
 
 
-def _run_dask_cupy_geodesic(data, lat_2d, lon_2d, a2, b2, z_factor):
+def _run_dask_cupy_geodesic(data, lat_2d, lon_2d, a2, b2, z_factor, boundary='nan'):
     lat_dask = da.from_array(cupy.asarray(lat_2d, dtype=cupy.float64),
                              chunks=data.chunksize)
     lon_dask = da.from_array(cupy.asarray(lon_2d, dtype=cupy.float64),
@@ -255,10 +294,11 @@ def _run_dask_cupy_geodesic(data, lat_2d, lon_2d, a2, b2, z_factor):
     ], axis=0).rechunk({0: 3})  # all 3 channels in one chunk
 
     _func = partial(_dask_geodesic_slope_chunk_cupy, a2=a2, b2=b2, z_factor=z_factor)
+    dask_bnd = _boundary_to_dask(boundary, is_cupy=True)
     out = stacked.map_overlap(
         _func,
         depth=(0, 1, 1),
-        boundary=cupy.nan,
+        boundary={0: cupy.nan, 1: dask_bnd, 2: dask_bnd},
         meta=cupy.array((), dtype=cupy.float32),
     )
     return out[0]
@@ -272,7 +312,8 @@ def _run_dask_cupy_geodesic(data, lat_2d, lon_2d, a2, b2, z_factor):
 def slope(agg: xr.DataArray,
           name: str = 'slope',
           method: str = 'planar',
-          z_unit: str = 'meter') -> xr.DataArray:
+          z_unit: str = 'meter',
+          boundary: str = 'nan') -> xr.DataArray:
     """
     Returns slope of input aggregate in degrees.
 
@@ -293,6 +334,12 @@ def slope(agg: xr.DataArray,
         Unit of the elevation values.  Only used when ``method='geodesic'``.
         Accepted values: ``'meter'``, ``'foot'``, ``'kilometer'``, ``'mile'``
         (and common aliases).
+    boundary : str, default='nan'
+        How to handle edges where the kernel extends beyond the raster.
+        ``'nan'``     — fill missing neighbours with NaN (default).
+        ``'nearest'`` — repeat edge values.
+        ``'reflect'`` — mirror at boundary.
+        ``'wrap'``    — periodic / toroidal.
 
     Returns
     -------
@@ -335,6 +382,7 @@ def slope(agg: xr.DataArray,
         raise ValueError(
             f"method must be 'planar' or 'geodesic', got {method!r}"
         )
+    _validate_boundary(boundary)
 
     if method == 'planar':
         cellsize_x, cellsize_y = get_dataarray_resolution(agg)
@@ -344,7 +392,7 @@ def slope(agg: xr.DataArray,
             dask_func=_run_dask_numpy,
             dask_cupy_func=_run_dask_cupy,
         )
-        out = mapper(agg)(agg.data, cellsize_x, cellsize_y)
+        out = mapper(agg)(agg.data, cellsize_x, cellsize_y, boundary)
 
     else:  # geodesic
         if z_unit not in Z_UNITS:
@@ -362,7 +410,7 @@ def slope(agg: xr.DataArray,
             dask_func=_run_dask_numpy_geodesic,
             dask_cupy_func=_run_dask_cupy_geodesic,
         )
-        out = mapper(agg)(agg.data, lat_2d, lon_2d, WGS84_A2, WGS84_B2, z_factor)
+        out = mapper(agg)(agg.data, lat_2d, lon_2d, WGS84_A2, WGS84_B2, z_factor, boundary)
 
     return xr.DataArray(out,
                         name=name,

--- a/xrspatial/tests/general_checks.py
+++ b/xrspatial/tests/general_checks.py
@@ -121,6 +121,59 @@ def assert_nan_edges_effect(result_agg):
         np.testing.assert_array_equal(edge, np.nan)
 
 
+def assert_boundary_mode_correctness(numpy_agg, dask_agg, func, depth=1, rtol=1e-5,
+                                     nan_edges=True):
+    """Verify that all boundary modes produce correct output.
+
+    Checks:
+    - 'nan' mode: edges are NaN (preserves existing behaviour) if nan_edges=True.
+    - 'nearest', 'reflect', 'wrap': shape matches input and
+      numpy matches dask result. When source data has no NaN,
+      edge cells should also have no NaN.
+
+    Parameters
+    ----------
+    nan_edges : bool
+        If True, verify that boundary='nan' produces NaN at edges.
+        Set to False for functions like mean/apply/hotspots that don't
+        produce NaN edges even with boundary='nan'.
+    """
+    from xrspatial.utils import VALID_BOUNDARY_MODES
+    from functools import partial as _partial
+
+    source_has_nan = np.any(np.isnan(numpy_agg.data))
+
+    for mode in VALID_BOUNDARY_MODES:
+        _func = _partial(func, boundary=mode)
+        result_np = _func(numpy_agg)
+
+        assert result_np.shape == numpy_agg.shape, (
+            f"boundary={mode!r}: shape mismatch "
+            f"{result_np.shape} vs {numpy_agg.shape}"
+        )
+
+        if mode == 'nan' and nan_edges:
+            assert_nan_edges_effect(result_np)
+        elif mode != 'nan' and not source_has_nan:
+            result_data = result_np.data
+            if has_dask_array() and isinstance(result_data, da.Array):
+                result_data = result_data.compute()
+            assert not np.any(np.isnan(result_data)), (
+                f"boundary={mode!r}: output should have no NaN values "
+                f"when source data has none"
+            )
+
+        if dask_agg is not None and has_dask_array():
+            result_da = _func(dask_agg)
+            da_data = result_da.data
+            if isinstance(da_data, da.Array):
+                da_data = da_data.compute()
+            np.testing.assert_allclose(
+                result_np.data, da_data,
+                equal_nan=True, rtol=rtol,
+            )
+
+
 def assert_numpy_equals_dask_numpy(numpy_agg, dask_agg, func, nan_edges=True):
     numpy_result = func(numpy_agg)
     if nan_edges:

--- a/xrspatial/tests/test_aspect.py
+++ b/xrspatial/tests/test_aspect.py
@@ -2,7 +2,8 @@ import numpy as np
 import pytest
 
 from xrspatial import aspect
-from xrspatial.tests.general_checks import (assert_nan_edges_effect,
+from xrspatial.tests.general_checks import (assert_boundary_mode_correctness,
+                                            assert_nan_edges_effect,
                                             assert_numpy_equals_cupy,
                                             assert_numpy_equals_dask_cupy,
                                             assert_numpy_equals_dask_numpy,
@@ -92,3 +93,53 @@ def test_numpy_equals_dask_cupy_random_data(random_data):
     numpy_agg = create_test_raster(random_data, backend='numpy')
     dask_cupy_agg = create_test_raster(random_data, backend='dask+cupy')
     assert_numpy_equals_dask_cupy(numpy_agg, dask_cupy_agg, aspect, atol=1e-6, rtol=1e-6)
+
+
+@dask_array_available
+def test_boundary_modes(elevation_raster):
+    numpy_agg = input_data(elevation_raster, 'numpy')
+    dask_agg = input_data(elevation_raster, 'dask+numpy')
+    assert_boundary_mode_correctness(numpy_agg, dask_agg, aspect)
+
+
+@dask_array_available
+@pytest.mark.parametrize("boundary", ['nan', 'nearest', 'reflect', 'wrap'])
+@pytest.mark.parametrize("size,chunks", [
+    ((6, 8), (3, 4)),
+    ((7, 9), (3, 3)),
+    ((10, 15), (5, 5)),
+    ((10, 15), (10, 15)),
+    ((5, 5), (2, 2)),
+])
+def test_boundary_numpy_equals_dask(boundary, size, chunks):
+    rng = np.random.default_rng(42)
+    data = rng.random(size).astype(np.float64) * 500
+    numpy_agg = create_test_raster(data, backend='numpy')
+    dask_agg = create_test_raster(data, backend='dask+numpy', chunks=chunks)
+    np_result = aspect(numpy_agg, boundary=boundary)
+    da_result = aspect(dask_agg, boundary=boundary)
+    np.testing.assert_allclose(
+        np_result.data, da_result.data.compute(), equal_nan=True, rtol=1e-5)
+
+
+@dask_array_available
+@pytest.mark.parametrize("boundary", ['nearest', 'reflect', 'wrap'])
+def test_boundary_no_nan_edges(boundary, elevation_raster_no_nans):
+    """Non-nan modes produce no NaN output when source has no NaN."""
+    numpy_agg = create_test_raster(elevation_raster_no_nans, backend='numpy')
+    dask_agg = create_test_raster(elevation_raster_no_nans, backend='dask+numpy',
+                                  chunks=(4, 3))
+    np_result = aspect(numpy_agg, boundary=boundary)
+    da_result = aspect(dask_agg, boundary=boundary)
+    # aspect returns -1 for flat areas, but should not return NaN
+    assert not np.any(np.isnan(np_result.data))
+    assert not np.any(np.isnan(da_result.data.compute()))
+    np.testing.assert_allclose(
+        np_result.data, da_result.data.compute(), equal_nan=True, rtol=1e-5)
+
+
+def test_boundary_invalid():
+    data = np.ones((4, 5), dtype=np.float32)
+    agg = create_test_raster(data)
+    with pytest.raises(ValueError, match="boundary must be one of"):
+        aspect(agg, boundary='invalid')

--- a/xrspatial/tests/test_curvature.py
+++ b/xrspatial/tests/test_curvature.py
@@ -2,7 +2,8 @@ import numpy as np
 import pytest
 
 from xrspatial import curvature
-from xrspatial.tests.general_checks import (assert_numpy_equals_cupy,
+from xrspatial.tests.general_checks import (assert_boundary_mode_correctness,
+                                            assert_numpy_equals_cupy,
                                             assert_numpy_equals_dask_cupy,
                                             assert_numpy_equals_dask_numpy,
                                             create_test_raster,
@@ -112,3 +113,54 @@ def test_numpy_equals_dask_cupy_random_data(random_data):
     numpy_agg = create_test_raster(random_data, backend='numpy')
     dask_cupy_agg = create_test_raster(random_data, backend='dask+cupy')
     assert_numpy_equals_dask_cupy(numpy_agg, dask_cupy_agg, curvature, atol=1e-6, rtol=1e-6)
+
+
+@dask_array_available
+def test_boundary_modes():
+    data = np.random.default_rng(42).random((8, 10)).astype(np.float64) * 100
+    numpy_agg = create_test_raster(data, attrs={'res': (1, 1)})
+    dask_agg = create_test_raster(data, backend='dask+numpy', attrs={'res': (1, 1)})
+    assert_boundary_mode_correctness(numpy_agg, dask_agg, curvature)
+
+
+@dask_array_available
+@pytest.mark.parametrize("boundary", ['nan', 'nearest', 'reflect', 'wrap'])
+@pytest.mark.parametrize("size,chunks", [
+    ((6, 8), (3, 4)),
+    ((7, 9), (3, 3)),
+    ((10, 15), (5, 5)),
+    ((10, 15), (10, 15)),
+    ((5, 5), (2, 2)),
+])
+def test_boundary_numpy_equals_dask(boundary, size, chunks):
+    rng = np.random.default_rng(42)
+    data = rng.random(size).astype(np.float64) * 100
+    numpy_agg = create_test_raster(data, backend='numpy', attrs={'res': (1, 1)})
+    dask_agg = create_test_raster(data, backend='dask+numpy',
+                                  attrs={'res': (1, 1)}, chunks=chunks)
+    np_result = curvature(numpy_agg, boundary=boundary)
+    da_result = curvature(dask_agg, boundary=boundary)
+    np.testing.assert_allclose(
+        np_result.data, da_result.data.compute(), equal_nan=True, rtol=1e-5)
+
+
+@dask_array_available
+@pytest.mark.parametrize("boundary", ['nearest', 'reflect', 'wrap'])
+def test_boundary_no_nan_flat(boundary):
+    """Flat surface with non-nan boundary should produce all zeros, no NaN."""
+    data = np.full((8, 10), 50.0, dtype=np.float64)
+    numpy_agg = create_test_raster(data, backend='numpy', attrs={'res': (1, 1)})
+    dask_agg = create_test_raster(data, backend='dask+numpy',
+                                  attrs={'res': (1, 1)}, chunks=(4, 5))
+    np_result = curvature(numpy_agg, boundary=boundary)
+    da_result = curvature(dask_agg, boundary=boundary)
+    np.testing.assert_allclose(np_result.data, 0.0, atol=1e-10)
+    np.testing.assert_allclose(np_result.data, da_result.data.compute(),
+                               equal_nan=True, rtol=1e-6)
+
+
+def test_boundary_invalid():
+    data = np.ones((4, 5), dtype=np.float32)
+    agg = create_test_raster(data, attrs={'res': (1, 1)})
+    with pytest.raises(ValueError, match="boundary must be one of"):
+        curvature(agg, boundary='invalid')

--- a/xrspatial/tests/test_focal.py
+++ b/xrspatial/tests/test_focal.py
@@ -11,7 +11,8 @@ from xrspatial import mean
 from xrspatial.convolution import (annulus_kernel, calc_cellsize, circle_kernel, convolution_2d,
                                    convolve_2d, custom_kernel)
 from xrspatial.focal import apply, focal_stats, hotspots
-from xrspatial.tests.general_checks import (create_test_raster,
+from xrspatial.tests.general_checks import (assert_boundary_mode_correctness,
+                                            create_test_raster,
                                             cuda_and_cupy_available,
                                             dask_array_available,
                                             general_output_checks)
@@ -508,3 +509,175 @@ def test_hotspot_gpu(data_hotspots):
             cupy_hotspots[coord].data, cupy_agg[coord].data, equal_nan=True
         )
     assert cupy_hotspots.attrs['unit'] == '%'
+
+
+@dask_array_available
+def test_convolution_2d_boundary_modes():
+    data = np.random.default_rng(42).random((8, 10)).astype(np.float64)
+    kernel = np.array([[0, 1, 0], [1, 1, 1], [0, 1, 0]], dtype=np.float64)
+    numpy_agg = create_test_raster(data)
+    dask_agg = create_test_raster(data, backend='dask+numpy')
+    from functools import partial
+    func = partial(convolution_2d, kernel=kernel)
+    assert_boundary_mode_correctness(numpy_agg, dask_agg, func)
+
+
+def test_convolution_2d_boundary_invalid():
+    data = np.ones((4, 5), dtype=np.float32)
+    agg = create_test_raster(data)
+    kernel = np.ones((3, 3))
+    with pytest.raises(ValueError, match="boundary must be one of"):
+        convolution_2d(agg, kernel, boundary='invalid')
+
+
+@dask_array_available
+def test_mean_boundary_modes():
+    data = np.random.default_rng(42).random((8, 10)).astype(np.float64)
+    numpy_agg = xr.DataArray(data, dims=['y', 'x'])
+    dask_numpy_agg = xr.DataArray(da.from_array(data, chunks=(4, 5)), dims=['y', 'x'])
+    assert_boundary_mode_correctness(numpy_agg, dask_numpy_agg, mean, nan_edges=False)
+
+
+def test_mean_boundary_invalid():
+    data = np.ones((4, 5), dtype=np.float32)
+    agg = xr.DataArray(data, dims=['y', 'x'])
+    with pytest.raises(ValueError, match="boundary must be one of"):
+        mean(agg, boundary='invalid')
+
+
+@dask_array_available
+def test_apply_boundary_modes():
+    data = np.random.default_rng(42).random((8, 10)).astype(np.float64)
+    kernel = np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]])
+    numpy_agg = create_test_raster(data)
+    dask_agg = create_test_raster(data, backend='dask+numpy')
+    from functools import partial
+    func = partial(apply, kernel=kernel, func=func_zero_cpu)
+    assert_boundary_mode_correctness(numpy_agg, dask_agg, func, nan_edges=False)
+
+
+def test_apply_boundary_invalid():
+    data = np.ones((4, 5), dtype=np.float32)
+    agg = create_test_raster(data)
+    kernel = np.ones((3, 3))
+    with pytest.raises(ValueError, match="boundary must be one of"):
+        apply(agg, kernel, func_zero_cpu, boundary='invalid')
+
+
+@dask_array_available
+def test_hotspots_boundary_modes():
+    data = np.random.default_rng(42).standard_normal((10, 12)).astype(np.float64)
+    kernel = np.array([[0, 1, 0], [1, 1, 1], [0, 1, 0]], dtype=np.float64)
+    numpy_agg = create_test_raster(data)
+    dask_agg = create_test_raster(data, backend='dask+numpy')
+    from functools import partial
+    func = partial(hotspots, kernel=kernel)
+    assert_boundary_mode_correctness(numpy_agg, dask_agg, func, nan_edges=False)
+
+
+def test_hotspots_boundary_invalid():
+    data = np.random.default_rng(42).standard_normal((10, 12)).astype(np.float64)
+    agg = create_test_raster(data)
+    kernel = np.ones((3, 3))
+    with pytest.raises(ValueError, match="boundary must be one of"):
+        hotspots(agg, kernel, boundary='invalid')
+
+
+# --- Parametrized numpy-vs-dask cross-backend boundary tests ---
+
+
+@dask_array_available
+@pytest.mark.parametrize("boundary", ['nan', 'nearest', 'reflect', 'wrap'])
+@pytest.mark.parametrize("size,chunks", [
+    ((6, 8), (3, 4)),
+    ((7, 9), (3, 3)),
+    ((10, 15), (5, 5)),
+    ((10, 15), (10, 15)),
+    ((5, 5), (2, 2)),
+])
+def test_convolution_2d_boundary_numpy_equals_dask(boundary, size, chunks):
+    rng = np.random.default_rng(42)
+    data = rng.random(size).astype(np.float64)
+    kernel = np.array([[0, 1, 0], [1, 1, 1], [0, 1, 0]], dtype=np.float64)
+    numpy_agg = create_test_raster(data, backend='numpy')
+    dask_agg = create_test_raster(data, backend='dask+numpy', chunks=chunks)
+    np_result = convolution_2d(numpy_agg, kernel, boundary=boundary)
+    da_result = convolution_2d(dask_agg, kernel, boundary=boundary)
+    np.testing.assert_allclose(
+        np_result.data, da_result.data.compute(), equal_nan=True, rtol=1e-5)
+
+
+@dask_array_available
+@pytest.mark.parametrize("boundary", ['nan', 'nearest', 'reflect', 'wrap'])
+@pytest.mark.parametrize("size,chunks", [
+    ((8, 10), (4, 5)),
+    ((7, 9), (3, 3)),
+    ((12, 12), (6, 4)),
+    ((5, 5), (2, 2)),
+])
+def test_mean_boundary_numpy_equals_dask(boundary, size, chunks):
+    rng = np.random.default_rng(42)
+    data = rng.random(size).astype(np.float64)
+    numpy_agg = xr.DataArray(data, dims=['y', 'x'])
+    dask_agg = xr.DataArray(da.from_array(data, chunks=chunks), dims=['y', 'x'])
+    np_result = mean(numpy_agg, boundary=boundary)
+    da_result = mean(dask_agg, boundary=boundary)
+    np.testing.assert_allclose(
+        np_result.data, da_result.data.compute(), equal_nan=True, rtol=1e-5)
+
+
+@dask_array_available
+@pytest.mark.parametrize("boundary", ['nan', 'nearest', 'reflect', 'wrap'])
+@pytest.mark.parametrize("size,chunks", [
+    ((6, 8), (3, 4)),
+    ((7, 9), (3, 3)),
+    ((10, 15), (5, 5)),
+    ((5, 5), (2, 2)),
+])
+def test_apply_boundary_numpy_equals_dask(boundary, size, chunks):
+    rng = np.random.default_rng(42)
+    data = rng.random(size).astype(np.float64)
+    kernel = np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]])
+    numpy_agg = create_test_raster(data, backend='numpy')
+    dask_agg = create_test_raster(data, backend='dask+numpy', chunks=chunks)
+    np_result = apply(numpy_agg, kernel, func_zero_cpu, boundary=boundary)
+    da_result = apply(dask_agg, kernel, func_zero_cpu, boundary=boundary)
+    np.testing.assert_allclose(
+        np_result.data, da_result.data.compute(), equal_nan=True, rtol=1e-5)
+
+
+@dask_array_available
+@pytest.mark.parametrize("boundary", ['nan', 'nearest', 'reflect', 'wrap'])
+@pytest.mark.parametrize("size,chunks", [
+    ((8, 10), (4, 5)),
+    ((7, 9), (3, 3)),
+    ((10, 12), (5, 6)),
+    ((5, 6), (2, 3)),
+])
+def test_hotspots_boundary_numpy_equals_dask(boundary, size, chunks):
+    rng = np.random.default_rng(42)
+    data = rng.standard_normal(size).astype(np.float64)
+    kernel = np.array([[0, 1, 0], [1, 1, 1], [0, 1, 0]], dtype=np.float64)
+    numpy_agg = create_test_raster(data, backend='numpy')
+    dask_agg = create_test_raster(data, backend='dask+numpy', chunks=chunks)
+    np_result = hotspots(numpy_agg, kernel, boundary=boundary)
+    da_result = hotspots(dask_agg, kernel, boundary=boundary)
+    np.testing.assert_allclose(
+        np_result.data, da_result.data.compute(), equal_nan=True, rtol=1e-5)
+
+
+@dask_array_available
+@pytest.mark.parametrize("boundary", ['nearest', 'reflect', 'wrap'])
+def test_convolution_2d_boundary_no_nan(boundary):
+    """Non-nan modes produce no NaN output when source has no NaN."""
+    rng = np.random.default_rng(99)
+    data = rng.random((10, 12)).astype(np.float64)
+    kernel = np.ones((3, 3), dtype=np.float64)
+    numpy_agg = create_test_raster(data, backend='numpy')
+    dask_agg = create_test_raster(data, backend='dask+numpy', chunks=(5, 4))
+    np_result = convolution_2d(numpy_agg, kernel, boundary=boundary)
+    da_result = convolution_2d(dask_agg, kernel, boundary=boundary)
+    assert not np.any(np.isnan(np_result.data))
+    assert not np.any(np.isnan(da_result.data.compute()))
+    np.testing.assert_allclose(
+        np_result.data, da_result.data.compute(), equal_nan=True, rtol=1e-5)

--- a/xrspatial/tests/test_hillshade.py
+++ b/xrspatial/tests/test_hillshade.py
@@ -5,7 +5,8 @@ from numpy.testing import assert_allclose, assert_array_less
 
 from xrspatial import hillshade
 from xrspatial.hillshade import _run_numpy
-from xrspatial.tests.general_checks import (assert_numpy_equals_cupy,
+from xrspatial.tests.general_checks import (assert_boundary_mode_correctness,
+                                            assert_numpy_equals_cupy,
                                             assert_numpy_equals_dask_cupy,
                                             assert_numpy_equals_dask_numpy,
                                             create_test_raster,
@@ -188,3 +189,53 @@ def test_hillshade_rtx_with_shadows(data_gaussian):
     diag_cpu = np.diagonal(cpu.data[::-1])[nhalf:]
     diag_rtx = np.diagonal(rtx.data[::-1])[nhalf:]
     assert_array_less(diag_rtx, diag_cpu + 1e-3)
+
+
+@dask_array_available
+def test_boundary_modes(data_gaussian):
+    numpy_agg = create_test_raster(data_gaussian, backend='numpy')
+    dask_agg = create_test_raster(data_gaussian, backend='dask+numpy')
+    assert_boundary_mode_correctness(numpy_agg, dask_agg, hillshade)
+
+
+@dask_array_available
+@pytest.mark.parametrize("boundary", ['nan', 'nearest', 'reflect', 'wrap'])
+@pytest.mark.parametrize("size,chunks", [
+    ((6, 8), (3, 4)),
+    ((7, 9), (3, 3)),
+    ((10, 15), (5, 5)),
+    ((10, 15), (10, 15)),
+    ((5, 5), (2, 2)),
+])
+def test_boundary_numpy_equals_dask(boundary, size, chunks):
+    rng = np.random.default_rng(42)
+    data = rng.random(size).astype(np.float64) * 500
+    numpy_agg = create_test_raster(data, backend='numpy')
+    dask_agg = create_test_raster(data, backend='dask+numpy', chunks=chunks)
+    np_result = hillshade(numpy_agg, boundary=boundary)
+    da_result = hillshade(dask_agg, boundary=boundary)
+    np.testing.assert_allclose(
+        np_result.data, da_result.data.compute(), equal_nan=True, rtol=1e-5)
+
+
+@dask_array_available
+@pytest.mark.parametrize("boundary", ['nearest', 'reflect', 'wrap'])
+def test_boundary_no_nan_edges(boundary):
+    """Non-nan modes produce no NaN output when source has no NaN."""
+    rng = np.random.default_rng(99)
+    data = rng.random((12, 14)).astype(np.float64) * 100
+    numpy_agg = create_test_raster(data, backend='numpy')
+    dask_agg = create_test_raster(data, backend='dask+numpy', chunks=(4, 7))
+    np_result = hillshade(numpy_agg, boundary=boundary)
+    da_result = hillshade(dask_agg, boundary=boundary)
+    assert not np.any(np.isnan(np_result.data))
+    assert not np.any(np.isnan(da_result.data.compute()))
+    np.testing.assert_allclose(
+        np_result.data, da_result.data.compute(), equal_nan=True, rtol=1e-5)
+
+
+def test_boundary_invalid():
+    data = np.ones((4, 5), dtype=np.float32)
+    agg = _make_raster(data)
+    with pytest.raises(ValueError, match="boundary must be one of"):
+        hillshade(agg, boundary='invalid')

--- a/xrspatial/tests/test_slope.py
+++ b/xrspatial/tests/test_slope.py
@@ -2,7 +2,8 @@ import numpy as np
 import pytest
 
 from xrspatial import slope
-from xrspatial.tests.general_checks import (assert_nan_edges_effect, assert_numpy_equals_cupy,
+from xrspatial.tests.general_checks import (assert_boundary_mode_correctness,
+                                            assert_nan_edges_effect, assert_numpy_equals_cupy,
                                             assert_numpy_equals_dask_cupy,
                                             assert_numpy_equals_dask_numpy, create_test_raster,
                                             cuda_and_cupy_available,
@@ -77,3 +78,72 @@ def test_numpy_equals_dask_cupy_random_data(random_data):
     numpy_agg = create_test_raster(random_data, backend='numpy')
     dask_cupy_agg = create_test_raster(random_data, backend='dask+cupy')
     assert_numpy_equals_dask_cupy(numpy_agg, dask_cupy_agg, slope, atol=1e-6, rtol=1e-6)
+
+
+@dask_array_available
+def test_boundary_modes(elevation_raster):
+    numpy_agg = input_data(elevation_raster, 'numpy')
+    dask_agg = input_data(elevation_raster, 'dask+numpy')
+    assert_boundary_mode_correctness(numpy_agg, dask_agg, slope)
+
+
+@dask_array_available
+@pytest.mark.parametrize("boundary", ['nan', 'nearest', 'reflect', 'wrap'])
+@pytest.mark.parametrize("size,chunks", [
+    ((6, 8), (3, 4)),      # chunks evenly divide array
+    ((7, 9), (3, 3)),      # ragged last chunk
+    ((10, 15), (5, 5)),    # larger array, medium chunks
+    ((10, 15), (10, 15)),  # single chunk (no overlap needed)
+    ((5, 5), (2, 2)),      # many small chunks
+])
+def test_boundary_numpy_equals_dask(boundary, size, chunks):
+    rng = np.random.default_rng(42)
+    data = rng.random(size).astype(np.float64) * 500
+    numpy_agg = create_test_raster(data, backend='numpy', attrs={'res': (1, 1)})
+    dask_agg = create_test_raster(data, backend='dask+numpy',
+                                  attrs={'res': (1, 1)}, chunks=chunks)
+    np_result = slope(numpy_agg, boundary=boundary)
+    da_result = slope(dask_agg, boundary=boundary)
+    np.testing.assert_allclose(
+        np_result.data, da_result.data.compute(), equal_nan=True, rtol=1e-5)
+
+
+@dask_array_available
+@pytest.mark.parametrize("boundary", ['nearest', 'reflect', 'wrap'])
+def test_boundary_no_nan_edges(boundary, elevation_raster_no_nans):
+    """Non-nan modes produce no NaN output when source has no NaN."""
+    numpy_agg = create_test_raster(elevation_raster_no_nans, backend='numpy',
+                                   attrs={'res': (1, 1)})
+    dask_agg = create_test_raster(elevation_raster_no_nans, backend='dask+numpy',
+                                  attrs={'res': (1, 1)}, chunks=(4, 3))
+    np_result = slope(numpy_agg, boundary=boundary)
+    da_result = slope(dask_agg, boundary=boundary)
+    assert not np.any(np.isnan(np_result.data))
+    assert not np.any(np.isnan(da_result.data.compute()))
+    np.testing.assert_allclose(
+        np_result.data, da_result.data.compute(), equal_nan=True, rtol=1e-5)
+
+
+@dask_array_available
+def test_boundary_constant_surface():
+    """Constant surface should produce zero slope for all boundary modes."""
+    data = np.full((8, 10), 42.0, dtype=np.float64)
+    numpy_agg = create_test_raster(data, backend='numpy', attrs={'res': (1, 1)})
+    dask_agg = create_test_raster(data, backend='dask+numpy',
+                                  attrs={'res': (1, 1)}, chunks=(4, 5))
+    for mode in ('nan', 'nearest', 'reflect', 'wrap'):
+        np_result = slope(numpy_agg, boundary=mode)
+        da_result = slope(dask_agg, boundary=mode)
+        np_data = np_result.data
+        da_data = da_result.data.compute()
+        # Interior should be zero; edges depend on mode
+        if mode != 'nan':
+            np.testing.assert_allclose(np_data, 0.0, atol=1e-10)
+        np.testing.assert_allclose(np_data, da_data, equal_nan=True, rtol=1e-6)
+
+
+def test_boundary_invalid():
+    data = np.ones((4, 5), dtype=np.float32)
+    agg = create_test_raster(data, attrs={'res': (1, 1)})
+    with pytest.raises(ValueError, match="boundary must be one of"):
+        slope(agg, boundary='invalid')

--- a/xrspatial/utils.py
+++ b/xrspatial/utils.py
@@ -31,6 +31,66 @@ except ImportError:
 ngjit = jit(nopython=True, nogil=True)
 
 
+# ---------- Boundary mode utilities ----------
+VALID_BOUNDARY_MODES = ('nan', 'nearest', 'reflect', 'wrap')
+
+
+def _validate_boundary(boundary):
+    """Raise ValueError if *boundary* is not a recognised mode."""
+    if boundary not in VALID_BOUNDARY_MODES:
+        raise ValueError(
+            f"boundary must be one of {VALID_BOUNDARY_MODES}, "
+            f"got {boundary!r}"
+        )
+
+
+def _boundary_to_dask(boundary, is_cupy=False):
+    """Convert a boundary mode string to the value expected by
+    ``dask.array.map_overlap``'s *boundary* parameter."""
+    if boundary == 'nan':
+        if is_cupy:
+            import cupy as _cp
+            return _cp.nan
+        return np.nan
+    _mode_map = {
+        'nearest': 'nearest',
+        'reflect': 'reflect',
+        'wrap': 'periodic',
+    }
+    return _mode_map[boundary]
+
+
+def _pad_array(data, depth, boundary):
+    """Pad a 2-D numpy or cupy array according to *boundary* mode.
+
+    Parameters
+    ----------
+    data : array-like
+        2-D array to pad.
+    depth : int or tuple of int
+        Number of cells to pad on each side.  An int pads all axes
+        equally; a tuple ``(d0, d1)`` pads each axis independently.
+    boundary : str
+        One of ``'nearest'``, ``'reflect'``, ``'wrap'``.
+        ``'nan'`` should be handled before calling this function.
+    """
+    # numpy.pad 'symmetric' matches dask map_overlap 'reflect'
+    # (both include the edge element in the reflection)
+    _np_mode_map = {
+        'nearest': 'edge',
+        'reflect': 'symmetric',
+        'wrap': 'wrap',
+    }
+    mode = _np_mode_map[boundary]
+    if isinstance(depth, int):
+        pad_width = ((depth, depth), (depth, depth))
+    else:
+        pad_width = tuple((d, d) for d in depth)
+    if is_cupy_array(data):
+        return cupy.pad(data, pad_width, mode=mode)
+    return np.pad(data, pad_width, mode=mode)
+
+
 def has_cuda_and_cupy():
     return _has_cuda() and _has_cupy()
 


### PR DESCRIPTION
## Summary

- Adds a `boundary` parameter to all kernel-based spatial operations: `slope`, `aspect`, `curvature`, `hillshade`, `convolve_2d`/`convolution_2d`, `mean`, `apply`, `focal_stats`, and `hotspots`
- Supported modes: `'nan'` (default, backward compatible), `'nearest'`, `'reflect'`, `'wrap'`
- Uses pad-compute-trim for numpy/cupy backends (zero changes to numba/CUDA kernels) and passes boundary mode through to `dask.array.map_overlap` for dask backends
- Adds shared utilities (`_validate_boundary`, `_boundary_to_dask`, `_pad_array`, `VALID_BOUNDARY_MODES`) in `utils.py`
- Resolves TODO comments in `curvature.py` for border edge handling

## Affected functions

| Function | File | Notes |
|---|---|---|
| `slope` | `slope.py` | Planar + geodesic, all 4 backends |
| `aspect` | `aspect.py` | Planar + geodesic, all 4 backends |
| `curvature` | `curvature.py` | Also resolves TODOs at L46, L87 |
| `hillshade` | `hillshade.py` | All 4 backends |
| `convolve_2d` / `convolution_2d` | `convolution.py` | Internal + public API |
| `mean` | `focal.py` | numpy, cupy, dask+numpy |
| `apply` | `focal.py` | numpy, dask+numpy |
| `focal_stats` | `focal.py` | Passes boundary to `apply()` |
| `hotspots` | `focal.py` | numpy, cupy, dask+numpy |

## Test plan

- [x] All 335 tests pass (up from 171 before this PR)
- [x] 164 new boundary-mode tests added across all test files
- [x] Parametrized `test_boundary_numpy_equals_dask` for each function: 4 boundary modes × 4–5 size/chunk combos verifying numpy-vs-dask consistency
- [x] `test_boundary_no_nan_edges` / `test_boundary_no_nan_flat`: non-nan modes produce no NaN when source has no NaN
- [x] `test_boundary_constant_surface`: constant surface produces zero slope/curvature for all modes
- [x] `test_boundary_invalid`: invalid mode raises `ValueError`
- [x] Existing tests unmodified and still passing (backward compatibility)