### PR TITLE
Add scalar diffusion solver

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,14 @@ In the GIS world, rasters are used for representing continuous phenomena (e.g. e
 
 -------
 
+### **Diffusion**
+
+| Name | Description | NumPy xr.DataArray | Dask xr.DataArray | CuPy GPU xr.DataArray | Dask GPU xr.DataArray |
+|:----------:|:------------|:----------------------:|:--------------------:|:-------------------:|:------:|
+| [Diffuse](xrspatial/diffusion.py) | Runs explicit forward-Euler diffusion on a 2D scalar field | ✅️ | ✅️ | ✅️ | ✅️ |
+
+-------
+
 ### **Focal**
 
 | Name | Description | NumPy xr.DataArray | Dask xr.DataArray | CuPy GPU xr.DataArray | Dask GPU xr.DataArray |

--- a/docs/source/reference/diffusion.rst
+++ b/docs/source/reference/diffusion.rst
@@ -1,0 +1,12 @@
+..  _reference.diffusion:
+
+*********
+Diffusion
+*********
+
+Diffuse
+=======
+.. autosummary::
+   :toctree: _autosummary
+
+   xrspatial.diffusion.diffuse

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -9,6 +9,7 @@ Reference
 
    classification
    dasymetric
+   diffusion
    fire
    flood
    focal

--- a/examples/user_guide/16_Diffusion.ipynb
+++ b/examples/user_guide/16_Diffusion.ipynb
@@ -1,0 +1,212 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Scalar Diffusion\n",
+    "\n",
+    "The `diffuse()` function models how a scalar field (temperature, concentration, humidity) spreads across a raster over time. It solves the 2D diffusion equation using an explicit forward-Euler scheme with a 5-point Laplacian stencil:\n",
+    "\n",
+    "    du/dt = alpha * laplacian(u)\n",
+    "\n",
+    "You can use a uniform diffusivity (single float) or a spatially varying diffusivity raster. The solver auto-selects a stable time step when you don't provide one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import xarray as xr\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from xrspatial.diffusion import diffuse"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Point source diffusion\n",
+    "\n",
+    "Start with a single hot cell in the center of a cold field and watch it spread."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a 51x51 grid with a hot spot at the center\n",
+    "shape = (51, 51)\n",
+    "data = np.zeros(shape)\n",
+    "data[25, 25] = 100.0\n",
+    "\n",
+    "initial = xr.DataArray(\n",
+    "    data,\n",
+    "    dims=['y', 'x'],\n",
+    "    attrs={'res': (1.0, 1.0)},\n",
+    ")\n",
+    "\n",
+    "# Run diffusion for different step counts\n",
+    "steps_list = [0, 10, 50, 200]\n",
+    "results = {}\n",
+    "for s in steps_list:\n",
+    "    if s == 0:\n",
+    "        results[s] = initial\n",
+    "    else:\n",
+    "        results[s] = diffuse(initial, diffusivity=1.0, steps=s, boundary='nearest')\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 4, figsize=(16, 4))\n",
+    "for ax, s in zip(axes, steps_list):\n",
+    "    im = ax.imshow(results[s].values, cmap='hot', vmin=0, vmax=10)\n",
+    "    ax.set_title(f'Step {s}')\n",
+    "    ax.axis('off')\n",
+    "fig.colorbar(im, ax=axes, shrink=0.6, label='Temperature')\n",
+    "plt.suptitle('Point source diffusion', y=1.02)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Boundary modes\n",
+    "\n",
+    "The `boundary` parameter controls what happens at the edges: `'nan'`, `'nearest'`, `'reflect'`, or `'wrap'`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Hot spot near the edge to highlight boundary behavior\n",
+    "data_edge = np.zeros((31, 31))\n",
+    "data_edge[2, 15] = 100.0\n",
+    "\n",
+    "edge_agg = xr.DataArray(\n",
+    "    data_edge, dims=['y', 'x'], attrs={'res': (1.0, 1.0)}\n",
+    ")\n",
+    "\n",
+    "boundaries = ['nan', 'nearest', 'reflect', 'wrap']\n",
+    "fig, axes = plt.subplots(1, 4, figsize=(16, 4))\n",
+    "for ax, bnd in zip(axes, boundaries):\n",
+    "    r = diffuse(edge_agg, diffusivity=1.0, steps=30, boundary=bnd)\n",
+    "    ax.imshow(r.values, cmap='hot', vmin=0, vmax=5)\n",
+    "    ax.set_title(f'boundary={bnd!r}')\n",
+    "    ax.axis('off')\n",
+    "plt.suptitle('Edge behavior with different boundary modes', y=1.02)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Spatially varying diffusivity\n",
+    "\n",
+    "You can pass a DataArray for `diffusivity` to model materials with different thermal properties. Here we create a wall (low diffusivity) that partially blocks heat flow."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "shape = (51, 51)\n",
+    "data = np.zeros(shape)\n",
+    "data[25, 10] = 100.0  # heat source on the left\n",
+    "\n",
+    "# Diffusivity field: mostly 1.0, with a vertical wall of low diffusivity\n",
+    "alpha = np.ones(shape)\n",
+    "alpha[:, 25] = 0.01  # thin wall in the middle\n",
+    "\n",
+    "field = xr.DataArray(data, dims=['y', 'x'], attrs={'res': (1.0, 1.0)})\n",
+    "alpha_da = xr.DataArray(alpha, dims=['y', 'x'], attrs={'res': (1.0, 1.0)})\n",
+    "\n",
+    "result = diffuse(field, diffusivity=alpha_da, steps=300, boundary='nearest')\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(12, 5))\n",
+    "axes[0].imshow(alpha, cmap='gray')\n",
+    "axes[0].set_title('Diffusivity (dark = wall)')\n",
+    "axes[0].axis('off')\n",
+    "\n",
+    "axes[1].imshow(result.values, cmap='hot', vmin=0)\n",
+    "axes[1].set_title('Temperature after 300 steps')\n",
+    "axes[1].axis('off')\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Practical example: HVAC failure\n",
+    "\n",
+    "Simulate what happens when a cooling unit fails in a building floor plan. We start with a comfortable 22 C everywhere, set the failed zone to 35 C, and let heat diffuse."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "shape = (61, 61)\n",
+    "temp = np.full(shape, 22.0)  # comfortable baseline\n",
+    "\n",
+    "# Failed zone: a 5x5 block near center heats up\n",
+    "temp[28:33, 28:33] = 35.0\n",
+    "\n",
+    "# Walls (NaN = impassable)\n",
+    "temp[20, 10:50] = np.nan  # horizontal wall\n",
+    "temp[40, 10:50] = np.nan  # horizontal wall\n",
+    "temp[20:41, 10] = np.nan  # left wall\n",
+    "temp[20:41, 50] = np.nan  # right wall\n",
+    "# Door opening\n",
+    "temp[20, 29:32] = 22.0\n",
+    "\n",
+    "field = xr.DataArray(temp, dims=['y', 'x'], attrs={'res': (1.0, 1.0)})\n",
+    "\n",
+    "snapshots = [0, 50, 150, 400]\n",
+    "fig, axes = plt.subplots(1, 4, figsize=(18, 4))\n",
+    "for ax, s in zip(axes, snapshots):\n",
+    "    if s == 0:\n",
+    "        r = field\n",
+    "    else:\n",
+    "        r = diffuse(field, diffusivity=0.5, steps=s, boundary='nearest')\n",
+    "    im = ax.imshow(r.values, cmap='coolwarm', vmin=20, vmax=36)\n",
+    "    ax.set_title(f'Step {s}')\n",
+    "    ax.axis('off')\n",
+    "fig.colorbar(im, ax=axes, shrink=0.6, label='Temperature (C)')\n",
+    "plt.suptitle('Heat spread after HVAC failure', y=1.02)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/xrspatial/__init__.py
+++ b/xrspatial/__init__.py
@@ -11,6 +11,7 @@ from xrspatial.classify import maximum_breaks  # noqa
 from xrspatial.classify import percentiles  # noqa
 from xrspatial.classify import std_mean  # noqa
 from xrspatial.diagnostics import diagnose  # noqa
+from xrspatial.diffusion import diffuse  # noqa
 from xrspatial.classify import equal_interval  # noqa
 from xrspatial.classify import natural_breaks  # noqa
 from xrspatial.classify import quantile  # noqa

--- a/xrspatial/accessor.py
+++ b/xrspatial/accessor.py
@@ -235,6 +235,12 @@ class XrsSpatialDataArrayAccessor:
         from .zonal import regions
         return regions(self._obj, **kwargs)
 
+    # ---- Diffusion ----
+
+    def diffuse(self, **kwargs):
+        from .diffusion import diffuse
+        return diffuse(self._obj, **kwargs)
+
     # ---- Dasymetric ----
 
     def disaggregate(self, values, weight, **kwargs):
@@ -494,6 +500,12 @@ class XrsSpatialDatasetAccessor:
     def focal_mean(self, **kwargs):
         from .focal import mean
         return mean(self._obj, **kwargs)
+
+    # ---- Diffusion ----
+
+    def diffuse(self, **kwargs):
+        from .diffusion import diffuse
+        return diffuse(self._obj, **kwargs)
 
     # ---- Proximity ----
 

--- a/xrspatial/diffusion.py
+++ b/xrspatial/diffusion.py
@@ -1,0 +1,314 @@
+"""Scalar diffusion solver for raster fields.
+
+Solves the 2D diffusion (heat) equation using an explicit forward-Euler
+finite-difference scheme with a 5-point Laplacian stencil::
+
+    du/dt = alpha * laplacian(u)
+
+Supports uniform or spatially varying diffusivity and all four backends
+(numpy, cupy, dask+numpy, dask+cupy).
+"""
+
+from __future__ import annotations
+
+from functools import partial
+
+import numpy as np
+import xarray as xr
+from xarray import DataArray
+
+from numba import cuda, prange
+
+try:
+    import cupy
+except ImportError:
+    class cupy:
+        ndarray = False
+
+try:
+    import dask.array as da
+except ImportError:
+    da = None
+
+from xrspatial.utils import (
+    ArrayTypeFunctionMapping,
+    _boundary_to_dask,
+    _pad_array,
+    _validate_boundary,
+    _validate_raster,
+    _validate_scalar,
+    calc_cuda_dims,
+    has_cuda_and_cupy,
+    is_cupy_array,
+    ngjit,
+    not_implemented_func,
+)
+
+
+# ---- numpy backend ----
+
+@ngjit
+def _diffuse_step_numpy(u, alpha_arr, dt_over_dx2, rows, cols):
+    """One forward-Euler step on a padded array.
+
+    *u* has shape ``(rows+2, cols+2)`` (1-cell pad on each side).
+    Writes the updated interior back into *u* in-place.
+    """
+    out = np.empty((rows, cols), dtype=u.dtype)
+    for i in prange(rows):
+        ip = i + 1  # padded index
+        for j in range(cols):
+            jp = j + 1
+            val = u[ip, jp]
+            if np.isnan(val):
+                out[i, j] = np.nan
+                continue
+            n = u[ip - 1, jp]
+            s = u[ip + 1, jp]
+            w = u[ip, jp - 1]
+            e = u[ip, jp + 1]
+            lap = n + s + w + e - 4.0 * val
+            out[i, j] = val + dt_over_dx2 * alpha_arr[i, j] * lap
+    return out
+
+
+def _diffuse_numpy(data, alpha_arr, steps, dt_over_dx2, boundary):
+    rows, cols = data.shape
+    u = data.astype(np.float64)
+    for _ in range(steps):
+        if boundary == 'nan':
+            padded = np.pad(u, 1, mode='constant', constant_values=np.nan)
+        else:
+            padded = _pad_array(u, 1, boundary)
+        u = _diffuse_step_numpy(padded, alpha_arr, dt_over_dx2, rows, cols)
+    return u
+
+
+# ---- cupy backend ----
+
+@cuda.jit
+def _diffuse_step_gpu(u, alpha_arr, dt_over_dx2, out):
+    """One forward-Euler step.  *u* is padded (rows+2, cols+2)."""
+    i, j = cuda.grid(2)
+    rows = out.shape[0]
+    cols = out.shape[1]
+    if i < rows and j < cols:
+        ip = i + 1
+        jp = j + 1
+        val = u[ip, jp]
+        if val != val:  # NaN check in device code
+            out[i, j] = val
+            return
+        n = u[ip - 1, jp]
+        s = u[ip + 1, jp]
+        w = u[ip, jp - 1]
+        e = u[ip, jp + 1]
+        lap = n + s + w + e - 4.0 * val
+        out[i, j] = val + dt_over_dx2 * alpha_arr[i, j] * lap
+
+
+def _diffuse_cupy(data, alpha_arr, steps, dt_over_dx2, boundary):
+    import cupy as cp
+
+    u = cp.asarray(data, dtype=cp.float64)
+    alpha_dev = cp.asarray(alpha_arr, dtype=cp.float64)
+    rows, cols = u.shape
+    bpg, tpb = calc_cuda_dims((rows, cols))
+
+    for _ in range(steps):
+        if boundary == 'nan':
+            padded = cp.pad(u, 1, mode='constant', constant_values=cp.nan)
+        else:
+            padded = _pad_array(u, 1, boundary)
+        out = cp.empty_like(u)
+        _diffuse_step_gpu[bpg, tpb](padded, alpha_dev, dt_over_dx2, out)
+        u = out
+    return u
+
+
+# ---- dask + numpy backend ----
+
+def _diffuse_chunk_numpy(chunk, alpha_chunk, steps, dt_over_dx2, block_info=None):
+    """Process a single dask chunk (already overlapped by 1 cell)."""
+    # The chunk arrives with 1-cell overlap on each side from map_overlap.
+    # We run steps iterations; for steps > 1 the boundary data is stale
+    # after the first step, but for typical usage (steps=1 per map_overlap
+    # call) this is correct.  The public function wraps this in a loop.
+    rows = chunk.shape[0] - 2
+    cols = chunk.shape[1] - 2
+    interior_alpha = alpha_chunk[1:-1, 1:-1]
+
+    u = chunk.copy()
+    for _ in range(steps):
+        interior = _diffuse_step_numpy(u, interior_alpha, dt_over_dx2, rows, cols)
+        # rebuild padded array from new interior for next iteration
+        u[1:-1, 1:-1] = interior
+    return u
+
+
+def _diffuse_dask_numpy(data, alpha_arr, steps, dt_over_dx2, boundary):
+    _func = partial(
+        _diffuse_chunk_numpy,
+        alpha_chunk=alpha_arr,
+        steps=1,
+        dt_over_dx2=dt_over_dx2,
+    )
+    u = data.astype(np.float64)
+    for _ in range(steps):
+        u = u.map_overlap(
+            _func,
+            depth=(1, 1),
+            boundary=_boundary_to_dask(boundary),
+            meta=np.array(()),
+        )
+    return u
+
+
+# ---- dask + cupy backend ----
+
+def _diffuse_chunk_cupy(chunk, alpha_chunk, dt_over_dx2, block_info=None):
+    import cupy as cp
+
+    alpha_dev = cp.asarray(alpha_chunk[1:-1, 1:-1], dtype=cp.float64)
+    rows = chunk.shape[0] - 2
+    cols = chunk.shape[1] - 2
+    bpg, tpb = calc_cuda_dims((rows, cols))
+    out = cp.empty((rows, cols), dtype=cp.float64)
+    _diffuse_step_gpu[bpg, tpb](chunk, alpha_dev, dt_over_dx2, out)
+    # rebuild padded shape expected by map_overlap
+    result = chunk.copy()
+    result[1:-1, 1:-1] = out
+    return result
+
+
+def _diffuse_dask_cupy(data, alpha_arr, steps, dt_over_dx2, boundary):
+    import cupy as cp
+
+    _func = partial(
+        _diffuse_chunk_cupy,
+        alpha_chunk=alpha_arr,
+        dt_over_dx2=dt_over_dx2,
+    )
+    u = data.astype(cp.float64)
+    for _ in range(steps):
+        u = u.map_overlap(
+            _func,
+            depth=(1, 1),
+            boundary=_boundary_to_dask(boundary, is_cupy=True),
+            meta=cp.array(()),
+        )
+    return u
+
+
+# ---- public API ----
+
+def diffuse(
+    agg,
+    diffusivity=1.0,
+    steps=1,
+    dt=None,
+    boundary='nan',
+    name='diffuse',
+):
+    """Run forward-Euler diffusion on a 2D scalar field.
+
+    Solves ``du/dt = alpha * laplacian(u)`` using an explicit 5-point
+    stencil for *steps* time steps.
+
+    Parameters
+    ----------
+    agg : xarray.DataArray
+        2D raster representing the initial scalar field (temperature,
+        concentration, etc.).
+    diffusivity : float or xarray.DataArray
+        Thermal/mass diffusivity.  A scalar applies uniformly; a
+        DataArray of the same shape allows spatially varying
+        diffusivity.
+    steps : int, default 1
+        Number of time steps to run.
+    dt : float or None
+        Time step size.  When ``None`` the largest stable step is
+        chosen automatically: ``dt = 0.25 * dx**2 / max(alpha)``.
+    boundary : str, default ``'nan'``
+        Edge handling: ``'nan'``, ``'nearest'``, ``'reflect'``, or
+        ``'wrap'``.
+    name : str, default ``'diffuse'``
+        Name for the output DataArray.
+
+    Returns
+    -------
+    xarray.DataArray
+        Scalar field after *steps* diffusion steps.
+    """
+    _validate_raster(agg, func_name='diffuse', name='agg', ndim=2)
+    _validate_scalar(steps, func_name='diffuse', name='steps', dtype=int, min_val=1)
+    _validate_boundary(boundary)
+
+    # resolve diffusivity to a numpy/cupy array matching agg
+    if isinstance(diffusivity, xr.DataArray):
+        _validate_raster(diffusivity, func_name='diffuse', name='diffusivity', ndim=2)
+        if diffusivity.shape != agg.shape:
+            raise ValueError(
+                f"diffuse(): diffusivity shape {diffusivity.shape} "
+                f"does not match agg shape {agg.shape}"
+            )
+        alpha_arr = diffusivity.values.astype(np.float64)
+    elif isinstance(diffusivity, (int, float)):
+        if diffusivity <= 0:
+            raise ValueError(
+                f"diffuse(): diffusivity must be > 0, got {diffusivity}"
+            )
+        alpha_arr = np.full(agg.shape, float(diffusivity), dtype=np.float64)
+    else:
+        raise TypeError(
+            f"diffuse(): diffusivity must be a float or xr.DataArray, "
+            f"got {type(diffusivity).__name__}"
+        )
+
+    # resolve cell size — assume square cells, use x dimension
+    res = agg.attrs.get('res')
+    if isinstance(res, (tuple, list, np.ndarray)) and len(res) >= 1:
+        dx = float(res[0]) if isinstance(res[0], (int, float)) else 1.0
+    elif isinstance(res, (int, float)):
+        dx = float(res)
+    else:
+        dx = 1.0
+
+    alpha_max = float(np.nanmax(alpha_arr))
+    if alpha_max <= 0:
+        raise ValueError("diffuse(): all diffusivity values must be > 0")
+
+    # auto dt from CFL stability condition
+    if dt is None:
+        dt = 0.25 * dx * dx / alpha_max
+    else:
+        _validate_scalar(dt, func_name='diffuse', name='dt', dtype=(int, float),
+                         min_val=0, min_exclusive=True)
+
+    dt_over_dx2 = float(dt) / (dx * dx)
+
+    # dispatch to backend
+    mapper = ArrayTypeFunctionMapping(
+        numpy_func=partial(_diffuse_numpy, alpha_arr=alpha_arr,
+                           steps=steps, dt_over_dx2=dt_over_dx2,
+                           boundary=boundary),
+        cupy_func=partial(_diffuse_cupy, alpha_arr=alpha_arr,
+                          steps=steps, dt_over_dx2=dt_over_dx2,
+                          boundary=boundary),
+        dask_func=partial(_diffuse_dask_numpy, alpha_arr=alpha_arr,
+                          steps=steps, dt_over_dx2=dt_over_dx2,
+                          boundary=boundary),
+        dask_cupy_func=partial(_diffuse_dask_cupy, alpha_arr=alpha_arr,
+                               steps=steps, dt_over_dx2=dt_over_dx2,
+                               boundary=boundary),
+    )
+
+    out = mapper(agg)(agg.data)
+
+    return DataArray(
+        out,
+        name=name,
+        dims=agg.dims,
+        coords=agg.coords,
+        attrs=agg.attrs,
+    )

--- a/xrspatial/tests/test_diffusion.py
+++ b/xrspatial/tests/test_diffusion.py
@@ -1,0 +1,219 @@
+import numpy as np
+import pytest
+import xarray as xr
+
+from xrspatial.diffusion import diffuse
+from xrspatial.tests.general_checks import (
+    create_test_raster,
+    general_output_checks,
+)
+
+
+# ---- helpers ----
+
+def _make_hotspot(shape=(21, 21), center=None, value=100.0, background=0.0):
+    """Create a raster with a single hot cell."""
+    data = np.full(shape, background, dtype=np.float64)
+    if center is None:
+        center = (shape[0] // 2, shape[1] // 2)
+    data[center] = value
+    return data
+
+
+# ---- correctness tests ----
+
+def test_single_step_known_values():
+    """One step of diffusion on a 3x3 field with a hot center."""
+    data = np.array([
+        [0.0, 0.0, 0.0],
+        [0.0, 4.0, 0.0],
+        [0.0, 0.0, 0.0],
+    ])
+    agg = create_test_raster(data, attrs={'res': (1.0, 1.0)})
+
+    # dt = 0.25 * 1^2 / 1.0 = 0.25, dt_over_dx2 = 0.25
+    # laplacian at center = 0+0+0+0 - 4*4 = -16
+    # new center = 4 + 0.25 * 1.0 * (-16) = 0.0
+    # corners stay 0 (boundary=nan, so neighbors outside are nan -> no update
+    # possible, but interior cells with all-finite neighbors do update)
+    result = diffuse(agg, diffusivity=1.0, steps=1, boundary='nearest')
+    out = result.values
+
+    # With 'nearest' boundary, edge cells pad with their own value (0).
+    # Center: 4 + 0.25*(0+0+0+0 - 16) = 0
+    # Edge cells e.g. (0,1): 0 + 0.25*(0+0+0+4 - 0) = 1.0
+    # Corner (0,0): 0 + 0.25*(0+0+0+0 - 0) = 0
+    assert out[1, 1] == pytest.approx(0.0)
+    assert out[0, 1] == pytest.approx(1.0)
+    assert out[1, 0] == pytest.approx(1.0)
+    assert out[0, 0] == pytest.approx(0.0)
+
+
+def test_uniform_field_unchanged():
+    """A uniform field should not change under diffusion."""
+    data = np.full((10, 10), 42.0)
+    agg = create_test_raster(data, attrs={'res': (1.0, 1.0)})
+    result = diffuse(agg, diffusivity=0.5, steps=10, boundary='nearest')
+    np.testing.assert_allclose(result.values, 42.0, atol=1e-10)
+
+
+def test_conservation_wrap_boundary():
+    """With wrap boundary, total mass should be conserved."""
+    data = _make_hotspot((15, 15))
+    agg = create_test_raster(data, attrs={'res': (1.0, 1.0)})
+    result = diffuse(agg, diffusivity=0.5, steps=20, boundary='wrap')
+    initial_sum = np.nansum(data)
+    final_sum = np.nansum(result.values)
+    np.testing.assert_allclose(final_sum, initial_sum, rtol=1e-10)
+
+
+def test_nan_propagation():
+    """NaN cells should remain NaN and not pollute neighbors (boundary=nearest)."""
+    data = np.ones((5, 5))
+    data[2, 2] = np.nan
+    agg = create_test_raster(data, attrs={'res': (1.0, 1.0)})
+    result = diffuse(agg, diffusivity=1.0, steps=1, boundary='nearest')
+    assert np.isnan(result.values[2, 2])
+    # Neighbors of NaN see NaN in the stencil; with the ngjit kernel
+    # the Laplacian includes NaN so those cells become NaN too.
+    # This is the expected behavior (NaN spreads to direct neighbors).
+
+
+def test_spatially_varying_diffusivity():
+    """Different diffusivity values produce different results."""
+    data = np.zeros((7, 7))
+    data[3, 3] = 10.0
+    agg = create_test_raster(data, attrs={'res': (1.0, 1.0)})
+
+    alpha_arr = np.ones((7, 7))
+    alpha_low = alpha_arr.copy()
+    alpha_low[:] = 0.1
+    alpha_high = alpha_arr.copy()
+    alpha_high[:] = 1.0
+
+    d_low = create_test_raster(alpha_low, attrs={'res': (1.0, 1.0)})
+    d_high = create_test_raster(alpha_high, attrs={'res': (1.0, 1.0)})
+
+    # Use a fixed small dt that's stable for both
+    dt = 0.05
+    r_low = diffuse(agg, diffusivity=d_low, steps=5, dt=dt, boundary='nearest')
+    r_high = diffuse(agg, diffusivity=d_high, steps=5, dt=dt, boundary='nearest')
+
+    # Higher diffusivity should spread the hotspot more (lower peak)
+    assert r_high.values[3, 3] < r_low.values[3, 3]
+
+
+def test_auto_dt():
+    """Auto dt should satisfy the CFL condition."""
+    data = _make_hotspot((11, 11))
+    agg = create_test_raster(data, attrs={'res': (2.0, 2.0)})
+
+    # dx=2, alpha=0.5 -> dt = 0.25 * 4 / 0.5 = 2.0
+    # With auto dt, 10 steps should complete without blowup
+    result = diffuse(agg, diffusivity=0.5, steps=10, boundary='nearest')
+    assert np.all(np.isfinite(result.values))
+    assert result.values.max() <= 100.0  # should not exceed initial max
+
+
+def test_multiple_steps_vs_loop():
+    """Running steps=N should equal running steps=1 N times."""
+    data = _make_hotspot((9, 9))
+    agg = create_test_raster(data, attrs={'res': (1.0, 1.0)})
+
+    result_batch = diffuse(agg, diffusivity=0.5, steps=5, boundary='nearest')
+
+    # manual loop
+    current = agg
+    for _ in range(5):
+        current = diffuse(current, diffusivity=0.5, steps=1, boundary='nearest')
+
+    np.testing.assert_allclose(
+        result_batch.values, current.values, rtol=1e-10
+    )
+
+
+# ---- output structure tests ----
+
+def test_output_preserves_metadata():
+    """Output should keep dims, coords, and attrs from input."""
+    data = _make_hotspot((8, 8))
+    agg = create_test_raster(data, attrs={'res': (1.0, 1.0)})
+    result = diffuse(agg, diffusivity=1.0, steps=1, boundary='nearest')
+    general_output_checks(agg, result, verify_attrs=True)
+
+
+# ---- dask backend ----
+
+try:
+    import dask.array as _da
+    _has_dask = True
+except ImportError:
+    _has_dask = False
+
+dask_array_available = pytest.mark.skipif(
+    not _has_dask, reason='dask not available'
+)
+
+
+@dask_array_available
+def test_dask_matches_numpy():
+    """Dask backend should produce the same result as numpy."""
+    data = _make_hotspot((11, 11))
+    numpy_agg = create_test_raster(data, backend='numpy', attrs={'res': (1.0, 1.0)})
+    dask_agg = create_test_raster(data, backend='dask', attrs={'res': (1.0, 1.0)},
+                                  chunks=(6, 6))
+
+    np_result = diffuse(numpy_agg, diffusivity=0.5, steps=5, boundary='nearest')
+    dk_result = diffuse(dask_agg, diffusivity=0.5, steps=5, boundary='nearest')
+
+    general_output_checks(dask_agg, dk_result, verify_attrs=True)
+    np.testing.assert_allclose(
+        np_result.values, dk_result.data.compute(), rtol=1e-10
+    )
+
+
+@dask_array_available
+def test_dask_wrap_boundary():
+    """Dask wrap boundary should conserve mass like numpy."""
+    data = _make_hotspot((15, 15))
+    dask_agg = create_test_raster(data, backend='dask', attrs={'res': (1.0, 1.0)},
+                                  chunks=(8, 8))
+    result = diffuse(dask_agg, diffusivity=0.5, steps=10, boundary='wrap')
+    final_sum = np.nansum(result.data.compute())
+    np.testing.assert_allclose(final_sum, np.nansum(data), rtol=1e-10)
+
+
+# ---- validation tests ----
+
+def test_invalid_steps():
+    data = np.ones((5, 5))
+    agg = create_test_raster(data)
+    with pytest.raises((TypeError, ValueError)):
+        diffuse(agg, steps=0)
+
+
+def test_invalid_diffusivity():
+    data = np.ones((5, 5))
+    agg = create_test_raster(data)
+    with pytest.raises(ValueError):
+        diffuse(agg, diffusivity=-1.0)
+
+
+def test_invalid_boundary():
+    data = np.ones((5, 5))
+    agg = create_test_raster(data)
+    with pytest.raises(ValueError):
+        diffuse(agg, boundary='invalid')
+
+
+def test_diffusivity_shape_mismatch():
+    data = np.ones((5, 5))
+    agg = create_test_raster(data)
+    bad_alpha = xr.DataArray(np.ones((3, 3)))
+    with pytest.raises(ValueError, match='does not match'):
+        diffuse(agg, diffusivity=bad_alpha)
+
+
+def test_non_dataarray_input():
+    with pytest.raises(TypeError):
+        diffuse(np.ones((5, 5)))


### PR DESCRIPTION
## Summary

- New `diffuse()` function: forward-Euler solver for the 2D diffusion equation (5-point Laplacian stencil)
- Uniform or spatially varying diffusivity, auto CFL time step, four boundary modes
- numpy (`@ngjit`), cupy (`@cuda.jit`), dask+numpy, dask+cupy via `map_overlap`

## Changes

- `xrspatial/diffusion.py` -- new module
- `xrspatial/tests/test_diffusion.py` -- 15 tests (correctness, conservation, NaN handling, dask parity, input validation)
- `xrspatial/__init__.py` -- re-export `diffuse`
- `xrspatial/accessor.py` -- `.xrs.diffuse()` on DataArray and Dataset
- `docs/source/reference/diffusion.rst` -- API docs
- `docs/source/reference/index.rst` -- toctree entry
- `README.md` -- feature matrix row
- `examples/user_guide/16_Diffusion.ipynb` -- user guide notebook

## Test plan

- [x] `pytest xrspatial/tests/test_diffusion.py` passes (15/15)
- [ ] Verify GPU backends on a CUDA machine
- [ ] Run the notebook end-to-end

Closes #940