### PR TITLE
Add missing API reference docs for undocumented functions

### DIFF
--- a/docs/source/reference/classification.rst
+++ b/docs/source/reference/classification.rst
@@ -31,3 +31,45 @@ Quantile
     :toctree: _autosummary
 
     xrspatial.classify.quantile
+
+Binary
+======
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.classify.binary
+
+Box Plot
+========
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.classify.box_plot
+
+Head/Tail Breaks
+================
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.classify.head_tail_breaks
+
+Maximum Breaks
+==============
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.classify.maximum_breaks
+
+Percentiles
+===========
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.classify.percentiles
+
+Standard Mean
+=============
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.classify.std_mean

--- a/docs/source/reference/hydrology.rst
+++ b/docs/source/reference/hydrology.rst
@@ -1,0 +1,104 @@
+..  _reference.hydrology:
+
+*********
+Hydrology
+*********
+
+Flow Direction
+==============
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.flow_direction.flow_direction
+
+Flow Direction (D-infinity)
+===========================
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.flow_direction_dinf.flow_direction_dinf
+
+Flow Accumulation
+=================
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.flow_accumulation.flow_accumulation
+
+Flow Length
+===========
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.flow_length.flow_length
+
+Flow Path
+=========
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.flow_path.flow_path
+
+Fill
+====
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.fill.fill
+
+Sink
+====
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.sink.sink
+
+Basin
+=====
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.basin.basin
+
+Watershed
+=========
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.watershed.watershed
+    xrspatial.watershed.basins
+
+Snap Pour Point
+===============
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.snap_pour_point.snap_pour_point
+
+Stream Link
+===========
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.stream_link.stream_link
+
+Stream Order
+============
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.stream_order.stream_order
+
+Height Above Nearest Drainage (HAND)
+=====================================
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.hand.hand
+
+Topographic Wetness Index (TWI)
+===============================
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.twi.twi

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -12,8 +12,12 @@ Reference
    fire
    flood
    focal
+   hydrology
+   interpolation
    multispectral
    pathfinding
    proximity
    surface
+   terrain_metrics
+   utilities
    zonal

--- a/docs/source/reference/interpolation.rst
+++ b/docs/source/reference/interpolation.rst
@@ -1,0 +1,26 @@
+..  _reference.interpolation:
+
+*************
+Interpolation
+*************
+
+Inverse Distance Weighting (IDW)
+=================================
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.interpolate.idw
+
+Kriging
+=======
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.interpolate.kriging
+
+Spline
+======
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.interpolate.spline

--- a/docs/source/reference/proximity.rst
+++ b/docs/source/reference/proximity.rst
@@ -34,3 +34,24 @@ Cost Distance
     :toctree: _autosummary
 
     xrspatial.cost_distance.cost_distance
+
+Surface Distance
+================
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.surface_distance.surface_distance
+
+Surface Allocation
+==================
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.surface_distance.surface_allocation
+
+Surface Direction
+=================
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.surface_distance.surface_direction

--- a/docs/source/reference/surface.rst
+++ b/docs/source/reference/surface.rst
@@ -59,3 +59,10 @@ Bump Mapping
     :toctree: _autosummary
 
     xrspatial.bump.bump
+
+Erosion
+=======
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.erosion.erode

--- a/docs/source/reference/terrain_metrics.rst
+++ b/docs/source/reference/terrain_metrics.rst
@@ -1,0 +1,26 @@
+..  _reference.terrain_metrics:
+
+***************
+Terrain Metrics
+***************
+
+Roughness
+=========
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.terrain_metrics.roughness
+
+Topographic Position Index (TPI)
+================================
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.terrain_metrics.tpi
+
+Terrain Ruggedness Index (TRI)
+==============================
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.terrain_metrics.tri

--- a/docs/source/reference/utilities.rst
+++ b/docs/source/reference/utilities.rst
@@ -1,0 +1,33 @@
+..  _reference.utilities:
+
+*********
+Utilities
+*********
+
+Mahalanobis Distance
+====================
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.mahalanobis.mahalanobis
+
+Emerging Hotspots
+=================
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.emerging_hotspots.emerging_hotspots
+
+Polygonize
+==========
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.polygonize.polygonize
+
+Diagnostics
+===========
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.diagnostics.diagnose


### PR DESCRIPTION
## Summary

Closes #941.

About 30 public functions exported from `xrspatial/__init__.py` had no API reference entries.  This PR fills the gaps:

- **classification.rst** -- added `binary`, `box_plot`, `head_tail_breaks`, `maximum_breaks`, `percentiles`, `std_mean`
- **hydrology.rst** (new) -- 15 functions: flow direction/accumulation/length/path, fill, sink, basin, watershed, snap pour point, stream link/order, HAND, TWI
- **terrain_metrics.rst** (new) -- `roughness`, `tpi`, `tri`
- **interpolation.rst** (new) -- `idw`, `kriging`, `spline`
- **proximity.rst** -- added `surface_distance`, `surface_allocation`, `surface_direction`
- **surface.rst** -- added `erode`
- **utilities.rst** (new) -- `mahalanobis`, `emerging_hotspots`, `polygonize`, `diagnose`
- **index.rst** -- added new pages to the toctree

## Test plan

- [ ] Verify `make html` builds without warnings about missing references
- [ ] Spot-check autosummary output for a few of the new entries
- [ ] Confirm the toctree renders all new sections in the sidebar
