### PR TITLE
Add GPU (CuPy) backend for cost_distance

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ In the GIS world, rasters are used for representing continuous phenomena (e.g. e
 | Name | Description | NumPy xr.DataArray | Dask xr.DataArray | CuPy GPU xr.DataArray | Dask GPU xr.DataArray |
 |:----------:|:------------|:----------------------:|:--------------------:|:-------------------:|:------:|
 | [Allocation](xrspatial/proximity.py) | Assigns each cell to the identity of the nearest source feature | ✅️ | ✅ | ✅️ | ✅️ |
-| [Cost Distance](xrspatial/cost_distance.py) | Computes minimum accumulated cost to the nearest source through a friction surface | ✅️ | ✅ | 🔄 | 🔄 |
+| [Cost Distance](xrspatial/cost_distance.py) | Computes minimum accumulated cost to the nearest source through a friction surface | ✅️ | ✅ | ✅️ | ✅️ |
 | [Direction](xrspatial/proximity.py) | Computes the direction from each cell to the nearest source feature | ✅️ | ✅ | ✅️ | ✅️ |
 | [Proximity](xrspatial/proximity.py) | Computes the distance from each cell to the nearest source feature | ✅️ | ✅ | ✅️ | ✅️ |
 

--- a/xrspatial/cost_distance.py
+++ b/xrspatial/cost_distance.py
@@ -28,6 +28,7 @@ time, keeping memory usage bounded regardless of raster size.
 
 from __future__ import annotations
 
+import math as _math
 from functools import partial
 from math import sqrt
 
@@ -39,8 +40,16 @@ try:
 except ImportError:
     da = None
 
+from numba import cuda
+
+try:
+    import cupy
+except ImportError:
+    class cupy:  # type: ignore[no-redef]
+        ndarray = False
+
 from xrspatial.utils import (
-    get_dataarray_resolution, ngjit,
+    cuda_args, get_dataarray_resolution, ngjit,
     has_cuda_and_cupy, is_cupy_array, is_dask_cupy,
 )
 from xrspatial.dataset_support import supports_dataset
@@ -233,6 +242,191 @@ def _cost_distance_numpy(source_data, friction_data, cellsize_x, cellsize_y,
         source_data, friction_data, height, width,
         cellsize_x, cellsize_y, max_cost,
         target_values, dy, dx, dd,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CuPy GPU backend — iterative parallel relaxation (parallel Bellman-Ford)
+# ---------------------------------------------------------------------------
+
+@cuda.jit
+def _cost_distance_relax_kernel(friction, dist, changed,
+                                height, width,
+                                dy, dx, dd, n_neighbors,
+                                max_cost):
+    """One relaxation pass: each pixel checks all neighbours for shorter paths.
+
+    Iterate until *changed* stays 0.  Convergence is guaranteed because
+    dist values only decrease and the graph has finite edge weights.
+    """
+    iy, ix = cuda.grid(2)
+    if iy >= height or ix >= width:
+        return
+
+    f_u = friction[iy, ix]
+    if not (_math.isfinite(f_u) and f_u > 0.0):
+        return
+
+    current = dist[iy, ix]
+    best = current
+
+    for k in range(n_neighbors):
+        vy = iy + dy[k]
+        vx = ix + dx[k]
+        if vy < 0 or vy >= height or vx < 0 or vx >= width:
+            continue
+
+        d_v = dist[vy, vx]
+        if d_v >= best:
+            continue
+
+        f_v = friction[vy, vx]
+        if not (_math.isfinite(f_v) and f_v > 0.0):
+            continue
+
+        edge_cost = dd[k] * (f_u + f_v) * 0.5
+        new_cost = d_v + edge_cost
+
+        if new_cost < best:
+            best = new_cost
+
+    if best < current and best <= max_cost:
+        dist[iy, ix] = best
+        changed[0] = 1
+
+
+def _cost_distance_cupy(source_data, friction_data, cellsize_x, cellsize_y,
+                        max_cost, target_values, dy, dx, dd):
+    """GPU cost-distance via iterative parallel relaxation.
+
+    Each CUDA thread processes one pixel per iteration, checking all
+    neighbours for shorter paths (parallel Bellman-Ford).  The wavefront
+    advances at least one pixel per iteration, so convergence takes at
+    most O(height + width) iterations.
+    """
+    import cupy as cp
+
+    height, width = source_data.shape
+    src = source_data.astype(cp.float64) if source_data.dtype != cp.float64 \
+        else source_data
+    fric = friction_data.astype(cp.float64) if friction_data.dtype != cp.float64 \
+        else friction_data
+
+    # Initialize all distances to inf
+    dist = cp.full((height, width), cp.inf, dtype=cp.float64)
+
+    # Find source pixels
+    if len(target_values) == 0:
+        source_mask = cp.isfinite(src) & (src != 0)
+    else:
+        source_mask = cp.isin(src, cp.asarray(target_values, dtype=cp.float64))
+        source_mask &= cp.isfinite(src)
+
+    # Only seed sources on passable terrain
+    passable = cp.isfinite(fric) & (fric > 0)
+    source_mask &= passable
+    dist[source_mask] = 0.0
+
+    if not cp.any(source_mask):
+        return cp.full((height, width), cp.nan, dtype=cp.float32)
+
+    # Transfer neighbor offsets to device
+    dy_d = cp.asarray(dy, dtype=cp.int64)
+    dx_d = cp.asarray(dx, dtype=cp.int64)
+    dd_d = cp.asarray(dd, dtype=cp.float64)
+    n_neighbors = len(dy)
+
+    changed = cp.zeros(1, dtype=cp.int32)
+    griddim, blockdim = cuda_args((height, width))
+
+    max_iterations = height + width
+    for _ in range(max_iterations):
+        changed[0] = 0
+        _cost_distance_relax_kernel[griddim, blockdim](
+            fric, dist, changed,
+            height, width,
+            dy_d, dx_d, dd_d, n_neighbors,
+            np.float64(max_cost),
+        )
+        if int(changed[0]) == 0:
+            break
+
+    # Convert: inf or over-budget -> NaN, else float32
+    out = cp.where(
+        cp.isinf(dist) | (dist > max_cost), cp.nan, dist,
+    ).astype(cp.float32)
+    return out
+
+
+def _cost_distance_dask_cupy(source_da, friction_da,
+                              cellsize_x, cellsize_y, max_cost,
+                              target_values, dy, dx, dd):
+    """Dask+CuPy cost distance.
+
+    Bounded max_cost: ``da.map_overlap`` with per-chunk GPU relaxation.
+    Unbounded / large radius: convert to dask+numpy, use CPU iterative path
+    (Dijkstra is O(N log N) vs parallel relaxation's O(N * diameter), so CPU
+    is more efficient for unbounded global shortest paths).
+    """
+    import cupy as cp
+
+    height, width = source_da.shape
+
+    use_map_overlap = False
+    if np.isfinite(max_cost):
+        positive_friction = da.where(friction_da > 0, friction_da, np.inf)
+        f_min = float(da.nanmin(positive_friction).compute())
+        if np.isfinite(f_min) and f_min > 0:
+            min_cellsize = min(cellsize_x, cellsize_y)
+            max_radius = max_cost / (f_min * min_cellsize)
+            pad = int(max_radius + 1)
+            chunks_y, chunks_x = source_da.chunks
+            if pad < max(chunks_y) and pad < max(chunks_x):
+                use_map_overlap = True
+
+    if use_map_overlap:
+        pad_y = int(max_cost / (f_min * cellsize_y) + 1)
+        pad_x = int(max_cost / (f_min * cellsize_x) + 1)
+
+        # Closure captures the scalar parameters
+        tv = target_values
+        mc = max_cost
+        cx, cy = cellsize_x, cellsize_y
+        _dy, _dx, _dd = dy, dx, dd
+
+        def _chunk_func(source_block, friction_block):
+            return _cost_distance_cupy(
+                source_block, friction_block,
+                cx, cy, mc, tv, _dy, _dx, _dd,
+            )
+
+        return da.map_overlap(
+            _chunk_func,
+            source_da, friction_da,
+            depth=(pad_y, pad_x),
+            boundary=np.nan,
+            dtype=np.float32,
+            meta=cp.array((), dtype=cp.float32),
+        )
+
+    # Unbounded or padding too large: convert to dask+numpy, use CPU path
+    source_np = source_da.map_blocks(
+        lambda b: b.get(), dtype=source_da.dtype,
+        meta=np.array((), dtype=source_da.dtype),
+    )
+    friction_np = friction_da.map_blocks(
+        lambda b: b.get(), dtype=friction_da.dtype,
+        meta=np.array((), dtype=friction_da.dtype),
+    )
+    result = _cost_distance_dask(
+        source_np, friction_np,
+        cellsize_x, cellsize_y, max_cost,
+        target_values, dy, dx, dd,
+    )
+    # Convert back to dask+cupy
+    return result.map_blocks(
+        cp.asarray, dtype=result.dtype,
+        meta=cp.array((), dtype=result.dtype),
     )
 
 
@@ -965,28 +1159,13 @@ def cost_distance(
                                           chunks=source_data.chunks)
 
     if _is_cupy_backend:
-        import cupy
-        # Transfer to CPU, run numpy kernel, transfer back
-        source_np = source_data.get()
-        friction_np = np.asarray(friction.data.get(), dtype=np.float64)
-        result_data = cupy.asarray(
-            _cost_distance_numpy(
-                source_np, friction_np,
-                cellsize_x, cellsize_y, max_cost_f,
-                target_values, dy, dx, dd,
-            )
+        result_data = _cost_distance_cupy(
+            source_data, friction_data,
+            cellsize_x, cellsize_y, max_cost_f,
+            target_values, dy, dx, dd,
         )
     elif _is_dask_cupy:
-        # Spill each chunk to CPU via map_overlap, then wrap back as dask
-        source_data = source_data.map_blocks(
-            lambda b: b.get(), dtype=source_data.dtype,
-            meta=np.array((), dtype=source_data.dtype),
-        )
-        friction_data = friction_data.map_blocks(
-            lambda b: b.get(), dtype=friction_data.dtype,
-            meta=np.array((), dtype=friction_data.dtype),
-        )
-        result_data = _cost_distance_dask(
+        result_data = _cost_distance_dask_cupy(
             source_data, friction_data,
             cellsize_x, cellsize_y, max_cost_f,
             target_values, dy, dx, dd,

--- a/xrspatial/tests/test_cost_distance.py
+++ b/xrspatial/tests/test_cost_distance.py
@@ -51,7 +51,7 @@ def _compute(arr):
 # Uniform friction = 1 should match Euclidean proximity
 # -----------------------------------------------------------------------
 
-@pytest.mark.parametrize("backend", ['numpy', 'dask+numpy'])
+@pytest.mark.parametrize("backend", ['numpy', 'dask+numpy', 'cupy', 'dask+cupy'])
 def test_uniform_friction_matches_euclidean(backend):
     """With uniform friction=1, cost_distance ≈ Euclidean distance."""
     data = np.zeros((7, 7), dtype=np.float64)
@@ -87,7 +87,7 @@ def test_uniform_friction_matches_euclidean(backend):
 # Hand-computed analytic case
 # -----------------------------------------------------------------------
 
-@pytest.mark.parametrize("backend", ['numpy', 'dask+numpy'])
+@pytest.mark.parametrize("backend", ['numpy', 'dask+numpy', 'cupy', 'dask+cupy'])
 def test_analytic_small_grid(backend):
     """3x3 grid with known costs, single source at (0,0)."""
     source = np.zeros((3, 3))
@@ -129,7 +129,7 @@ def test_analytic_small_grid(backend):
 # Barriers: NaN and zero-friction cells are impassable
 # -----------------------------------------------------------------------
 
-@pytest.mark.parametrize("backend", ['numpy', 'dask+numpy'])
+@pytest.mark.parametrize("backend", ['numpy', 'dask+numpy', 'cupy', 'dask+cupy'])
 def test_barriers_nan_and_zero(backend):
     """NaN and zero-friction cells block paths."""
     source = np.zeros((3, 5))
@@ -162,7 +162,7 @@ def test_barriers_nan_and_zero(backend):
 # Multiple sources: verify nearest-by-cost wins
 # -----------------------------------------------------------------------
 
-@pytest.mark.parametrize("backend", ['numpy', 'dask+numpy'])
+@pytest.mark.parametrize("backend", ['numpy', 'dask+numpy', 'cupy', 'dask+cupy'])
 def test_multiple_sources(backend):
     """Two sources — each pixel gets cost from the cheaper one."""
     source = np.zeros((1, 5))
@@ -194,7 +194,7 @@ def test_multiple_sources(backend):
 # max_cost truncation
 # -----------------------------------------------------------------------
 
-@pytest.mark.parametrize("backend", ['numpy', 'dask+numpy'])
+@pytest.mark.parametrize("backend", ['numpy', 'dask+numpy', 'cupy', 'dask+cupy'])
 def test_max_cost_truncation(backend):
     """Pixels beyond max_cost should be NaN."""
     source = np.zeros((1, 10))
@@ -251,7 +251,7 @@ def test_dask_matches_numpy():
 # 4-connectivity vs 8-connectivity
 # -----------------------------------------------------------------------
 
-@pytest.mark.parametrize("backend", ['numpy'])
+@pytest.mark.parametrize("backend", ['numpy', 'cupy'])
 def test_connectivity_4_vs_8(backend):
     """4-connectivity diagonal cost should be higher than 8-connectivity."""
     source = np.zeros((3, 3))
@@ -277,7 +277,7 @@ def test_connectivity_4_vs_8(backend):
 # target_values parameter
 # -----------------------------------------------------------------------
 
-@pytest.mark.parametrize("backend", ['numpy', 'dask+numpy'])
+@pytest.mark.parametrize("backend", ['numpy', 'dask+numpy', 'cupy', 'dask+cupy'])
 def test_target_values(backend):
     """Only specified target values should be sources."""
     source = np.array([
@@ -396,7 +396,7 @@ def test_wrong_dims():
 # Source at impassable cell
 # -----------------------------------------------------------------------
 
-@pytest.mark.parametrize("backend", ['numpy'])
+@pytest.mark.parametrize("backend", ['numpy', 'cupy'])
 def test_source_on_impassable_cell(backend):
     """Source on NaN-friction cell should not seed Dijkstra."""
     source = np.zeros((3, 3))
@@ -416,12 +416,12 @@ def test_source_on_impassable_cell(backend):
 
 
 # -----------------------------------------------------------------------
-# CuPy GPU spill-to-CPU tests
+# CuPy GPU tests
 # -----------------------------------------------------------------------
 
 @cuda_and_cupy_available
 def test_cupy_matches_numpy():
-    """CuPy (CPU fallback) path should produce identical results to numpy."""
+    """CuPy GPU path should produce identical results to numpy."""
     np.random.seed(42)
     source = np.zeros((7, 7))
     source[3, 3] = 1.0
@@ -475,13 +475,13 @@ def test_cupy_returns_cupy_array():
 
 
 # -----------------------------------------------------------------------
-# Dask + CuPy GPU spill-to-CPU tests
+# Dask + CuPy GPU tests
 # -----------------------------------------------------------------------
 
 @cuda_and_cupy_available
 @pytest.mark.skipif(not has_dask_array(), reason="Requires dask.Array")
 def test_dask_cupy_matches_numpy():
-    """Dask+CuPy (CPU fallback) should produce identical results to numpy."""
+    """Dask+CuPy GPU path should produce identical results to numpy."""
     np.random.seed(42)
     source = np.zeros((10, 12))
     source[2, 3] = 1.0
@@ -501,6 +501,49 @@ def test_dask_cupy_matches_numpy():
     ))
 
     np.testing.assert_allclose(result_dc, result_np, equal_nan=True, atol=1e-5)
+
+
+@cuda_and_cupy_available
+@pytest.mark.skipif(not has_dask_array(), reason="Requires dask.Array")
+def test_dask_cupy_unbounded_matches_numpy():
+    """Dask+CuPy unbounded (CPU fallback via iterative) matches numpy."""
+    np.random.seed(42)
+    source = np.zeros((10, 12))
+    source[5, 6] = 1.0
+
+    friction_data = np.random.uniform(0.5, 5.0, (10, 12))
+
+    result_np = _compute(cost_distance(
+        _make_raster(source, backend='numpy'),
+        _make_raster(friction_data, backend='numpy'),
+    ))
+    with pytest.warns(UserWarning, match="iterative tile Dijkstra"):
+        result_dc = _compute(cost_distance(
+            _make_raster(source, backend='dask+cupy', chunks=(5, 6)),
+            _make_raster(friction_data, backend='dask+cupy', chunks=(5, 6)),
+        ))
+
+    np.testing.assert_allclose(result_dc, result_np, equal_nan=True, atol=1e-5)
+
+
+@cuda_and_cupy_available
+@pytest.mark.skipif(not has_dask_array(), reason="Requires dask.Array")
+def test_dask_cupy_returns_cupy_chunks():
+    """Dask+CuPy result should have cupy-backed chunks."""
+    from xrspatial.utils import is_dask_cupy
+
+    source = np.zeros((12, 12))
+    source[6, 6] = 1.0
+    friction_data = np.ones((12, 12))
+
+    # max_cost=2 -> pad=3, chunk=6 -> pad < chunk => map_overlap GPU path
+    result = cost_distance(
+        _make_raster(source, backend='dask+cupy', chunks=(6, 6)),
+        _make_raster(friction_data, backend='dask+cupy', chunks=(6, 6)),
+        max_cost=2.0,
+    )
+    assert isinstance(result.data, da.Array)
+    assert is_dask_cupy(result)
 
 
 # -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Replaces CPU spill-to-host fallback with native CUDA iterative parallel relaxation (parallel Bellman-Ford)
- Each CUDA thread processes one pixel per iteration, checking all 4/8 neighbours for shorter paths; the wavefront advances at least one pixel per iteration
- Convergence in O(height + width) iterations with early termination when no pixel changes
- **CuPy path**: seeds sources at cost 0, iterates relaxation kernel, converts inf/over-budget to NaN
- **Dask+CuPy**: bounded `max_cost` uses `da.map_overlap` with per-chunk GPU relaxation (out-of-core, no OOM); unbounded falls back to CPU iterative tile Dijkstra
- Tests extended with `cupy` and `dask+cupy` across 8 parametrized test functions + 2 new GPU-specific tests
- README updated: Cost Distance row now shows checkmarks for CuPy and Dask GPU columns

Fixes #905

## Test plan
- [x] All 44 cost_distance tests pass (including 16 new cupy/dask+cupy variants)
- [x] Verified on GPU (NVIDIA RTX A6000) with cupy 13.6.0
- [x] Uniform friction, analytic grids, barriers, multiple sources, max_cost truncation, target_values, 4/8 connectivity all validated against numpy reference
- [x] Bounded dask+cupy hits map_overlap GPU path (verified no iterative warning)
- [x] Unbounded dask+cupy correctly falls back to CPU iterative tile Dijkstra
- [x] Output types verified: cupy returns cupy array, dask+cupy returns dask+cupy chunks