### PR TITLE
Fix test warnings: suppress expected GPU/NaN warnings, fix real code issues

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -73,5 +73,9 @@ exclude =
     __pycache__,
 max-line-length = 100
 
+[tool:pytest]
+filterwarnings =
+    ignore::numba.core.errors.NumbaPerformanceWarning
+
 [isort]
 line_length = 100

--- a/xrspatial/classify.py
+++ b/xrspatial/classify.py
@@ -840,8 +840,10 @@ def _run_equal_interval(agg, k, module):
     # Replace ±inf with nan in a single pass (no ravel needed)
     data_clean = module.where(module.isinf(data), np.nan, data)
 
-    min_lazy = module.nanmin(data_clean)
-    max_lazy = module.nanmax(data_clean)
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore', 'All-NaN slice', RuntimeWarning)
+        min_lazy = module.nanmin(data_clean)
+        max_lazy = module.nanmax(data_clean)
 
     if module == cupy:
         min_data = float(min_lazy.get())

--- a/xrspatial/convolution.py
+++ b/xrspatial/convolution.py
@@ -381,6 +381,7 @@ def _convolve_2d_cuda(data, kernel, out):
 
 
 def _convolve_2d_cupy(data, kernel, boundary='nan'):
+    kernel = cupy.asarray(kernel)
     if boundary != 'nan':
         pad_h = kernel.shape[0] // 2
         pad_w = kernel.shape[1] // 2

--- a/xrspatial/curvature.py
+++ b/xrspatial/curvature.py
@@ -94,7 +94,7 @@ def _run_cupy(data: cupy.ndarray,
         return result[1:-1, 1:-1]
 
     data = data.astype(cupy.float32)
-    cellsize_arr = cupy.array([float(cellsize)], dtype='f4')
+    cellsize_arr = cupy.array([float(cupy.asnumpy(cellsize).item())], dtype='f4')
 
     griddim, blockdim = cuda_args(data.shape)
     out = cupy.empty(data.shape, dtype='f4')
@@ -109,7 +109,7 @@ def _run_dask_cupy(data: da.Array,
                    cellsize: Union[int, float],
                    boundary: str = 'nan') -> da.Array:
     data = data.astype(cupy.float32)
-    cellsize_arr = cupy.array([float(cellsize)], dtype='f4')
+    cellsize_arr = cupy.array([float(cupy.asnumpy(cellsize).item())], dtype='f4')
 
     _func = partial(_run_cupy, cellsize=cellsize_arr)
 

--- a/xrspatial/focal.py
+++ b/xrspatial/focal.py
@@ -750,6 +750,7 @@ def _focal_sum_cuda(data, kernel, out):
 
 
 def _focal_stats_func_cupy(data, kernel, func=_focal_max_cuda):
+    kernel = cupy.asarray(kernel)
     out = cupy.empty(data.shape, dtype='f4')
     out[:, :] = cupy.nan
     griddim, blockdim = cuda_args(data.shape)


### PR DESCRIPTION
## Summary

- **Add `[tool:pytest]` filterwarnings** in `setup.cfg` to silence `NumbaPerformanceWarning` (GPU under-utilization from small test arrays — 28 instances)
- **Suppress `RuntimeWarning`** for all-NaN slices in `classify.py:_run_equal_interval`, which is a valid code path handled correctly downstream (2 instances)
- **Fix `DeprecationWarning`** in `curvature.py` by extracting scalars explicitly via `cupy.asnumpy().item()` instead of `float()` on an ndarray (12 instances)
- **Fix host-to-device copy overhead** in `focal.py` and `convolution.py` by converting kernel to `cupy.asarray()` before passing to CUDA kernels (10 instances)

Reduces test warnings from 55 to 0 under normal `pytest` runs.

## Test plan
- [x] `pytest --tb=short -q` passes (843 passed, 12 skipped, 0 warnings)
- [x] `pytest -W all` confirms DeprecationWarning, "Host array", and "All-NaN slice" warnings are gone (only expected NumbaPerformanceWarning remains, which `-W all` forces visible)