### PR TITLE
Add HAND and TWI to README feature matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,8 @@ In the GIS world, rasters are used for representing continuous phenomena (e.g. e
 | [Stream Link](xrspatial/stream_link.py) | Assigns unique IDs to each stream segment between junctions | ✅️ | ✅️ | ✅️ | 🔄 |
 | [Snap Pour Point](xrspatial/snap_pour_point.py) | Snaps pour points to the highest-accumulation cell within a search radius | ✅️ | ✅️ | 🔄 | 🔄 |
 | [Flow Path](xrspatial/flow_path.py) | Traces downstream flow paths from start points through a D8 direction grid | ✅️ | ✅️ | 🔄 | 🔄 |
+| [HAND](xrspatial/hand.py) | Computes Height Above Nearest Drainage by tracing D8 flow to the nearest stream cell | ✅️ | ✅️ | 🔄 | 🔄 |
+| [TWI](xrspatial/twi.py) | Topographic Wetness Index: ln(specific catchment area / tan(slope)) | ✅️ | ✅️ | ✅️ | 🔄 |
 
 -----------
 


### PR DESCRIPTION
Closes #954.

## Summary

- Added HAND (Height Above Nearest Drainage) and TWI (Topographic Wetness Index) rows to the Hydrology section of the README feature matrix
- Both functions were already implemented in `xrspatial/hand.py` and `xrspatial/twi.py` with full API reference docs, but were missing from the README

## Test plan

- [x] Verify the two new rows render correctly in the GitHub README preview
- [x] Confirm backend checkmarks match actual implementation (HAND: native NumPy/Dask, fallback CuPy; TWI: native NumPy/Dask/CuPy, fallback Dask+CuPy)