### PR TITLE
Fixes #878: extend KDTree path to allocation/direction to prevent OOM

### DIFF
--- a/xrspatial/proximity.py
+++ b/xrspatial/proximity.py
@@ -266,6 +266,21 @@ def _calc_direction(x1, x2, y1, y2):
     return np.float32(d)
 
 
+def _vectorized_calc_direction(x1, x2, y1, y2):
+    """Array-based compass direction from (x1, y1) to (x2, y2).
+
+    Uses the same conversion constant (57.29578) as _calc_direction
+    to ensure identical floating-point behaviour.
+    """
+    dx = x2 - x1
+    dy = y2 - y1
+    d = np.arctan2(-dy, dx) * 57.29578
+    result = np.where(d < 0, 90.0 - d,
+             np.where(d > 90.0, 360.0 - d + 90.0, 90.0 - d))
+    result[(x1 == x2) & (y1 == y2)] = 0.0
+    return result.astype(np.float32)
+
+
 @ngjit
 def _process_proximity_line(
     source_line,
@@ -407,8 +422,9 @@ def _process_proximity_line(
 
 
 def _kdtree_chunk_fn(block, y_coords_1d, x_coords_1d,
-                     tree, block_info, max_distance, p):
-    """Query k-d tree for nearest target distance for every pixel in block."""
+                     tree, block_info, max_distance, p,
+                     process_mode, target_vals, target_coords):
+    """Query k-d tree for nearest target for every pixel in block."""
     if block_info is None or block_info == []:
         return np.full(block.shape, np.nan, dtype=np.float32)
 
@@ -421,11 +437,30 @@ def _kdtree_chunk_fn(block, y_coords_1d, x_coords_1d,
     yy, xx = np.meshgrid(chunk_ys, chunk_xs, indexing='ij')
     query_pts = np.column_stack([yy.ravel(), xx.ravel()])
 
-    dists, _ = tree.query(query_pts, p=p,
-                          distance_upper_bound=max_distance)
-    dists = dists.reshape(h, w).astype(np.float32)
-    dists[dists == np.inf] = np.nan
-    return dists
+    dists, indices = tree.query(query_pts, p=p,
+                                distance_upper_bound=max_distance)
+
+    n_targets = len(target_vals)
+    oob = indices >= n_targets
+    safe_idx = np.where(oob, 0, indices)
+
+    if process_mode == PROXIMITY:
+        result = dists.astype(np.float32)
+        result[result == np.inf] = np.nan
+    elif process_mode == ALLOCATION:
+        result = target_vals[safe_idx].astype(np.float32)
+        result[oob] = np.nan
+    else:  # DIRECTION
+        query_x = xx.ravel()
+        query_y = yy.ravel()
+        target_x = target_coords[safe_idx, 1]
+        target_y = target_coords[safe_idx, 0]
+        result = _vectorized_calc_direction(
+            query_x, target_x, query_y, target_y)
+        result[oob] = np.nan
+        result[dists == 0] = 0.0
+
+    return result.reshape(h, w)
 
 
 def _target_mask(chunk_data, target_values):
@@ -439,19 +474,21 @@ def _stream_target_counts(raster, target_values, y_coords, x_coords,
                           chunks_y, chunks_x):
     """Stream all dask chunks, counting targets per chunk.
 
-    Caches per-chunk coordinate arrays within a 25% memory budget to
-    reduce re-reads in later phases.
+    Caches per-chunk coordinate arrays and pixel values within a 25%
+    memory budget to reduce re-reads in later phases.
 
     Returns
     -------
     target_counts : ndarray, shape (n_tile_y, n_tile_x), dtype int64
     total_targets : int
     coords_cache : dict  (iy, ix) -> ndarray shape (N, 2)
+    values_cache : dict  (iy, ix) -> ndarray shape (N,), dtype float32
     """
     n_tile_y = len(chunks_y)
     n_tile_x = len(chunks_x)
     target_counts = np.zeros((n_tile_y, n_tile_x), dtype=np.int64)
     coords_cache = {}
+    values_cache = {}
     cache_bytes = 0
     budget = int(0.25 * _available_memory_bytes())
 
@@ -472,13 +509,15 @@ def _stream_target_counts(raster, target_values, y_coords, x_coords,
                     y_coords[y_offsets[iy] + rows],
                     x_coords[x_offsets[ix] + cols],
                 ])
-                entry_bytes = coords.nbytes
+                vals = chunk_data[rows, cols].astype(np.float32)
+                entry_bytes = coords.nbytes + vals.nbytes
                 if cache_bytes + entry_bytes <= budget:
                     coords_cache[(iy, ix)] = coords
+                    values_cache[(iy, ix)] = vals
                     cache_bytes += entry_bytes
 
     total_targets = int(target_counts.sum())
-    return target_counts, total_targets, coords_cache
+    return target_counts, total_targets, coords_cache, values_cache
 
 
 def _chunk_offsets(chunks):
@@ -491,19 +530,22 @@ def _chunk_offsets(chunks):
 def _collect_region_targets(raster, jy_lo, jy_hi, jx_lo, jx_hi,
                             target_values, target_counts,
                             y_coords, x_coords,
-                            y_offsets, x_offsets, coords_cache):
-    """Collect target (y, x) coords from chunks in [jy_lo:jy_hi, jx_lo:jx_hi].
+                            y_offsets, x_offsets,
+                            coords_cache, values_cache):
+    """Collect target (y, x) coords and pixel values from chunks.
 
     Uses cache where available, re-reads uncached chunks via .compute().
-    Returns ndarray shape (N, 2) or None if no targets in region.
+    Returns (coords ndarray (N, 2), vals ndarray (N,)) or (None, None).
     """
-    parts = []
+    coord_parts = []
+    val_parts = []
     for iy in range(jy_lo, jy_hi):
         for ix in range(jx_lo, jx_hi):
             if target_counts[iy, ix] == 0:
                 continue
             if (iy, ix) in coords_cache:
-                parts.append(coords_cache[(iy, ix)])
+                coord_parts.append(coords_cache[(iy, ix)])
+                val_parts.append(values_cache[(iy, ix)])
             else:
                 chunk_data = raster.data.blocks[iy, ix].compute()
                 mask = _target_mask(chunk_data, target_values)
@@ -513,10 +555,13 @@ def _collect_region_targets(raster, jy_lo, jy_hi, jx_lo, jx_hi,
                         y_coords[y_offsets[iy] + rows],
                         x_coords[x_offsets[ix] + cols],
                     ])
-                    parts.append(coords)
-    if not parts:
-        return None
-    return np.concatenate(parts)
+                    coord_parts.append(coords)
+                    val_parts.append(
+                        chunk_data[rows, cols].astype(np.float32)
+                    )
+    if not coord_parts:
+        return None, None
+    return np.concatenate(coord_parts), np.concatenate(val_parts)
 
 
 def _min_boundary_distance(iy, ix, y_coords, x_coords,
@@ -568,11 +613,12 @@ def _min_boundary_distance(iy, ix, y_coords, x_coords,
     return min(gaps) if gaps else np.inf
 
 
-def _tiled_chunk_proximity(raster, iy, ix, y_coords, x_coords,
-                           y_offsets, x_offsets,
-                           target_values, target_counts,
-                           coords_cache, max_distance, p,
-                           n_tile_y, n_tile_x):
+def _tiled_chunk_query(raster, iy, ix, y_coords, x_coords,
+                       y_offsets, x_offsets,
+                       target_values, target_counts,
+                       coords_cache, values_cache,
+                       max_distance, p,
+                       n_tile_y, n_tile_x, process_mode):
     """Expanding-ring local KDTree for one output chunk.
 
     Returns ndarray shape (h, w), dtype float32.
@@ -596,10 +642,11 @@ def _tiled_chunk_proximity(raster, iy, ix, y_coords, x_coords,
         covers_full = (jy_lo == 0 and jy_hi == n_tile_y
                        and jx_lo == 0 and jx_hi == n_tile_x)
 
-        target_coords = _collect_region_targets(
+        target_coords, target_vals = _collect_region_targets(
             raster, jy_lo, jy_hi, jx_lo, jx_hi,
             target_values, target_counts,
-            y_coords, x_coords, y_offsets, x_offsets, coords_cache,
+            y_coords, x_coords, y_offsets, x_offsets,
+            coords_cache, values_cache,
         )
 
         if target_coords is None:
@@ -611,29 +658,53 @@ def _tiled_chunk_proximity(raster, iy, ix, y_coords, x_coords,
 
         tree = cKDTree(target_coords)
         ub = max_distance if np.isfinite(max_distance) else np.inf
-        dists, _ = tree.query(query_pts, p=p, distance_upper_bound=ub)
-        dists = dists.reshape(h, w).astype(np.float32)
-        dists[dists == np.inf] = np.nan
+        dists, indices = tree.query(query_pts, p=p, distance_upper_bound=ub)
 
-        if covers_full:
-            return dists
+        n_targets = len(target_vals)
+        oob = indices >= n_targets
+        safe_idx = np.where(oob, 0, indices)
 
-        # Validate: max_nearest_dist < min_boundary_distance
-        max_nearest = np.nanmax(dists) if not np.all(np.isnan(dists)) else 0.0
-        min_bd = _min_boundary_distance(
-            iy, ix, y_coords, x_coords, y_offsets, x_offsets,
-            jy_lo, jy_hi, jx_lo, jx_hi, n_tile_y, n_tile_x,
-        )
-        if max_nearest < min_bd:
-            return dists
+        # Always compute dists for convergence check
+        dist_result = dists.reshape(h, w).astype(np.float32)
+        dist_result[dist_result == np.inf] = np.nan
+
+        def _converged():
+            if covers_full:
+                return True
+            max_nearest = (np.nanmax(dist_result)
+                           if not np.all(np.isnan(dist_result)) else 0.0)
+            min_bd = _min_boundary_distance(
+                iy, ix, y_coords, x_coords, y_offsets, x_offsets,
+                jy_lo, jy_hi, jx_lo, jx_hi, n_tile_y, n_tile_x,
+            )
+            return max_nearest < min_bd
+
+        if _converged():
+            if process_mode == PROXIMITY:
+                return dist_result
+            elif process_mode == ALLOCATION:
+                result = target_vals[safe_idx].astype(np.float32)
+                result[oob] = np.nan
+                return result.reshape(h, w)
+            else:  # DIRECTION
+                query_x = xx.ravel()
+                query_y = yy.ravel()
+                target_x = target_coords[safe_idx, 1]
+                target_y = target_coords[safe_idx, 0]
+                result = _vectorized_calc_direction(
+                    query_x, target_x, query_y, target_y)
+                result[oob] = np.nan
+                result[dists == 0] = 0.0
+                return result.reshape(h, w)
 
         ring += 1
 
 
 def _build_tiled_kdtree(raster, y_coords, x_coords, target_values,
-                        max_distance, p, target_counts, coords_cache,
-                        chunks_y, chunks_x):
-    """Tiled (eager) KDTree proximity — memory-safe fallback."""
+                        max_distance, p, target_counts,
+                        coords_cache, values_cache,
+                        chunks_y, chunks_x, process_mode):
+    """Tiled (eager) KDTree query — memory-safe fallback."""
     H, W = raster.shape
     result_bytes = H * W * 4  # float32
     avail = _available_memory_bytes()
@@ -659,11 +730,12 @@ def _build_tiled_kdtree(raster, y_coords, x_coords, target_values,
 
     for iy in range(n_tile_y):
         for ix in range(n_tile_x):
-            chunk_result = _tiled_chunk_proximity(
+            chunk_result = _tiled_chunk_query(
                 raster, iy, ix, y_coords, x_coords,
                 y_offsets, x_offsets,
-                target_values, target_counts, coords_cache,
-                max_distance, p, n_tile_y, n_tile_x,
+                target_values, target_counts,
+                coords_cache, values_cache,
+                max_distance, p, n_tile_y, n_tile_x, process_mode,
             )
             r0 = int(y_offsets[iy])
             r1 = int(y_offsets[iy + 1])
@@ -675,18 +747,20 @@ def _build_tiled_kdtree(raster, y_coords, x_coords, target_values,
 
 
 def _build_global_kdtree(raster, y_coords, x_coords, target_values,
-                         max_distance, p, target_counts, coords_cache,
-                         chunks_y, chunks_x):
-    """Global KDTree proximity — fast, lazy via da.map_blocks."""
+                         max_distance, p, target_counts,
+                         coords_cache, values_cache,
+                         chunks_y, chunks_x, process_mode):
+    """Global KDTree query — fast, lazy via da.map_blocks."""
     n_tile_y = len(chunks_y)
     n_tile_x = len(chunks_x)
     y_offsets = _chunk_offsets(chunks_y)
     x_offsets = _chunk_offsets(chunks_x)
 
-    target_coords = _collect_region_targets(
+    target_coords, target_vals = _collect_region_targets(
         raster, 0, n_tile_y, 0, n_tile_x,
         target_values, target_counts,
-        y_coords, x_coords, y_offsets, x_offsets, coords_cache,
+        y_coords, x_coords, y_offsets, x_offsets,
+        coords_cache, values_cache,
     )
 
     tree = cKDTree(target_coords)
@@ -698,6 +772,9 @@ def _build_global_kdtree(raster, y_coords, x_coords, target_values,
         tree=tree,
         max_distance=max_distance if np.isfinite(max_distance) else np.inf,
         p=p,
+        process_mode=process_mode,
+        target_vals=target_vals,
+        target_coords=target_coords,
     )
 
     return da.map_blocks(
@@ -709,8 +786,9 @@ def _build_global_kdtree(raster, y_coords, x_coords, target_values,
 
 
 def _process_dask_kdtree(raster, x_coords, y_coords,
-                         target_values, max_distance, distance_metric):
-    """Memory-guarded k-d tree proximity for dask arrays.
+                         target_values, max_distance, distance_metric,
+                         process_mode):
+    """Memory-guarded k-d tree query for dask arrays.
 
     Phase 0: stream through chunks counting targets (with caching).
     Then choose global tree (fast, lazy) or tiled tree (memory-safe, eager)
@@ -721,29 +799,32 @@ def _process_dask_kdtree(raster, x_coords, y_coords,
     chunks_y, chunks_x = raster.data.chunks
 
     # Phase 0: streaming count pass
-    target_counts, total_targets, coords_cache = _stream_target_counts(
-        raster, target_values, y_coords, x_coords, chunks_y, chunks_x,
-    )
+    target_counts, total_targets, coords_cache, values_cache = \
+        _stream_target_counts(
+            raster, target_values, y_coords, x_coords, chunks_y, chunks_x,
+        )
 
     if total_targets == 0:
         return da.full(raster.shape, np.nan, dtype=np.float32,
                        chunks=raster.data.chunks)
 
-    # Memory decision: 16 bytes per coord pair + ~32 bytes tree overhead
-    estimate = total_targets * 48
+    # Memory decision: 16 bytes coords + 4 bytes value + ~32 bytes tree overhead
+    estimate = total_targets * 52
     avail = _available_memory_bytes()
 
     if estimate < 0.5 * avail:
         return _build_global_kdtree(
             raster, y_coords, x_coords, target_values,
-            max_distance, p, target_counts, coords_cache,
-            chunks_y, chunks_x,
+            max_distance, p, target_counts,
+            coords_cache, values_cache,
+            chunks_y, chunks_x, process_mode,
         )
     else:
         return _build_tiled_kdtree(
             raster, y_coords, x_coords, target_values,
-            max_distance, p, target_counts, coords_cache,
-            chunks_y, chunks_x,
+            max_distance, p, target_counts,
+            coords_cache, values_cache,
+            chunks_y, chunks_x, process_mode,
         )
 
 
@@ -984,7 +1065,6 @@ def _process(
     elif da is not None and isinstance(raster.data, da.Array):
         use_kdtree = (
             cKDTree is not None
-            and process_mode == PROXIMITY
             and distance_metric in (EUCLIDEAN, MANHATTAN)
             and max_distance >= max_possible_distance
         )
@@ -992,8 +1072,29 @@ def _process(
             result = _process_dask_kdtree(
                 raster, x_coords, y_coords,
                 target_values, max_distance, distance_metric,
+                process_mode,
             )
         else:
+            # Memory guard: unbounded distance on large rasters can OOM
+            if max_distance >= max_possible_distance:
+                H, W = raster.shape
+                required = H * W * 4 * 3  # raster + xs + ys, float32
+                avail = _available_memory_bytes()
+                if required > 0.8 * avail:
+                    if cKDTree is None:
+                        raise MemoryError(
+                            "Raster too large for single-chunk processing "
+                            "and scipy is not installed for memory-safe "
+                            "KDTree path. Install scipy or set a finite "
+                            "max_distance."
+                        )
+                    else:  # must be GREAT_CIRCLE
+                        raise MemoryError(
+                            "GREAT_CIRCLE with unbounded max_distance on "
+                            "this raster would exceed available memory. "
+                            "Set a finite max_distance."
+                        )
+
             # Existing path: build 2D coordinate arrays as dask arrays
             x_coords_da = da.from_array(x_coords, chunks=x_coords.shape[0])
             y_coords_da = da.from_array(y_coords, chunks=y_coords.shape[0])

--- a/xrspatial/tests/test_proximity.py
+++ b/xrspatial/tests/test_proximity.py
@@ -711,3 +711,248 @@ def test_proximity_dask_kdtree_global_uses_cache():
     np.testing.assert_allclose(
         dask_result.values, numpy_result.values, rtol=1e-5, equal_nan=True,
     )
+
+
+# ---------------------------------------------------------------------------
+# Allocation / Direction KDTree tests
+# ---------------------------------------------------------------------------
+
+def _check_allocation_consistency(raster_data, alloc_data, prox_data,
+                                   x_coords, y_coords, metric):
+    """Verify allocation is consistent: distance to allocated target == proximity."""
+    from xrspatial.proximity import euclidean_distance, manhattan_distance
+    dist_fn = euclidean_distance if metric == "EUCLIDEAN" else manhattan_distance
+
+    h, w = raster_data.shape
+    for y in range(h):
+        for x in range(w):
+            a = alloc_data[y, x]
+            p = prox_data[y, x]
+            if np.isnan(a):
+                assert np.isnan(p), f"NaN allocation but non-NaN proximity at ({y},{x})"
+                continue
+            # Find target pixel(s) with this value
+            ty, tx = np.where(raster_data == a)
+            assert len(ty) > 0, f"Allocated value {a} not found in raster"
+            min_d = min(
+                dist_fn(x_coords[x], x_coords[tx[i]],
+                        y_coords[y], y_coords[ty[i]])
+                for i in range(len(ty))
+            )
+            np.testing.assert_allclose(p, min_d, rtol=1e-4,
+                                       err_msg=f"at ({y},{x})")
+
+
+def _check_direction_consistency(raster_data, dir_data, alloc_data,
+                                  x_coords, y_coords):
+    """Verify direction is consistent with allocation."""
+    h, w = raster_data.shape
+    for y in range(h):
+        for x in range(w):
+            d = dir_data[y, x]
+            a = alloc_data[y, x]
+            if np.isnan(d):
+                assert np.isnan(a), f"NaN direction but non-NaN allocation at ({y},{x})"
+                continue
+            ty, tx = np.where(raster_data == a)
+            assert len(ty) > 0
+            expected = _calc_direction(x_coords[x], x_coords[tx[0]],
+                                       y_coords[y], y_coords[ty[0]])
+            # 0 and 360 are equivalent for north
+            if abs(d - expected) > 359.0:
+                np.testing.assert_allclose(
+                    d % 360.0, expected % 360.0, atol=0.5,
+                    err_msg=f"at ({y},{x})")
+            else:
+                np.testing.assert_allclose(d, expected, rtol=1e-4, atol=0.5,
+                                           err_msg=f"at ({y},{x})")
+
+
+@pytest.mark.skipif(da is None, reason="dask is not installed")
+@pytest.mark.parametrize("metric", ["EUCLIDEAN", "MANHATTAN"])
+def test_allocation_dask_kdtree_matches_numpy(metric):
+    """k-d tree dask allocation is correct (consistent with proximity)."""
+    raster = _make_kdtree_raster()
+
+    dask_alloc = allocation(raster, x='lon', y='lat',
+                            distance_metric=metric)
+    dask_prox = proximity(raster, x='lon', y='lat',
+                          distance_metric=metric)
+
+    assert isinstance(dask_alloc.data, da.Array)
+    _check_allocation_consistency(
+        raster.data.compute(), dask_alloc.values, dask_prox.values,
+        raster['lon'].values, raster['lat'].values, metric,
+    )
+
+
+@pytest.mark.skipif(da is None, reason="dask is not installed")
+@pytest.mark.parametrize("metric", ["EUCLIDEAN", "MANHATTAN"])
+def test_direction_dask_kdtree_matches_numpy(metric):
+    """k-d tree dask direction is correct (consistent with allocation)."""
+    raster = _make_kdtree_raster()
+
+    dask_dir = direction(raster, x='lon', y='lat', distance_metric=metric)
+    dask_alloc = allocation(raster, x='lon', y='lat', distance_metric=metric)
+
+    assert isinstance(dask_dir.data, da.Array)
+    _check_direction_consistency(
+        raster.data.compute(), dask_dir.values, dask_alloc.values,
+        raster['lon'].values, raster['lat'].values,
+    )
+
+
+@pytest.mark.skipif(da is None, reason="dask is not installed")
+def test_allocation_dask_kdtree_with_target_values():
+    """target_values filtering works through the k-d tree allocation path."""
+    raster = _make_kdtree_raster()
+
+    target_values = [2, 3]
+    dask_alloc = allocation(raster, x='lon', y='lat',
+                            target_values=target_values)
+    dask_prox = proximity(raster, x='lon', y='lat',
+                          target_values=target_values)
+
+    assert isinstance(dask_alloc.data, da.Array)
+    alloc_vals = dask_alloc.values
+    valid_vals = np.isnan(alloc_vals) | np.isin(alloc_vals, target_values)
+    assert np.all(valid_vals), "Allocation produced values outside target set"
+    _check_allocation_consistency(
+        raster.data.compute(), alloc_vals, dask_prox.values,
+        raster['lon'].values, raster['lat'].values, "EUCLIDEAN",
+    )
+
+
+@pytest.mark.skipif(da is None, reason="dask is not installed")
+def test_direction_dask_kdtree_with_target_values():
+    """target_values filtering works through the k-d tree direction path."""
+    raster = _make_kdtree_raster()
+
+    target_values = [2, 3]
+    dask_dir = direction(raster, x='lon', y='lat',
+                         target_values=target_values)
+    dask_alloc = allocation(raster, x='lon', y='lat',
+                            target_values=target_values)
+
+    assert isinstance(dask_dir.data, da.Array)
+    vals = dask_dir.values
+    valid = vals[~np.isnan(vals)]
+    assert np.all((valid >= 0) & (valid <= 360))
+    _check_direction_consistency(
+        raster.data.compute(), dask_dir.values, dask_alloc.values,
+        raster['lon'].values, raster['lat'].values,
+    )
+
+
+@pytest.mark.skipif(da is None, reason="dask is not installed")
+def test_allocation_dask_kdtree_no_targets():
+    """No target pixels -> allocation result is all NaN."""
+    data = np.zeros((10, 10), dtype=np.float64)
+    _lon = np.arange(10, dtype=np.float64)
+    _lat = np.arange(10, dtype=np.float64)[::-1]
+    raster = xr.DataArray(data, dims=['lat', 'lon'])
+    raster['lon'] = _lon
+    raster['lat'] = _lat
+    raster.data = da.from_array(data, chunks=(5, 5))
+
+    result = allocation(raster, x='lon', y='lat')
+    assert isinstance(result.data, da.Array)
+    assert np.all(np.isnan(result.values))
+
+
+@pytest.mark.skipif(da is None, reason="dask is not installed")
+def test_direction_dask_kdtree_no_targets():
+    """No target pixels -> direction result is all NaN."""
+    data = np.zeros((10, 10), dtype=np.float64)
+    _lon = np.arange(10, dtype=np.float64)
+    _lat = np.arange(10, dtype=np.float64)[::-1]
+    raster = xr.DataArray(data, dims=['lat', 'lon'])
+    raster['lon'] = _lon
+    raster['lat'] = _lat
+    raster.data = da.from_array(data, chunks=(5, 5))
+
+    result = direction(raster, x='lon', y='lat')
+    assert isinstance(result.data, da.Array)
+    assert np.all(np.isnan(result.values))
+
+
+@pytest.mark.skipif(da is None, reason="dask is not installed")
+def test_allocation_dask_kdtree_max_distance():
+    """Pixels beyond max_distance are NaN in allocation via KDTree."""
+    raster = _make_kdtree_raster()
+    numpy_raster = raster.copy()
+    numpy_raster.data = raster.data.compute()
+
+    max_dist = 5.0
+    numpy_result = allocation(numpy_raster, x='lon', y='lat',
+                              max_distance=max_dist)
+    dask_result = allocation(raster, x='lon', y='lat',
+                             max_distance=max_dist)
+
+    np.testing.assert_allclose(
+        dask_result.values, numpy_result.values, rtol=1e-5, equal_nan=True,
+    )
+
+
+@pytest.mark.skipif(da is None, reason="dask is not installed")
+def test_direction_dask_kdtree_max_distance():
+    """Pixels beyond max_distance are NaN in direction via KDTree."""
+    raster = _make_kdtree_raster()
+    numpy_raster = raster.copy()
+    numpy_raster.data = raster.data.compute()
+
+    max_dist = 5.0
+    numpy_result = direction(numpy_raster, x='lon', y='lat',
+                             max_distance=max_dist)
+    dask_result = direction(raster, x='lon', y='lat',
+                            max_distance=max_dist)
+
+    np.testing.assert_allclose(
+        dask_result.values, numpy_result.values, rtol=1e-5, equal_nan=True,
+    )
+
+
+@pytest.mark.skipif(da is None, reason="dask is not installed")
+def test_great_circle_dask_unbounded_memory_guard():
+    """GREAT_CIRCLE with unbounded max_distance raises MemoryError when OOM."""
+    height, width = 100, 100
+    data = np.zeros((height, width), dtype=np.float64)
+    data[50, 50] = 1.0
+    _lon = np.linspace(-10, 10, width)
+    _lat = np.linspace(10, -10, height)
+    raster = xr.DataArray(data, dims=['lat', 'lon'])
+    raster['lon'] = _lon
+    raster['lat'] = _lat
+    raster.data = da.from_array(data, chunks=(25, 25))
+
+    with patch('xrspatial.proximity._available_memory_bytes', return_value=1):
+        with pytest.raises(MemoryError, match="GREAT_CIRCLE"):
+            proximity(raster, x='lon', y='lat',
+                      distance_metric='GREAT_CIRCLE')
+
+
+@pytest.mark.skipif(da is None, reason="dask is not installed")
+def test_no_scipy_dask_unbounded_memory_guard():
+    """No scipy + large raster + unbounded distance raises MemoryError."""
+    import sys
+    prox_mod = sys.modules['xrspatial.proximity']
+
+    height, width = 100, 100
+    data = np.zeros((height, width), dtype=np.float64)
+    data[50, 50] = 1.0
+    _lon = np.linspace(0, 99, width)
+    _lat = np.linspace(99, 0, height)
+    raster = xr.DataArray(data, dims=['lat', 'lon'])
+    raster['lon'] = _lon
+    raster['lat'] = _lat
+    raster.data = da.from_array(data, chunks=(25, 25))
+
+    original_ckdtree = prox_mod.cKDTree
+    try:
+        prox_mod.cKDTree = None
+        with patch('xrspatial.proximity._available_memory_bytes',
+                   return_value=1):
+            with pytest.raises(MemoryError, match="scipy"):
+                proximity(raster, x='lon', y='lat')
+    finally:
+        prox_mod.cKDTree = original_ckdtree


### PR DESCRIPTION
## Summary

- Extends the memory-safe KDTree path (previously PROXIMITY-only) to handle **ALLOCATION** and **DIRECTION** modes, preventing OOM when `max_distance=inf` on large dask-backed rasters
- `cKDTree.query()` returns both distances and nearest-target indices, which is enough to derive allocation values and compass direction angles
- Adds a memory guard in the non-KDTree fallback path (GREAT_CIRCLE or missing scipy) that raises `MemoryError` with actionable guidance instead of silently OOMing

## Key changes

- **`_vectorized_calc_direction()`** — new array-based compass direction function matching the scalar `_calc_direction()` floating-point behaviour
- **`_stream_target_counts()`** — now also caches target pixel values alongside coordinates
- **`_collect_region_targets()`** — returns `(coords, vals)` tuple
- **`_kdtree_chunk_fn()` / `_tiled_chunk_query()`** — extended with mode dispatch (PROXIMITY/ALLOCATION/DIRECTION)
- **KDTree gate widened** — removed `process_mode == PROXIMITY` restriction
- **Memory guard** — `MemoryError` raised when single-chunk rechunk would exceed 80% available memory

## Test plan

- [x] `test_allocation_dask_kdtree_matches_numpy` (EUCLIDEAN + MANHATTAN) — consistency check against proximity
- [x] `test_direction_dask_kdtree_matches_numpy` (EUCLIDEAN + MANHATTAN) — consistency check against allocation
- [x] `test_allocation_dask_kdtree_with_target_values` — target filtering through KDTree
- [x] `test_direction_dask_kdtree_with_target_values` — target filtering through KDTree
- [x] `test_allocation_dask_kdtree_no_targets` / `test_direction_dask_kdtree_no_targets` — all-NaN
- [x] `test_allocation_dask_kdtree_max_distance` / `test_direction_dask_kdtree_max_distance` — truncation
- [x] `test_great_circle_dask_unbounded_memory_guard` — MemoryError for GREAT_CIRCLE
- [x] `test_no_scipy_dask_unbounded_memory_guard` — MemoryError when scipy missing
- [x] All 51 existing + new tests pass, no regressions