### PR TITLE
Add native CUDA kernel for hydraulic erosion (#961)

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ In the GIS world, rasters are used for representing continuous phenomena (e.g. e
 | [Min Observable Height](xrspatial/experimental/min_observable_height.py) | Finds the minimum observer height needed to see each cell *(experimental)* | ✅️ | | | |
 | [Perlin Noise](xrspatial/perlin.py) | Generates smooth continuous random noise for procedural textures | ✅️ | ✅️ | ✅️ | ✅️ |
 | [Worley Noise](xrspatial/worley.py) | Generates cellular (Voronoi) noise returning distance to the nearest feature point | ✅️ | ✅️ | ✅️ | ✅️ |
-| [Hydraulic Erosion](xrspatial/erosion.py) | Simulates particle-based water erosion to carve valleys and deposit sediment | ✅️ | 🔄 | 🔄 | 🔄 |
+| [Hydraulic Erosion](xrspatial/erosion.py) | Simulates particle-based water erosion to carve valleys and deposit sediment | ✅️ | ✅️ | ✅️ | ✅️ |
 | [Bump Mapping](xrspatial/bump.py) | Adds randomized bump features to simulate natural terrain variation | ✅️ | ✅️ | ✅️ | ✅️ |
 
 -----------

--- a/examples/user_guide/21_Hydraulic_Erosion.ipynb
+++ b/examples/user_guide/21_Hydraulic_Erosion.ipynb
@@ -1,0 +1,235 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell-0",
+   "metadata": {},
+   "source": [
+    "# Hydraulic Erosion\n",
+    "\n",
+    "The `erode()` function simulates particle-based hydraulic erosion on a terrain raster. Thousands of virtual water droplets are dropped on the surface, each one tracing a path downhill. Along the way, droplets pick up sediment from steep slopes and deposit it when they slow down or encounter flatter ground.\n",
+    "\n",
+    "This produces realistic valley networks and smoothed ridgelines from synthetic or real terrain data. The function supports numpy, cupy, dask+numpy, and dask+cupy backends. On GPU, each particle runs as a separate CUDA thread for large speedups on high-resolution grids."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import xarray as xr\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from xrspatial.erosion import erode"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-2",
+   "metadata": {},
+   "source": [
+    "## 1. Generate synthetic terrain\n",
+    "\n",
+    "We build a simple terrain using layered sine waves plus random noise. This gives enough slope variation for erosion to produce visible channels."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "size = 256\n",
+    "y = np.linspace(0, 4 * np.pi, size)\n",
+    "x = np.linspace(0, 4 * np.pi, size)\n",
+    "xx, yy = np.meshgrid(x, y)\n",
+    "\n",
+    "# Layered sine terrain with noise\n",
+    "rng = np.random.default_rng(42)\n",
+    "terrain = (\n",
+    "    200 * np.sin(xx * 0.3) * np.cos(yy * 0.2)\n",
+    "    + 100 * np.sin(xx * 0.7 + yy * 0.5)\n",
+    "    + 50 * rng.random((size, size))\n",
+    "    + 500  # raise the baseline so values stay positive\n",
+    ")\n",
+    "\n",
+    "agg = xr.DataArray(\n",
+    "    terrain.astype(np.float32),\n",
+    "    dims=['y', 'x'],\n",
+    "    attrs={'res': (1.0, 1.0)},\n",
+    ")\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(8, 6))\n",
+    "im = ax.imshow(agg.values, cmap='terrain')\n",
+    "ax.set_title('Original terrain')\n",
+    "ax.axis('off')\n",
+    "fig.colorbar(im, ax=ax, shrink=0.7, label='Elevation')\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-4",
+   "metadata": {},
+   "source": [
+    "## 2. Basic erosion\n",
+    "\n",
+    "Run erosion with default parameters and compare against the original."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eroded = erode(agg, iterations=50000, seed=42)\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 3, figsize=(18, 5))\n",
+    "\n",
+    "axes[0].imshow(agg.values, cmap='terrain')\n",
+    "axes[0].set_title('Before')\n",
+    "axes[0].axis('off')\n",
+    "\n",
+    "axes[1].imshow(eroded.values, cmap='terrain')\n",
+    "axes[1].set_title('After erosion')\n",
+    "axes[1].axis('off')\n",
+    "\n",
+    "diff = eroded.values - agg.values\n",
+    "vlim = max(abs(diff.min()), abs(diff.max()))\n",
+    "im = axes[2].imshow(diff, cmap='RdBu', vmin=-vlim, vmax=vlim)\n",
+    "axes[2].set_title('Elevation change')\n",
+    "axes[2].axis('off')\n",
+    "fig.colorbar(im, ax=axes[2], shrink=0.7, label='Change')\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-6",
+   "metadata": {},
+   "source": [
+    "## 3. Parameter effects\n",
+    "\n",
+    "The `params` dict controls the erosion behavior. The most impactful ones:\n",
+    "\n",
+    "- **erosion**: how aggressively particles remove material (default 0.3)\n",
+    "- **capacity**: how much sediment water can carry (default 4.0)\n",
+    "- **deposition**: how quickly excess sediment is dropped (default 0.3)\n",
+    "- **radius**: size of the erosion brush in cells (default 3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "configs = {\n",
+    "    'Default': None,\n",
+    "    'High erosion': {'erosion': 0.9},\n",
+    "    'Large brush': {'radius': 6},\n",
+    "    'High capacity': {'capacity': 12.0},\n",
+    "}\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 4, figsize=(20, 5))\n",
+    "for ax, (label, p) in zip(axes, configs.items()):\n",
+    "    result = erode(agg, iterations=30000, seed=42, params=p)\n",
+    "    diff = result.values - agg.values\n",
+    "    vlim = max(abs(diff.min()), abs(diff.max()), 1)\n",
+    "    ax.imshow(diff, cmap='RdBu', vmin=-vlim, vmax=vlim)\n",
+    "    ax.set_title(label)\n",
+    "    ax.axis('off')\n",
+    "\n",
+    "plt.suptitle('Elevation change under different parameters', y=1.02)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-8",
+   "metadata": {},
+   "source": [
+    "## 4. Iterative refinement\n",
+    "\n",
+    "More iterations means more droplets, which produces deeper, more developed channel networks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "iter_counts = [5000, 20000, 50000, 100000]\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 4, figsize=(20, 5))\n",
+    "for ax, n in zip(axes, iter_counts):\n",
+    "    result = erode(agg, iterations=n, seed=42)\n",
+    "    ax.imshow(result.values, cmap='terrain')\n",
+    "    ax.set_title(f'{n:,} droplets')\n",
+    "    ax.axis('off')\n",
+    "\n",
+    "plt.suptitle('Erosion depth vs. iteration count', y=1.02)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-10",
+   "metadata": {},
+   "source": [
+    "## 5. Cross-section comparison\n",
+    "\n",
+    "A 1D slice through the terrain shows how erosion carves valleys and smooths peaks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "row = size // 2\n",
+    "eroded_heavy = erode(agg, iterations=80000, seed=42)\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(12, 4))\n",
+    "ax.plot(agg.values[row, :], label='Original', linewidth=2)\n",
+    "ax.plot(eroded.values[row, :], label='50k droplets', linewidth=1.5)\n",
+    "ax.plot(eroded_heavy.values[row, :], label='80k droplets', linewidth=1.5)\n",
+    "ax.set_xlabel('Column')\n",
+    "ax.set_ylabel('Elevation')\n",
+    "ax.set_title(f'Cross-section at row {row}')\n",
+    "ax.legend()\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/xrspatial/erosion.py
+++ b/xrspatial/erosion.py
@@ -17,7 +17,12 @@ try:
 except ImportError:
     da = None
 
-from xrspatial.utils import has_cuda_and_cupy, is_cupy_array, is_dask_cupy
+from xrspatial.utils import (
+    ArrayTypeFunctionMapping,
+    has_cuda_and_cupy,
+    is_cupy_array,
+    is_dask_cupy,
+)
 
 # Default erosion parameters
 _DEFAULT_PARAMS = dict(
@@ -157,6 +162,199 @@ def _erode_cpu(heightmap, random_pos, boy, box, bw,
     return heightmap
 
 
+# ---------------------------------------------------------------------------
+# GPU (CuPy / CUDA) implementation
+# ---------------------------------------------------------------------------
+
+if cuda is not None:
+
+    @cuda.jit
+    def _erode_gpu_kernel(
+        heightmap, random_pos, boy, box, bw,
+        inertia, capacity, deposition, erosion_rate,
+        evaporation, gravity, min_slope, max_lifetime,
+    ):
+        """One CUDA thread per particle.
+
+        Particles within a single launch are independent.  Conflicts at
+        shared heightmap cells are resolved via ``cuda.atomic.add``.
+        """
+        tid = cuda.grid(1)
+        n_iterations = random_pos.shape[0]
+        if tid >= n_iterations:
+            return
+
+        height = heightmap.shape[0]
+        width = heightmap.shape[1]
+        n_brush = bw.shape[0]
+
+        pos_x = random_pos[tid, 0] * (width - 3) + 1
+        pos_y = random_pos[tid, 1] * (height - 3) + 1
+        dir_x = 0.0
+        dir_y = 0.0
+        speed = 1.0
+        water = 1.0
+        sediment = 0.0
+
+        for step in range(max_lifetime):
+            node_x = int(pos_x)
+            node_y = int(pos_y)
+
+            if node_x < 1 or node_x >= width - 2:
+                return
+            if node_y < 1 or node_y >= height - 2:
+                return
+
+            fx = pos_x - node_x
+            fy = pos_y - node_y
+
+            h00 = heightmap[node_y, node_x]
+            h10 = heightmap[node_y, node_x + 1]
+            h01 = heightmap[node_y + 1, node_x]
+            h11 = heightmap[node_y + 1, node_x + 1]
+
+            grad_x = (h10 - h00) * (1 - fy) + (h11 - h01) * fy
+            grad_y = (h01 - h00) * (1 - fx) + (h11 - h10) * fx
+
+            dir_x = dir_x * inertia - grad_x * (1 - inertia)
+            dir_y = dir_y * inertia - grad_y * (1 - inertia)
+
+            dir_len = (dir_x * dir_x + dir_y * dir_y) ** 0.5
+            if dir_len < 1e-10:
+                return
+            dir_x /= dir_len
+            dir_y /= dir_len
+
+            new_x = pos_x + dir_x
+            new_y = pos_y + dir_y
+
+            if new_x < 1 or new_x >= width - 2:
+                return
+            if new_y < 1 or new_y >= height - 2:
+                return
+
+            h_old = (h00 * (1 - fx) * (1 - fy) + h10 * fx * (1 - fy) +
+                     h01 * (1 - fx) * fy + h11 * fx * fy)
+
+            new_node_x = int(new_x)
+            new_node_y = int(new_y)
+            new_fx = new_x - new_node_x
+            new_fy = new_y - new_node_y
+            h_new = (heightmap[new_node_y, new_node_x] * (1 - new_fx) * (1 - new_fy) +
+                     heightmap[new_node_y, new_node_x + 1] * new_fx * (1 - new_fy) +
+                     heightmap[new_node_y + 1, new_node_x] * (1 - new_fx) * new_fy +
+                     heightmap[new_node_y + 1, new_node_x + 1] * new_fx * new_fy)
+
+            h_diff = h_new - h_old
+
+            neg_h_diff = -h_diff
+            if neg_h_diff < min_slope:
+                neg_h_diff = min_slope
+            sed_capacity = neg_h_diff * speed * water * capacity
+
+            if sediment > sed_capacity or h_diff > 0:
+                if h_diff > 0:
+                    amount = h_diff if h_diff < sediment else sediment
+                else:
+                    amount = (sediment - sed_capacity) * deposition
+
+                sediment -= amount
+
+                cuda.atomic.add(heightmap, (node_y, node_x),
+                                amount * (1 - fx) * (1 - fy))
+                cuda.atomic.add(heightmap, (node_y, node_x + 1),
+                                amount * fx * (1 - fy))
+                cuda.atomic.add(heightmap, (node_y + 1, node_x),
+                                amount * (1 - fx) * fy)
+                cuda.atomic.add(heightmap, (node_y + 1, node_x + 1),
+                                amount * fx * fy)
+            else:
+                neg_h = -h_diff
+                sc_minus_sed = (sed_capacity - sediment) * erosion_rate
+                amount = sc_minus_sed if sc_minus_sed < neg_h else neg_h
+
+                for k in range(n_brush):
+                    ey = node_y + boy[k]
+                    ex = node_x + box[k]
+                    if 0 <= ey < height and 0 <= ex < width:
+                        cuda.atomic.add(heightmap, (ey, ex),
+                                        -(amount * bw[k]))
+
+                sediment += amount
+
+            speed_sq = speed * speed + h_diff * gravity
+            if speed_sq > 0:
+                speed = speed_sq ** 0.5
+            else:
+                speed = 0.0
+            water *= (1 - evaporation)
+
+            pos_x = new_x
+            pos_y = new_y
+
+
+def _erode_cupy(data, random_pos_np, boy, box, bw, params):
+    """Run erosion on a CuPy array using the CUDA kernel."""
+    hm = data.astype(cupy.float64)
+
+    # Transfer brush and random positions to device
+    random_pos_d = cupy.asarray(random_pos_np)
+    boy_d = cupy.asarray(boy)
+    box_d = cupy.asarray(box)
+    bw_d = cupy.asarray(bw)
+
+    n_particles = random_pos_np.shape[0]
+    threads_per_block = 256
+    blocks = (n_particles + threads_per_block - 1) // threads_per_block
+
+    _erode_gpu_kernel[blocks, threads_per_block](
+        hm, random_pos_d, boy_d, box_d, bw_d,
+        params['inertia'], params['capacity'], params['deposition'],
+        params['erosion'], params['evaporation'], params['gravity'],
+        params['min_slope'], int(params['max_lifetime']),
+    )
+    cuda.synchronize()
+
+    return hm.astype(cupy.float32)
+
+
+def _erode_numpy(data, random_pos, boy, box, bw, params):
+    """Run erosion on a NumPy array using the CPU kernel."""
+    hm = data.astype(np.float64).copy()
+
+    hm = _erode_cpu(
+        hm, random_pos, boy, box, bw,
+        params['inertia'], params['capacity'], params['deposition'],
+        params['erosion'], params['evaporation'], params['gravity'],
+        params['min_slope'], int(params['max_lifetime']),
+    )
+
+    return hm.astype(np.float32)
+
+
+def _erode_dask_numpy(data, random_pos, boy, box, bw, params):
+    """Run erosion on a dask+numpy array.
+
+    Erosion is a global operation (particles traverse the full grid),
+    so we materialize to numpy, run the CPU kernel, then re-wrap.
+    """
+    np_data = data.compute()
+    result = _erode_numpy(np_data, random_pos, boy, box, bw, params)
+    return da.from_array(result, chunks=data.chunksize)
+
+
+def _erode_dask_cupy(data, random_pos, boy, box, bw, params):
+    """Run erosion on a dask+cupy array.
+
+    Materializes to a single CuPy array, runs the GPU kernel, then
+    re-wraps as dask.
+    """
+    cp_data = data.compute()  # CuPy ndarray
+    result = _erode_cupy(cp_data, random_pos, boy, box, bw, params)
+    return da.from_array(result, chunks=data.chunksize,
+                         meta=cupy.array((), dtype=cupy.float32))
+
+
 def erode(agg, iterations=50000, seed=42, params=None):
     """Apply particle-based hydraulic erosion to a terrain DataArray.
 
@@ -185,49 +383,19 @@ def erode(agg, iterations=50000, seed=42, params=None):
     if params is not None:
         p.update(params)
 
-    data = agg.data
-    is_dask = da is not None and isinstance(data, da.Array)
-    is_gpu = False
-
-    if is_dask:
-        if is_dask_cupy(agg):
-            is_gpu = True
-            data = data.compute()  # cupy ndarray
-        else:
-            data = data.compute()  # numpy ndarray
-
-    if has_cuda_and_cupy() and is_cupy_array(data):
-        is_gpu = True
-
-    # work on a copy
-    if is_gpu:
-        hm = cupy.asnumpy(data).astype(np.float64)
-    else:
-        hm = data.astype(np.float64).copy()
-
-    # precompute brush and random positions outside JIT
+    # Precompute brush and random positions on the host
     boy, box, bw = _build_brush(int(p['radius']))
     rng = np.random.RandomState(seed)
     random_pos = rng.random((iterations, 2))
 
-    hm = _erode_cpu(
-        hm, random_pos, boy, box, bw,
-        p['inertia'], p['capacity'], p['deposition'], p['erosion'],
-        p['evaporation'], p['gravity'], p['min_slope'],
-        int(p['max_lifetime']),
+    mapper = ArrayTypeFunctionMapping(
+        numpy_func=lambda d: _erode_numpy(d, random_pos, boy, box, bw, p),
+        cupy_func=lambda d: _erode_cupy(d, random_pos, boy, box, bw, p),
+        dask_func=lambda d: _erode_dask_numpy(d, random_pos, boy, box, bw, p),
+        dask_cupy_func=lambda d: _erode_dask_cupy(d, random_pos, boy, box, bw, p),
     )
 
-    result_data = hm.astype(np.float32)
-    if is_gpu:
-        result_data = cupy.asarray(result_data)
-
-    if is_dask:
-        if is_gpu:
-            result_data = da.from_array(result_data,
-                                        chunks=agg.data.chunksize,
-                                        meta=cupy.array((), dtype=cupy.float32))
-        else:
-            result_data = da.from_array(result_data, chunks=agg.data.chunksize)
+    result_data = mapper(agg)(agg.data)
 
     return xr.DataArray(result_data, dims=agg.dims, coords=agg.coords,
                         attrs=agg.attrs, name=agg.name)

--- a/xrspatial/tests/test_erosion.py
+++ b/xrspatial/tests/test_erosion.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from xrspatial.erosion import erode, _build_brush
+from xrspatial.tests.general_checks import (
+    create_test_raster,
+    general_output_checks,
+    cuda_and_cupy_available,
+    dask_array_available,
+)
+
+
+# ---- helpers ----
+
+def _make_terrain(size=64, seed=12345):
+    """Build a simple synthetic terrain for testing."""
+    rng = np.random.default_rng(seed)
+    data = rng.random((size, size)).astype(np.float32) * 500
+    return data
+
+
+def _input(data, backend='numpy', chunks=(32, 32)):
+    return create_test_raster(data, backend=backend, chunks=chunks)
+
+
+# ---- brush tests ----
+
+def test_build_brush_weights_sum_to_one():
+    for r in (1, 2, 3, 5):
+        _, _, bw = _build_brush(r)
+        assert abs(bw.sum() - 1.0) < 1e-12, f"radius={r}: weights sum to {bw.sum()}"
+
+
+def test_build_brush_offsets_within_radius():
+    for r in (1, 3):
+        boy, box, bw = _build_brush(r)
+        for dy, dx in zip(boy, box):
+            assert dx * dx + dy * dy <= r * r
+
+
+# ---- numpy correctness ----
+
+def test_erode_numpy_basic():
+    """Erosion should lower peaks and raise valleys relative to input."""
+    data = _make_terrain(size=64)
+    agg = _input(data, 'numpy')
+    result = erode(agg, iterations=5000, seed=42)
+
+    general_output_checks(agg, result, verify_attrs=True)
+
+    result_np = result.data
+    # Volume change is bounded but not zero — particles that exit the
+    # grid carry sediment out, and the brush erodes more broadly than
+    # deposition covers.  Check that results differ from input and the
+    # total doesn't explode.
+    assert not np.array_equal(result_np, data)
+    assert np.isfinite(result_np).all()
+
+
+def test_erode_numpy_deterministic():
+    """Same seed must produce identical results."""
+    data = _make_terrain(size=32)
+    r1 = erode(_input(data, 'numpy'), iterations=2000, seed=99)
+    r2 = erode(_input(data, 'numpy'), iterations=2000, seed=99)
+    np.testing.assert_array_equal(r1.data, r2.data)
+
+
+def test_erode_numpy_different_seeds():
+    """Different seeds should give different results."""
+    data = _make_terrain(size=32)
+    r1 = erode(_input(data, 'numpy'), iterations=2000, seed=1)
+    r2 = erode(_input(data, 'numpy'), iterations=2000, seed=2)
+    assert not np.array_equal(r1.data, r2.data)
+
+
+def test_erode_custom_params():
+    """Custom parameters should be accepted and change the result."""
+    data = _make_terrain(size=32)
+    r_default = erode(_input(data, 'numpy'), iterations=1000, seed=42)
+    r_custom = erode(
+        _input(data, 'numpy'), iterations=1000, seed=42,
+        params={'erosion': 0.9, 'capacity': 10.0},
+    )
+    assert not np.array_equal(r_default.data, r_custom.data)
+
+
+def test_erode_preserves_coords_and_attrs():
+    """Output DataArray should keep the input's coordinates and attributes."""
+    data = _make_terrain(size=16)
+    agg = _input(data, 'numpy')
+    result = erode(agg, iterations=500, seed=42)
+    assert result.dims == agg.dims
+    assert result.attrs == agg.attrs
+    for coord in agg.coords:
+        np.testing.assert_array_equal(result[coord].data, agg[coord].data)
+
+
+def test_erode_flat_terrain_unchanged():
+    """A perfectly flat surface should be unchanged by erosion."""
+    data = np.full((32, 32), 100.0, dtype=np.float32)
+    agg = _input(data, 'numpy')
+    result = erode(agg, iterations=2000, seed=42)
+    np.testing.assert_allclose(result.data, data, atol=1e-5)
+
+
+def test_erode_small_raster():
+    """Erosion should handle a small raster without crashing."""
+    data = np.array([[10, 20, 30],
+                     [40, 50, 60],
+                     [70, 80, 90]], dtype=np.float32)
+    agg = _input(data, 'numpy')
+    result = erode(agg, iterations=100, seed=42)
+    assert result.shape == (3, 3)
+
+
+# ---- dask+numpy backend ----
+
+@dask_array_available
+def test_erode_dask_numpy_matches_numpy():
+    """Dask+numpy backend should produce identical results to pure numpy."""
+    data = _make_terrain(size=32)
+    np_result = erode(_input(data, 'numpy'), iterations=2000, seed=42)
+    da_result = erode(_input(data, 'dask+numpy', chunks=(16, 16)),
+                      iterations=2000, seed=42)
+
+    general_output_checks(
+        _input(data, 'dask+numpy', chunks=(16, 16)), da_result,
+    )
+    np.testing.assert_array_equal(np_result.data, da_result.data.compute())
+
+
+# ---- cupy backend ----
+
+@cuda_and_cupy_available
+def test_erode_cupy_runs():
+    """CuPy backend should run and return a CuPy-backed DataArray."""
+    import cupy as cp
+
+    data = _make_terrain(size=64)
+    agg = _input(data, 'cupy')
+    result = erode(agg, iterations=5000, seed=42)
+
+    general_output_checks(agg, result, verify_attrs=True)
+    # result should stay on GPU
+    assert hasattr(result.data, 'get'), "Expected CuPy array"
+
+
+@cuda_and_cupy_available
+def test_erode_cupy_modifies_terrain():
+    """GPU erosion should modify the terrain and produce finite results."""
+    data = _make_terrain(size=64)
+    agg = _input(data, 'cupy')
+    result = erode(agg, iterations=5000, seed=42)
+
+    result_np = result.data.get()
+    assert not np.array_equal(result_np, data)
+    assert np.isfinite(result_np).all()
+
+
+@cuda_and_cupy_available
+def test_erode_cupy_flat_unchanged():
+    """Flat terrain on GPU should remain flat."""
+    data = np.full((32, 32), 100.0, dtype=np.float32)
+    agg = _input(data, 'cupy')
+    result = erode(agg, iterations=2000, seed=42)
+    np.testing.assert_allclose(result.data.get(), data, atol=1e-5)
+
+
+@cuda_and_cupy_available
+def test_erode_cupy_consistent_structure():
+    """Multiple GPU runs should produce structurally similar results.
+
+    GPU erosion is non-deterministic due to cuda.atomic.add ordering,
+    so we check that the overall erosion pattern is consistent rather
+    than requiring bitwise equality.
+    """
+    data = _make_terrain(size=64)
+    # Use fewer particles on a larger grid to reduce contention
+    r1 = erode(_input(data, 'cupy'), iterations=500, seed=99)
+    r2 = erode(_input(data, 'cupy'), iterations=500, seed=99)
+
+    r1_np = r1.data.get()
+    r2_np = r2.data.get()
+
+    # Both should modify terrain in similar ways — correlation should be high.
+    # Not exact due to atomic operation ordering.
+    corr = np.corrcoef(r1_np.ravel(), r2_np.ravel())[0, 1]
+    assert corr > 0.8, f"Correlation between GPU runs: {corr:.4f}"
+
+
+# ---- dask+cupy backend ----
+
+@cuda_and_cupy_available
+@dask_array_available
+def test_erode_dask_cupy_runs():
+    """Dask+CuPy should run and return sensible results."""
+    data = _make_terrain(size=32)
+    agg = _input(data, 'dask+cupy', chunks=(16, 16))
+    result = erode(agg, iterations=2000, seed=42)
+
+    general_output_checks(agg, result, verify_attrs=True)
+    result_np = result.data.compute().get()
+    assert not np.array_equal(result_np, data)
+    assert np.isfinite(result_np).all()


### PR DESCRIPTION
Closes #961

## Summary

- Adds `_erode_gpu_kernel` (`@cuda.jit`), one CUDA thread per particle, with `cuda.atomic.add` for heightmap conflicts
- Replaces the CPU-fallback path for CuPy and Dask+CuPy arrays with on-device execution
- Refactors `erode()` to use `ArrayTypeFunctionMapping` dispatch instead of manual type checks
- Adds `test_erosion.py` (15 tests across numpy, dask+numpy, cupy, dask+cupy)
- Adds user guide notebook `21_Hydraulic_Erosion.ipynb`
- Updates README feature matrix from fallback to native for GPU columns

## Notes

- GPU results are non-deterministic because `cuda.atomic.add` ordering depends on thread scheduling. GPU tests use correlation checks instead of exact comparison.
- Float64 arithmetic in the GPU kernel to match the CPU path.
- Erosion is a global operation (particles traverse the full grid), so dask arrays are still materialized before processing. They just run on-device now instead of round-tripping through NumPy.

## Test plan

- [x] 15 new tests in `test_erosion.py`, all passing
- [ ] Verify GPU tests pass on CI with CUDA
- [ ] Run user guide notebook end-to-end to check plots render