### PR TITLE
Add native Dask+CuPy backends for hydrology core functions (#952)

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,13 +286,13 @@ In the GIS world, rasters are used for representing continuous phenomena (e.g. e
 | [Flow Direction (D8)](xrspatial/flow_direction.py) | Computes D8 flow direction from each cell toward the steepest downhill neighbor | ✅️ | ✅️ | ✅️ | ✅️ |
 | [Flow Direction (Dinf)](xrspatial/flow_direction_dinf.py) | Computes D-infinity flow direction as a continuous angle toward the steepest downslope facet | ✅️ | ✅️ | ✅️ | ✅️ |
 | [Flow Direction (MFD)](xrspatial/flow_direction_mfd.py) | Partitions flow to all downslope neighbors with an adaptive exponent (Qin et al. 2007) | ✅️ | ✅️ | ✅️ | ✅️ |
-| [Flow Accumulation (D8)](xrspatial/flow_accumulation.py) | Counts upstream cells draining through each cell in a D8 flow direction grid | ✅️ | ✅️ | ✅️ | 🔄 |
+| [Flow Accumulation (D8)](xrspatial/flow_accumulation.py) | Counts upstream cells draining through each cell in a D8 flow direction grid | ✅️ | ✅️ | ✅️ | ✅️ |
 | [Flow Accumulation (MFD)](xrspatial/flow_accumulation_mfd.py) | Accumulates upstream area through all MFD flow paths weighted by directional fractions | ✅️ | ✅️ | ✅️ | 🔄 |
-| [Watershed](xrspatial/watershed.py) | Labels each cell with the pour point it drains to via D8 flow direction | ✅️ | ✅️ | ✅️ | 🔄 |
-| [Basins](xrspatial/watershed.py) | Delineates drainage basins by labeling each cell with its outlet ID | ✅️ | ✅️ | ✅️ | 🔄 |
-| [Stream Order](xrspatial/stream_order.py) | Assigns Strahler or Shreve stream order to cells in a drainage network | ✅️ | ✅️ | ✅️ | 🔄 |
-| [Stream Link](xrspatial/stream_link.py) | Assigns unique IDs to each stream segment between junctions | ✅️ | ✅️ | ✅️ | 🔄 |
-| [Snap Pour Point](xrspatial/snap_pour_point.py) | Snaps pour points to the highest-accumulation cell within a search radius | ✅️ | ✅️ | 🔄 | 🔄 |
+| [Watershed](xrspatial/watershed.py) | Labels each cell with the pour point it drains to via D8 flow direction | ✅️ | ✅️ | ✅️ | ✅️ |
+| [Basins](xrspatial/watershed.py) | Delineates drainage basins by labeling each cell with its outlet ID | ✅️ | ✅️ | ✅️ | ✅️ |
+| [Stream Order](xrspatial/stream_order.py) | Assigns Strahler or Shreve stream order to cells in a drainage network | ✅️ | ✅️ | ✅️ | ✅️ |
+| [Stream Link](xrspatial/stream_link.py) | Assigns unique IDs to each stream segment between junctions | ✅️ | ✅️ | ✅️ | ✅️ |
+| [Snap Pour Point](xrspatial/snap_pour_point.py) | Snaps pour points to the highest-accumulation cell within a search radius | ✅️ | ✅️ | ✅️ | ✅️ |
 | [Flow Path](xrspatial/flow_path.py) | Traces downstream flow paths from start points through a D8 direction grid | ✅️ | ✅️ | 🔄 | 🔄 |
 | [HAND](xrspatial/hand.py) | Computes Height Above Nearest Drainage by tracing D8 flow to the nearest stream cell | ✅️ | ✅️ | 🔄 | 🔄 |
 | [TWI](xrspatial/twi.py) | Topographic Wetness Index: ln(specific catchment area / tan(slope)) | ✅️ | ✅️ | ✅️ | 🔄 |

--- a/xrspatial/basin.py
+++ b/xrspatial/basin.py
@@ -298,18 +298,33 @@ def _basins_dask_iterative(flow_dir_da):
 
 
 def _basins_dask_cupy(flow_dir_da):
-    """Dask+CuPy basins: convert to numpy, run CPU iterative, convert back."""
+    """Dask+CuPy basins: native GPU via watershed infrastructure."""
     import cupy as cp
+    from xrspatial.watershed import _watershed_dask_cupy
 
-    flow_dir_np = flow_dir_da.map_blocks(
-        lambda b: b.get(), dtype=flow_dir_da.dtype,
-        meta=np.array((), dtype=flow_dir_da.dtype),
-    )
-    result = _basins_dask_iterative(flow_dir_np)
-    return result.map_blocks(
-        cp.asarray, dtype=result.dtype,
-        meta=cp.array((), dtype=result.dtype),
-    )
+    chunks_y = flow_dir_da.chunks[0]
+    chunks_x = flow_dir_da.chunks[1]
+    total_h = sum(chunks_y)
+    total_w = sum(chunks_x)
+
+    def _basins_make_pp_block(flow_dir_block, block_info=None):
+        if block_info is None or 0 not in block_info:
+            return cp.full(flow_dir_block.shape, cp.nan, dtype=cp.float64)
+        row_off = block_info[0]['array-location'][0][0]
+        col_off = block_info[0]['array-location'][1][0]
+        h, w = flow_dir_block.shape
+        chunk_np = flow_dir_block.get() if hasattr(flow_dir_block, 'get') \
+            else np.asarray(flow_dir_block)
+        chunk_np = np.asarray(chunk_np, dtype=np.float64)
+        pp = _basins_init_labels(chunk_np, h, w, total_h, total_w,
+                                  row_off, col_off)
+        return cp.asarray(np.where(pp >= 0, pp, np.nan))
+
+    pour_points_da = da.map_blocks(
+        _basins_make_pp_block, flow_dir_da,
+        dtype=np.float64, meta=cp.array((), dtype=cp.float64))
+
+    return _watershed_dask_cupy(flow_dir_da, pour_points_da)
 
 
 # =====================================================================

--- a/xrspatial/flow_accumulation.py
+++ b/xrspatial/flow_accumulation.py
@@ -44,6 +44,16 @@ from xrspatial._boundary_store import BoundaryStore
 from xrspatial.dataset_support import supports_dataset
 
 
+def _to_numpy_f64(arr):
+    """Convert *arr* to a contiguous numpy float64 array.
+
+    Handles CuPy arrays transparently via ``.get()``.
+    """
+    if hasattr(arr, 'get'):
+        arr = arr.get()
+    return np.asarray(arr, dtype=np.float64)
+
+
 # =====================================================================
 # Direction helpers
 # =====================================================================
@@ -481,6 +491,58 @@ def _flow_accum_cupy(flow_dir_data):
     return accum
 
 
+def _flow_accum_tile_cupy(flow_dir_data,
+                           seed_top, seed_bottom, seed_left, seed_right,
+                           seed_tl, seed_tr, seed_bl, seed_br):
+    """GPU seeded flow accumulation for a single tile.
+
+    Same algorithm as ``_flow_accum_cupy`` but injects external seed
+    values at boundary cells before frontier peeling.  Seeds are
+    NumPy arrays; they are transferred to GPU inside this function.
+    """
+    import cupy as cp
+
+    H, W = flow_dir_data.shape
+    flow_dir_f64 = flow_dir_data.astype(cp.float64)
+
+    accum = cp.zeros((H, W), dtype=cp.float64)
+    in_degree = cp.zeros((H, W), dtype=cp.int32)
+    state = cp.zeros((H, W), dtype=cp.int32)
+    changed = cp.zeros(1, dtype=cp.int32)
+
+    griddim, blockdim = cuda_args((H, W))
+
+    _init_accum_indegree[griddim, blockdim](
+        flow_dir_f64, accum, in_degree, state, H, W)
+
+    # Inject seeds at boundary cells.  Invalid cells (state==0) are
+    # masked to NaN at the end and never enter frontier peeling, so
+    # adding seeds to them is harmless.
+    accum[0, :] += cp.asarray(seed_top)
+    accum[H - 1, :] += cp.asarray(seed_bottom)
+    accum[:, 0] += cp.asarray(seed_left)
+    accum[:, W - 1] += cp.asarray(seed_right)
+    accum[0, 0] += seed_tl
+    accum[0, W - 1] += seed_tr
+    accum[H - 1, 0] += seed_bl
+    accum[H - 1, W - 1] += seed_br
+
+    max_iter = H * W
+    for _ in range(max_iter):
+        changed[0] = 0
+        _find_ready_and_finalize[griddim, blockdim](
+            in_degree, state, changed, H, W)
+
+        if int(changed[0]) == 0:
+            break
+
+        _pull_from_frontier[griddim, blockdim](
+            flow_dir_f64, accum, in_degree, state, H, W)
+
+    accum = cp.where(state == 0, cp.nan, accum)
+    return accum
+
+
 # =====================================================================
 # Dinf GPU kernels
 # =====================================================================
@@ -663,6 +725,50 @@ def _flow_accum_dinf_cupy(flow_dir_data):
     return accum
 
 
+def _flow_accum_dinf_tile_cupy(flow_dir_data,
+                                seed_top, seed_bottom, seed_left, seed_right,
+                                seed_tl, seed_tr, seed_bl, seed_br):
+    """GPU seeded Dinf flow accumulation for a single tile."""
+    import cupy as cp
+
+    H, W = flow_dir_data.shape
+    flow_dir_f64 = flow_dir_data.astype(cp.float64)
+
+    accum = cp.zeros((H, W), dtype=cp.float64)
+    in_degree = cp.zeros((H, W), dtype=cp.int32)
+    state = cp.zeros((H, W), dtype=cp.int32)
+    changed = cp.zeros(1, dtype=cp.int32)
+
+    griddim, blockdim = cuda_args((H, W))
+
+    _init_accum_indegree_dinf[griddim, blockdim](
+        flow_dir_f64, accum, in_degree, state, H, W)
+
+    accum[0, :] += cp.asarray(seed_top)
+    accum[H - 1, :] += cp.asarray(seed_bottom)
+    accum[:, 0] += cp.asarray(seed_left)
+    accum[:, W - 1] += cp.asarray(seed_right)
+    accum[0, 0] += seed_tl
+    accum[0, W - 1] += seed_tr
+    accum[H - 1, 0] += seed_bl
+    accum[H - 1, W - 1] += seed_br
+
+    max_iter = H * W
+    for _ in range(max_iter):
+        changed[0] = 0
+        _find_ready_and_finalize[griddim, blockdim](
+            in_degree, state, changed, H, W)
+
+        if int(changed[0]) == 0:
+            break
+
+        _pull_from_frontier_dinf[griddim, blockdim](
+            flow_dir_f64, accum, in_degree, state, H, W)
+
+    accum = cp.where(state == 0, cp.nan, accum)
+    return accum
+
+
 # =====================================================================
 # Tile kernel for dask iterative path
 # =====================================================================
@@ -773,14 +879,10 @@ def _preprocess_tiles(flow_dir_da, chunks_y, chunks_x):
     for iy in range(n_tile_y):
         for ix in range(n_tile_x):
             chunk = flow_dir_da.blocks[iy, ix].compute()
-            flow_bdry.set('top', iy, ix,
-                          np.asarray(chunk[0, :], dtype=np.float64))
-            flow_bdry.set('bottom', iy, ix,
-                          np.asarray(chunk[-1, :], dtype=np.float64))
-            flow_bdry.set('left', iy, ix,
-                          np.asarray(chunk[:, 0], dtype=np.float64))
-            flow_bdry.set('right', iy, ix,
-                          np.asarray(chunk[:, -1], dtype=np.float64))
+            flow_bdry.set('top', iy, ix, _to_numpy_f64(chunk[0, :]))
+            flow_bdry.set('bottom', iy, ix, _to_numpy_f64(chunk[-1, :]))
+            flow_bdry.set('left', iy, ix, _to_numpy_f64(chunk[:, 0]))
+            flow_bdry.set('right', iy, ix, _to_numpy_f64(chunk[:, -1]))
 
     return flow_bdry
 
@@ -1016,19 +1118,108 @@ def _assemble_result(flow_dir_da, boundaries, flow_bdry,
     )
 
 
-def _flow_accum_dask_cupy(flow_dir_da):
-    """Dask+CuPy: convert to numpy, run CPU iterative path, convert back."""
+def _process_tile_cupy(iy, ix, flow_dir_da, boundaries, flow_bdry,
+                        chunks_y, chunks_x, n_tile_y, n_tile_x):
+    """Run seeded GPU flow accumulation on one tile; update boundaries."""
     import cupy as cp
 
-    flow_dir_np = flow_dir_da.map_blocks(
-        lambda b: b.get(), dtype=flow_dir_da.dtype,
-        meta=np.array((), dtype=flow_dir_da.dtype),
+    chunk = cp.asarray(
+        flow_dir_da.blocks[iy, ix].compute(), dtype=cp.float64)
+
+    seeds = _compute_seeds(
+        iy, ix, boundaries, flow_bdry,
+        chunks_y, chunks_x, n_tile_y, n_tile_x)
+
+    accum = _flow_accum_tile_cupy(chunk, *seeds)
+
+    # Extract boundaries to CPU (small 1-D strips)
+    new_top = accum[0, :].get().copy()
+    new_bottom = accum[-1, :].get().copy()
+    new_left = accum[:, 0].get().copy()
+    new_right = accum[:, -1].get().copy()
+
+    change = 0.0
+    for side, new in (('top', new_top), ('bottom', new_bottom),
+                      ('left', new_left), ('right', new_right)):
+        old = boundaries.get(side, iy, ix)
+        with np.errstate(invalid='ignore'):
+            diff = np.abs(new - old)
+        diff = np.where(np.isnan(diff), 0.0, diff)
+        m = float(np.max(diff))
+        if m > change:
+            change = m
+
+    boundaries.set('top', iy, ix, new_top)
+    boundaries.set('bottom', iy, ix, new_bottom)
+    boundaries.set('left', iy, ix, new_left)
+    boundaries.set('right', iy, ix, new_right)
+
+    return change
+
+
+def _assemble_result_cupy(flow_dir_da, boundaries, flow_bdry,
+                           chunks_y, chunks_x, n_tile_y, n_tile_x):
+    """Build a lazy dask+cupy array using GPU tile kernel."""
+    import cupy as cp
+
+    def _tile_fn(flow_dir_block, block_info=None):
+        if block_info is None or 0 not in block_info:
+            return cp.full(flow_dir_block.shape, cp.nan, dtype=cp.float64)
+        iy, ix = block_info[0]['chunk-location']
+        seeds = _compute_seeds(
+            iy, ix, boundaries, flow_bdry,
+            chunks_y, chunks_x, n_tile_y, n_tile_x)
+        return _flow_accum_tile_cupy(
+            cp.asarray(flow_dir_block, dtype=cp.float64), *seeds)
+
+    return da.map_blocks(
+        _tile_fn,
+        flow_dir_da,
+        dtype=np.float64,
+        meta=cp.array((), dtype=cp.float64),
     )
-    result = _flow_accum_dask_iterative(flow_dir_np)
-    return result.map_blocks(
-        cp.asarray, dtype=result.dtype,
-        meta=cp.array((), dtype=result.dtype),
-    )
+
+
+def _flow_accum_dask_cupy(flow_dir_da):
+    """Dask+CuPy D8: native GPU processing per tile."""
+    chunks_y = flow_dir_da.chunks[0]
+    chunks_x = flow_dir_da.chunks[1]
+    n_tile_y = len(chunks_y)
+    n_tile_x = len(chunks_x)
+
+    flow_bdry = _preprocess_tiles(flow_dir_da, chunks_y, chunks_x)
+    flow_bdry = flow_bdry.snapshot()
+
+    boundaries = BoundaryStore(chunks_y, chunks_x, fill_value=0.0)
+
+    max_iterations = max(n_tile_y, n_tile_x) + 10
+
+    for _iteration in range(max_iterations):
+        max_change = 0.0
+
+        for iy in range(n_tile_y):
+            for ix in range(n_tile_x):
+                c = _process_tile_cupy(iy, ix, flow_dir_da, boundaries,
+                                        flow_bdry, chunks_y, chunks_x,
+                                        n_tile_y, n_tile_x)
+                if c > max_change:
+                    max_change = c
+
+        for iy in reversed(range(n_tile_y)):
+            for ix in reversed(range(n_tile_x)):
+                c = _process_tile_cupy(iy, ix, flow_dir_da, boundaries,
+                                        flow_bdry, chunks_y, chunks_x,
+                                        n_tile_y, n_tile_x)
+                if c > max_change:
+                    max_change = c
+
+        if max_change == 0.0:
+            break
+
+    boundaries = boundaries.snapshot()
+
+    return _assemble_result_cupy(flow_dir_da, boundaries, flow_bdry,
+                                  chunks_y, chunks_x, n_tile_y, n_tile_x)
 
 
 # =====================================================================
@@ -1357,19 +1548,109 @@ def _assemble_result_dinf(flow_dir_da, boundaries, flow_bdry,
     )
 
 
-def _flow_accum_dinf_dask_cupy(flow_dir_da):
-    """Dask+CuPy Dinf: convert to numpy, run iterative, convert back."""
+def _process_tile_dinf_cupy(iy, ix, flow_dir_da, boundaries, flow_bdry,
+                             chunks_y, chunks_x, n_tile_y, n_tile_x):
+    """Run seeded GPU Dinf flow accumulation on one tile."""
     import cupy as cp
 
-    flow_dir_np = flow_dir_da.map_blocks(
-        lambda b: b.get(), dtype=flow_dir_da.dtype,
-        meta=np.array((), dtype=flow_dir_da.dtype),
+    chunk = cp.asarray(
+        flow_dir_da.blocks[iy, ix].compute(), dtype=cp.float64)
+
+    seeds = _compute_seeds_dinf(
+        iy, ix, boundaries, flow_bdry,
+        chunks_y, chunks_x, n_tile_y, n_tile_x)
+
+    accum = _flow_accum_dinf_tile_cupy(chunk, *seeds)
+
+    new_top = accum[0, :].get().copy()
+    new_bottom = accum[-1, :].get().copy()
+    new_left = accum[:, 0].get().copy()
+    new_right = accum[:, -1].get().copy()
+
+    change = 0.0
+    for side, new in (('top', new_top), ('bottom', new_bottom),
+                      ('left', new_left), ('right', new_right)):
+        old = boundaries.get(side, iy, ix)
+        with np.errstate(invalid='ignore'):
+            diff = np.abs(new - old)
+        diff = np.where(np.isnan(diff), 0.0, diff)
+        m = float(np.max(diff))
+        if m > change:
+            change = m
+
+    boundaries.set('top', iy, ix, new_top)
+    boundaries.set('bottom', iy, ix, new_bottom)
+    boundaries.set('left', iy, ix, new_left)
+    boundaries.set('right', iy, ix, new_right)
+
+    return change
+
+
+def _assemble_result_dinf_cupy(flow_dir_da, boundaries, flow_bdry,
+                                chunks_y, chunks_x, n_tile_y, n_tile_x):
+    """Build lazy dask+cupy array using GPU Dinf tile kernel."""
+    import cupy as cp
+
+    def _tile_fn(flow_dir_block, block_info=None):
+        if block_info is None or 0 not in block_info:
+            return cp.full(flow_dir_block.shape, cp.nan, dtype=cp.float64)
+        iy, ix = block_info[0]['chunk-location']
+        seeds = _compute_seeds_dinf(
+            iy, ix, boundaries, flow_bdry,
+            chunks_y, chunks_x, n_tile_y, n_tile_x)
+        return _flow_accum_dinf_tile_cupy(
+            cp.asarray(flow_dir_block, dtype=cp.float64), *seeds)
+
+    return da.map_blocks(
+        _tile_fn,
+        flow_dir_da,
+        dtype=np.float64,
+        meta=cp.array((), dtype=cp.float64),
     )
-    result = _flow_accum_dinf_dask_iterative(flow_dir_np)
-    return result.map_blocks(
-        cp.asarray, dtype=result.dtype,
-        meta=cp.array((), dtype=result.dtype),
-    )
+
+
+def _flow_accum_dinf_dask_cupy(flow_dir_da):
+    """Dask+CuPy Dinf: native GPU processing per tile."""
+    chunks_y = flow_dir_da.chunks[0]
+    chunks_x = flow_dir_da.chunks[1]
+    n_tile_y = len(chunks_y)
+    n_tile_x = len(chunks_x)
+
+    flow_bdry = _preprocess_tiles(flow_dir_da, chunks_y, chunks_x)
+    flow_bdry = flow_bdry.snapshot()
+
+    boundaries = BoundaryStore(chunks_y, chunks_x, fill_value=0.0)
+
+    max_iterations = max(n_tile_y, n_tile_x) + 10
+
+    for _iteration in range(max_iterations):
+        max_change = 0.0
+
+        for iy in range(n_tile_y):
+            for ix in range(n_tile_x):
+                c = _process_tile_dinf_cupy(
+                    iy, ix, flow_dir_da, boundaries,
+                    flow_bdry, chunks_y, chunks_x,
+                    n_tile_y, n_tile_x)
+                if c > max_change:
+                    max_change = c
+
+        for iy in reversed(range(n_tile_y)):
+            for ix in reversed(range(n_tile_x)):
+                c = _process_tile_dinf_cupy(
+                    iy, ix, flow_dir_da, boundaries,
+                    flow_bdry, chunks_y, chunks_x,
+                    n_tile_y, n_tile_x)
+                if c > max_change:
+                    max_change = c
+
+        if max_change == 0.0:
+            break
+
+    boundaries = boundaries.snapshot()
+
+    return _assemble_result_dinf_cupy(flow_dir_da, boundaries, flow_bdry,
+                                       chunks_y, chunks_x, n_tile_y, n_tile_x)
 
 
 # =====================================================================

--- a/xrspatial/snap_pour_point.py
+++ b/xrspatial/snap_pour_point.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import numpy as np
 import xarray as xr
+from numba import cuda
 
 try:
     import cupy
@@ -35,12 +36,20 @@ except ImportError:
 
 from xrspatial.utils import (
     _validate_raster,
+    cuda_args,
     has_cuda_and_cupy,
     is_cupy_array,
     is_dask_cupy,
     ngjit,
 )
 from xrspatial.dataset_support import supports_dataset
+
+
+def _to_numpy_f64(arr):
+    """Convert *arr* to a contiguous numpy float64 array (handles CuPy)."""
+    if hasattr(arr, 'get'):
+        arr = arr.get()
+    return np.asarray(arr, dtype=np.float64)
 
 
 # =====================================================================
@@ -106,17 +115,99 @@ def _snap_pour_point_cpu(flow_accum, pour_points, search_radius, H, W):
 # CuPy backend
 # =====================================================================
 
+@cuda.jit
+def _snap_pour_point_gpu(flow_accum, pp_rows, pp_cols,
+                          snap_rows, snap_cols, search_radius,
+                          n_pp, H, W):
+    """Each thread handles one pour point: windowed max search on GPU."""
+    k = cuda.grid(1)
+    if k >= n_pp:
+        return
+
+    r = pp_rows[k]
+    c = pp_cols[k]
+
+    best_r = r
+    best_c = c
+    fa_val = flow_accum[r, c]
+    if fa_val == fa_val:  # not NaN
+        best_accum = fa_val
+    else:
+        best_accum = -1e308
+
+    radius_sq = search_radius * search_radius
+
+    r_lo = r - search_radius
+    if r_lo < 0:
+        r_lo = 0
+    r_hi = r + search_radius
+    if r_hi >= H:
+        r_hi = H - 1
+    c_lo = c - search_radius
+    if c_lo < 0:
+        c_lo = 0
+    c_hi = c + search_radius
+    if c_hi >= W:
+        c_hi = W - 1
+
+    for nr in range(r_lo, r_hi + 1):
+        for nc in range(c_lo, c_hi + 1):
+            dr = nr - r
+            dc = nc - c
+            if dr * dr + dc * dc > radius_sq:
+                continue
+            fa_n = flow_accum[nr, nc]
+            if fa_n != fa_n:  # NaN
+                continue
+            if fa_n > best_accum:
+                best_accum = fa_n
+                best_r = nr
+                best_c = nc
+
+    snap_rows[k] = best_r
+    snap_cols[k] = best_c
+
+
 def _snap_pour_point_cupy(flow_accum_data, pour_points_data, search_radius):
-    """CuPy: convert to numpy, run CPU kernel, convert back."""
+    """Native CuPy: CUDA kernel for windowed max search per pour point.
+
+    Flow accumulation data stays on GPU.  Only pour point coordinates
+    (sparse, typically < 100) are transferred CPU/GPU.
+    """
     import cupy as cp
 
-    fa_np = flow_accum_data.get() if hasattr(flow_accum_data, 'get') else np.asarray(flow_accum_data)
-    pp_np = pour_points_data.get() if hasattr(pour_points_data, 'get') else np.asarray(pour_points_data)
-    fa_np = fa_np.astype(np.float64)
-    pp_np = pp_np.astype(np.float64)
-    H, W = fa_np.shape
-    out = _snap_pour_point_cpu(fa_np, pp_np, search_radius, H, W)
-    return cp.asarray(out)
+    H, W = flow_accum_data.shape
+    fa = flow_accum_data.astype(cp.float64)
+    pp = pour_points_data.astype(cp.float64)
+    out = cp.full((H, W), cp.nan, dtype=cp.float64)
+
+    mask = ~cp.isnan(pp)
+    if not cp.any(mask):
+        return out
+
+    rows, cols = cp.where(mask)
+    labels = pp[rows, cols]
+    n_pp = len(rows)
+
+    snap_rows = cp.empty(n_pp, dtype=cp.int64)
+    snap_cols = cp.empty(n_pp, dtype=cp.int64)
+
+    threads = min(256, n_pp)
+    blocks = (n_pp + threads - 1) // threads
+
+    _snap_pour_point_gpu[blocks, threads](
+        fa, rows, cols, snap_rows, snap_cols,
+        search_radius, n_pp, H, W)
+
+    # Write labels in raster-scan order (last wins if overlap)
+    # Sort by raster-scan position to ensure deterministic ordering
+    raster_pos = rows * W + cols
+    sort_idx = cp.argsort(raster_pos)
+
+    for k in sort_idx.get():
+        out[int(snap_rows[k]), int(snap_cols[k])] = float(labels[k])
+
+    return out
 
 
 # =====================================================================
@@ -247,22 +338,114 @@ def _snap_pour_point_dask(flow_accum_data, pour_points_data, search_radius):
 # =====================================================================
 
 def _snap_pour_point_dask_cupy(flow_accum_data, pour_points_data, search_radius):
-    """Dask+CuPy: convert cupy chunks to numpy, run dask path, convert back."""
+    """Dask+CuPy: sparse pour-point processing with GPU-resident flow_accum.
+
+    Extracts sparse pour point coordinates from CuPy chunks (small
+    transfers), performs windowed search via dask slicing, and assembles
+    output as dask+cupy.
+    """
     import cupy as cp
 
-    fa_np = flow_accum_data.map_blocks(
-        lambda b: b.get(), dtype=flow_accum_data.dtype,
-        meta=np.array((), dtype=flow_accum_data.dtype),
-    )
-    pp_np = pour_points_data.map_blocks(
-        lambda b: b.get(), dtype=pour_points_data.dtype,
-        meta=np.array((), dtype=pour_points_data.dtype),
-    )
+    H, W = flow_accum_data.shape
+    chunks_y = pour_points_data.chunks[0]
+    chunks_x = pour_points_data.chunks[1]
 
-    result = _snap_pour_point_dask(fa_np, pp_np, search_radius)
-    return result.map_blocks(
-        cp.asarray, dtype=result.dtype,
-        meta=cp.array((), dtype=result.dtype),
+    # Phase 1: identify chunks with pour points
+    def _has_pp(block):
+        b = block.get() if hasattr(block, 'get') else np.asarray(block)
+        return np.array([[np.any(~np.isnan(b)).item()]], dtype=np.int8)
+
+    flags = da.map_blocks(
+        _has_pp, pour_points_data,
+        dtype=np.int8,
+        chunks=tuple((1,) * len(c) for c in pour_points_data.chunks),
+    ).compute()
+
+    # Phase 2: extract coordinates from flagged chunks
+    points = []
+    row_off = 0
+    for iy, cy in enumerate(chunks_y):
+        col_off = 0
+        for ix, cx in enumerate(chunks_x):
+            if flags[iy, ix]:
+                chunk = _to_numpy_f64(
+                    pour_points_data.blocks[iy, ix].compute())
+                rs, cs = np.where(~np.isnan(chunk))
+                for k in range(len(rs)):
+                    points.append((
+                        row_off + int(rs[k]),
+                        col_off + int(cs[k]),
+                        float(chunk[rs[k], cs[k]]),
+                    ))
+            col_off += cx
+        row_off += cy
+
+    # Phase 3: windowed search
+    snapped = []
+    radius_sq = search_radius * search_radius
+
+    for r, c, label in points:
+        r_lo = max(0, r - search_radius)
+        r_hi = min(H - 1, r + search_radius)
+        c_lo = max(0, c - search_radius)
+        c_hi = min(W - 1, c + search_radius)
+
+        window = _to_numpy_f64(
+            flow_accum_data[r_lo:r_hi + 1, c_lo:c_hi + 1].compute())
+
+        best_r, best_c = r, c
+        fa_val = window[r - r_lo, c - c_lo]
+        best_accum = fa_val if not np.isnan(fa_val) else -np.inf
+
+        for wr in range(window.shape[0]):
+            for wc in range(window.shape[1]):
+                nr = r_lo + wr
+                nc = c_lo + wc
+                dr = nr - r
+                dc = nc - c
+                if dr * dr + dc * dc > radius_sq:
+                    continue
+                fa_n = window[wr, wc]
+                if np.isnan(fa_n):
+                    continue
+                if fa_n > best_accum:
+                    best_accum = fa_n
+                    best_r = nr
+                    best_c = nc
+
+        snapped.append((best_r, best_c, label))
+
+    # Phase 4: lazy output assembly as dask+cupy
+    snap_rows = np.array([s[0] for s in snapped], dtype=np.int64) \
+        if snapped else np.array([], dtype=np.int64)
+    snap_cols = np.array([s[1] for s in snapped], dtype=np.int64) \
+        if snapped else np.array([], dtype=np.int64)
+    snap_labels = np.array([s[2] for s in snapped], dtype=np.float64) \
+        if snapped else np.array([], dtype=np.float64)
+
+    _snap_rows = snap_rows
+    _snap_cols = snap_cols
+    _snap_labels = snap_labels
+
+    def _assemble_block(block, block_info=None):
+        if block_info is None or 0 not in block_info:
+            return cp.full(block.shape, cp.nan, dtype=cp.float64)
+        row_start, row_end = block_info[0]['array-location'][0]
+        col_start, col_end = block_info[0]['array-location'][1]
+        h, w = block.shape
+        out = np.full((h, w), np.nan, dtype=np.float64)
+        for k in range(len(_snap_rows)):
+            sr = _snap_rows[k]
+            sc = _snap_cols[k]
+            if row_start <= sr < row_end and col_start <= sc < col_end:
+                out[sr - row_start, sc - col_start] = _snap_labels[k]
+        return cp.asarray(out)
+
+    dummy = da.zeros((H, W), chunks=flow_accum_data.chunks, dtype=np.float64)
+    return da.map_blocks(
+        _assemble_block, dummy,
+        dtype=np.float64,
+        meta=cp.array((), dtype=cp.float64),
     )
 
 

--- a/xrspatial/stream_link.py
+++ b/xrspatial/stream_link.py
@@ -45,7 +45,7 @@ from xrspatial.utils import (
 from xrspatial._boundary_store import BoundaryStore
 from xrspatial.dataset_support import supports_dataset
 from xrspatial.flow_accumulation import _code_to_offset, _code_to_offset_py
-from xrspatial.stream_order import _preprocess_stream_tiles
+from xrspatial.stream_order import _preprocess_stream_tiles, _to_numpy_f64
 
 
 # =====================================================================
@@ -318,6 +318,100 @@ def _stream_link_cupy(flow_dir_data, stream_mask_data):
         changed[0] = 0
         _stream_link_find_ready[griddim, blockdim](
             in_degree, orig_indeg, state, link_id, changed, H, W)
+
+        if int(changed[0]) == 0:
+            break
+
+        _stream_link_pull[griddim, blockdim](
+            flow_dir_f64, stream_mask_i8, in_degree, orig_indeg,
+            state, link_id, H, W)
+
+    link_id = cp.where(stream_mask_i8 == 0, cp.nan, link_id)
+    return link_id
+
+
+@cuda.jit
+def _stream_link_find_ready_tile(in_degree, orig_indeg, state, link_id,
+                                  changed, H, W, row_off, col_off, total_w):
+    """Tile-aware find_ready: uses global coordinates for link IDs."""
+    i, j = cuda.grid(2)
+    if i >= H or j >= W:
+        return
+
+    if state[i, j] == 2:
+        state[i, j] = 3
+
+    if state[i, j] == 1 and in_degree[i, j] == 0:
+        state[i, j] = 2
+        if orig_indeg[i, j] == 0 or orig_indeg[i, j] >= 2:
+            gi = row_off + i
+            gj = col_off + j
+            link_id[i, j] = float(gi * total_w + gj + 1)
+        cuda.atomic.add(changed, 0, 1)
+
+
+def _stream_link_tile_cupy(flow_dir_data, stream_mask_data,
+                            seed_id_top, seed_id_bottom,
+                            seed_id_left, seed_id_right,
+                            seed_ext_top, seed_ext_bottom,
+                            seed_ext_left, seed_ext_right,
+                            row_offset, col_offset, total_width):
+    """GPU seeded stream link for a single tile.
+
+    Uses GPU frontier peeling with tile-aware global ID assignment.
+    """
+    import cupy as cp
+
+    H, W = flow_dir_data.shape
+    flow_dir_f64 = flow_dir_data.astype(cp.float64)
+    stream_mask_i8 = stream_mask_data.astype(cp.int8)
+
+    in_degree = cp.zeros((H, W), dtype=cp.int32)
+    orig_indeg = cp.zeros((H, W), dtype=cp.int32)
+    state = cp.zeros((H, W), dtype=cp.int32)
+    link_id = cp.zeros((H, W), dtype=cp.float64)
+    changed = cp.zeros(1, dtype=cp.int32)
+
+    griddim, blockdim = cuda_args((H, W))
+
+    _stream_link_init_gpu[griddim, blockdim](
+        flow_dir_f64, stream_mask_i8, in_degree, orig_indeg,
+        state, link_id, H, W)
+
+    _stream_link_save_indeg[griddim, blockdim](
+        in_degree, orig_indeg, stream_mask_i8, H, W)
+
+    # Add external in-degree counts to orig_indeg (for junction detection)
+    for r_idx, ext in [
+        ((0, slice(None)), seed_ext_top),
+        ((H - 1, slice(None)), seed_ext_bottom),
+        ((slice(None), 0), seed_ext_left),
+        ((slice(None), W - 1), seed_ext_right),
+    ]:
+        ext_cp = cp.asarray(ext).astype(cp.int32)
+        is_stream = stream_mask_i8[r_idx] == 1
+        orig_indeg[r_idx] += cp.where(is_stream, ext_cp, 0)
+
+    # Pre-set link_ids for non-junction boundary cells with seed values
+    for r_idx, s_id in [
+        ((0, slice(None)), seed_id_top),
+        ((H - 1, slice(None)), seed_id_bottom),
+        ((slice(None), 0), seed_id_left),
+        ((slice(None), W - 1), seed_id_right),
+    ]:
+        sid_cp = cp.asarray(s_id)
+        is_stream = stream_mask_i8[r_idx] == 1
+        non_junction = orig_indeg[r_idx] < 2
+        has_seed = sid_cp > 0
+        mask = is_stream & non_junction & has_seed
+        link_id[r_idx] = cp.where(mask, sid_cp, link_id[r_idx])
+
+    max_iter = H * W
+    for _ in range(max_iter):
+        changed[0] = 0
+        _stream_link_find_ready_tile[griddim, blockdim](
+            in_degree, orig_indeg, state, link_id, changed,
+            H, W, row_offset, col_offset, total_width)
 
         if int(changed[0]) == 0:
             break
@@ -765,21 +859,122 @@ def _stream_link_dask(flow_dir_da, accum_da, threshold):
         dtype=np.float64, meta=np.array((), dtype=np.float64))
 
 
-def _stream_link_dask_cupy(flow_dir_da, accum_da, threshold):
-    """Dask+CuPy: convert to numpy, run CPU dask path, convert back."""
+def _process_link_tile_cupy(iy, ix, flow_dir_da, accum_da, threshold,
+                             boundaries, indeg_bdry, flow_bdry, mask_bdry,
+                             chunks_y, chunks_x, n_tile_y, n_tile_x,
+                             row_offsets, col_offsets, total_width):
+    """Run seeded GPU stream link on one tile; update boundary stores."""
     import cupy as cp
 
-    fd_np = flow_dir_da.map_blocks(
-        lambda b: b.get(), dtype=flow_dir_da.dtype,
-        meta=np.array((), dtype=flow_dir_da.dtype))
-    ac_np = accum_da.map_blocks(
-        lambda b: b.get(), dtype=accum_da.dtype,
-        meta=np.array((), dtype=accum_da.dtype))
+    fd_chunk = cp.asarray(
+        flow_dir_da.blocks[iy, ix].compute(), dtype=cp.float64)
+    ac_chunk = _to_numpy_f64(accum_da.blocks[iy, ix].compute())
+    fd_np = fd_chunk.get()
+    sm = np.where(ac_chunk >= threshold, 1, 0).astype(np.int8)
+    sm = np.where(np.isnan(ac_chunk), 0, sm).astype(np.int8)
+    sm = np.where(np.isnan(fd_np), 0, sm).astype(np.int8)
+    sm_cp = cp.asarray(sm)
 
-    result = _stream_link_dask(fd_np, ac_np, threshold)
-    return result.map_blocks(
-        cp.asarray, dtype=result.dtype,
-        meta=cp.array((), dtype=result.dtype))
+    seeds = _compute_link_seeds(
+        iy, ix, boundaries, indeg_bdry, flow_bdry, mask_bdry,
+        chunks_y, chunks_x, n_tile_y, n_tile_x)
+
+    link = _stream_link_tile_cupy(
+        fd_chunk, sm_cp, *seeds,
+        row_offsets[iy], col_offsets[ix], total_width)
+
+    change = 0.0
+    for side, strip_cp in [('top', link[0, :]),
+                           ('bottom', link[-1, :]),
+                           ('left', link[:, 0]),
+                           ('right', link[:, -1])]:
+        new_vals = strip_cp.get().copy()
+        new_vals = np.where(np.isnan(new_vals), 0.0, new_vals)
+        old = boundaries.get(side, iy, ix).copy()
+        with np.errstate(invalid='ignore'):
+            diff = np.abs(new_vals - old)
+        diff = np.where(np.isnan(diff), 0.0, diff)
+        m = float(np.max(diff))
+        if m > change:
+            change = m
+        boundaries.set(side, iy, ix, new_vals)
+
+    return change
+
+
+def _stream_link_dask_cupy(flow_dir_da, accum_da, threshold):
+    """Dask+CuPy: native GPU processing per tile."""
+    import cupy as cp
+
+    chunks_y = flow_dir_da.chunks[0]
+    chunks_x = flow_dir_da.chunks[1]
+    n_tile_y = len(chunks_y)
+    n_tile_x = len(chunks_x)
+    total_width = sum(chunks_x)
+
+    row_offsets = np.zeros(n_tile_y, dtype=np.int64)
+    col_offsets = np.zeros(n_tile_x, dtype=np.int64)
+    if n_tile_y > 1:
+        np.cumsum(chunks_y[:-1], out=row_offsets[1:])
+    if n_tile_x > 1:
+        np.cumsum(chunks_x[:-1], out=col_offsets[1:])
+
+    flow_bdry, mask_bdry = _preprocess_stream_tiles(
+        flow_dir_da, accum_da, threshold, chunks_y, chunks_x)
+    flow_bdry = flow_bdry.snapshot()
+    mask_bdry = mask_bdry.snapshot()
+
+    boundaries = BoundaryStore(chunks_y, chunks_x, fill_value=0.0)
+    indeg_bdry = BoundaryStore(chunks_y, chunks_x, fill_value=0.0)
+
+    max_iterations = max(n_tile_y, n_tile_x) + 10
+    for _ in range(max_iterations):
+        max_change = 0.0
+        for iy in range(n_tile_y):
+            for ix in range(n_tile_x):
+                c = _process_link_tile_cupy(
+                    iy, ix, flow_dir_da, accum_da, threshold,
+                    boundaries, indeg_bdry, flow_bdry, mask_bdry,
+                    chunks_y, chunks_x, n_tile_y, n_tile_x,
+                    row_offsets, col_offsets, total_width)
+                if c > max_change:
+                    max_change = c
+        for iy in reversed(range(n_tile_y)):
+            for ix in reversed(range(n_tile_x)):
+                c = _process_link_tile_cupy(
+                    iy, ix, flow_dir_da, accum_da, threshold,
+                    boundaries, indeg_bdry, flow_bdry, mask_bdry,
+                    chunks_y, chunks_x, n_tile_y, n_tile_x,
+                    row_offsets, col_offsets, total_width)
+                if c > max_change:
+                    max_change = c
+        if max_change == 0.0:
+            break
+
+    _boundaries = boundaries.snapshot()
+    _indeg_bdry = indeg_bdry.snapshot()
+
+    def _tile_fn(block, accum_block, block_info=None):
+        if block_info is None or 0 not in block_info:
+            return cp.full(block.shape, cp.nan, dtype=cp.float64)
+        iy, ix = block_info[0]['chunk-location']
+        fd = cp.asarray(block, dtype=cp.float64)
+        ac_np = _to_numpy_f64(accum_block)
+        fd_np = fd.get()
+        sm = np.where(ac_np >= threshold, 1, 0).astype(np.int8)
+        sm = np.where(np.isnan(ac_np), 0, sm).astype(np.int8)
+        sm = np.where(np.isnan(fd_np), 0, sm).astype(np.int8)
+        sm_cp = cp.asarray(sm)
+        seeds = _compute_link_seeds(
+            iy, ix, _boundaries, _indeg_bdry, flow_bdry, mask_bdry,
+            chunks_y, chunks_x, n_tile_y, n_tile_x)
+        return _stream_link_tile_cupy(
+            fd, sm_cp, *seeds,
+            row_offsets[iy], col_offsets[ix], total_width)
+
+    return da.map_blocks(
+        _tile_fn, flow_dir_da, accum_da,
+        dtype=np.float64, meta=cp.array((), dtype=cp.float64))
 
 
 # =====================================================================

--- a/xrspatial/stream_order.py
+++ b/xrspatial/stream_order.py
@@ -49,6 +49,13 @@ from xrspatial.dataset_support import supports_dataset
 from xrspatial.flow_accumulation import _code_to_offset, _code_to_offset_py
 
 
+def _to_numpy_f64(arr):
+    """Convert *arr* to a contiguous numpy float64 array (handles CuPy)."""
+    if hasattr(arr, 'get'):
+        arr = arr.get()
+    return np.asarray(arr, dtype=np.float64)
+
+
 # =====================================================================
 # CPU kernels
 # =====================================================================
@@ -681,12 +688,11 @@ def _preprocess_stream_tiles(flow_dir_da, accum_da, threshold,
 
     for iy in range(n_tile_y):
         for ix in range(n_tile_x):
-            fd_chunk = np.asarray(
-                flow_dir_da.blocks[iy, ix].compute(), dtype=np.float64)
-            ac_chunk = np.asarray(
-                accum_da.blocks[iy, ix].compute(), dtype=np.float64)
+            fd_chunk = _to_numpy_f64(
+                flow_dir_da.blocks[iy, ix].compute())
+            ac_chunk = _to_numpy_f64(
+                accum_da.blocks[iy, ix].compute())
             sm = np.where(ac_chunk >= threshold, 1.0, 0.0)
-            # NaN in accum → not stream
             sm = np.where(np.isnan(ac_chunk), 0.0, sm)
 
             for side, row_data_fd, row_data_sm in [
@@ -1178,25 +1184,270 @@ def _stream_order_dask_shreve(flow_dir_da, accum_da, threshold):
         dtype=np.float64, meta=np.array((), dtype=np.float64))
 
 
-def _stream_order_dask_cupy(flow_dir_da, accum_da, threshold, method):
-    """Dask+CuPy: convert to numpy, run CPU dask path, convert back."""
+def _stream_order_tile_cupy(flow_dir_data, stream_mask_data, method,
+                             seeds):
+    """GPU seeded stream order for a single tile.
+
+    Uses GPU frontier peeling with seeds injected after initialisation.
+    For Strahler, seeds are (max_top, cnt_top, max_bot, cnt_bot, ...).
+    For Shreve, seeds are (top, bot, left, right).
+    """
     import cupy as cp
 
-    fd_np = flow_dir_da.map_blocks(
-        lambda b: b.get(), dtype=flow_dir_da.dtype,
-        meta=np.array((), dtype=flow_dir_da.dtype))
-    ac_np = accum_da.map_blocks(
-        lambda b: b.get(), dtype=accum_da.dtype,
-        meta=np.array((), dtype=accum_da.dtype))
+    H, W = flow_dir_data.shape
+    flow_dir_f64 = flow_dir_data.astype(cp.float64)
+    stream_mask_i8 = stream_mask_data.astype(cp.int8)
+
+    in_degree = cp.zeros((H, W), dtype=cp.int32)
+    state = cp.zeros((H, W), dtype=cp.int32)
+    order = cp.zeros((H, W), dtype=cp.float64)
+    max_in = cp.zeros((H, W), dtype=cp.float64)
+    cnt_max = cp.zeros((H, W), dtype=cp.int32)
+    changed = cp.zeros(1, dtype=cp.int32)
+
+    griddim, blockdim = cuda_args((H, W))
+
+    _stream_order_init_gpu[griddim, blockdim](
+        flow_dir_f64, stream_mask_i8, in_degree, state,
+        order, max_in, cnt_max, H, W)
 
     if method == 'strahler':
-        result = _stream_order_dask_strahler(fd_np, ac_np, threshold)
+        (smax_top, scnt_top, smax_bot, scnt_bot,
+         smax_left, scnt_left, smax_right, scnt_right) = seeds
+        # Inject Strahler seeds at boundaries.
+        # After init, max_in is 0.0 everywhere.  Where seed_max > 0,
+        # set max_in and cnt_max.
+        for r_idx, s_max, s_cnt in [
+            ((0, slice(None)), smax_top, scnt_top),
+            ((H - 1, slice(None)), smax_bot, scnt_bot),
+            ((slice(None), 0), smax_left, scnt_left),
+            ((slice(None), W - 1), smax_right, scnt_right),
+        ]:
+            sm_cp = cp.asarray(s_max)
+            sc_cp = cp.asarray(s_cnt).astype(cp.int32)
+            is_stream = stream_mask_i8[r_idx] == 1
+            has_seed = sm_cp > 0
+            mask = is_stream & has_seed
+            # Since max_in starts at 0, seed_max > 0 always wins
+            max_in[r_idx] = cp.where(mask, sm_cp, max_in[r_idx])
+            cnt_max[r_idx] = cp.where(mask, sc_cp, cnt_max[r_idx])
     else:
-        result = _stream_order_dask_shreve(fd_np, ac_np, threshold)
+        (seed_top, seed_bot, seed_left, seed_right) = seeds
+        # Inject Shreve seeds: additive, same as flow_accumulation
+        order[0, :] += cp.asarray(seed_top)
+        order[H - 1, :] += cp.asarray(seed_bot)
+        order[:, 0] += cp.asarray(seed_left)
+        order[:, W - 1] += cp.asarray(seed_right)
 
-    return result.map_blocks(
-        cp.asarray, dtype=result.dtype,
-        meta=cp.array((), dtype=result.dtype))
+    max_iter = H * W
+    for _ in range(max_iter):
+        changed[0] = 0
+        _stream_order_find_ready[griddim, blockdim](
+            in_degree, state, order, changed, H, W)
+
+        if int(changed[0]) == 0:
+            break
+
+        if method == 'strahler':
+            _stream_order_pull_strahler[griddim, blockdim](
+                flow_dir_f64, stream_mask_i8, in_degree, state,
+                order, max_in, cnt_max, H, W)
+        else:
+            _stream_order_pull_shreve[griddim, blockdim](
+                flow_dir_f64, stream_mask_i8, in_degree, state,
+                order, H, W)
+
+    order = cp.where(stream_mask_i8 == 0, cp.nan, order)
+    return order
+
+
+def _make_stream_mask_np(ac_chunk, fd_chunk, threshold):
+    """Build stream mask as numpy int8 from accumulation chunk."""
+    sm = np.where(ac_chunk >= threshold, 1, 0).astype(np.int8)
+    sm = np.where(np.isnan(ac_chunk), 0, sm).astype(np.int8)
+    sm = np.where(np.isnan(fd_chunk), 0, sm).astype(np.int8)
+    return sm
+
+
+def _process_strahler_tile_cupy(iy, ix, flow_dir_da, accum_da, threshold,
+                                  bdry_max, bdry_cnt, flow_bdry, mask_bdry,
+                                  chunks_y, chunks_x, n_tile_y, n_tile_x):
+    """Run seeded GPU Strahler on one tile; update boundary stores."""
+    import cupy as cp
+
+    fd_chunk = cp.asarray(
+        flow_dir_da.blocks[iy, ix].compute(), dtype=cp.float64)
+    ac_chunk = _to_numpy_f64(accum_da.blocks[iy, ix].compute())
+    fd_np = fd_chunk.get()
+    sm_np = _make_stream_mask_np(ac_chunk, fd_np, threshold)
+    sm_cp = cp.asarray(sm_np)
+
+    seeds = _compute_strahler_seeds(
+        iy, ix, bdry_max, bdry_cnt, flow_bdry, mask_bdry,
+        chunks_y, chunks_x, n_tile_y, n_tile_x)
+
+    order = _stream_order_tile_cupy(fd_chunk, sm_cp, 'strahler', seeds)
+
+    change = 0.0
+    for side, strip_cp in [('top', order[0, :]),
+                           ('bottom', order[-1, :]),
+                           ('left', order[:, 0]),
+                           ('right', order[:, -1])]:
+        new_vals = strip_cp.get().copy()
+        new_max = np.where(np.isnan(new_vals), 0.0, new_vals)
+        new_cnt = np.where(new_max > 0, 1.0, 0.0)
+
+        old_max = bdry_max.get(side, iy, ix).copy()
+        with np.errstate(invalid='ignore'):
+            diff = np.abs(new_max - old_max)
+        diff = np.where(np.isnan(diff), 0.0, diff)
+        m = float(np.max(diff))
+        if m > change:
+            change = m
+
+        bdry_max.set(side, iy, ix, new_max)
+        bdry_cnt.set(side, iy, ix, new_cnt)
+
+    return change
+
+
+def _process_shreve_tile_cupy(iy, ix, flow_dir_da, accum_da, threshold,
+                                boundaries, flow_bdry, mask_bdry,
+                                chunks_y, chunks_x, n_tile_y, n_tile_x):
+    """Run seeded GPU Shreve on one tile; update boundaries."""
+    import cupy as cp
+
+    fd_chunk = cp.asarray(
+        flow_dir_da.blocks[iy, ix].compute(), dtype=cp.float64)
+    ac_chunk = _to_numpy_f64(accum_da.blocks[iy, ix].compute())
+    fd_np = fd_chunk.get()
+    sm_np = _make_stream_mask_np(ac_chunk, fd_np, threshold)
+    sm_cp = cp.asarray(sm_np)
+
+    seeds = _compute_shreve_seeds(
+        iy, ix, boundaries, flow_bdry, mask_bdry,
+        chunks_y, chunks_x, n_tile_y, n_tile_x)
+
+    order = _stream_order_tile_cupy(fd_chunk, sm_cp, 'shreve', seeds)
+
+    change = 0.0
+    for side, strip_cp in [('top', order[0, :]),
+                           ('bottom', order[-1, :]),
+                           ('left', order[:, 0]),
+                           ('right', order[:, -1])]:
+        new_vals = strip_cp.get().copy()
+        new_vals = np.where(np.isnan(new_vals), 0.0, new_vals)
+        old = boundaries.get(side, iy, ix).copy()
+        with np.errstate(invalid='ignore'):
+            diff = np.abs(new_vals - old)
+        diff = np.where(np.isnan(diff), 0.0, diff)
+        m = float(np.max(diff))
+        if m > change:
+            change = m
+        boundaries.set(side, iy, ix, new_vals)
+
+    return change
+
+
+def _stream_order_dask_cupy(flow_dir_da, accum_da, threshold, method):
+    """Dask+CuPy: native GPU processing per tile."""
+    import cupy as cp
+
+    chunks_y = flow_dir_da.chunks[0]
+    chunks_x = flow_dir_da.chunks[1]
+    n_tile_y = len(chunks_y)
+    n_tile_x = len(chunks_x)
+
+    flow_bdry, mask_bdry = _preprocess_stream_tiles(
+        flow_dir_da, accum_da, threshold, chunks_y, chunks_x)
+    flow_bdry = flow_bdry.snapshot()
+    mask_bdry = mask_bdry.snapshot()
+
+    max_iterations = max(n_tile_y, n_tile_x) + 10
+
+    if method == 'strahler':
+        bdry_max = BoundaryStore(chunks_y, chunks_x, fill_value=0.0)
+        bdry_cnt = BoundaryStore(chunks_y, chunks_x, fill_value=0.0)
+
+        for _ in range(max_iterations):
+            max_change = 0.0
+            for iy in range(n_tile_y):
+                for ix in range(n_tile_x):
+                    c = _process_strahler_tile_cupy(
+                        iy, ix, flow_dir_da, accum_da, threshold,
+                        bdry_max, bdry_cnt, flow_bdry, mask_bdry,
+                        chunks_y, chunks_x, n_tile_y, n_tile_x)
+                    if c > max_change:
+                        max_change = c
+            for iy in reversed(range(n_tile_y)):
+                for ix in reversed(range(n_tile_x)):
+                    c = _process_strahler_tile_cupy(
+                        iy, ix, flow_dir_da, accum_da, threshold,
+                        bdry_max, bdry_cnt, flow_bdry, mask_bdry,
+                        chunks_y, chunks_x, n_tile_y, n_tile_x)
+                    if c > max_change:
+                        max_change = c
+            if max_change == 0.0:
+                break
+
+        _bdry_max = bdry_max.snapshot()
+        _bdry_cnt = bdry_cnt.snapshot()
+
+        def _tile_fn(block, accum_block, block_info=None):
+            if block_info is None or 0 not in block_info:
+                return cp.full(block.shape, cp.nan, dtype=cp.float64)
+            iy, ix = block_info[0]['chunk-location']
+            fd = cp.asarray(block, dtype=cp.float64)
+            ac_np = _to_numpy_f64(accum_block)
+            fd_np = fd.get()
+            sm = cp.asarray(_make_stream_mask_np(ac_np, fd_np, threshold))
+            seeds = _compute_strahler_seeds(
+                iy, ix, _bdry_max, _bdry_cnt, flow_bdry, mask_bdry,
+                chunks_y, chunks_x, n_tile_y, n_tile_x)
+            return _stream_order_tile_cupy(fd, sm, 'strahler', seeds)
+
+    else:  # shreve
+        boundaries = BoundaryStore(chunks_y, chunks_x, fill_value=0.0)
+
+        for _ in range(max_iterations):
+            max_change = 0.0
+            for iy in range(n_tile_y):
+                for ix in range(n_tile_x):
+                    c = _process_shreve_tile_cupy(
+                        iy, ix, flow_dir_da, accum_da, threshold,
+                        boundaries, flow_bdry, mask_bdry,
+                        chunks_y, chunks_x, n_tile_y, n_tile_x)
+                    if c > max_change:
+                        max_change = c
+            for iy in reversed(range(n_tile_y)):
+                for ix in reversed(range(n_tile_x)):
+                    c = _process_shreve_tile_cupy(
+                        iy, ix, flow_dir_da, accum_da, threshold,
+                        boundaries, flow_bdry, mask_bdry,
+                        chunks_y, chunks_x, n_tile_y, n_tile_x)
+                    if c > max_change:
+                        max_change = c
+            if max_change == 0.0:
+                break
+
+        _boundaries = boundaries.snapshot()
+
+        def _tile_fn(block, accum_block, block_info=None):
+            if block_info is None or 0 not in block_info:
+                return cp.full(block.shape, cp.nan, dtype=cp.float64)
+            iy, ix = block_info[0]['chunk-location']
+            fd = cp.asarray(block, dtype=cp.float64)
+            ac_np = _to_numpy_f64(accum_block)
+            fd_np = fd.get()
+            sm = cp.asarray(_make_stream_mask_np(ac_np, fd_np, threshold))
+            seeds = _compute_shreve_seeds(
+                iy, ix, _boundaries, flow_bdry, mask_bdry,
+                chunks_y, chunks_x, n_tile_y, n_tile_x)
+            return _stream_order_tile_cupy(fd, sm, 'shreve', seeds)
+
+    return da.map_blocks(
+        _tile_fn, flow_dir_da, accum_da,
+        dtype=np.float64, meta=cp.array((), dtype=cp.float64))
 
 
 # =====================================================================

--- a/xrspatial/tests/test_basin.py
+++ b/xrspatial/tests/test_basin.py
@@ -215,3 +215,49 @@ def test_basin_numpy_equals_cupy():
     cp_result = basin(cp_fd)
     np.testing.assert_allclose(
         np_result.data, cp_result.data.get(), equal_nan=True)
+
+
+@dask_array_available
+@cuda_and_cupy_available
+def test_basin_numpy_equals_dask_cupy():
+    """Dask+CuPy matches NumPy for basin."""
+    flow_dir = np.array([
+        [2.0,  4.0,  8.0],
+        [1.0,  0.0, 16.0],
+        [128.0, 64.0, 32.0],
+    ], dtype=np.float64)
+    np_fd = create_test_raster(flow_dir, backend='numpy')
+    dcp_fd = create_test_raster(flow_dir, backend='dask+cupy', chunks=(2, 2))
+    np_result = basin(np_fd)
+    dcp_result = basin(dcp_fd)
+    np.testing.assert_allclose(
+        np_result.data, dcp_result.data.compute().get(), equal_nan=True)
+
+
+@dask_array_available
+@cuda_and_cupy_available
+def test_basin_dask_cupy_random():
+    """Random acyclic flow_dir: dask+cupy basin matches dask+numpy.
+
+    Compared against dask+numpy rather than numpy because the tile-sweep
+    has pre-existing convergence limitations for some grids/chunk combos.
+    This test verifies the GPU tile kernel produces identical results to
+    the CPU tile kernel.
+    """
+    from xrspatial import flow_direction
+
+    rng = np.random.default_rng(952)
+    elev = rng.random((8, 10)).astype(np.float64)
+    elev_da = create_test_raster(elev, backend='numpy')
+    fd_data = flow_direction(elev_da).data
+
+    for chunks in [(3, 3), (4, 5), (2, 2)]:
+        dk_fd = create_test_raster(fd_data, backend='dask', chunks=chunks)
+        dk_result = basin(dk_fd).data.compute()
+
+        dcp_fd = create_test_raster(fd_data, backend='dask+cupy', chunks=chunks)
+        dcp_result = basin(dcp_fd).data.compute().get()
+
+        np.testing.assert_allclose(
+            dk_result, dcp_result, equal_nan=True,
+        ), f"Mismatch with chunks={chunks}"

--- a/xrspatial/tests/test_flow_accumulation.py
+++ b/xrspatial/tests/test_flow_accumulation.py
@@ -350,6 +350,27 @@ def test_numpy_equals_dask_cupy():
         np_result.data, dcp_result.data.compute().get(), equal_nan=True)
 
 
+@dask_array_available
+@cuda_and_cupy_available
+@pytest.mark.parametrize("chunks", [(3, 3), (5, 6), (2, 4)])
+def test_dask_cupy_chunk_configs(chunks):
+    """Dask+CuPy matches NumPy across chunk sizes."""
+    from xrspatial import flow_direction
+
+    rng = np.random.default_rng(952)
+    elev = rng.random((10, 12)).astype(np.float64)
+    elev_da = create_test_raster(elev, backend='numpy')
+    flow_dir = flow_direction(elev_da).data
+
+    numpy_agg = create_test_raster(flow_dir, backend='numpy')
+    dcp_agg = create_test_raster(flow_dir, backend='dask+cupy', chunks=chunks)
+    np_result = flow_accumulation(numpy_agg)
+    dcp_result = flow_accumulation(dcp_agg)
+    np.testing.assert_allclose(
+        np_result.data, dcp_result.data.compute().get(), equal_nan=True,
+    ), f"Mismatch with chunks={chunks}"
+
+
 # ===========================================================================
 # Dinf flow accumulation tests
 # ===========================================================================

--- a/xrspatial/tests/test_snap_pour_point.py
+++ b/xrspatial/tests/test_snap_pour_point.py
@@ -302,3 +302,29 @@ def test_numpy_equals_dask_cupy():
 
     np.testing.assert_allclose(
         np_result.data, dcp_result.data.compute().get(), equal_nan=True)
+
+
+@dask_array_available
+@cuda_and_cupy_available
+@pytest.mark.parametrize("chunks", [(2, 2), (3, 3), (1, 5), (5, 1)])
+def test_dask_cupy_chunk_configs(chunks):
+    """Dask+CuPy matches NumPy across chunk sizes."""
+    accum = np.array([
+        [50.0, 1.0, 1.0, 1.0, 80.0],
+        [1.0,  1.0, 1.0, 1.0, 1.0],
+        [1.0,  1.0, 1.0, 1.0, 1.0],
+    ])
+    pp = np.full((3, 5), np.nan)
+    pp[0, 1] = 10.0
+    pp[0, 3] = 20.0
+
+    fa_np, pp_np = _make_accum_and_pp(accum, pp, backend='numpy')
+    fa_dcp, pp_dcp = _make_accum_and_pp(accum, pp, backend='dask+cupy',
+                                         chunks=chunks)
+
+    np_result = snap_pour_point(fa_np, pp_np, search_radius=2)
+    dcp_result = snap_pour_point(fa_dcp, pp_dcp, search_radius=2)
+
+    np.testing.assert_allclose(
+        np_result.data, dcp_result.data.compute().get(), equal_nan=True,
+    ), f"Mismatch with chunks={chunks}"

--- a/xrspatial/tests/test_stream_link.py
+++ b/xrspatial/tests/test_stream_link.py
@@ -268,3 +268,28 @@ def test_stream_link_numpy_equals_dask_cupy():
     dcp_result = stream_link(dcp_fd, dcp_fa, threshold=1)
     np.testing.assert_allclose(
         np_result.data, dcp_result.data.compute().get(), equal_nan=True)
+
+
+@dask_array_available
+@cuda_and_cupy_available
+def test_stream_link_dask_cupy_random():
+    """Random acyclic flow: dask+cupy stream_link matches numpy."""
+    from xrspatial import flow_direction, flow_accumulation
+
+    rng = np.random.default_rng(952)
+    elev = rng.random((8, 10)).astype(np.float64)
+    elev_da = create_test_raster(elev, backend='numpy')
+    fd = flow_direction(elev_da)
+    fa = flow_accumulation(fd)
+
+    np_result = stream_link(fd, fa, threshold=3)
+
+    fd_data = fd.data
+    fa_data = fa.data
+    for chunks in [(3, 3), (4, 5), (2, 2)]:
+        dcp_fd = create_test_raster(fd_data, backend='dask+cupy', chunks=chunks)
+        dcp_fa = create_test_raster(fa_data, backend='dask+cupy', chunks=chunks)
+        dcp_result = stream_link(dcp_fd, dcp_fa, threshold=3)
+        np.testing.assert_allclose(
+            np_result.data, dcp_result.data.compute().get(), equal_nan=True,
+        ), f"Mismatch with chunks={chunks}"

--- a/xrspatial/tests/test_stream_order.py
+++ b/xrspatial/tests/test_stream_order.py
@@ -441,3 +441,29 @@ def test_dask_cupy_equivalence(method):
     dcp_result = stream_order(dcp_fd, dcp_fa, threshold=1, method=method)
     np.testing.assert_allclose(
         np_result.data, dcp_result.data.compute().get(), equal_nan=True)
+
+
+@dask_array_available
+@cuda_and_cupy_available
+@pytest.mark.parametrize("method", ['strahler', 'shreve'])
+def test_dask_cupy_random(method):
+    """Random acyclic flow: dask+cupy matches numpy."""
+    from xrspatial import flow_direction, flow_accumulation
+
+    rng = np.random.default_rng(952)
+    elev = rng.random((8, 10)).astype(np.float64)
+    elev_da = create_test_raster(elev, backend='numpy')
+    fd = flow_direction(elev_da)
+    fa = flow_accumulation(fd)
+
+    np_result = stream_order(fd, fa, threshold=3, method=method)
+
+    fd_data = fd.data
+    fa_data = fa.data
+    for chunks in [(3, 3), (4, 5), (2, 2)]:
+        dcp_fd = create_test_raster(fd_data, backend='dask+cupy', chunks=chunks)
+        dcp_fa = create_test_raster(fa_data, backend='dask+cupy', chunks=chunks)
+        dcp_result = stream_order(dcp_fd, dcp_fa, threshold=3, method=method)
+        np.testing.assert_allclose(
+            np_result.data, dcp_result.data.compute().get(), equal_nan=True,
+        ), f"Mismatch with chunks={chunks}, method={method}"

--- a/xrspatial/tests/test_watershed.py
+++ b/xrspatial/tests/test_watershed.py
@@ -329,3 +329,31 @@ def test_watershed_numpy_equals_dask_cupy():
     dcp_result = watershed(dcp_fd, dcp_pp)
     np.testing.assert_allclose(
         np_result.data, dcp_result.data.compute().get(), equal_nan=True)
+
+
+@dask_array_available
+@cuda_and_cupy_available
+def test_watershed_dask_cupy_random():
+    """Random acyclic flow_dir: dask+cupy watershed matches numpy."""
+    from xrspatial import flow_direction, flow_accumulation
+
+    rng = np.random.default_rng(952)
+    elev = rng.random((8, 10)).astype(np.float64)
+    elev_da = create_test_raster(elev, backend='numpy')
+    fd_data = flow_direction(elev_da).data
+
+    pp = np.full_like(fd_data, np.nan)
+    pit_mask = fd_data == 0
+    pp[pit_mask] = np.arange(1, pit_mask.sum() + 1, dtype=np.float64)
+
+    np_fd = create_test_raster(fd_data, backend='numpy')
+    np_pp = create_test_raster(pp, backend='numpy')
+    np_result = watershed(np_fd, np_pp)
+
+    for chunks in [(3, 3), (4, 5), (2, 2)]:
+        dcp_fd = create_test_raster(fd_data, backend='dask+cupy', chunks=chunks)
+        dcp_pp = create_test_raster(pp, backend='dask+cupy', chunks=chunks)
+        dcp_result = watershed(dcp_fd, dcp_pp)
+        np.testing.assert_allclose(
+            np_result.data, dcp_result.data.compute().get(), equal_nan=True,
+        ), f"Mismatch with chunks={chunks}"

--- a/xrspatial/watershed.py
+++ b/xrspatial/watershed.py
@@ -43,6 +43,13 @@ from xrspatial._boundary_store import BoundaryStore
 from xrspatial.dataset_support import supports_dataset
 
 
+def _to_numpy_f64(arr):
+    """Convert *arr* to a contiguous numpy float64 array (handles CuPy)."""
+    if hasattr(arr, 'get'):
+        arr = arr.get()
+    return np.asarray(arr, dtype=np.float64)
+
+
 # =====================================================================
 # Direction helpers
 # =====================================================================
@@ -386,14 +393,10 @@ def _preprocess_tiles(flow_dir_da, chunks_y, chunks_x):
     for iy in range(n_tile_y):
         for ix in range(n_tile_x):
             chunk = flow_dir_da.blocks[iy, ix].compute()
-            flow_bdry.set('top', iy, ix,
-                          np.asarray(chunk[0, :], dtype=np.float64))
-            flow_bdry.set('bottom', iy, ix,
-                          np.asarray(chunk[-1, :], dtype=np.float64))
-            flow_bdry.set('left', iy, ix,
-                          np.asarray(chunk[:, 0], dtype=np.float64))
-            flow_bdry.set('right', iy, ix,
-                          np.asarray(chunk[:, -1], dtype=np.float64))
+            flow_bdry.set('top', iy, ix, _to_numpy_f64(chunk[0, :]))
+            flow_bdry.set('bottom', iy, ix, _to_numpy_f64(chunk[-1, :]))
+            flow_bdry.set('left', iy, ix, _to_numpy_f64(chunk[:, 0]))
+            flow_bdry.set('right', iy, ix, _to_numpy_f64(chunk[:, -1]))
 
     return flow_bdry
 
@@ -713,23 +716,182 @@ def _assemble_watershed(flow_dir_da, pour_points_da,
 
 
 
-def _watershed_dask_cupy(flow_dir_da, pour_points_da):
-    """Dask+CuPy: convert to numpy, run CPU iterative path, convert back."""
+def _watershed_tile_cupy(flow_dir_data, pour_points_data,
+                          exit_top, exit_bottom, exit_left, exit_right,
+                          exit_tl, exit_tr, exit_bl, exit_br):
+    """GPU seeded watershed for a single tile.
+
+    Uses GPU label propagation with exit labels injected at boundary
+    cells before iteration.
+    """
     import cupy as cp
 
-    flow_dir_np = flow_dir_da.map_blocks(
-        lambda b: b.get(), dtype=flow_dir_da.dtype,
-        meta=np.array((), dtype=flow_dir_da.dtype),
+    H, W = flow_dir_data.shape
+    flow_dir_f64 = flow_dir_data.astype(cp.float64)
+    pp_f64 = pour_points_data.astype(cp.float64)
+
+    labels = cp.zeros((H, W), dtype=cp.float64)
+    state = cp.zeros((H, W), dtype=cp.int32)
+    changed = cp.zeros(1, dtype=cp.int32)
+
+    griddim, blockdim = cuda_args((H, W))
+
+    _init_watershed_gpu[griddim, blockdim](
+        flow_dir_f64, pp_f64, labels, state, H, W)
+
+    # Inject exit labels at boundary cells where active (state==1)
+    # and exit label is resolved (not NaN, >= 0).
+    exit_top_cp = cp.asarray(exit_top)
+    m = (state[0, :] == 1) & ~cp.isnan(exit_top_cp) & (exit_top_cp >= 0)
+    labels[0, :] = cp.where(m, exit_top_cp, labels[0, :])
+    state[0, :] = cp.where(m, 2, state[0, :])
+
+    exit_bot_cp = cp.asarray(exit_bottom)
+    m = (state[H - 1, :] == 1) & ~cp.isnan(exit_bot_cp) & (exit_bot_cp >= 0)
+    labels[H - 1, :] = cp.where(m, exit_bot_cp, labels[H - 1, :])
+    state[H - 1, :] = cp.where(m, 2, state[H - 1, :])
+
+    exit_left_cp = cp.asarray(exit_left)
+    m = (state[:, 0] == 1) & ~cp.isnan(exit_left_cp) & (exit_left_cp >= 0)
+    labels[:, 0] = cp.where(m, exit_left_cp, labels[:, 0])
+    state[:, 0] = cp.where(m, 2, state[:, 0])
+
+    exit_right_cp = cp.asarray(exit_right)
+    m = (state[:, W - 1] == 1) & ~cp.isnan(exit_right_cp) & (exit_right_cp >= 0)
+    labels[:, W - 1] = cp.where(m, exit_right_cp, labels[:, W - 1])
+    state[:, W - 1] = cp.where(m, 2, state[:, W - 1])
+
+    # Corner exit labels
+    for r, c, val in [(0, 0, exit_tl), (0, W - 1, exit_tr),
+                       (H - 1, 0, exit_bl), (H - 1, W - 1, exit_br)]:
+        if val == val and val >= 0 and int(state[r, c]) == 1:
+            labels[r, c] = val
+            state[r, c] = 2
+
+    max_iter = H * W
+    for _ in range(max_iter):
+        changed[0] = 0
+        _propagate_labels_gpu[griddim, blockdim](
+            flow_dir_f64, labels, state, changed, H, W)
+        if int(changed[0]) == 0:
+            break
+        _advance_frontier_gpu[griddim, blockdim](state, H, W)
+
+    labels = cp.where((state == 1) | (state == 0), cp.nan, labels)
+    return labels
+
+
+def _process_tile_watershed_cupy(iy, ix, flow_dir_da, pour_points_da,
+                                  boundaries, flow_bdry,
+                                  chunks_y, chunks_x, n_tile_y, n_tile_x):
+    """Run seeded GPU watershed on one tile; update boundaries."""
+    import cupy as cp
+
+    chunk = cp.asarray(
+        flow_dir_da.blocks[iy, ix].compute(), dtype=cp.float64)
+    pp_chunk = cp.asarray(
+        pour_points_da.blocks[iy, ix].compute(), dtype=cp.float64)
+
+    exits = _compute_exit_labels(
+        iy, ix, boundaries, flow_bdry,
+        chunks_y, chunks_x, n_tile_y, n_tile_x)
+
+    result = _watershed_tile_cupy(chunk, pp_chunk, *exits)
+
+    new_top = result[0, :].get().copy()
+    new_bottom = result[-1, :].get().copy()
+    new_left = result[:, 0].get().copy()
+    new_right = result[:, -1].get().copy()
+
+    changed = False
+    for side, new in (('top', new_top), ('bottom', new_bottom),
+                      ('left', new_left), ('right', new_right)):
+        old = boundaries.get(side, iy, ix).copy()
+        with np.errstate(invalid='ignore'):
+            mask = ~(np.isnan(old) & np.isnan(new))
+            if mask.any():
+                diff = old[mask] != new[mask]
+                if np.any(diff):
+                    changed = True
+                    break
+
+    boundaries.set('top', iy, ix, new_top)
+    boundaries.set('bottom', iy, ix, new_bottom)
+    boundaries.set('left', iy, ix, new_left)
+    boundaries.set('right', iy, ix, new_right)
+
+    return changed
+
+
+def _assemble_watershed_cupy(flow_dir_da, pour_points_da,
+                              boundaries, flow_bdry,
+                              chunks_y, chunks_x, n_tile_y, n_tile_x):
+    """Build lazy dask+cupy array using GPU watershed tile kernel."""
+    import cupy as cp
+
+    def _tile_fn(flow_dir_block, pp_block, block_info=None):
+        if block_info is None or 0 not in block_info:
+            return cp.full(flow_dir_block.shape, cp.nan, dtype=cp.float64)
+        iy, ix = block_info[0]['chunk-location']
+        exits = _compute_exit_labels(
+            iy, ix, boundaries, flow_bdry,
+            chunks_y, chunks_x, n_tile_y, n_tile_x)
+        return _watershed_tile_cupy(
+            cp.asarray(flow_dir_block, dtype=cp.float64),
+            cp.asarray(pp_block, dtype=cp.float64),
+            *exits)
+
+    return da.map_blocks(
+        _tile_fn,
+        flow_dir_da, pour_points_da,
+        dtype=np.float64,
+        meta=cp.array((), dtype=cp.float64),
     )
-    pp_np = pour_points_da.map_blocks(
-        lambda b: b.get(), dtype=pour_points_da.dtype,
-        meta=np.array((), dtype=pour_points_da.dtype),
-    )
-    result = _watershed_dask_iterative(flow_dir_np, pp_np)
-    return result.map_blocks(
-        cp.asarray, dtype=result.dtype,
-        meta=cp.array((), dtype=result.dtype),
-    )
+
+
+def _watershed_dask_cupy(flow_dir_da, pour_points_da):
+    """Dask+CuPy watershed: native GPU processing per tile."""
+    chunks_y = flow_dir_da.chunks[0]
+    chunks_x = flow_dir_da.chunks[1]
+    n_tile_y = len(chunks_y)
+    n_tile_x = len(chunks_x)
+
+    flow_bdry = _preprocess_tiles(flow_dir_da, chunks_y, chunks_x)
+    flow_bdry = flow_bdry.snapshot()
+
+    boundaries = BoundaryStore(chunks_y, chunks_x, fill_value=np.nan)
+
+    max_iterations = max(n_tile_y, n_tile_x) * 2 + 10
+
+    for _iteration in range(max_iterations):
+        any_changed = False
+
+        for iy in range(n_tile_y):
+            for ix in range(n_tile_x):
+                c = _process_tile_watershed_cupy(
+                    iy, ix, flow_dir_da, pour_points_da,
+                    boundaries, flow_bdry,
+                    chunks_y, chunks_x, n_tile_y, n_tile_x)
+                if c:
+                    any_changed = True
+
+        for iy in reversed(range(n_tile_y)):
+            for ix in reversed(range(n_tile_x)):
+                c = _process_tile_watershed_cupy(
+                    iy, ix, flow_dir_da, pour_points_da,
+                    boundaries, flow_bdry,
+                    chunks_y, chunks_x, n_tile_y, n_tile_x)
+                if c:
+                    any_changed = True
+
+        if not any_changed:
+            break
+
+    boundaries = boundaries.snapshot()
+
+    return _assemble_watershed_cupy(flow_dir_da, pour_points_da,
+                                     boundaries, flow_bdry,
+                                     chunks_y, chunks_x, n_tile_y, n_tile_x)
 
 
 


### PR DESCRIPTION
## Summary
- Replaces CPU fallback with native GPU tile kernels for six hydrology functions (`flow_accumulation`, `watershed`, `basin`, `stream_order`, `stream_link`, `snap_pour_point`) when running on Dask+CuPy arrays
- Each tile now runs existing CUDA kernels directly with seed injection at boundaries, keeping data GPU-resident through the iterative tile sweep
- Adds a native CUDA kernel for `snap_pour_point`'s single-GPU CuPy path (previously fell back to CPU)
- Updates README feature matrix: all six functions now show native support across all four backends

## What changed

**Per-tile GPU kernels with seed injection**: The Dask+CuPy path previously converted CuPy chunks to NumPy, ran the CPU tile kernel, then converted back. Now each tile runs the same GPU frontier-peeling kernels used by the single-GPU path, with external boundary values injected before the peeling loop starts. Seeds are transferred CPU-side only at tile boundaries (small O(edge_length) strips), while all tile-interior computation stays on GPU.

**snap_pour_point native CuPy**: Added `_snap_pour_point_gpu` CUDA kernel where each thread handles one pour point's windowed max search. The flow accumulation array stays on GPU instead of being pulled to CPU.

**stream_link tile-aware kernel**: Added `_stream_link_find_ready_tile` CUDA kernel that uses global coordinate offsets for position-based link IDs, so tile-local results are consistent with full-array results.

## Test plan
- [x] All 158 existing + new tests pass for all six modules
- [x] New dask+cupy tests with multiple chunk sizes and random acyclic grids for each function
- [x] Verified dask+cupy output matches dask+numpy output exactly for basin (pre-existing tile-sweep convergence issue affects both backends identically)