### PR TITLE
Add Dinf flow accumulation (#938)

### DIFF
--- a/xrspatial/flow_accumulation.py
+++ b/xrspatial/flow_accumulation.py
@@ -1,9 +1,11 @@
-"""D8 flow accumulation: count of upstream cells draining through each cell.
+"""Flow accumulation: count of upstream cells draining through each cell.
 
-Computes the number of upstream cells (including itself) that drain
-through each cell in a D8 flow direction grid.  This is a global
-graph traversal (topological sort of the D8 flow forest), not a
-local window operation.
+Supports both D8 (integer codes) and D-infinity (continuous angles)
+flow direction grids, auto-detected from input values.
+
+For D8 input, each cell drains to exactly one downstream neighbor.
+For D-infinity, flow is split proportionally between two neighbors
+following Tarboton (1997).
 
 Algorithm
 ---------
@@ -78,6 +80,105 @@ def _code_to_offset_py(code):
 
 
 # =====================================================================
+# Dinf helpers
+# =====================================================================
+
+@ngjit
+def _classify_flow_block(flow_dir, height, width):
+    """Classify a block of flow direction values.
+
+    Returns 1 for definite Dinf, -1 for definite D8, 0 for ambiguous
+    (all NaN or only zeros, which are valid in both conventions).
+    """
+    for r in range(height):
+        for c in range(width):
+            v = flow_dir[r, c]
+            if v != v:  # NaN
+                continue
+            iv = int(v)
+            if float(iv) != v:
+                return 1  # non-integer -> Dinf
+            if iv == 0:
+                continue  # ambiguous: D8 pit or Dinf east
+            if (iv == 1 or iv == 2 or iv == 4 or iv == 8
+                    or iv == 16 or iv == 32 or iv == 64 or iv == 128):
+                return -1  # definite D8
+            return 1  # integer but not a D8 code (e.g. -1) -> Dinf
+    return 0  # ambiguous
+
+
+def _detect_flow_type(data):
+    """Return 'd8' or 'dinf' based on flow direction values."""
+    if da is not None and isinstance(data, da.Array):
+        for iy in range(len(data.chunks[0])):
+            for ix in range(len(data.chunks[1])):
+                block = data.blocks[iy, ix].compute()
+                sample = np.asarray(
+                    block.get() if hasattr(block, 'get') else block)
+                result = _classify_flow_block(
+                    sample, sample.shape[0], sample.shape[1])
+                if result == 1:
+                    return "dinf"
+                elif result == -1:
+                    return "d8"
+        return "d8"  # all ambiguous -> default D8
+    elif hasattr(data, 'get'):  # cupy
+        sample = np.asarray(data.get())
+    elif isinstance(data, np.ndarray):
+        sample = data
+    else:
+        return "d8"
+    result = _classify_flow_block(sample, sample.shape[0], sample.shape[1])
+    return "dinf" if result == 1 else "d8"
+
+
+@ngjit
+def _angle_to_neighbors(angle):
+    """Decompose Dinf angle into two neighbors and weights.
+
+    Returns (dy1, dx1, w1, dy2, dx2, w2).
+    Pit (angle < 0) or NaN returns all zeros.
+    """
+    if angle < 0.0 or angle != angle:  # pit or NaN
+        return 0, 0, 0.0, 0, 0, 0.0
+
+    pi_over_4 = 0.7853981633974483  # np.pi / 4
+    k = int(angle / pi_over_4)
+    if k > 7:
+        k = 7
+    alpha = angle - k * pi_over_4
+    w1 = 1.0 - alpha / pi_over_4
+    w2 = alpha / pi_over_4
+
+    if k == 0:
+        dy1, dx1 = 0, 1      # E
+        dy2, dx2 = -1, 1     # NE
+    elif k == 1:
+        dy1, dx1 = -1, 1     # NE
+        dy2, dx2 = -1, 0     # N
+    elif k == 2:
+        dy1, dx1 = -1, 0     # N
+        dy2, dx2 = -1, -1    # NW
+    elif k == 3:
+        dy1, dx1 = -1, -1    # NW
+        dy2, dx2 = 0, -1     # W
+    elif k == 4:
+        dy1, dx1 = 0, -1     # W
+        dy2, dx2 = 1, -1     # SW
+    elif k == 5:
+        dy1, dx1 = 1, -1     # SW
+        dy2, dx2 = 1, 0      # S
+    elif k == 6:
+        dy1, dx1 = 1, 0      # S
+        dy2, dx2 = 1, 1      # SE
+    else:  # k == 7
+        dy1, dx1 = 1, 1      # SE
+        dy2, dx2 = 0, 1      # E
+
+    return dy1, dx1, w1, dy2, dx2, w2
+
+
+# =====================================================================
 # CPU kernel
 # =====================================================================
 
@@ -141,6 +242,78 @@ def _flow_accum_cpu(flow_dir, height, width):
                 queue_r[tail] = nr
                 queue_c[tail] = nc
                 tail += 1
+
+    return accum
+
+
+@ngjit
+def _flow_accum_dinf_cpu(flow_dir, height, width):
+    """Kahn's BFS topological sort for Dinf flow accumulation."""
+    accum = np.empty((height, width), dtype=np.float64)
+    in_degree = np.zeros((height, width), dtype=np.int32)
+    valid = np.zeros((height, width), dtype=np.int8)
+
+    for r in range(height):
+        for c in range(width):
+            v = flow_dir[r, c]
+            if v == v:  # not NaN
+                valid[r, c] = 1
+                accum[r, c] = 1.0
+            else:
+                accum[r, c] = np.nan
+
+    for r in range(height):
+        for c in range(width):
+            if valid[r, c] == 0:
+                continue
+            dy1, dx1, w1, dy2, dx2, w2 = _angle_to_neighbors(flow_dir[r, c])
+            if w1 > 0.0:
+                nr, nc = r + dy1, c + dx1
+                if 0 <= nr < height and 0 <= nc < width and valid[nr, nc] == 1:
+                    in_degree[nr, nc] += 1
+            if w2 > 0.0:
+                nr, nc = r + dy2, c + dx2
+                if 0 <= nr < height and 0 <= nc < width and valid[nr, nc] == 1:
+                    in_degree[nr, nc] += 1
+
+    queue_r = np.empty(height * width, dtype=np.int64)
+    queue_c = np.empty(height * width, dtype=np.int64)
+    head = np.int64(0)
+    tail = np.int64(0)
+
+    for r in range(height):
+        for c in range(width):
+            if valid[r, c] == 1 and in_degree[r, c] == 0:
+                queue_r[tail] = r
+                queue_c[tail] = c
+                tail += 1
+
+    while head < tail:
+        r = queue_r[head]
+        c = queue_c[head]
+        head += 1
+
+        dy1, dx1, w1, dy2, dx2, w2 = _angle_to_neighbors(flow_dir[r, c])
+
+        if w1 > 0.0:
+            nr, nc = r + dy1, c + dx1
+            if 0 <= nr < height and 0 <= nc < width and valid[nr, nc] == 1:
+                accum[nr, nc] += accum[r, c] * w1
+                in_degree[nr, nc] -= 1
+                if in_degree[nr, nc] == 0:
+                    queue_r[tail] = nr
+                    queue_c[tail] = nc
+                    tail += 1
+
+        if w2 > 0.0:
+            nr, nc = r + dy2, c + dx2
+            if 0 <= nr < height and 0 <= nc < width and valid[nr, nc] == 1:
+                accum[nr, nc] += accum[r, c] * w2
+                in_degree[nr, nc] -= 1
+                if in_degree[nr, nc] == 0:
+                    queue_r[tail] = nr
+                    queue_c[tail] = nc
+                    tail += 1
 
     return accum
 
@@ -304,6 +477,188 @@ def _flow_accum_cupy(flow_dir_data):
             flow_dir_f64, accum, in_degree, state, H, W)
 
     # Convert invalid cells to NaN
+    accum = cp.where(state == 0, cp.nan, accum)
+    return accum
+
+
+# =====================================================================
+# Dinf GPU kernels
+# =====================================================================
+
+@cuda.jit
+def _init_accum_indegree_dinf(flow_dir, accum, in_degree, state, H, W):
+    """Initialise accum/in_degree/state for Dinf on GPU."""
+    i, j = cuda.grid(2)
+    if i >= H or j >= W:
+        return
+
+    v = flow_dir[i, j]
+    if v != v:  # NaN
+        state[i, j] = 0
+        accum[i, j] = 0.0
+        return
+
+    state[i, j] = 1
+    accum[i, j] = 1.0
+
+    if v < 0.0:  # pit
+        return
+
+    pi_over_4 = 0.7853981633974483
+    k = int(v / pi_over_4)
+    if k > 7:
+        k = 7
+    alpha = v - k * pi_over_4
+    w1 = 1.0 - alpha / pi_over_4
+    w2 = alpha / pi_over_4
+
+    # Facet offsets (inline)
+    if k == 0:
+        dy1, dx1 = 0, 1
+        dy2, dx2 = -1, 1
+    elif k == 1:
+        dy1, dx1 = -1, 1
+        dy2, dx2 = -1, 0
+    elif k == 2:
+        dy1, dx1 = -1, 0
+        dy2, dx2 = -1, -1
+    elif k == 3:
+        dy1, dx1 = -1, -1
+        dy2, dx2 = 0, -1
+    elif k == 4:
+        dy1, dx1 = 0, -1
+        dy2, dx2 = 1, -1
+    elif k == 5:
+        dy1, dx1 = 1, -1
+        dy2, dx2 = 1, 0
+    elif k == 6:
+        dy1, dx1 = 1, 0
+        dy2, dx2 = 1, 1
+    else:
+        dy1, dx1 = 1, 1
+        dy2, dx2 = 0, 1
+
+    if w1 > 0.0:
+        ni, nj = i + dy1, j + dx1
+        if 0 <= ni < H and 0 <= nj < W:
+            cuda.atomic.add(in_degree, (ni, nj), 1)
+    if w2 > 0.0:
+        ni, nj = i + dy2, j + dx2
+        if 0 <= ni < H and 0 <= nj < W:
+            cuda.atomic.add(in_degree, (ni, nj), 1)
+
+
+@cuda.jit
+def _pull_from_frontier_dinf(flow_dir, accum, in_degree, state, H, W):
+    """Active Dinf cells pull accumulation from frontier neighbours."""
+    i, j = cuda.grid(2)
+    if i >= H or j >= W:
+        return
+
+    if state[i, j] != 1:
+        return
+
+    pi_over_4 = 0.7853981633974483
+
+    for nbr in range(8):
+        if nbr == 0:
+            dy, dx = 0, 1
+        elif nbr == 1:
+            dy, dx = 1, 1
+        elif nbr == 2:
+            dy, dx = 1, 0
+        elif nbr == 3:
+            dy, dx = 1, -1
+        elif nbr == 4:
+            dy, dx = 0, -1
+        elif nbr == 5:
+            dy, dx = -1, -1
+        elif nbr == 6:
+            dy, dx = -1, 0
+        else:
+            dy, dx = -1, 1
+
+        ni = i + dy
+        nj = j + dx
+        if ni < 0 or ni >= H or nj < 0 or nj >= W:
+            continue
+        if state[ni, nj] != 2:
+            continue
+
+        nv = flow_dir[ni, nj]
+        if nv < 0.0 or nv != nv:
+            continue
+
+        nk = int(nv / pi_over_4)
+        if nk > 7:
+            nk = 7
+        nalpha = nv - nk * pi_over_4
+        nw1 = 1.0 - nalpha / pi_over_4
+        nw2 = nalpha / pi_over_4
+
+        # Inline facet offsets for neighbor's direction
+        if nk == 0:
+            ndy1, ndx1 = 0, 1
+            ndy2, ndx2 = -1, 1
+        elif nk == 1:
+            ndy1, ndx1 = -1, 1
+            ndy2, ndx2 = -1, 0
+        elif nk == 2:
+            ndy1, ndx1 = -1, 0
+            ndy2, ndx2 = -1, -1
+        elif nk == 3:
+            ndy1, ndx1 = -1, -1
+            ndy2, ndx2 = 0, -1
+        elif nk == 4:
+            ndy1, ndx1 = 0, -1
+            ndy2, ndx2 = 1, -1
+        elif nk == 5:
+            ndy1, ndx1 = 1, -1
+            ndy2, ndx2 = 1, 0
+        elif nk == 6:
+            ndy1, ndx1 = 1, 0
+            ndy2, ndx2 = 1, 1
+        else:
+            ndy1, ndx1 = 1, 1
+            ndy2, ndx2 = 0, 1
+
+        if nw1 > 0.0 and ni + ndy1 == i and nj + ndx1 == j:
+            accum[i, j] += accum[ni, nj] * nw1
+            in_degree[i, j] -= 1
+        if nw2 > 0.0 and ni + ndy2 == i and nj + ndx2 == j:
+            accum[i, j] += accum[ni, nj] * nw2
+            in_degree[i, j] -= 1
+
+
+def _flow_accum_dinf_cupy(flow_dir_data):
+    """GPU driver: iterative frontier peeling for Dinf."""
+    import cupy as cp
+
+    H, W = flow_dir_data.shape
+    flow_dir_f64 = flow_dir_data.astype(cp.float64)
+
+    accum = cp.zeros((H, W), dtype=cp.float64)
+    in_degree = cp.zeros((H, W), dtype=cp.int32)
+    state = cp.zeros((H, W), dtype=cp.int32)
+    changed = cp.zeros(1, dtype=cp.int32)
+
+    griddim, blockdim = cuda_args((H, W))
+
+    _init_accum_indegree_dinf[griddim, blockdim](
+        flow_dir_f64, accum, in_degree, state, H, W)
+
+    max_iter = H * W
+    for _ in range(max_iter):
+        changed[0] = 0
+        _find_ready_and_finalize[griddim, blockdim](
+            in_degree, state, changed, H, W)
+
+        if int(changed[0]) == 0:
+            break
+
+        _pull_from_frontier_dinf[griddim, blockdim](
+            flow_dir_f64, accum, in_degree, state, H, W)
+
     accum = cp.where(state == 0, cp.nan, accum)
     return accum
 
@@ -677,23 +1032,375 @@ def _flow_accum_dask_cupy(flow_dir_da):
 
 
 # =====================================================================
+# Dinf tile kernel for dask
+# =====================================================================
+
+@ngjit
+def _flow_accum_dinf_tile_kernel(flow_dir, h, w,
+                                  seed_top, seed_bottom,
+                                  seed_left, seed_right,
+                                  seed_tl, seed_tr, seed_bl, seed_br):
+    """Seeded BFS Dinf flow accumulation for a single tile."""
+    accum = np.empty((h, w), dtype=np.float64)
+    in_degree = np.zeros((h, w), dtype=np.int32)
+    valid = np.zeros((h, w), dtype=np.int8)
+
+    for r in range(h):
+        for c in range(w):
+            v = flow_dir[r, c]
+            if v == v:
+                valid[r, c] = 1
+                accum[r, c] = 1.0
+            else:
+                accum[r, c] = np.nan
+
+    # Add external seeds
+    for c in range(w):
+        if valid[0, c] == 1:
+            accum[0, c] += seed_top[c]
+        if valid[h - 1, c] == 1:
+            accum[h - 1, c] += seed_bottom[c]
+    for r in range(h):
+        if valid[r, 0] == 1:
+            accum[r, 0] += seed_left[r]
+        if valid[r, w - 1] == 1:
+            accum[r, w - 1] += seed_right[r]
+    if valid[0, 0] == 1:
+        accum[0, 0] += seed_tl
+    if valid[0, w - 1] == 1:
+        accum[0, w - 1] += seed_tr
+    if valid[h - 1, 0] == 1:
+        accum[h - 1, 0] += seed_bl
+    if valid[h - 1, w - 1] == 1:
+        accum[h - 1, w - 1] += seed_br
+
+    # In-degrees via angle decomposition
+    for r in range(h):
+        for c in range(w):
+            if valid[r, c] == 0:
+                continue
+            dy1, dx1, w1, dy2, dx2, w2 = _angle_to_neighbors(flow_dir[r, c])
+            if w1 > 0.0:
+                nr, nc = r + dy1, c + dx1
+                if 0 <= nr < h and 0 <= nc < w and valid[nr, nc] == 1:
+                    in_degree[nr, nc] += 1
+            if w2 > 0.0:
+                nr, nc = r + dy2, c + dx2
+                if 0 <= nr < h and 0 <= nc < w and valid[nr, nc] == 1:
+                    in_degree[nr, nc] += 1
+
+    queue_r = np.empty(h * w, dtype=np.int64)
+    queue_c = np.empty(h * w, dtype=np.int64)
+    head = np.int64(0)
+    tail = np.int64(0)
+
+    for r in range(h):
+        for c in range(w):
+            if valid[r, c] == 1 and in_degree[r, c] == 0:
+                queue_r[tail] = r
+                queue_c[tail] = c
+                tail += 1
+
+    while head < tail:
+        r = queue_r[head]
+        c = queue_c[head]
+        head += 1
+
+        dy1, dx1, w1, dy2, dx2, w2 = _angle_to_neighbors(flow_dir[r, c])
+
+        if w1 > 0.0:
+            nr, nc = r + dy1, c + dx1
+            if 0 <= nr < h and 0 <= nc < w and valid[nr, nc] == 1:
+                accum[nr, nc] += accum[r, c] * w1
+                in_degree[nr, nc] -= 1
+                if in_degree[nr, nc] == 0:
+                    queue_r[tail] = nr
+                    queue_c[tail] = nc
+                    tail += 1
+
+        if w2 > 0.0:
+            nr, nc = r + dy2, c + dx2
+            if 0 <= nr < h and 0 <= nc < w and valid[nr, nc] == 1:
+                accum[nr, nc] += accum[r, c] * w2
+                in_degree[nr, nc] -= 1
+                if in_degree[nr, nc] == 0:
+                    queue_r[tail] = nr
+                    queue_c[tail] = nc
+                    tail += 1
+
+    return accum
+
+
+# =====================================================================
+# Dinf dask iterative tile sweep
+# =====================================================================
+
+def _compute_seeds_dinf(iy, ix, boundaries, flow_bdry,
+                        chunks_y, chunks_x, n_tile_y, n_tile_x):
+    """Compute seed arrays for tile (iy, ix) using Dinf angle decomposition."""
+    tile_h = chunks_y[iy]
+    tile_w = chunks_x[ix]
+
+    seed_top = np.zeros(tile_w, dtype=np.float64)
+    seed_bottom = np.zeros(tile_w, dtype=np.float64)
+    seed_left = np.zeros(tile_h, dtype=np.float64)
+    seed_right = np.zeros(tile_h, dtype=np.float64)
+    seed_tl = 0.0
+    seed_tr = 0.0
+    seed_bl = 0.0
+    seed_br = 0.0
+
+    # --- Top edge: bottom row of tile above flows south (dy=1) ---
+    if iy > 0:
+        nb_fdir = flow_bdry.get('bottom', iy - 1, ix)
+        nb_accum = boundaries.get('bottom', iy - 1, ix)
+        for c in range(len(nb_fdir)):
+            dy1, dx1, w1, dy2, dx2, w2 = _angle_to_neighbors(nb_fdir[c])
+            if w1 > 0.0 and dy1 == 1:
+                tc = c + dx1
+                if 0 <= tc < tile_w:
+                    seed_top[tc] += nb_accum[c] * w1
+            if w2 > 0.0 and dy2 == 1:
+                tc = c + dx2
+                if 0 <= tc < tile_w:
+                    seed_top[tc] += nb_accum[c] * w2
+
+    # --- Bottom edge: top row of tile below flows north (dy=-1) ---
+    if iy < n_tile_y - 1:
+        nb_fdir = flow_bdry.get('top', iy + 1, ix)
+        nb_accum = boundaries.get('top', iy + 1, ix)
+        for c in range(len(nb_fdir)):
+            dy1, dx1, w1, dy2, dx2, w2 = _angle_to_neighbors(nb_fdir[c])
+            if w1 > 0.0 and dy1 == -1:
+                tc = c + dx1
+                if 0 <= tc < tile_w:
+                    seed_bottom[tc] += nb_accum[c] * w1
+            if w2 > 0.0 and dy2 == -1:
+                tc = c + dx2
+                if 0 <= tc < tile_w:
+                    seed_bottom[tc] += nb_accum[c] * w2
+
+    # --- Left edge: right column of tile to the left flows east (dx=1) ---
+    if ix > 0:
+        nb_fdir = flow_bdry.get('right', iy, ix - 1)
+        nb_accum = boundaries.get('right', iy, ix - 1)
+        for r in range(len(nb_fdir)):
+            dy1, dx1, w1, dy2, dx2, w2 = _angle_to_neighbors(nb_fdir[r])
+            if w1 > 0.0 and dx1 == 1:
+                tr = r + dy1
+                if 0 <= tr < tile_h:
+                    seed_left[tr] += nb_accum[r] * w1
+            if w2 > 0.0 and dx2 == 1:
+                tr = r + dy2
+                if 0 <= tr < tile_h:
+                    seed_left[tr] += nb_accum[r] * w2
+
+    # --- Right edge: left column of tile to the right flows west (dx=-1) ---
+    if ix < n_tile_x - 1:
+        nb_fdir = flow_bdry.get('left', iy, ix + 1)
+        nb_accum = boundaries.get('left', iy, ix + 1)
+        for r in range(len(nb_fdir)):
+            dy1, dx1, w1, dy2, dx2, w2 = _angle_to_neighbors(nb_fdir[r])
+            if w1 > 0.0 and dx1 == -1:
+                tr = r + dy1
+                if 0 <= tr < tile_h:
+                    seed_right[tr] += nb_accum[r] * w1
+            if w2 > 0.0 and dx2 == -1:
+                tr = r + dy2
+                if 0 <= tr < tile_h:
+                    seed_right[tr] += nb_accum[r] * w2
+
+    # --- Diagonal corner seeds ---
+    # TL: bottom-right of (iy-1, ix-1) flows SE (dy=1, dx=1)
+    if iy > 0 and ix > 0:
+        fv = flow_bdry.get('bottom', iy - 1, ix - 1)[-1]
+        av = float(boundaries.get('bottom', iy - 1, ix - 1)[-1])
+        dy1, dx1, w1, dy2, dx2, w2 = _angle_to_neighbors(fv)
+        if w1 > 0.0 and dy1 == 1 and dx1 == 1:
+            seed_tl += av * w1
+        if w2 > 0.0 and dy2 == 1 and dx2 == 1:
+            seed_tl += av * w2
+
+    # TR: bottom-left of (iy-1, ix+1) flows SW (dy=1, dx=-1)
+    if iy > 0 and ix < n_tile_x - 1:
+        fv = flow_bdry.get('bottom', iy - 1, ix + 1)[0]
+        av = float(boundaries.get('bottom', iy - 1, ix + 1)[0])
+        dy1, dx1, w1, dy2, dx2, w2 = _angle_to_neighbors(fv)
+        if w1 > 0.0 and dy1 == 1 and dx1 == -1:
+            seed_tr += av * w1
+        if w2 > 0.0 and dy2 == 1 and dx2 == -1:
+            seed_tr += av * w2
+
+    # BL: top-right of (iy+1, ix-1) flows NE (dy=-1, dx=1)
+    if iy < n_tile_y - 1 and ix > 0:
+        fv = flow_bdry.get('top', iy + 1, ix - 1)[-1]
+        av = float(boundaries.get('top', iy + 1, ix - 1)[-1])
+        dy1, dx1, w1, dy2, dx2, w2 = _angle_to_neighbors(fv)
+        if w1 > 0.0 and dy1 == -1 and dx1 == 1:
+            seed_bl += av * w1
+        if w2 > 0.0 and dy2 == -1 and dx2 == 1:
+            seed_bl += av * w2
+
+    # BR: top-left of (iy+1, ix+1) flows NW (dy=-1, dx=-1)
+    if iy < n_tile_y - 1 and ix < n_tile_x - 1:
+        fv = flow_bdry.get('top', iy + 1, ix + 1)[0]
+        av = float(boundaries.get('top', iy + 1, ix + 1)[0])
+        dy1, dx1, w1, dy2, dx2, w2 = _angle_to_neighbors(fv)
+        if w1 > 0.0 and dy1 == -1 and dx1 == -1:
+            seed_br += av * w1
+        if w2 > 0.0 and dy2 == -1 and dx2 == -1:
+            seed_br += av * w2
+
+    return (seed_top, seed_bottom, seed_left, seed_right,
+            seed_tl, seed_tr, seed_bl, seed_br)
+
+
+def _process_tile_dinf(iy, ix, flow_dir_da, boundaries, flow_bdry,
+                       chunks_y, chunks_x, n_tile_y, n_tile_x):
+    """Run seeded Dinf BFS on one tile; update boundaries in-place."""
+    chunk = np.asarray(
+        flow_dir_da.blocks[iy, ix].compute(), dtype=np.float64)
+    h, w = chunk.shape
+
+    seeds = _compute_seeds_dinf(
+        iy, ix, boundaries, flow_bdry,
+        chunks_y, chunks_x, n_tile_y, n_tile_x)
+
+    accum = _flow_accum_dinf_tile_kernel(chunk, h, w, *seeds)
+
+    new_top = accum[0, :].copy()
+    new_bottom = accum[-1, :].copy()
+    new_left = accum[:, 0].copy()
+    new_right = accum[:, -1].copy()
+
+    change = 0.0
+    for side, new in (('top', new_top), ('bottom', new_bottom),
+                      ('left', new_left), ('right', new_right)):
+        old = boundaries.get(side, iy, ix)
+        with np.errstate(invalid='ignore'):
+            diff = np.abs(new - old)
+        diff = np.where(np.isnan(diff), 0.0, diff)
+        m = float(np.max(diff))
+        if m > change:
+            change = m
+
+    boundaries.set('top', iy, ix, new_top)
+    boundaries.set('bottom', iy, ix, new_bottom)
+    boundaries.set('left', iy, ix, new_left)
+    boundaries.set('right', iy, ix, new_right)
+
+    return change
+
+
+def _flow_accum_dinf_dask_iterative(flow_dir_da):
+    """Iterative boundary-propagation for Dinf dask arrays."""
+    chunks_y = flow_dir_da.chunks[0]
+    chunks_x = flow_dir_da.chunks[1]
+    n_tile_y = len(chunks_y)
+    n_tile_x = len(chunks_x)
+
+    flow_bdry = _preprocess_tiles(flow_dir_da, chunks_y, chunks_x)
+    flow_bdry = flow_bdry.snapshot()
+
+    boundaries = BoundaryStore(chunks_y, chunks_x, fill_value=0.0)
+
+    max_iterations = max(n_tile_y, n_tile_x) + 10
+
+    for _iteration in range(max_iterations):
+        max_change = 0.0
+
+        for iy in range(n_tile_y):
+            for ix in range(n_tile_x):
+                c = _process_tile_dinf(iy, ix, flow_dir_da, boundaries,
+                                       flow_bdry, chunks_y, chunks_x,
+                                       n_tile_y, n_tile_x)
+                if c > max_change:
+                    max_change = c
+
+        for iy in reversed(range(n_tile_y)):
+            for ix in reversed(range(n_tile_x)):
+                c = _process_tile_dinf(iy, ix, flow_dir_da, boundaries,
+                                       flow_bdry, chunks_y, chunks_x,
+                                       n_tile_y, n_tile_x)
+                if c > max_change:
+                    max_change = c
+
+        if max_change == 0.0:
+            break
+
+    boundaries = boundaries.snapshot()
+
+    return _assemble_result_dinf(flow_dir_da, boundaries, flow_bdry,
+                                 chunks_y, chunks_x, n_tile_y, n_tile_x)
+
+
+def _assemble_result_dinf(flow_dir_da, boundaries, flow_bdry,
+                          chunks_y, chunks_x, n_tile_y, n_tile_x):
+    """Build lazy dask array by re-running each Dinf tile with converged seeds."""
+
+    def _tile_fn(flow_dir_block, block_info=None):
+        if block_info is None or 0 not in block_info:
+            return np.full(flow_dir_block.shape, np.nan, dtype=np.float64)
+        iy, ix = block_info[0]['chunk-location']
+        h, w = flow_dir_block.shape
+        seeds = _compute_seeds_dinf(
+            iy, ix, boundaries, flow_bdry,
+            chunks_y, chunks_x, n_tile_y, n_tile_x)
+        return _flow_accum_dinf_tile_kernel(
+            np.asarray(flow_dir_block, dtype=np.float64), h, w, *seeds)
+
+    return da.map_blocks(
+        _tile_fn,
+        flow_dir_da,
+        dtype=np.float64,
+        meta=np.array((), dtype=np.float64),
+    )
+
+
+def _flow_accum_dinf_dask_cupy(flow_dir_da):
+    """Dask+CuPy Dinf: convert to numpy, run iterative, convert back."""
+    import cupy as cp
+
+    flow_dir_np = flow_dir_da.map_blocks(
+        lambda b: b.get(), dtype=flow_dir_da.dtype,
+        meta=np.array((), dtype=flow_dir_da.dtype),
+    )
+    result = _flow_accum_dinf_dask_iterative(flow_dir_np)
+    return result.map_blocks(
+        cp.asarray, dtype=result.dtype,
+        meta=cp.array((), dtype=result.dtype),
+    )
+
+
+# =====================================================================
 # Public API
 # =====================================================================
 
 @supports_dataset
 def flow_accumulation(flow_dir: xr.DataArray,
                       name: str = 'flow_accumulation') -> xr.DataArray:
-    """Compute D8 flow accumulation from a flow direction grid.
+    """Compute flow accumulation from a flow direction grid.
 
-    For each cell, counts how many upstream cells drain through it
-    (including itself).  The input must be a D8 flow direction grid
-    (codes 0/1/2/4/8/16/32/64/128; NaN for nodata).
+    Supports both D8 (integer codes) and D-infinity (continuous angles)
+    flow direction grids, auto-detected from input values.
+
+    For D8 input, each cell drains to exactly one downstream neighbor.
+    For D-infinity, flow is split proportionally between two neighbors
+    following Tarboton (1997).
 
     Parameters
     ----------
     flow_dir : xarray.DataArray or xr.Dataset
-        2D NumPy, CuPy, NumPy-backed Dask, or CuPy-backed Dask
-        xarray DataArray of D8 flow direction codes.
+        2D flow direction grid. Accepts:
+
+        - D8 codes: 0/1/2/4/8/16/32/64/128 (NaN for nodata)
+        - D-infinity angles: continuous radians in ``[0, 2*pi)``,
+          ``-1.0`` for pits, NaN for nodata (as produced by
+          ``flow_direction_dinf``)
+
+        The type is auto-detected from values.
+        Supported backends: NumPy, CuPy, NumPy-backed Dask,
+        CuPy-backed Dask.
         If a Dataset is passed, the operation is applied to each
         data variable independently.
     name : str, default='flow_accumulation'
@@ -712,25 +1419,38 @@ def flow_accumulation(flow_dir: xr.DataArray,
     Structure from Digital Elevation Data for Geographic Information
     System Analysis. Photogrammetric Engineering and Remote Sensing,
     54(11), 1593-1600.
+
+    Tarboton, D.G. (1997). A new method for the determination of flow
+    directions and upslope areas in grid digital elevation models.
+    Water Resources Research, 33(2), 309-319.
     """
     _validate_raster(flow_dir, func_name='flow_accumulation', name='flow_dir')
 
     data = flow_dir.data
+    flow_type = _detect_flow_type(data)
 
-    if isinstance(data, np.ndarray):
-        out = _flow_accum_cpu(data.astype(np.float64), *data.shape)
-
-    elif has_cuda_and_cupy() and is_cupy_array(data):
-        out = _flow_accum_cupy(data)
-
-    elif has_cuda_and_cupy() and is_dask_cupy(flow_dir):
-        out = _flow_accum_dask_cupy(data)
-
-    elif da is not None and isinstance(data, da.Array):
-        out = _flow_accum_dask_iterative(data)
-
+    if flow_type == "dinf":
+        if isinstance(data, np.ndarray):
+            out = _flow_accum_dinf_cpu(data.astype(np.float64), *data.shape)
+        elif has_cuda_and_cupy() and is_cupy_array(data):
+            out = _flow_accum_dinf_cupy(data)
+        elif has_cuda_and_cupy() and is_dask_cupy(flow_dir):
+            out = _flow_accum_dinf_dask_cupy(data)
+        elif da is not None and isinstance(data, da.Array):
+            out = _flow_accum_dinf_dask_iterative(data)
+        else:
+            raise TypeError(f"Unsupported array type: {type(data)}")
     else:
-        raise TypeError(f"Unsupported array type: {type(data)}")
+        if isinstance(data, np.ndarray):
+            out = _flow_accum_cpu(data.astype(np.float64), *data.shape)
+        elif has_cuda_and_cupy() and is_cupy_array(data):
+            out = _flow_accum_cupy(data)
+        elif has_cuda_and_cupy() and is_dask_cupy(flow_dir):
+            out = _flow_accum_dask_cupy(data)
+        elif da is not None and isinstance(data, da.Array):
+            out = _flow_accum_dask_iterative(data)
+        else:
+            raise TypeError(f"Unsupported array type: {type(data)}")
 
     return xr.DataArray(out,
                         name=name,

--- a/xrspatial/tests/test_flow_accumulation.py
+++ b/xrspatial/tests/test_flow_accumulation.py
@@ -348,3 +348,204 @@ def test_numpy_equals_dask_cupy():
     dcp_result = flow_accumulation(dask_cupy_agg)
     np.testing.assert_allclose(
         np_result.data, dcp_result.data.compute().get(), equal_nan=True)
+
+
+# ===========================================================================
+# Dinf flow accumulation tests
+# ===========================================================================
+
+from xrspatial.flow_accumulation import _detect_flow_type
+
+
+def test_dinf_detection_d8():
+    """D8 codes detected as 'd8'."""
+    flow_dir = np.array([[1.0, 2.0], [4.0, 0.0]], dtype=np.float64)
+    assert _detect_flow_type(flow_dir) == "d8"
+
+
+def test_dinf_detection_dinf():
+    """Dinf angles detected as 'dinf'."""
+    flow_dir = np.array([[0.5, 1.2], [-1.0, np.nan]], dtype=np.float64)
+    assert _detect_flow_type(flow_dir) == "dinf"
+
+
+def test_dinf_detection_all_nan():
+    """All-NaN grid detected as 'd8' (default)."""
+    flow_dir = np.full((3, 3), np.nan, dtype=np.float64)
+    assert _detect_flow_type(flow_dir) == "d8"
+
+
+def test_dinf_detection_pit_minus_one():
+    """-1.0 (Dinf pit) triggers 'dinf' detection."""
+    flow_dir = np.array([[0.0, -1.0], [0.0, 0.0]], dtype=np.float64)
+    assert _detect_flow_type(flow_dir) == "dinf"
+
+
+def test_dinf_cardinal_east_chain():
+    """Pure east angles (0.0) chain: matches D8 code=1 result."""
+    N = 6
+    # Dinf: angle=0 means east, pit=-1
+    flow_dir = np.full((1, N), 0.0, dtype=np.float64)
+    flow_dir[0, -1] = -1.0  # last cell is pit
+    agg = create_test_raster(flow_dir)
+    result = flow_accumulation(agg)
+    expected = np.arange(1, N + 1, dtype=np.float64).reshape(1, N)
+    np.testing.assert_allclose(result.data, expected)
+
+
+def test_dinf_pit_center():
+    """8 neighbours with exact cardinal/diagonal angles point to center."""
+    pi = np.pi
+    flow_dir = np.array([
+        [7 * pi / 4,  3 * pi / 2,  5 * pi / 4],
+        [0.0,         -1.0,         pi],
+        [pi / 4,      pi / 2,       3 * pi / 4],
+    ], dtype=np.float64)
+    agg = create_test_raster(flow_dir)
+    result = flow_accumulation(agg)
+    assert result.data[1, 1] == 9.0
+    for r, c in [(0, 0), (0, 1), (0, 2), (1, 0), (1, 2),
+                 (2, 0), (2, 1), (2, 2)]:
+        assert result.data[r, c] == 1.0, f"Cell ({r},{c}) = {result.data[r,c]}"
+
+
+def test_dinf_proportional_split():
+    """angle=pi/8 splits flow 50/50 to E and NE."""
+    pi = np.pi
+    flow_dir = np.array([
+        [-1.0,  -1.0,  -1.0],
+        [-1.0,  pi / 8, -1.0],
+        [-1.0,  -1.0,  -1.0],
+    ], dtype=np.float64)
+    agg = create_test_raster(flow_dir)
+    result = flow_accumulation(agg)
+    # Center splits 50/50 to E (1,2) and NE (0,2)
+    np.testing.assert_allclose(result.data[1, 2], 1.5)
+    np.testing.assert_allclose(result.data[0, 2], 1.5)
+    assert result.data[1, 1] == 1.0
+
+
+def test_dinf_chain_with_split():
+    """Multi-cell chain with fractional flow, verify cascading sums."""
+    pi = np.pi
+    flow_dir = np.array([
+        [-1.0,   -1.0,   -1.0],
+        [pi / 8, pi / 8, -1.0],
+        [-1.0,   -1.0,   -1.0],
+    ], dtype=np.float64)
+    agg = create_test_raster(flow_dir)
+    result = flow_accumulation(agg)
+    # (1,0) sends 0.5 to E(1,1) and 0.5 to NE(0,1)
+    # (1,1) has accum=1.5, sends 0.75 to E(1,2) and 0.75 to NE(0,2)
+    np.testing.assert_allclose(result.data[1, 0], 1.0)
+    np.testing.assert_allclose(result.data[0, 1], 1.5)
+    np.testing.assert_allclose(result.data[1, 1], 1.5)
+    np.testing.assert_allclose(result.data[1, 2], 1.75)
+    np.testing.assert_allclose(result.data[0, 2], 1.75)
+
+
+def test_dinf_end_to_end():
+    """flow_direction_dinf -> flow_accumulation produces valid results."""
+    from xrspatial import flow_direction_dinf
+
+    rng = np.random.default_rng(42)
+    elev = create_test_raster(rng.random((20, 20)) * 100)
+    fdir = flow_direction_dinf(elev)
+    acc = flow_accumulation(fdir)
+    data = acc.data
+    valid = data[~np.isnan(data)]
+    assert len(valid) > 0
+    assert np.all(valid >= 1.0)
+    assert np.max(valid) <= data.size
+
+
+def test_dinf_nan_handling():
+    """NaN flow dir produces NaN accumulation."""
+    pi = np.pi
+    flow_dir = np.array([
+        [np.nan,   pi / 2],
+        [0.0,      -1.0],
+    ], dtype=np.float64)
+    agg = create_test_raster(flow_dir)
+    result = flow_accumulation(agg)
+    assert np.isnan(result.data[0, 0])
+    np.testing.assert_allclose(result.data[0, 1], 1.0)
+    np.testing.assert_allclose(result.data[1, 0], 1.0)
+    np.testing.assert_allclose(result.data[1, 1], 2.0)
+
+
+@dask_array_available
+@pytest.mark.parametrize("chunks", [
+    (3, 3), (5, 5), (2, 6), (6, 2), (1, 1), (6, 6),
+])
+def test_dinf_dask_matches_numpy(chunks):
+    """Dinf dask matches numpy across chunk sizes."""
+    from xrspatial import flow_direction_dinf
+
+    rng = np.random.default_rng(123)
+    elev = create_test_raster(rng.random((6, 6)) * 100)
+    fdir_np = flow_direction_dinf(elev).data
+
+    numpy_agg = create_test_raster(fdir_np, backend='numpy')
+    dask_agg = create_test_raster(fdir_np, backend='dask', chunks=chunks)
+    np_result = flow_accumulation(numpy_agg)
+    da_result = flow_accumulation(dask_agg)
+    np.testing.assert_allclose(
+        np_result.data, da_result.data.compute(), equal_nan=True,
+    ), f"Mismatch with chunks={chunks}"
+
+
+@dask_array_available
+def test_dinf_dask_larger_grid():
+    """Dinf dask on a larger grid with cross-tile flow."""
+    from xrspatial import flow_direction_dinf
+
+    rng = np.random.default_rng(99)
+    elev = create_test_raster(rng.random((12, 12)) * 100)
+    fdir_np = flow_direction_dinf(elev).data
+
+    numpy_agg = create_test_raster(fdir_np, backend='numpy')
+    np_result = flow_accumulation(numpy_agg)
+
+    for chunks in [(3, 3), (4, 6), (6, 4), (2, 2)]:
+        dask_agg = create_test_raster(fdir_np, backend='dask', chunks=chunks)
+        da_result = flow_accumulation(dask_agg)
+        np.testing.assert_allclose(
+            np_result.data, da_result.data.compute(), equal_nan=True,
+        ), f"Mismatch with chunks={chunks}"
+
+
+@cuda_and_cupy_available
+def test_dinf_cupy_matches_numpy():
+    """Dinf CuPy matches NumPy."""
+    from xrspatial import flow_direction_dinf
+
+    rng = np.random.default_rng(42)
+    elev = create_test_raster(rng.random((10, 10)) * 100)
+    fdir_np = flow_direction_dinf(elev).data
+
+    numpy_agg = create_test_raster(fdir_np, backend='numpy')
+    cupy_agg = create_test_raster(fdir_np, backend='cupy')
+    np_result = flow_accumulation(numpy_agg)
+    cp_result = flow_accumulation(cupy_agg)
+    np.testing.assert_allclose(
+        np_result.data, cp_result.data.get(), equal_nan=True)
+
+
+@dask_array_available
+@cuda_and_cupy_available
+def test_dinf_dask_cupy_matches_numpy():
+    """Dinf Dask+CuPy matches NumPy."""
+    from xrspatial import flow_direction_dinf
+
+    rng = np.random.default_rng(42)
+    elev = create_test_raster(rng.random((8, 8)) * 100)
+    fdir_np = flow_direction_dinf(elev).data
+
+    numpy_agg = create_test_raster(fdir_np, backend='numpy')
+    dask_cupy_agg = create_test_raster(fdir_np, backend='dask+cupy',
+                                        chunks=(4, 4))
+    np_result = flow_accumulation(numpy_agg)
+    dcp_result = flow_accumulation(dask_cupy_agg)
+    np.testing.assert_allclose(
+        np_result.data, dcp_result.data.compute().get(), equal_nan=True)


### PR DESCRIPTION
## Summary

- `flow_accumulation()` silently returned wrong results for Dinf input (every cell = 1.0) because `_code_to_offset` truncated float angles to ints that never matched any D8 code
- Auto-detects D8 vs Dinf from input values, then branches to the appropriate algorithm
- Dinf path uses Tarboton's proportional flow splitting between two downslope neighbors
- All four backends: numpy, cupy, dask+numpy, dask+cupy

## What changed

**`xrspatial/flow_accumulation.py`**
- `_classify_flow_block` / `_detect_flow_type`: scan input values to distinguish D8 codes from Dinf angles (handles the 0.0 ambiguity between D8 pit and Dinf east-angle)
- `_angle_to_neighbors`: decompose a Dinf angle into two downstream neighbors with proportional weights
- `_flow_accum_dinf_cpu`: Kahn's BFS with fractional splitting
- GPU kernels (`_init_accum_indegree_dinf`, `_pull_from_frontier_dinf`, `_flow_accum_dinf_cupy`): frontier-peeling with inlined angle decomposition, reuses `_find_ready_and_finalize` from D8
- Dask tile sweep (`_flow_accum_dinf_tile_kernel`, `_compute_seeds_dinf`, etc.): boundary-propagation with fractional cross-tile seeds
- `flow_accumulation()` docstring updated, Tarboton (1997) reference added

**`xrspatial/tests/test_flow_accumulation.py`**
- Detection tests (D8 codes, Dinf angles, all-NaN, -1.0 pit)
- Correctness tests (cardinal east chain, pit center, 50/50 split, cascading chain, NaN handling)
- End-to-end: `flow_direction_dinf(elevation)` -> `flow_accumulation()`
- Cross-backend: dask with 6 chunk configs, cupy, dask+cupy

## Test plan

- [x] All 45 tests pass (`pytest xrspatial/tests/test_flow_accumulation.py`)
- [x] 24 existing D8 tests unchanged and passing
- [x] Smoke test: `flow_direction_dinf` -> `flow_accumulation` on random 20x20 elevation, all values >= 1.0