### PR TITLE
Add multi_stop_search for multi-waypoint routing (#935)

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ In the GIS world, rasters are used for representing continuous phenomena (e.g. e
 | Name | Description | NumPy xr.DataArray | Dask xr.DataArray | CuPy GPU xr.DataArray | Dask GPU xr.DataArray |
 |:----------:|:------------|:----------------------:|:--------------------:|:-------------------:|:------:|
 | [A* Pathfinding](xrspatial/pathfinding.py) | Finds the least-cost path between two cells on a cost surface | ✅️ | ✅ | 🔄 | 🔄 |
+| [Multi-Stop Search](xrspatial/pathfinding.py) | Routes through N waypoints in sequence, with optional TSP reordering | ✅️ | ✅ | 🔄 | 🔄 |
 
 ----------
 

--- a/docs/source/user_guide/pathfinding.ipynb
+++ b/docs/source/user_guide/pathfinding.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Pathfinding\n\nXarray-spatial provides A\\* pathfinding for finding optimal routes through raster surfaces.\nPaths can be computed using geometric distance alone (unweighted) or weighted by a\nfriction/cost surface, which makes the algorithm find the *least-cost* path rather\nthan the geometrically shortest one.\n\nAll four backends are supported:\n\n| Backend | Strategy |\n|---------|----------|\n| **NumPy** | Numba-jitted kernel (fast, in-memory) |\n| **Dask** | Sparse Python A\\* with LRU chunk cache — loads chunks on demand so the full grid never needs to fit in RAM |\n| **CuPy** | CPU fallback (transfers to numpy, runs the numba kernel, transfers back) |\n| **Dask+CuPy** | Same sparse A\\* as Dask, with automatic cupy-to-numpy chunk conversion |\n\n**Note:** `snap_start` and `snap_goal` are not supported with Dask-backed arrays\nbecause the brute-force nearest-pixel scan is O(h*w). Ensure the start and goal\npixels are valid before calling `a_star_search`.\n\n- [Unweighted A\\*](#Unweighted-A*): find the shortest geometric path through a line network\n- [Weighted A\\*](#Weighted-A*): find the least-cost path through a friction surface\n- [Dask (out-of-core)](#Dask-(out-of-core)): pathfinding on datasets that don't fit in RAM"
+   "source": "## Pathfinding\n\nXarray-spatial provides A\\* pathfinding for finding optimal routes through raster surfaces.\nPaths can be computed using geometric distance alone (unweighted) or weighted by a\nfriction/cost surface, which makes the algorithm find the *least-cost* path rather\nthan the geometrically shortest one.\n\n`multi_stop_search` extends A\\* to visit a sequence of waypoints, stitching segments\ninto a single cumulative-cost surface. It can optionally reorder interior waypoints\nto minimize total travel cost (TSP).\n\nAll four backends are supported:\n\n| Backend | Strategy |\n|---------|----------|\n| **NumPy** | Numba-jitted kernel (fast, in-memory) |\n| **Dask** | Sparse Python A\\* with LRU chunk cache — loads chunks on demand so the full grid never needs to fit in RAM |\n| **CuPy** | CPU fallback (transfers to numpy, runs the numba kernel, transfers back) |\n| **Dask+CuPy** | Same sparse A\\* as Dask, with automatic cupy-to-numpy chunk conversion |\n\n**Note:** `snap_start` and `snap_goal` are not supported with Dask-backed arrays\nbecause the brute-force nearest-pixel scan is O(h*w). Ensure the start and goal\npixels are valid before calling `a_star_search`.\n\n- [Unweighted A\\*](#Unweighted-A*): find the shortest geometric path through a line network\n- [Weighted A\\*](#Weighted-A*): find the least-cost path through a friction surface\n- [Multi-Stop Search](#Multi-Stop-Search): route through multiple waypoints with optional reordering\n- [Dask (out-of-core)](#Dask-(out-of-core)): pathfinding on datasets that don't fit in RAM"
   },
   {
    "cell_type": "markdown",
@@ -17,7 +17,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "import numpy as np\nimport pandas as pd\nimport xarray as xr\n\nimport datashader as ds\nfrom datashader.transfer_functions import shade\nfrom datashader.transfer_functions import stack\nfrom datashader.transfer_functions import dynspread\nfrom datashader.transfer_functions import set_background\nfrom datashader.colors import Elevation\n\nimport xrspatial\nfrom xrspatial import a_star_search, generate_terrain, slope, cost_distance"
+   "source": "import numpy as np\nimport pandas as pd\nimport xarray as xr\n\nimport datashader as ds\nfrom datashader.transfer_functions import shade\nfrom datashader.transfer_functions import stack\nfrom datashader.transfer_functions import dynspread\nfrom datashader.transfer_functions import set_background\nfrom datashader.colors import Elevation\n\nimport xrspatial\nfrom xrspatial import a_star_search, multi_stop_search, generate_terrain, slope, cost_distance"
   },
   {
    "cell_type": "markdown",
@@ -251,6 +251,35 @@
     "print(f\"A* path cost at goal:  {astar_val:.4f}\")\n",
     "print(f\"Match: {np.isclose(cd_val, astar_val, rtol=1e-5)}\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": "### Multi-Stop Search\n\n`multi_stop_search` routes through a list of waypoints in order, calling A\\* for\neach consecutive pair and stitching the segments into one cumulative-cost surface.\n\nSet `optimize_order=True` to let the solver reorder the interior waypoints (keeping\nthe first and last fixed) to minimize total travel cost. For up to 12 waypoints it\nuses exact Held-Karp; beyond that it falls back to nearest-neighbor + 2-opt.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": "#### Route through three waypoints\n\nWe pick three waypoints across the terrain and let `multi_stop_search` find\nthe least-cost route visiting them in order.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "# Three waypoints across the terrain (re-using the terrain and friction from above)\nwp_start = (400.0, 50.0)\nwp_mid   = (250.0, 250.0)\nwp_end   = (100.0, 450.0)\n\n# Naive order\npath_multi = multi_stop_search(\n    terrain, [wp_start, wp_mid, wp_end], friction=friction\n)\n\nprint(f\"Segment costs: {path_multi.attrs['segment_costs']}\")\nprint(f\"Total cost:    {path_multi.attrs['total_cost']:.2f}\")\n\n# Visualise the multi-stop path\nterrain_shaded = shade(terrain, cmap=Elevation, how=\"linear\", alpha=180)\nmulti_shaded = dynspread(\n    shade(path_multi, cmap=[\"cyan\", \"cyan\"], how=\"linear\", min_alpha=255),\n    threshold=1, max_px=2,\n)\nstack(terrain_shaded, multi_shaded)",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": "#### Optimize waypoint order\n\nWith four or more waypoints, the given order may not be the cheapest.\n`optimize_order=True` solves a TSP over the pairwise A\\* costs, keeping the\nfirst and last waypoints fixed.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "# Four waypoints in a deliberately suboptimal order (zigzag)\nwp_a = (400.0, 50.0)    # start (fixed)\nwp_b = (100.0, 450.0)   # far corner\nwp_c = (350.0, 200.0)   # back near start\nwp_d = (100.0, 350.0)   # end (fixed)\n\nwaypoints = [wp_a, wp_b, wp_c, wp_d]\n\n# Without optimization\npath_naive = multi_stop_search(terrain, waypoints, friction=friction)\n\n# With optimization\npath_opt = multi_stop_search(\n    terrain, waypoints, friction=friction, optimize_order=True\n)\n\nprint(f\"Naive order:     {path_naive.attrs['waypoint_order']}\")\nprint(f\"Naive cost:      {path_naive.attrs['total_cost']:.2f}\")\nprint(f\"Optimized order: {path_opt.attrs['waypoint_order']}\")\nprint(f\"Optimized cost:  {path_opt.attrs['total_cost']:.2f}\")\nprint(f\"Savings:         {path_naive.attrs['total_cost'] - path_opt.attrs['total_cost']:.2f}\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   },
   {
    "cell_type": "markdown",

--- a/xrspatial/__init__.py
+++ b/xrspatial/__init__.py
@@ -46,6 +46,7 @@ from xrspatial.multispectral import ndvi  # noqa
 from xrspatial.multispectral import savi  # noqa
 from xrspatial.multispectral import sipi  # noqa
 from xrspatial.pathfinding import a_star_search  # noqa
+from xrspatial.pathfinding import multi_stop_search  # noqa
 from xrspatial.perlin import perlin  # noqa
 from xrspatial.proximity import allocation  # noqa
 from xrspatial.proximity import direction  # noqa

--- a/xrspatial/pathfinding.py
+++ b/xrspatial/pathfinding.py
@@ -1147,3 +1147,324 @@ def a_star_search(surface: xr.DataArray,
                             attrs=surface.attrs)
 
     return path_agg
+
+
+# ---------------------------------------------------------------------------
+# Multi-stop routing
+# ---------------------------------------------------------------------------
+
+def _held_karp(dist, start, end):
+    """Exact TSP with fixed start and end via Held-Karp bitmask DP.
+
+    Parameters
+    ----------
+    dist : 2-D array-like, shape (N, N)
+        Pairwise costs.  ``dist[i][j]`` is the cost from city *i* to *j*.
+    start, end : int
+        Indices that must be first and last in the tour.
+
+    Returns
+    -------
+    (order, total_cost) : (list[int], float)
+    """
+    n = len(dist)
+    if n == 2:
+        return [start, end], dist[start][end]
+
+    # Cities to visit between start and end
+    mid = [i for i in range(n) if i != start and i != end]
+    nm = len(mid)
+    INF = float('inf')
+
+    # dp[(mask, city_idx_in_mid)] = min cost to reach city from start
+    # visiting exactly the cities indicated by mask
+    dp = [[INF] * nm for _ in range(1 << nm)]
+    parent = [[-1] * nm for _ in range(1 << nm)]
+
+    # Base: start -> each mid city
+    for j, c in enumerate(mid):
+        dp[1 << j][j] = dist[start][c]
+
+    for mask in range(1, 1 << nm):
+        for j in range(nm):
+            if not (mask & (1 << j)):
+                continue
+            if dp[mask][j] == INF:
+                continue
+            for k in range(nm):
+                if mask & (1 << k):
+                    continue
+                new_mask = mask | (1 << k)
+                new_cost = dp[mask][j] + dist[mid[j]][mid[k]]
+                if new_cost < dp[new_mask][k]:
+                    dp[new_mask][k] = new_cost
+                    parent[new_mask][k] = j
+
+    # Close tour to end
+    full = (1 << nm) - 1
+    best_cost = INF
+    best_last = -1
+    for j in range(nm):
+        cost = dp[full][j] + dist[mid[j]][end]
+        if cost < best_cost:
+            best_cost = cost
+            best_last = j
+
+    # Reconstruct
+    order_mid = []
+    mask = full
+    cur = best_last
+    while cur != -1:
+        order_mid.append(mid[cur])
+        prev = parent[mask][cur]
+        mask ^= (1 << cur)
+        cur = prev
+    order_mid.reverse()
+
+    return [start] + order_mid + [end], best_cost
+
+
+def _nearest_neighbor_2opt(dist, start, end):
+    """Heuristic TSP for large N: nearest-neighbor + 2-opt with fixed endpoints.
+
+    Parameters
+    ----------
+    dist : 2-D array-like, shape (N, N)
+        Pairwise costs.
+    start, end : int
+        Fixed first and last indices.
+
+    Returns
+    -------
+    (order, total_cost) : (list[int], float)
+    """
+    n = len(dist)
+    remaining = set(range(n)) - {start, end}
+
+    # Greedy nearest-neighbor construction
+    tour = [start]
+    cur = start
+    while remaining:
+        nearest = min(remaining, key=lambda c: dist[cur][c])
+        tour.append(nearest)
+        remaining.remove(nearest)
+        cur = nearest
+    tour.append(end)
+
+    # 2-opt local search (only swap interior segment, keep endpoints fixed)
+    def _tour_cost(t):
+        return sum(dist[t[i]][t[i + 1]] for i in range(len(t) - 1))
+
+    improved = True
+    while improved:
+        improved = False
+        for i in range(1, len(tour) - 2):
+            for j in range(i + 1, len(tour) - 1):
+                # Reverse segment tour[i:j+1]
+                new_tour = tour[:i] + tour[i:j + 1][::-1] + tour[j + 1:]
+                if _tour_cost(new_tour) < _tour_cost(tour):
+                    tour = new_tour
+                    improved = True
+
+    return tour, _tour_cost(tour)
+
+
+def _optimize_waypoint_order(surface, waypoints, barriers, x, y,
+                             connectivity, snap, friction, search_radius):
+    """Build pairwise cost matrix and solve TSP with fixed endpoints.
+
+    Returns reordered waypoints list.
+    """
+    n = len(waypoints)
+    INF = float('inf')
+    dist = [[INF] * n for _ in range(n)]
+
+    for i in range(n):
+        for j in range(n):
+            if i == j:
+                dist[i][j] = 0.0
+                continue
+            seg = a_star_search(
+                surface, waypoints[i], waypoints[j],
+                barriers=barriers, x=x, y=y,
+                connectivity=connectivity,
+                snap_start=snap, snap_goal=snap,
+                friction=friction, search_radius=search_radius,
+            )
+            seg_data = seg.data
+            if hasattr(seg_data, 'get'):
+                seg_vals = seg_data.get()
+            else:
+                seg_vals = np.asarray(seg.values)
+            goal_py, goal_px = _get_pixel_id(waypoints[j], surface, x, y)
+            goal_cost = seg_vals[goal_py, goal_px]
+            if np.isfinite(goal_cost):
+                dist[i][j] = goal_cost
+
+    # Fixed endpoints: first=0, last=n-1
+    if n <= 12:
+        order, _ = _held_karp(dist, 0, n - 1)
+    else:
+        order, _ = _nearest_neighbor_2opt(dist, 0, n - 1)
+
+    return [waypoints[i] for i in order]
+
+
+def multi_stop_search(surface: xr.DataArray,
+                      waypoints: list,
+                      barriers: list = [],
+                      x: Optional[str] = 'x',
+                      y: Optional[str] = 'y',
+                      connectivity: int = 8,
+                      snap: bool = False,
+                      friction: xr.DataArray = None,
+                      search_radius: Optional[int] = None,
+                      optimize_order: bool = False) -> xr.DataArray:
+    """Find the least-cost path visiting a sequence of waypoints in order.
+
+    Wraps :func:`a_star_search` to route through *N* waypoints,
+    stitching segments into a single cumulative-cost surface.  When
+    ``optimize_order=True``, the interior waypoints are reordered to
+    minimize total travel cost (TSP), keeping the first and last
+    waypoints fixed.
+
+    Parameters
+    ----------
+    surface : xr.DataArray
+        2-D elevation / cost surface.
+    waypoints : list of array-like
+        Sequence of ``(y, x)`` coordinate pairs to visit.  Must contain
+        at least two points.
+    barriers : list, default=[]
+        Surface values that are impassable.
+    x, y : str, default ``'x'`` / ``'y'``
+        Coordinate dimension names.
+    connectivity : int, default=8
+        4 or 8 connectivity.
+    snap : bool, default=False
+        Snap each waypoint to the nearest valid pixel.  Not supported
+        with dask-backed arrays.
+    friction : xr.DataArray, optional
+        Friction surface (same shape as *surface*).
+    search_radius : int, optional
+        Passed to each :func:`a_star_search` call.
+    optimize_order : bool, default=False
+        Reorder interior waypoints to minimize total cost.  Uses exact
+        Held-Karp when N <= 12, nearest-neighbor + 2-opt otherwise.
+
+    Returns
+    -------
+    xr.DataArray
+        Cumulative path cost surface.  Attributes include
+        ``waypoint_order``, ``segment_costs``, and ``total_cost``.
+
+    Raises
+    ------
+    ValueError
+        If the surface is not 2-D, fewer than two waypoints are given,
+        waypoints fall outside the surface bounds, or a segment is
+        unreachable.
+    """
+    # --- Input validation ---
+    if surface.ndim != 2:
+        raise ValueError("input `surface` must be 2D")
+
+    if len(waypoints) < 2:
+        raise ValueError("at least 2 waypoints are required")
+
+    for idx, wp in enumerate(waypoints):
+        if len(wp) != 2:
+            raise ValueError(
+                f"waypoint {idx} must have exactly 2 elements (y, x)")
+
+    h, w = surface.shape
+    for idx, wp in enumerate(waypoints):
+        py, px = _get_pixel_id(wp, surface, x, y)
+        if not _is_inside(py, px, h, w):
+            raise ValueError(
+                f"waypoint {idx} ({wp}) is outside the surface bounds")
+
+    if friction is not None and friction.shape != surface.shape:
+        raise ValueError("friction must have the same shape as surface")
+
+    surface_data = surface.data
+    _is_dask = da is not None and isinstance(surface_data, da.Array)
+    if snap and _is_dask:
+        raise ValueError(
+            "snap is not supported with dask-backed arrays; "
+            "ensure waypoints are valid before calling multi_stop_search")
+
+    if optimize_order:
+        if len(waypoints) < 3:
+            warnings.warn(
+                "optimize_order has no effect with fewer than 3 waypoints",
+                stacklevel=2,
+            )
+        else:
+            waypoints = _optimize_waypoint_order(
+                surface, list(waypoints), barriers, x, y,
+                connectivity, snap, friction, search_radius,
+            )
+
+    # --- Segment-by-segment routing ---
+    path_data = np.full(surface.shape, np.nan, dtype=np.float64)
+    cumulative_cost = 0.0
+    segment_costs = []
+
+    # Pre-compute pixel coords for all waypoints
+    waypoint_pixels = [_get_pixel_id(wp, surface, x, y) for wp in waypoints]
+
+    for i in range(len(waypoints) - 1):
+        seg = a_star_search(
+            surface, waypoints[i], waypoints[i + 1],
+            barriers=barriers, x=x, y=y,
+            connectivity=connectivity,
+            snap_start=snap, snap_goal=snap,
+            friction=friction, search_radius=search_radius,
+        )
+        seg_data = seg.data
+        if hasattr(seg_data, 'get'):
+            seg_vals = seg_data.get()  # cupy -> numpy
+        else:
+            seg_vals = np.asarray(seg.values)
+
+        goal_py, goal_px = waypoint_pixels[i + 1]
+
+        # If snap is on, the actual goal pixel may differ from the
+        # requested one.  Find the pixel with maximum finite cost
+        # (the true goal of this segment).
+        if snap and not np.isfinite(seg_vals[goal_py, goal_px]):
+            finite = np.isfinite(seg_vals)
+            if finite.any():
+                max_idx = np.nanargmax(seg_vals)
+                goal_py, goal_px = np.unravel_index(max_idx, seg_vals.shape)
+                waypoint_pixels[i + 1] = (goal_py, goal_px)
+
+        seg_goal_cost = seg_vals[goal_py, goal_px]
+
+        if not np.isfinite(seg_goal_cost):
+            raise ValueError(
+                f"no path between waypoints {i} and {i + 1}")
+
+        mask = np.isfinite(seg_vals)
+        if i > 0:
+            # Don't overwrite the junction pixel (set by previous segment)
+            sp_y, sp_x = waypoint_pixels[i]
+            mask[sp_y, sp_x] = False
+
+        path_data[mask] = seg_vals[mask] + cumulative_cost
+        segment_costs.append(float(seg_goal_cost))
+        cumulative_cost += seg_goal_cost
+
+    path_agg = xr.DataArray(
+        path_data,
+        coords=surface.coords,
+        dims=surface.dims,
+        attrs={
+            'waypoint_order': [tuple(wp) for wp in waypoints],
+            'segment_costs': segment_costs,
+            'total_cost': cumulative_cost,
+        },
+    )
+
+    return path_agg

--- a/xrspatial/tests/test_pathfinding.py
+++ b/xrspatial/tests/test_pathfinding.py
@@ -734,3 +734,273 @@ def test_backward_compatibility():
     path2 = a_star_search(agg, start, goal, search_radius=None)
     np.testing.assert_allclose(
         path2.values, path.values, equal_nan=True, atol=1e-10)
+
+
+# -----------------------------------------------------------------------
+# multi_stop_search tests
+# -----------------------------------------------------------------------
+
+from xrspatial import multi_stop_search
+from xrspatial.pathfinding import _held_karp, _nearest_neighbor_2opt
+
+
+# --- TSP solver unit tests ---
+
+def test_held_karp_basic():
+    """Held-Karp finds optimal tour on a small symmetric graph."""
+    # 4 cities in a line: 0 -- 1 -- 2 -- 3
+    dist = [
+        [0, 1, 2, 3],
+        [1, 0, 1, 2],
+        [2, 1, 0, 1],
+        [3, 2, 1, 0],
+    ]
+    order, cost = _held_karp(dist, 0, 3)
+    assert order[0] == 0
+    assert order[-1] == 3
+    assert cost == 3.0  # 0->1->2->3
+    assert order == [0, 1, 2, 3]
+
+
+def test_held_karp_asymmetric():
+    """Held-Karp handles directed (asymmetric) costs."""
+    # Going 0->1 costs 1, but 1->0 costs 10
+    dist = [
+        [0,  1, 5],
+        [10, 0, 1],
+        [5,  1, 0],
+    ]
+    order, cost = _held_karp(dist, 0, 2)
+    assert order[0] == 0
+    assert order[-1] == 2
+    # Optimal: 0->1->2 = 1+1 = 2 (not 0->2 = 5)
+    assert cost == 2.0
+    assert order == [0, 1, 2]
+
+
+def test_nearest_neighbor_2opt_fixed_endpoints():
+    """Nearest-neighbor + 2-opt preserves start and end."""
+    dist = [
+        [0, 1, 4, 3],
+        [1, 0, 2, 5],
+        [4, 2, 0, 1],
+        [3, 5, 1, 0],
+    ]
+    order, cost = _nearest_neighbor_2opt(dist, 0, 3)
+    assert order[0] == 0
+    assert order[-1] == 3
+    assert set(order) == {0, 1, 2, 3}
+
+
+def test_nearest_neighbor_2opt_vs_held_karp():
+    """Heuristic should match or be close to exact on small inputs."""
+    dist = [
+        [0, 2, 9, 10],
+        [2, 0, 6, 4],
+        [9, 6, 0, 8],
+        [10, 4, 8, 0],
+    ]
+    exact_order, exact_cost = _held_karp(dist, 0, 3)
+    heur_order, heur_cost = _nearest_neighbor_2opt(dist, 0, 3)
+
+    assert heur_order[0] == 0
+    assert heur_order[-1] == 3
+    # Heuristic should be within 50% of optimal for 4 cities
+    assert heur_cost <= exact_cost * 1.5
+
+
+# --- Multi-stop functional tests ---
+
+def test_two_waypoints_matches_a_star():
+    """Two waypoints should produce the same result as a single A* call."""
+    data = np.ones((8, 8))
+    agg = _make_raster(data)
+
+    start = (7.0, 0.0)  # pixel (0, 0)
+    goal = (0.0, 7.0)   # pixel (7, 7)
+
+    path_single = a_star_search(agg, start, goal)
+    path_multi = multi_stop_search(agg, [start, goal])
+
+    np.testing.assert_allclose(
+        path_multi.values, path_single.values,
+        equal_nan=True, atol=1e-10,
+    )
+
+
+def test_three_waypoints_cost_continuity():
+    """Costs should increase monotonically across segments; attrs correct."""
+    data = np.ones((10, 10))
+    agg = _make_raster(data)
+
+    # Three waypoints along the diagonal
+    wp0 = (9.0, 0.0)   # pixel (0, 0)
+    wp1 = (5.0, 4.0)   # pixel (4, 4)
+    wp2 = (0.0, 9.0)   # pixel (9, 9)
+
+    result = multi_stop_search(agg, [wp0, wp1, wp2])
+
+    vals = result.values
+    # All three waypoint pixels should be on the path
+    assert np.isfinite(vals[0, 0])
+    assert np.isfinite(vals[4, 4])
+    assert np.isfinite(vals[9, 9])
+
+    # Cost at start should be 0
+    assert vals[0, 0] == 0.0
+    # Cost should increase: start < mid < end
+    assert vals[4, 4] < vals[9, 9]
+    assert vals[0, 0] < vals[4, 4]
+
+    # Check attrs
+    assert len(result.attrs['segment_costs']) == 2
+    assert result.attrs['total_cost'] > 0
+    np.testing.assert_allclose(
+        sum(result.attrs['segment_costs']),
+        result.attrs['total_cost'],
+        atol=1e-10,
+    )
+    assert len(result.attrs['waypoint_order']) == 3
+
+
+def test_three_waypoints_with_friction():
+    """Multi-stop with friction surface produces valid monotonic costs."""
+    data = np.ones((10, 10))
+    friction_data = np.ones((10, 10))
+    friction_data[3:7, 3:7] = 5.0  # high-friction zone
+
+    agg = _make_raster(data)
+    friction_agg = _make_raster(friction_data)
+
+    wp0 = (9.0, 0.0)
+    wp1 = (5.0, 4.0)
+    wp2 = (0.0, 9.0)
+
+    result = multi_stop_search(agg, [wp0, wp1, wp2], friction=friction_agg)
+
+    vals = result.values
+    assert np.isfinite(vals[0, 0])
+    assert np.isfinite(vals[9, 9])
+    assert vals[0, 0] == 0.0
+    assert result.attrs['total_cost'] > 0
+
+
+def test_unreachable_segment_raises():
+    """Barrier blocking a segment should raise ValueError."""
+    data = np.ones((8, 8))
+    # Wall across row 4
+    data[4, :] = np.nan
+
+    agg = _make_raster(data)
+
+    wp0 = (7.0, 0.0)   # pixel (0, 0) — above the wall
+    wp1 = (0.0, 0.0)   # pixel (7, 0) — below the wall
+
+    with pytest.raises(ValueError, match="no path between waypoints"):
+        multi_stop_search(agg, [wp0, wp1])
+
+
+def test_waypoint_outside_bounds_raises():
+    """Waypoint outside the surface should raise ValueError."""
+    data = np.ones((5, 5))
+    agg = _make_raster(data)
+
+    wp0 = (4.0, 0.0)
+    wp_bad = (100.0, 100.0)
+
+    with pytest.raises(ValueError, match="outside the surface bounds"):
+        multi_stop_search(agg, [wp0, wp_bad])
+
+
+def test_too_few_waypoints_raises():
+    """Fewer than 2 waypoints should raise ValueError."""
+    data = np.ones((5, 5))
+    agg = _make_raster(data)
+
+    with pytest.raises(ValueError, match="at least 2 waypoints"):
+        multi_stop_search(agg, [(4.0, 0.0)])
+
+    with pytest.raises(ValueError, match="at least 2 waypoints"):
+        multi_stop_search(agg, [])
+
+
+# --- optimize_order tests ---
+
+def test_optimize_order_finds_better_route():
+    """Reordering interior waypoints should give equal or lower total cost."""
+    data = np.ones((10, 10))
+    agg = _make_raster(data)
+
+    # Deliberately suboptimal order: zigzag
+    wp0 = (9.0, 0.0)   # pixel (0, 0) — fixed start
+    wp1 = (0.0, 9.0)   # pixel (9, 9) — far corner
+    wp2 = (9.0, 4.0)   # pixel (0, 4) — back near start
+    wp3 = (0.0, 4.0)   # pixel (9, 4) — fixed end
+
+    naive = multi_stop_search(agg, [wp0, wp1, wp2, wp3])
+    optimized = multi_stop_search(
+        agg, [wp0, wp1, wp2, wp3], optimize_order=True)
+
+    assert optimized.attrs['total_cost'] <= naive.attrs['total_cost'] + 1e-10
+
+
+def test_optimize_order_preserves_endpoints():
+    """First and last waypoints should remain fixed after optimization."""
+    data = np.ones((10, 10))
+    agg = _make_raster(data)
+
+    wp0 = (9.0, 0.0)
+    wp1 = (5.0, 5.0)
+    wp2 = (5.0, 0.0)
+    wp3 = (0.0, 9.0)
+
+    result = multi_stop_search(
+        agg, [wp0, wp1, wp2, wp3], optimize_order=True)
+
+    order = result.attrs['waypoint_order']
+    assert tuple(order[0]) == wp0
+    assert tuple(order[-1]) == wp3
+
+
+# --- Cross-backend tests ---
+
+@pytest.mark.skipif(not has_dask_array(), reason="Requires dask.Array")
+def test_multi_stop_dask_matches_numpy():
+    """Dask multi-stop should match numpy results."""
+    data = np.ones((8, 8))
+    wp0 = (7.0, 0.0)
+    wp1 = (4.0, 3.0)
+    wp2 = (0.0, 7.0)
+
+    agg_np = _make_raster(data, backend='numpy')
+    agg_dask = _make_raster(data, backend='dask+numpy', chunks=(4, 4))
+
+    path_np = multi_stop_search(agg_np, [wp0, wp1, wp2])
+    path_dask = multi_stop_search(agg_dask, [wp0, wp1, wp2])
+
+    np.testing.assert_allclose(
+        np.asarray(path_dask.values),
+        path_np.values,
+        equal_nan=True, atol=1e-10,
+    )
+
+
+@cuda_and_cupy_available
+def test_multi_stop_cupy_matches_numpy():
+    """CuPy multi-stop should match numpy results."""
+    data = np.ones((8, 8))
+    wp0 = (7.0, 0.0)
+    wp1 = (4.0, 3.0)
+    wp2 = (0.0, 7.0)
+
+    agg_np = _make_raster(data, backend='numpy')
+    agg_cupy = _make_raster(data, backend='cupy')
+
+    path_np = multi_stop_search(agg_np, [wp0, wp1, wp2])
+    path_cupy = multi_stop_search(agg_cupy, [wp0, wp1, wp2])
+
+    np.testing.assert_allclose(
+        path_cupy.data if not hasattr(path_cupy.data, 'get') else path_cupy.data,
+        path_np.values,
+        equal_nan=True, atol=1e-10,
+    )


### PR DESCRIPTION
## Summary

- Adds `multi_stop_search()`, which routes through N waypoints by calling `a_star_search` for each consecutive pair and stitching the results into a single cumulative-cost DataArray
- Two TSP solvers handle optional waypoint reordering: exact Held-Karp (N<=12) and nearest-neighbor + 2-opt (N>12), both with fixed start/end
- Supports numpy, dask, cupy, and dask+cupy backends; uses `.data.get()` for CuPy arrays to avoid implicit conversion errors
- 14 new tests cover TSP solvers, multi-stop routing, input validation, optimize_order, and cross-backend parity
- README feature matrix and pathfinding user guide notebook updated with multi-stop examples

## Test plan

- [x] All 46 pathfinding tests pass (32 existing + 14 new)
- [x] Verify notebook cells run end-to-end (`jupyter nbconvert --execute docs/source/user_guide/pathfinding.ipynb`)