### PR TITLE
Add balanced service area partitioning (#939)

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ In the GIS world, rasters are used for representing continuous phenomena (e.g. e
 | Name | Description | NumPy xr.DataArray | Dask xr.DataArray | CuPy GPU xr.DataArray | Dask GPU xr.DataArray |
 |:----------:|:------------|:----------------------:|:--------------------:|:-------------------:|:------:|
 | [Allocation](xrspatial/proximity.py) | Assigns each cell to the identity of the nearest source feature | ✅️ | ✅ | ✅️ | ✅️ |
+| [Balanced Allocation](xrspatial/balanced_allocation.py) | Partitions a cost surface into territories of roughly equal cost-weighted area | ✅️ | ✅ | ✅️ | ✅️ |
 | [Cost Distance](xrspatial/cost_distance.py) | Computes minimum accumulated cost to the nearest source through a friction surface | ✅️ | ✅ | ✅️ | ✅️ |
 | [Direction](xrspatial/proximity.py) | Computes the direction from each cell to the nearest source feature | ✅️ | ✅ | ✅️ | ✅️ |
 | [Proximity](xrspatial/proximity.py) | Computes the distance from each cell to the nearest source feature | ✅️ | ✅ | ✅️ | ✅️ |

--- a/docs/source/reference/proximity.rst
+++ b/docs/source/reference/proximity.rst
@@ -35,6 +35,13 @@ Cost Distance
 
     xrspatial.cost_distance.cost_distance
 
+Balanced Allocation
+====================
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.balanced_allocation.balanced_allocation
+
 Surface Distance
 ================
 .. autosummary::

--- a/examples/user_guide/15_Balanced_Allocation.ipynb
+++ b/examples/user_guide/15_Balanced_Allocation.ipynb
@@ -1,0 +1,373 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Xarray-spatial\n",
+    "### User Guide: Balanced Service Area Partitioning\n",
+    "-----\n",
+    "\n",
+    "The `balanced_allocation` function partitions a cost surface into territories of roughly equal **cost-weighted area**. Standard `allocation` assigns each cell to the nearest source by cost distance, which can produce lopsided territories when friction varies across the landscape. `balanced_allocation` adds an iterative bias-adjustment step so that each source ends up responsible for a similar total workload.\n",
+    "\n",
+    "**Contents:**\n",
+    "- [Setup](#Setup)\n",
+    "- [1. Standard allocation vs balanced allocation](#1.-Standard-allocation-vs-balanced-allocation)\n",
+    "- [2. Asymmetric friction](#2.-Asymmetric-friction)\n",
+    "- [3. Three sources](#3.-Three-sources)\n",
+    "- [4. Tuning tolerance and iterations](#4.-Tuning-tolerance-and-iterations)\n",
+    "- [5. Barriers](#5.-Barriers)\n",
+    "\n",
+    "-----"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import xarray as xr\n",
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib.colors import ListedColormap\n",
+    "\n",
+    "from xrspatial import cost_distance, allocation\n",
+    "from xrspatial.balanced_allocation import balanced_allocation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def make_raster(data, res=1.0):\n",
+    "    \"\"\"Helper: create a DataArray with y/x coordinates.\"\"\"\n",
+    "    h, w = data.shape\n",
+    "    raster = xr.DataArray(\n",
+    "        data.astype(np.float64),\n",
+    "        dims=['y', 'x'],\n",
+    "        attrs={'res': (res, res)},\n",
+    "    )\n",
+    "    raster['y'] = np.arange(h) * res\n",
+    "    raster['x'] = np.arange(w) * res\n",
+    "    return raster\n",
+    "\n",
+    "\n",
+    "def plot_territories(alloc_arr, title, source_locs=None, ax=None):\n",
+    "    \"\"\"Plot a territory allocation with distinct colours per source.\"\"\"\n",
+    "    if ax is None:\n",
+    "        fig, ax = plt.subplots(figsize=(6, 5))\n",
+    "    data = alloc_arr.values if hasattr(alloc_arr, 'values') else alloc_arr\n",
+    "    ids = np.unique(data[np.isfinite(data)])\n",
+    "    colors = plt.cm.Set2(np.linspace(0, 1, max(len(ids), 3)))\n",
+    "    cmap = ListedColormap(colors[:len(ids)])\n",
+    "    im = ax.imshow(data, cmap=cmap, origin='upper', interpolation='nearest')\n",
+    "    ax.set_title(title)\n",
+    "    if source_locs is not None:\n",
+    "        for r, c in source_locs:\n",
+    "            ax.plot(c, r, 'k*', markersize=12)\n",
+    "    plt.colorbar(im, ax=ax, shrink=0.8)\n",
+    "    return ax\n",
+    "\n",
+    "\n",
+    "def territory_stats(alloc_arr, friction_arr):\n",
+    "    \"\"\"Print cell count and cost-weighted area per territory.\"\"\"\n",
+    "    alloc = alloc_arr.values if hasattr(alloc_arr, 'values') else alloc_arr\n",
+    "    fric = friction_arr.values if hasattr(friction_arr, 'values') else friction_arr\n",
+    "    ids = sorted(np.unique(alloc[np.isfinite(alloc)]))\n",
+    "    print(f\"{'Source':>8}  {'Cells':>6}  {'Cost-weighted area':>18}\")\n",
+    "    print('-' * 38)\n",
+    "    for sid in ids:\n",
+    "        mask = alloc == sid\n",
+    "        n = int(np.sum(mask))\n",
+    "        w = float(np.sum(fric[mask]))\n",
+    "        print(f\"{sid:>8.0f}  {n:>6d}  {w:>18.1f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Standard allocation vs balanced allocation\n",
+    "\n",
+    "With uniform friction, standard `allocation` assigns each cell to the nearest source by cost distance. The resulting territories depend on source placement and have no guarantee of equal size. `balanced_allocation` adjusts boundaries so each territory has roughly the same total friction (cost-weighted area)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Two sources placed asymmetrically on a 30x30 grid\n",
+    "source_data = np.zeros((30, 30))\n",
+    "source_data[5, 5] = 1.0    # source near top-left corner\n",
+    "source_data[15, 15] = 2.0  # source near centre\n",
+    "\n",
+    "raster = make_raster(source_data)\n",
+    "friction = make_raster(np.ones((30, 30)))\n",
+    "locs = [(5, 5), (15, 15)]\n",
+    "\n",
+    "# Standard allocation (nearest by cost)\n",
+    "std_alloc = allocation(raster)\n",
+    "\n",
+    "# Balanced allocation\n",
+    "bal_alloc = balanced_allocation(raster, friction, tolerance=0.05)\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(12, 5))\n",
+    "plot_territories(std_alloc, 'Standard allocation', locs, ax=axes[0])\n",
+    "plot_territories(bal_alloc, 'Balanced allocation', locs, ax=axes[1])\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "\n",
+    "print('\\nStandard allocation:')\n",
+    "territory_stats(std_alloc, friction)\n",
+    "print('\\nBalanced allocation:')\n",
+    "territory_stats(bal_alloc, friction)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The balanced version shifts the boundary so both territories end up with a similar number of cells (and since friction is uniform, similar cost-weighted area)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Asymmetric friction\n",
+    "\n",
+    "When friction varies, balancing by cost-weighted area means the territory with expensive cells gets fewer of them, while the territory with cheap cells gets more. The total friction within each territory converges to the same value."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Left half has low friction, right half has high friction\n",
+    "source_data2 = np.zeros((30, 30))\n",
+    "source_data2[15, 5] = 1.0   # source on the cheap side\n",
+    "source_data2[15, 25] = 2.0  # source on the expensive side\n",
+    "\n",
+    "fric_data2 = np.ones((30, 30))\n",
+    "fric_data2[:, 15:] = 4.0  # right half is 4x more costly\n",
+    "\n",
+    "raster2 = make_raster(source_data2)\n",
+    "friction2 = make_raster(fric_data2)\n",
+    "locs2 = [(15, 5), (15, 25)]\n",
+    "\n",
+    "bal2 = balanced_allocation(raster2, friction2, tolerance=0.05)\n",
+    "\n",
+    "# Also compute cost_distance for reference\n",
+    "cd2 = cost_distance(raster2, friction2)\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 3, figsize=(16, 5))\n",
+    "axes[0].imshow(fric_data2, cmap='YlOrRd', origin='upper')\n",
+    "axes[0].set_title('Friction surface')\n",
+    "plt.colorbar(axes[0].images[0], ax=axes[0], shrink=0.8)\n",
+    "\n",
+    "axes[1].imshow(cd2.values, cmap='magma', origin='upper')\n",
+    "axes[1].set_title('Cost distance')\n",
+    "plt.colorbar(axes[1].images[0], ax=axes[1], shrink=0.8)\n",
+    "\n",
+    "plot_territories(bal2, 'Balanced allocation', locs2, ax=axes[2])\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "\n",
+    "print('\\nBalanced allocation territory stats:')\n",
+    "territory_stats(bal2, friction2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Source 1 (cheap side) covers more cells but the same total friction as source 2 (expensive side), which covers fewer cells."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Three sources\n",
+    "\n",
+    "The algorithm works with any number of sources. Each territory converges to roughly 1/N of the total cost-weighted area."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Three sources on a grid with some friction variation\n",
+    "np.random.seed(42)\n",
+    "source_data3 = np.zeros((40, 40))\n",
+    "source_data3[8, 20] = 1.0\n",
+    "source_data3[30, 8] = 2.0\n",
+    "source_data3[30, 32] = 3.0\n",
+    "\n",
+    "# Smooth random friction field\n",
+    "from scipy.ndimage import gaussian_filter\n",
+    "raw_fric = np.random.uniform(1.0, 5.0, (40, 40))\n",
+    "fric_data3 = gaussian_filter(raw_fric, sigma=3)\n",
+    "fric_data3 = np.clip(fric_data3, 1.0, None)\n",
+    "\n",
+    "raster3 = make_raster(source_data3)\n",
+    "friction3 = make_raster(fric_data3)\n",
+    "locs3 = [(8, 20), (30, 8), (30, 32)]\n",
+    "\n",
+    "bal3 = balanced_allocation(raster3, friction3, tolerance=0.05)\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(12, 5))\n",
+    "axes[0].imshow(fric_data3, cmap='YlOrRd', origin='upper')\n",
+    "axes[0].set_title('Friction surface')\n",
+    "for r, c in locs3:\n",
+    "    axes[0].plot(c, r, 'k*', markersize=12)\n",
+    "plt.colorbar(axes[0].images[0], ax=axes[0], shrink=0.8)\n",
+    "\n",
+    "plot_territories(bal3, 'Balanced allocation (3 sources)', locs3, ax=axes[1])\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "\n",
+    "print('\\nTerritory stats:')\n",
+    "territory_stats(bal3, friction3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Tuning tolerance and iterations\n",
+    "\n",
+    "The `tolerance` parameter controls how close to equal the territories need to be (as a fraction of the mean). Tighter tolerance means more iterations. The `learning_rate` controls how aggressively biases are updated each step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Compare different tolerance values\n",
+    "fig, axes = plt.subplots(1, 3, figsize=(16, 5))\n",
+    "\n",
+    "for ax, tol in zip(axes, [0.20, 0.05, 0.01]):\n",
+    "    result = balanced_allocation(\n",
+    "        raster3, friction3, tolerance=tol, max_iterations=200,\n",
+    "    )\n",
+    "    plot_territories(result, f'tolerance={tol}', locs3, ax=ax)\n",
+    "    \n",
+    "    # Compute balance quality\n",
+    "    vals = result.values\n",
+    "    weights = []\n",
+    "    for sid in [1.0, 2.0, 3.0]:\n",
+    "        weights.append(float(np.sum(fric_data3[vals == sid])))\n",
+    "    mean_w = np.mean(weights)\n",
+    "    max_dev = max(abs(w - mean_w) / mean_w for w in weights)\n",
+    "    ax.set_xlabel(f'max deviation: {max_dev:.1%}')\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Barriers\n",
+    "\n",
+    "NaN cells in the friction surface act as impassable barriers, just like in `cost_distance`. The balanced allocation respects these barriers and leaves unreachable cells as NaN."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Grid with a diagonal barrier\n",
+    "source_data4 = np.zeros((30, 30))\n",
+    "source_data4[5, 5] = 1.0\n",
+    "source_data4[25, 25] = 2.0\n",
+    "\n",
+    "fric_data4 = np.ones((30, 30))\n",
+    "# Diagonal barrier with a gap\n",
+    "for i in range(30):\n",
+    "    if abs(i - 15) > 2:  # gap near the middle\n",
+    "        fric_data4[i, i] = np.nan\n",
+    "        if i + 1 < 30:\n",
+    "            fric_data4[i, i + 1] = np.nan\n",
+    "\n",
+    "raster4 = make_raster(source_data4)\n",
+    "friction4 = make_raster(fric_data4)\n",
+    "locs4 = [(5, 5), (25, 25)]\n",
+    "\n",
+    "bal4 = balanced_allocation(raster4, friction4, tolerance=0.05)\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(12, 5))\n",
+    "\n",
+    "barrier_vis = fric_data4.copy()\n",
+    "barrier_vis[np.isnan(barrier_vis)] = 0\n",
+    "axes[0].imshow(barrier_vis, cmap='gray', origin='upper')\n",
+    "axes[0].set_title('Friction (dark = barrier)')\n",
+    "for r, c in locs4:\n",
+    "    axes[0].plot(c, r, 'r*', markersize=12)\n",
+    "\n",
+    "plot_territories(bal4, 'Balanced allocation with barrier', locs4, ax=axes[1])\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n",
+    "\n",
+    "print('\\nTerritory stats:')\n",
+    "territory_stats(bal4, friction4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Both sources must route through the gap in the barrier. The balanced allocation still equalizes the cost-weighted area on each side, subject to the constraint that paths must go through the gap.\n",
+    "\n",
+    "-----\n",
+    "\n",
+    "## Summary\n",
+    "\n",
+    "| Parameter | Default | What it does |\n",
+    "|---|---|---|\n",
+    "| `raster` | (required) | Source raster with non-zero values as source IDs |\n",
+    "| `friction` | (required) | Cost surface (positive values, NaN = impassable) |\n",
+    "| `tolerance` | 0.05 | Convergence threshold (fraction of mean) |\n",
+    "| `max_iterations` | 100 | Maximum balancing iterations |\n",
+    "| `learning_rate` | 0.5 | Bias update aggressiveness |\n",
+    "| `max_cost` | inf | Cost budget passed to `cost_distance` |\n",
+    "| `connectivity` | 8 | 4 or 8 pixel connectivity |"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.9.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/xrspatial/__init__.py
+++ b/xrspatial/__init__.py
@@ -1,4 +1,5 @@
 from xrspatial.aspect import aspect  # noqa
+from xrspatial.balanced_allocation import balanced_allocation  # noqa
 from xrspatial.bump import bump  # noqa
 from xrspatial.cost_distance import cost_distance  # noqa
 from xrspatial.dasymetric import disaggregate  # noqa

--- a/xrspatial/balanced_allocation.py
+++ b/xrspatial/balanced_allocation.py
@@ -1,0 +1,354 @@
+"""Balanced service area partitioning.
+
+Partitions a cost surface into territories of roughly equal cost-weighted
+area.  Each cell is assigned to the source whose biased cost-distance is
+lowest, where biases are iteratively adjusted so that no source's territory
+is disproportionately large or small.
+
+Algorithm
+---------
+1. Run ``cost_distance`` once per source to get N cost surfaces.
+2. Assign each cell to ``argmin(cost[i] + bias[i])``.
+3. Compute each territory's cost-weighted area (sum of friction values).
+4. Adjust biases proportionally: increase for over-large territories,
+   decrease for under-served ones.
+5. Repeat 2-4 until convergence or ``max_iterations``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import xarray as xr
+
+from xrspatial.cost_distance import cost_distance
+from xrspatial.utils import _validate_raster
+
+try:
+    import dask.array as da
+except ImportError:
+    da = None
+
+try:
+    import cupy
+except ImportError:
+    class cupy:  # type: ignore[no-redef]
+        ndarray = False
+
+
+def _to_numpy(arr):
+    """Convert any array (numpy, cupy, dask) to a numpy array."""
+    if da is not None and isinstance(arr, da.Array):
+        arr = arr.compute()
+    if hasattr(arr, 'get'):  # cupy
+        return arr.get()
+    return np.asarray(arr)
+
+
+def _extract_sources(raster, target_values):
+    """Return sorted array of unique source IDs from the raster."""
+    data = _to_numpy(raster.data)
+    if len(target_values) > 0:
+        ids = np.asarray(target_values, dtype=np.float64)
+    else:
+        mask = np.isfinite(data) & (data != 0)
+        ids = np.unique(data[mask])
+    return ids[np.isfinite(ids)]
+
+
+def _make_single_source_raster(raster, source_id):
+    """Create a raster with only one source value, rest zero."""
+    data = raster.data
+    # Build mask for this source
+    if da is not None and isinstance(data, da.Array):
+        single = da.where(data == source_id, source_id, 0.0)
+    elif hasattr(data, 'get'):  # cupy
+        import cupy as cp
+        single = cp.where(data == source_id, source_id, 0.0)
+    else:
+        single = np.where(data == source_id, source_id, 0.0)
+
+    return xr.DataArray(
+        single,
+        coords=raster.coords,
+        dims=raster.dims,
+        attrs=raster.attrs,
+    )
+
+
+def _sum_where(friction_data, alloc_data, source_id):
+    """Sum friction values where allocation matches source_id.
+
+    Returns a Python float.  Works with numpy, cupy, and dask arrays.
+    """
+    if da is not None and isinstance(friction_data, da.Array):
+        masked = da.where(alloc_data == source_id, friction_data, 0.0)
+        return float(masked.sum().compute())
+    elif hasattr(friction_data, 'get'):  # cupy
+        import cupy as cp
+        masked = cp.where(alloc_data == source_id, friction_data, 0.0)
+        return float(cp.asnumpy(masked.sum()))
+    else:
+        masked = np.where(alloc_data == source_id, friction_data, 0.0)
+        return float(masked.sum())
+
+
+def _allocate_from_costs(cost_stack, source_ids, fill_value=np.nan):
+    """Assign each cell to the source with lowest cost.
+
+    Parameters
+    ----------
+    cost_stack : list of arrays
+        Per-source cost-distance arrays (same shape).
+    source_ids : 1-D numpy array
+        Source ID for each layer in cost_stack.
+    fill_value : float
+        Value for cells unreachable from any source.
+
+    Returns
+    -------
+    allocation : array
+        2-D array of source IDs.
+    """
+    # Stack along axis 0 -> shape (N, H, W)
+    first = cost_stack[0]
+    if da is not None and isinstance(first, da.Array):
+        stacked = da.stack(cost_stack, axis=0)
+        # Replace NaN with inf for argmin
+        stacked_clean = da.where(da.isnan(stacked), np.inf, stacked)
+        best_idx = da.argmin(stacked_clean, axis=0).compute()
+        best_idx = np.asarray(best_idx)
+    elif hasattr(first, 'get'):  # cupy
+        import cupy as cp
+        stacked = cp.stack(cost_stack, axis=0)
+        stacked_clean = cp.where(cp.isnan(stacked), cp.inf, stacked)
+        best_idx = cp.asnumpy(cp.argmin(stacked_clean, axis=0))
+    else:
+        stacked = np.stack(cost_stack, axis=0)
+        stacked_clean = np.where(np.isnan(stacked), np.inf, stacked)
+        best_idx = np.argmin(stacked_clean, axis=0)
+
+    # Map index back to source ID
+    alloc = source_ids[best_idx]
+
+    # Mark cells that are unreachable from all sources
+    if da is not None and isinstance(first, da.Array):
+        all_nan = da.all(da.isnan(da.stack(cost_stack, axis=0)), axis=0)
+        all_nan = np.asarray(all_nan.compute())
+    elif hasattr(first, 'get'):
+        import cupy as cp
+        all_nan = cp.asnumpy(
+            cp.all(cp.isnan(cp.stack(cost_stack, axis=0)), axis=0)
+        )
+    else:
+        all_nan = np.all(np.isnan(np.stack(cost_stack, axis=0)), axis=0)
+
+    alloc = alloc.astype(np.float32)
+    alloc[all_nan] = fill_value
+
+    return alloc
+
+
+def _allocate_biased(cost_stack, biases, source_ids, fill_value=np.nan):
+    """Assign each cell to source with lowest (cost + bias).
+
+    Like _allocate_from_costs but adds per-source bias before argmin.
+    """
+    first = cost_stack[0]
+    n = len(cost_stack)
+
+    if da is not None and isinstance(first, da.Array):
+        layers = []
+        for i in range(n):
+            layer = da.where(da.isnan(cost_stack[i]), np.inf,
+                             cost_stack[i] + biases[i])
+            layers.append(layer)
+        stacked = da.stack(layers, axis=0)
+        best_idx = da.argmin(stacked, axis=0).compute()
+        best_idx = np.asarray(best_idx)
+    elif hasattr(first, 'get'):
+        import cupy as cp
+        layers = []
+        for i in range(n):
+            layer = cp.where(cp.isnan(cost_stack[i]), cp.inf,
+                             cost_stack[i] + biases[i])
+            layers.append(layer)
+        stacked = cp.stack(layers, axis=0)
+        best_idx = cp.asnumpy(cp.argmin(stacked, axis=0))
+    else:
+        layers = []
+        for i in range(n):
+            layer = np.where(np.isnan(cost_stack[i]), np.inf,
+                             cost_stack[i] + biases[i])
+            layers.append(layer)
+        stacked = np.stack(layers, axis=0)
+        best_idx = np.argmin(stacked, axis=0)
+
+    alloc = source_ids[best_idx].astype(np.float32)
+
+    # Mark unreachable cells
+    if da is not None and isinstance(first, da.Array):
+        all_nan = da.all(da.isnan(da.stack(cost_stack, axis=0)), axis=0)
+        all_nan = np.asarray(all_nan.compute())
+    elif hasattr(first, 'get'):
+        import cupy as cp
+        all_nan = cp.asnumpy(
+            cp.all(cp.isnan(cp.stack(cost_stack, axis=0)), axis=0)
+        )
+    else:
+        all_nan = np.all(np.isnan(np.stack(cost_stack, axis=0)), axis=0)
+
+    alloc[all_nan] = fill_value
+    return alloc
+
+
+def balanced_allocation(
+    raster: xr.DataArray,
+    friction: xr.DataArray,
+    x: str = "x",
+    y: str = "y",
+    target_values: list = [],
+    max_cost: float = np.inf,
+    connectivity: int = 8,
+    tolerance: float = 0.05,
+    max_iterations: int = 100,
+    learning_rate: float = 0.5,
+) -> xr.DataArray:
+    """Partition a cost surface into balanced service territories.
+
+    Assigns each cell to a source such that all territories have roughly
+    equal cost-weighted area (sum of friction values).  This extends
+    standard cost-distance allocation by iteratively adjusting per-source
+    biases until the workload is balanced.
+
+    Parameters
+    ----------
+    raster : xr.DataArray
+        2-D source raster.  Source pixels are identified by non-zero
+        finite values (or values in *target_values*).  Each unique value
+        is treated as a separate source.
+    friction : xr.DataArray
+        2-D friction (cost) surface.  Must have the same shape and
+        coordinates as *raster*.
+    x : str, default='x'
+        Name of the x coordinate.
+    y : str, default='y'
+        Name of the y coordinate.
+    target_values : list, optional
+        Specific pixel values in *raster* to treat as sources.
+        If empty, all non-zero finite pixels are sources.
+    max_cost : float, default=np.inf
+        Maximum accumulated cost passed to ``cost_distance``.
+    connectivity : int, default=8
+        Pixel connectivity (4 or 8) passed to ``cost_distance``.
+    tolerance : float, default=0.05
+        Convergence threshold.  The loop stops when every territory's
+        cost-weighted area is within ``tolerance`` of the mean (as a
+        fraction of the mean).
+    max_iterations : int, default=100
+        Maximum number of bias-adjustment iterations.
+    learning_rate : float, default=0.5
+        Controls how aggressively biases are updated each iteration.
+        Smaller values are more stable; larger values converge faster.
+
+    Returns
+    -------
+    xr.DataArray
+        2-D array of source IDs (float32).  Each cell contains the ID
+        of the source it is assigned to.  Unreachable cells are NaN.
+    """
+    _validate_raster(raster, func_name='balanced_allocation', name='raster')
+    _validate_raster(friction, func_name='balanced_allocation',
+                     name='friction')
+    if raster.shape != friction.shape:
+        raise ValueError("raster and friction must have the same shape")
+    if raster.dims != (y, x):
+        raise ValueError(
+            f"raster.dims should be ({y!r}, {x!r}), got {raster.dims}"
+        )
+    if connectivity not in (4, 8):
+        raise ValueError("connectivity must be 4 or 8")
+    if tolerance <= 0:
+        raise ValueError("tolerance must be positive")
+    if max_iterations < 1:
+        raise ValueError("max_iterations must be >= 1")
+
+    source_ids = _extract_sources(raster, target_values)
+    n_sources = len(source_ids)
+
+    if n_sources == 0:
+        out = np.full(raster.shape, np.nan, dtype=np.float32)
+        return xr.DataArray(out, coords=raster.coords, dims=raster.dims,
+                            attrs=raster.attrs)
+
+    if n_sources == 1:
+        # Only one source: every reachable cell goes to it
+        cd = cost_distance(raster, friction, x=x, y=y,
+                           target_values=list(target_values),
+                           max_cost=max_cost, connectivity=connectivity)
+        cd_np = _to_numpy(cd.data)
+        out = np.where(np.isfinite(cd_np), source_ids[0], np.nan)
+        return xr.DataArray(out.astype(np.float32), coords=raster.coords,
+                            dims=raster.dims, attrs=raster.attrs)
+
+    # Step 1: compute per-source cost-distance surfaces
+    cost_surfaces = []  # list of raw data arrays (numpy/cupy/dask)
+    for sid in source_ids:
+        single = _make_single_source_raster(raster, sid)
+        cd = cost_distance(single, friction, x=x, y=y,
+                           max_cost=max_cost, connectivity=connectivity)
+        cost_surfaces.append(cd.data)
+
+    # Step 2: get friction data for weighting
+    fric_data = friction.data
+    if da is not None and isinstance(fric_data, da.Array):
+        fric_np = fric_data.compute()
+        if hasattr(fric_np, 'get'):
+            fric_np = fric_np.get()
+    elif hasattr(fric_data, 'get'):
+        fric_np = fric_data.get()
+    else:
+        fric_np = np.asarray(fric_data)
+
+    # Replace non-positive and NaN friction with 0 for weighting
+    fric_weight = np.where(np.isfinite(fric_np) & (fric_np > 0), fric_np, 0.0)
+
+    # Step 3: iterative balancing
+    biases = np.zeros(n_sources, dtype=np.float64)
+
+    for iteration in range(max_iterations):
+        # Allocate with current biases
+        alloc = _allocate_biased(cost_surfaces, biases, source_ids)
+
+        # Compute per-territory cost-weighted area
+        weights = np.array([
+            float(np.sum(fric_weight[alloc == sid]))
+            for sid in source_ids
+        ])
+
+        # Handle sources with no reachable cells
+        total = weights.sum()
+        if total == 0:
+            break
+
+        target_weight = total / n_sources
+
+        # Check convergence: max relative deviation
+        nonzero = weights > 0
+        if np.any(nonzero):
+            max_dev = np.max(np.abs(weights - target_weight)) / target_weight
+            if max_dev <= tolerance:
+                break
+
+        # Update biases proportionally
+        for i in range(n_sources):
+            if target_weight > 0:
+                deviation = (weights[i] - target_weight) / target_weight
+                biases[i] += learning_rate * deviation
+
+    # Build output DataArray
+    return xr.DataArray(
+        alloc.astype(np.float32),
+        coords=raster.coords,
+        dims=raster.dims,
+        attrs=raster.attrs,
+    )

--- a/xrspatial/tests/test_balanced_allocation.py
+++ b/xrspatial/tests/test_balanced_allocation.py
@@ -1,0 +1,270 @@
+"""Tests for xrspatial.balanced_allocation."""
+
+try:
+    import dask.array as da
+except ImportError:
+    da = None
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from xrspatial.balanced_allocation import balanced_allocation
+from xrspatial.tests.general_checks import cuda_and_cupy_available
+from xrspatial.utils import has_cuda_and_cupy, has_dask_array
+
+
+def _make_raster(data, backend='numpy', chunks=(5, 5)):
+    """Build a DataArray with y/x coords, optionally dask/cupy-backed."""
+    h, w = data.shape
+    raster = xr.DataArray(
+        data.astype(np.float64),
+        dims=['y', 'x'],
+        attrs={'res': (1.0, 1.0)},
+    )
+    raster['y'] = np.arange(h, dtype=np.float64)
+    raster['x'] = np.arange(w, dtype=np.float64)
+    if 'dask' in backend and da is not None:
+        raster.data = da.from_array(raster.data, chunks=chunks)
+    if 'cupy' in backend and has_cuda_and_cupy():
+        import cupy
+        if isinstance(raster.data, da.Array):
+            raster.data = raster.data.map_blocks(cupy.asarray)
+        else:
+            raster.data = cupy.asarray(raster.data)
+    return raster
+
+
+def _compute(arr):
+    """Extract numpy data from DataArray (works for numpy, dask, or cupy)."""
+    if da is not None and isinstance(arr.data, da.Array):
+        val = arr.data.compute()
+        if hasattr(val, 'get'):
+            return val.get()
+        return val
+    if hasattr(arr.data, 'get'):
+        return arr.data.get()
+    return arr.data
+
+
+# -----------------------------------------------------------------------
+# Two sources with uniform friction should converge to equal areas
+# -----------------------------------------------------------------------
+
+@pytest.mark.parametrize("backend", ['numpy', 'dask+numpy', 'cupy', 'dask+cupy'])
+def test_two_sources_uniform_friction(backend):
+    """With uniform friction, territories should have roughly equal area."""
+    if 'cupy' in backend and not has_cuda_and_cupy():
+        pytest.skip("No GPU/CuPy available")
+    if 'dask' in backend and da is None:
+        pytest.skip("Dask not available")
+
+    # 10x10 grid with two sources at opposite corners
+    data = np.zeros((10, 10), dtype=np.float64)
+    data[1, 1] = 1.0   # source A
+    data[8, 8] = 2.0   # source B
+
+    raster = _make_raster(data, backend=backend, chunks=(10, 10))
+    friction = _make_raster(np.ones((10, 10)), backend=backend,
+                            chunks=(10, 10))
+
+    result = balanced_allocation(raster, friction, tolerance=0.10)
+    out = _compute(result)
+
+    # Both source IDs should be present
+    unique = set(np.unique(out[np.isfinite(out)]))
+    assert 1.0 in unique
+    assert 2.0 in unique
+
+    # Count cells per territory
+    n1 = np.sum(out == 1.0)
+    n2 = np.sum(out == 2.0)
+    total = n1 + n2
+
+    # Territories should be roughly balanced (within 20% of half)
+    assert abs(n1 - n2) / total < 0.25
+
+
+# -----------------------------------------------------------------------
+# Single source: everything reachable goes to that source
+# -----------------------------------------------------------------------
+
+def test_single_source():
+    """With one source, all reachable cells should be assigned to it."""
+    data = np.zeros((5, 5), dtype=np.float64)
+    data[2, 2] = 7.0
+
+    raster = _make_raster(data)
+    friction = _make_raster(np.ones((5, 5)))
+
+    result = balanced_allocation(raster, friction)
+    out = _compute(result)
+
+    # All cells should be 7.0
+    assert np.all(out[np.isfinite(out)] == 7.0)
+
+
+# -----------------------------------------------------------------------
+# No sources: all NaN
+# -----------------------------------------------------------------------
+
+def test_no_sources():
+    """With no sources, output should be all NaN."""
+    data = np.zeros((5, 5), dtype=np.float64)
+    raster = _make_raster(data)
+    friction = _make_raster(np.ones((5, 5)))
+
+    result = balanced_allocation(raster, friction)
+    out = _compute(result)
+
+    assert np.all(np.isnan(out))
+
+
+# -----------------------------------------------------------------------
+# NaN friction barrier
+# -----------------------------------------------------------------------
+
+def test_nan_barrier():
+    """NaN friction should block cost paths and leave cells unreachable."""
+    data = np.zeros((5, 5), dtype=np.float64)
+    data[0, 0] = 1.0
+    data[0, 4] = 2.0
+
+    fric = np.ones((5, 5), dtype=np.float64)
+    # Wall of NaN in the middle column
+    fric[:, 2] = np.nan
+
+    raster = _make_raster(data)
+    friction = _make_raster(fric)
+
+    result = balanced_allocation(raster, friction)
+    out = _compute(result)
+
+    # Left side should be source 1, right side should be source 2
+    # Middle column should be NaN (impassable)
+    assert np.all(out[:, 2] != out[:, 2])  # NaN check
+    left = out[:, :2]
+    right = out[:, 3:]
+    assert np.all(left[np.isfinite(left)] == 1.0)
+    assert np.all(right[np.isfinite(right)] == 2.0)
+
+
+# -----------------------------------------------------------------------
+# Asymmetric friction should shift boundaries
+# -----------------------------------------------------------------------
+
+def test_asymmetric_friction_shifts_boundary():
+    """High-friction zone should make that territory smaller by cell count."""
+    # 1x20 strip with sources at each end
+    data = np.zeros((1, 20), dtype=np.float64)
+    data[0, 0] = 1.0
+    data[0, 19] = 2.0
+
+    # Left half cheap, right half expensive
+    fric = np.ones((1, 20), dtype=np.float64)
+    fric[0, 10:] = 5.0
+
+    raster = _make_raster(data, chunks=(1, 20))
+    friction = _make_raster(fric, chunks=(1, 20))
+
+    result = balanced_allocation(raster, friction, tolerance=0.10)
+    out = _compute(result)
+
+    # Source 2 (expensive side) should have fewer cells than source 1
+    n1 = np.sum(out == 1.0)
+    n2 = np.sum(out == 2.0)
+    assert n1 > n2, (
+        f"Expected source 1 to have more cells (cheap friction), "
+        f"got n1={n1}, n2={n2}"
+    )
+
+
+# -----------------------------------------------------------------------
+# Three sources
+# -----------------------------------------------------------------------
+
+def test_three_sources():
+    """Three sources should each get roughly 1/3 of the cost-weighted area."""
+    data = np.zeros((12, 12), dtype=np.float64)
+    data[2, 6] = 1.0
+    data[9, 2] = 2.0
+    data[9, 10] = 3.0
+
+    raster = _make_raster(data, chunks=(12, 12))
+    friction = _make_raster(np.ones((12, 12)), chunks=(12, 12))
+
+    result = balanced_allocation(raster, friction, tolerance=0.15)
+    out = _compute(result)
+
+    unique = set(np.unique(out[np.isfinite(out)]))
+    assert {1.0, 2.0, 3.0} == unique
+
+    # Each territory should have at least 20% of cells
+    total = np.sum(np.isfinite(out))
+    for sid in [1.0, 2.0, 3.0]:
+        frac = np.sum(out == sid) / total
+        assert frac > 0.15, f"Source {sid} only got {frac:.1%} of cells"
+
+
+# -----------------------------------------------------------------------
+# Validation errors
+# -----------------------------------------------------------------------
+
+def test_shape_mismatch():
+    """Should raise ValueError if raster and friction shapes differ."""
+    raster = _make_raster(np.zeros((5, 5)))
+    friction = _make_raster(np.zeros((5, 6)))
+    with pytest.raises(ValueError, match="same shape"):
+        balanced_allocation(raster, friction)
+
+
+def test_bad_connectivity():
+    """Should raise ValueError for invalid connectivity."""
+    data = np.zeros((5, 5))
+    data[2, 2] = 1.0
+    raster = _make_raster(data)
+    friction = _make_raster(np.ones((5, 5)))
+    with pytest.raises(ValueError, match="connectivity"):
+        balanced_allocation(raster, friction, connectivity=6)
+
+
+def test_bad_tolerance():
+    """Should raise ValueError for non-positive tolerance."""
+    data = np.zeros((5, 5))
+    data[2, 2] = 1.0
+    raster = _make_raster(data)
+    friction = _make_raster(np.ones((5, 5)))
+    with pytest.raises(ValueError, match="tolerance"):
+        balanced_allocation(raster, friction, tolerance=0)
+
+
+def test_bad_max_iterations():
+    """Should raise ValueError for max_iterations < 1."""
+    data = np.zeros((5, 5))
+    data[2, 2] = 1.0
+    raster = _make_raster(data)
+    friction = _make_raster(np.ones((5, 5)))
+    with pytest.raises(ValueError, match="max_iterations"):
+        balanced_allocation(raster, friction, max_iterations=0)
+
+
+# -----------------------------------------------------------------------
+# target_values parameter
+# -----------------------------------------------------------------------
+
+def test_target_values():
+    """target_values should restrict which pixel values are treated as sources."""
+    data = np.zeros((8, 8), dtype=np.float64)
+    data[1, 1] = 1.0
+    data[6, 6] = 2.0
+    data[1, 6] = 3.0  # this one should be ignored
+
+    raster = _make_raster(data, chunks=(8, 8))
+    friction = _make_raster(np.ones((8, 8)), chunks=(8, 8))
+
+    result = balanced_allocation(raster, friction, target_values=[1.0, 2.0])
+    out = _compute(result)
+
+    unique = set(np.unique(out[np.isfinite(out)]))
+    assert 3.0 not in unique
+    assert {1.0, 2.0} == unique


### PR DESCRIPTION
## Summary

- Adds `balanced_allocation()` which partitions a cost surface into territories of roughly equal cost-weighted area
- Runs `cost_distance` per source, then iteratively adjusts additive biases until territory weights converge
- All four backends work (NumPy, CuPy, Dask+NumPy, Dask+CuPy) -- the balancing loop is just argmin + masked sums on top of `cost_distance`, no custom kernels

Closes #939

## What changed

- `xrspatial/balanced_allocation.py` -- new module with the `balanced_allocation` function
- `xrspatial/__init__.py` -- export
- `xrspatial/tests/test_balanced_allocation.py` -- 12 tests (two/three/single/no sources, NaN barriers, asymmetric friction, target_values, validation errors)
- `docs/source/reference/proximity.rst` -- API docs entry
- `examples/user_guide/15_Balanced_Allocation.ipynb` -- user guide notebook
- `README.md` -- feature matrix row

## Test plan

- [x] `pytest xrspatial/tests/test_balanced_allocation.py -k "not cupy"` -- 12/12 pass
- [ ] GPU tests (need CuPy environment)
- [ ] Run the notebook end to end