### PR TITLE
Add least-cost corridor analysis (#965)

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ In the GIS world, rasters are used for representing continuous phenomena (e.g. e
 | [Allocation](xrspatial/proximity.py) | Assigns each cell to the identity of the nearest source feature | ✅️ | ✅ | ✅️ | ✅️ |
 | [Balanced Allocation](xrspatial/balanced_allocation.py) | Partitions a cost surface into territories of roughly equal cost-weighted area | ✅️ | ✅ | ✅️ | ✅️ |
 | [Cost Distance](xrspatial/cost_distance.py) | Computes minimum accumulated cost to the nearest source through a friction surface | ✅️ | ✅ | ✅️ | ✅️ |
+| [Least-Cost Corridor](xrspatial/corridor.py) | Identifies zones of low cumulative cost between two source locations | ✅️ | ✅ | ✅️ | ✅️ |
 | [Direction](xrspatial/proximity.py) | Computes the direction from each cell to the nearest source feature | ✅️ | ✅ | ✅️ | ✅️ |
 | [Proximity](xrspatial/proximity.py) | Computes the distance from each cell to the nearest source feature | ✅️ | ✅ | ✅️ | ✅️ |
 | [Surface Distance](xrspatial/surface_distance.py) | Computes distance along the 3D terrain surface to the nearest source | ✅️ | ✅ | ✅️ | ✅️ |

--- a/docs/source/reference/proximity.rst
+++ b/docs/source/reference/proximity.rst
@@ -35,6 +35,13 @@ Cost Distance
 
     xrspatial.cost_distance.cost_distance
 
+Least-Cost Corridor
+====================
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.corridor.least_cost_corridor
+
 Balanced Allocation
 ====================
 .. autosummary::

--- a/examples/user_guide/20_Corridor_Analysis.ipynb
+++ b/examples/user_guide/20_Corridor_Analysis.ipynb
@@ -1,0 +1,452 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell-0",
+   "metadata": {},
+   "source": [
+    "# Xarray-spatial\n",
+    "### User Guide: Least-Cost Corridor Analysis\n",
+    "-----\n",
+    "\n",
+    "The `least_cost_corridor` function identifies zones of low cumulative travel cost between two (or more) source locations on a friction surface. Unlike a single-cell path (e.g., A* search), a corridor shows **all cells** within a cost threshold of the optimal route.\n",
+    "\n",
+    "Typical use cases:\n",
+    "- **Wildlife connectivity**: connecting two habitat patches through the cheapest terrain\n",
+    "- **Infrastructure routing**: finding broad zones suitable for roads or pipelines\n",
+    "- **Conservation planning**: prioritizing land parcels that lie along low-cost connections\n",
+    "\n",
+    "**How it works:**\n",
+    "1. Compute `cost_distance` from source A and from source B.\n",
+    "2. Sum the two surfaces: `corridor = cd_A + cd_B`.\n",
+    "3. Normalize by subtracting the minimum: cells on the optimal route get value 0.\n",
+    "4. Optionally threshold to produce a binary corridor mask.\n",
+    "\n",
+    "**Contents:**\n",
+    "- [Setup](#Setup)\n",
+    "- [1. Basic corridor between two points](#1.-Basic-corridor-between-two-points)\n",
+    "- [2. Corridor with variable friction](#2.-Corridor-with-variable-friction)\n",
+    "- [3. Thresholding: absolute vs relative](#3.-Thresholding:-absolute-vs-relative)\n",
+    "- [4. Barriers force corridor detours](#4.-Barriers-force-corridor-detours)\n",
+    "- [5. Pre-computed cost-distance surfaces](#5.-Pre-computed-cost-distance-surfaces)\n",
+    "- [6. Multi-source pairwise corridors](#6.-Multi-source-pairwise-corridors)\n",
+    "\n",
+    "-----"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-1",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import xarray as xr\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from xrspatial import least_cost_corridor, cost_distance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def make_raster(data, res=1.0):\n",
+    "    \"\"\"Helper: create a DataArray with y/x coordinates.\"\"\"\n",
+    "    h, w = data.shape\n",
+    "    raster = xr.DataArray(\n",
+    "        data.astype(np.float64),\n",
+    "        dims=['y', 'x'],\n",
+    "        attrs={'res': (res, res)},\n",
+    "    )\n",
+    "    raster['y'] = np.arange(h) * res\n",
+    "    raster['x'] = np.arange(w) * res\n",
+    "    return raster\n",
+    "\n",
+    "\n",
+    "def plot_corridor(arrays, titles, cmaps=None, figsize=None):\n",
+    "    \"\"\"Plot multiple arrays side by side.\"\"\"\n",
+    "    n = len(arrays)\n",
+    "    if figsize is None:\n",
+    "        figsize = (5 * n, 4)\n",
+    "    if cmaps is None:\n",
+    "        cmaps = ['viridis'] * n\n",
+    "    fig, axes = plt.subplots(1, n, figsize=figsize)\n",
+    "    if n == 1:\n",
+    "        axes = [axes]\n",
+    "    for ax, arr, title, cmap in zip(axes, arrays, titles, cmaps):\n",
+    "        data = arr.values if hasattr(arr, 'values') else arr\n",
+    "        im = ax.imshow(data, cmap=cmap, origin='upper')\n",
+    "        ax.set_title(title)\n",
+    "        plt.colorbar(im, ax=ax, shrink=0.8)\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-4",
+   "metadata": {},
+   "source": [
+    "## 1. Basic corridor between two points\n",
+    "\n",
+    "With uniform friction, the corridor cost surface is symmetric and centred on the straight-line path between the two sources."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n = 31\n",
+    "friction_data = np.ones((n, n))\n",
+    "\n",
+    "# Two sources on opposite sides\n",
+    "src_a_data = np.zeros((n, n))\n",
+    "src_a_data[15, 3] = 1.0\n",
+    "\n",
+    "src_b_data = np.zeros((n, n))\n",
+    "src_b_data[15, 27] = 1.0\n",
+    "\n",
+    "friction = make_raster(friction_data)\n",
+    "src_a = make_raster(src_a_data)\n",
+    "src_b = make_raster(src_b_data)\n",
+    "\n",
+    "corridor = least_cost_corridor(friction, src_a, src_b)\n",
+    "\n",
+    "plot_corridor(\n",
+    "    [corridor],\n",
+    "    ['Corridor (uniform friction)'],\n",
+    "    cmaps=['magma'],\n",
+    "    figsize=(8, 5),\n",
+    ")\n",
+    "\n",
+    "print(f\"Min corridor cost (optimal route): {float(corridor.min()):.4f}\")\n",
+    "print(f\"Max corridor cost (corners):       {float(corridor.max()):.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-6",
+   "metadata": {},
+   "source": [
+    "The darkest band shows cells on or near the optimal route (cost = 0). Brighter values are farther from the optimal connection, measured in accumulated cost."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-7",
+   "metadata": {},
+   "source": [
+    "## 2. Corridor with variable friction\n",
+    "\n",
+    "When friction varies across the landscape, the corridor bends to follow cheaper terrain. Here we add a high-friction band and a low-friction channel that the corridor routes through."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n = 31\n",
+    "friction_var = np.ones((n, n)) * 2.0\n",
+    "\n",
+    "# High-cost zone across the middle\n",
+    "friction_var[10:21, :] = 8.0\n",
+    "\n",
+    "# Low-cost channel through the high-cost zone\n",
+    "friction_var[14:17, :] = 1.0\n",
+    "\n",
+    "src_a_data = np.zeros((n, n))\n",
+    "src_a_data[15, 2] = 1.0\n",
+    "\n",
+    "src_b_data = np.zeros((n, n))\n",
+    "src_b_data[15, 28] = 1.0\n",
+    "\n",
+    "friction_v = make_raster(friction_var)\n",
+    "sa = make_raster(src_a_data)\n",
+    "sb = make_raster(src_b_data)\n",
+    "\n",
+    "corridor_var = least_cost_corridor(friction_v, sa, sb)\n",
+    "\n",
+    "plot_corridor(\n",
+    "    [friction_v, corridor_var],\n",
+    "    ['Friction surface', 'Corridor'],\n",
+    "    cmaps=['YlOrRd', 'magma'],\n",
+    "    figsize=(12, 5),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-9",
+   "metadata": {},
+   "source": [
+    "The corridor is concentrated along the low-cost channel. Cells outside the channel have much higher corridor cost because any route through them must also cross the high-friction zone."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-10",
+   "metadata": {},
+   "source": [
+    "## 3. Thresholding: absolute vs relative\n",
+    "\n",
+    "The `threshold` parameter masks out cells that deviate too far from the optimal route. This turns the continuous corridor surface into a discrete corridor zone.\n",
+    "\n",
+    "- **Absolute** (`relative=False`): cells with normalized cost > threshold are masked.\n",
+    "- **Relative** (`relative=True`): threshold is a fraction of the minimum corridor cost. For example, `threshold=0.10` keeps cells within 10% of the optimal cost."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Reuse uniform friction setup\n",
+    "n = 31\n",
+    "friction_u = make_raster(np.ones((n, n)))\n",
+    "\n",
+    "sa_data = np.zeros((n, n))\n",
+    "sa_data[15, 3] = 1.0\n",
+    "\n",
+    "sb_data = np.zeros((n, n))\n",
+    "sb_data[15, 27] = 1.0\n",
+    "\n",
+    "sa_u = make_raster(sa_data)\n",
+    "sb_u = make_raster(sb_data)\n",
+    "\n",
+    "# Absolute threshold\n",
+    "corridor_abs = least_cost_corridor(friction_u, sa_u, sb_u, threshold=3.0)\n",
+    "\n",
+    "# Relative threshold (10% of minimum corridor cost)\n",
+    "corridor_rel = least_cost_corridor(\n",
+    "    friction_u, sa_u, sb_u, threshold=0.10, relative=True\n",
+    ")\n",
+    "\n",
+    "plot_corridor(\n",
+    "    [corridor_abs, corridor_rel],\n",
+    "    ['Absolute threshold=3.0', 'Relative threshold=10%'],\n",
+    "    cmaps=['magma', 'magma'],\n",
+    "    figsize=(12, 5),\n",
+    ")\n",
+    "\n",
+    "# Count cells in each corridor\n",
+    "print(f\"Cells in absolute corridor: {int(np.sum(np.isfinite(corridor_abs.values)))}\")\n",
+    "print(f\"Cells in relative corridor: {int(np.sum(np.isfinite(corridor_rel.values)))}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-12",
+   "metadata": {},
+   "source": [
+    "The relative threshold adapts to the scale of the corridor cost. For long-distance corridors with high total cost, a 10% relative threshold produces a wider corridor than for short-distance ones. The absolute threshold gives a fixed-width band in cost units regardless of distance."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-13",
+   "metadata": {},
+   "source": [
+    "## 4. Barriers force corridor detours\n",
+    "\n",
+    "NaN cells in the friction surface are impassable. The corridor routes around them, just as `cost_distance` does."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n = 31\n",
+    "friction_barrier = np.ones((n, n))\n",
+    "\n",
+    "# Vertical wall with a gap\n",
+    "friction_barrier[5:26, 15] = np.nan\n",
+    "friction_barrier[15, 15] = 1.0  # gap at the midpoint\n",
+    "\n",
+    "sa_data = np.zeros((n, n))\n",
+    "sa_data[15, 3] = 1.0\n",
+    "\n",
+    "sb_data = np.zeros((n, n))\n",
+    "sb_data[15, 27] = 1.0\n",
+    "\n",
+    "fric_b = make_raster(friction_barrier)\n",
+    "sa_b = make_raster(sa_data)\n",
+    "sb_b = make_raster(sb_data)\n",
+    "\n",
+    "corridor_barrier = least_cost_corridor(fric_b, sa_b, sb_b)\n",
+    "\n",
+    "# Show friction with barrier visible\n",
+    "barrier_vis = friction_barrier.copy()\n",
+    "barrier_vis[np.isnan(barrier_vis)] = 0\n",
+    "\n",
+    "plot_corridor(\n",
+    "    [make_raster(barrier_vis), corridor_barrier],\n",
+    "    ['Friction (dark = barrier)', 'Corridor (routes through gap)'],\n",
+    "    cmaps=['gray', 'magma'],\n",
+    "    figsize=(12, 5),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-15",
+   "metadata": {},
+   "source": [
+    "All routes between the two sources funnel through the gap in the wall. The corridor cost surface reflects this bottleneck -- cells near the gap have low corridor cost, while cells far from it have high cost because detour paths through the gap are longer."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-16",
+   "metadata": {},
+   "source": [
+    "## 5. Pre-computed cost-distance surfaces\n",
+    "\n",
+    "If you have already computed cost-distance surfaces (e.g., to reuse them for multiple corridor pairs), pass them directly with `precomputed=True` to skip the internal `cost_distance` calls."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n = 21\n",
+    "friction_p = make_raster(np.ones((n, n)))\n",
+    "\n",
+    "sa_data = np.zeros((n, n))\n",
+    "sa_data[10, 2] = 1.0\n",
+    "sb_data = np.zeros((n, n))\n",
+    "sb_data[10, 18] = 1.0\n",
+    "\n",
+    "sa_p = make_raster(sa_data)\n",
+    "sb_p = make_raster(sb_data)\n",
+    "\n",
+    "# Compute cost-distance surfaces once\n",
+    "cd_a = cost_distance(sa_p, friction_p)\n",
+    "cd_b = cost_distance(sb_p, friction_p)\n",
+    "\n",
+    "# Reuse for corridor (skips redundant cost_distance calls)\n",
+    "corridor_pre = least_cost_corridor(\n",
+    "    friction_p, cd_a, cd_b, precomputed=True\n",
+    ")\n",
+    "\n",
+    "# Compare with the regular call\n",
+    "corridor_reg = least_cost_corridor(friction_p, sa_p, sb_p)\n",
+    "\n",
+    "diff = np.abs(corridor_pre.values - corridor_reg.values)\n",
+    "print(f\"Max difference: {np.nanmax(diff):.10f} (should be ~0)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-18",
+   "metadata": {},
+   "source": [
+    "## 6. Multi-source pairwise corridors\n",
+    "\n",
+    "With three or more source locations, `least_cost_corridor` can compute corridors for every pair at once. Pass the sources as a list with `pairwise=True`. The result is an `xr.Dataset` with one variable per pair."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-19",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n = 31\n",
+    "friction_m = make_raster(np.ones((n, n)))\n",
+    "\n",
+    "# Three habitat patches\n",
+    "positions = [(5, 5), (5, 25), (25, 15)]\n",
+    "sources = []\n",
+    "for r, c in positions:\n",
+    "    s = np.zeros((n, n))\n",
+    "    s[r, c] = 1.0\n",
+    "    sources.append(make_raster(s))\n",
+    "\n",
+    "corridors = least_cost_corridor(\n",
+    "    friction_m, sources=sources, pairwise=True\n",
+    ")\n",
+    "\n",
+    "print(\"Corridor pairs:\", list(corridors.data_vars))\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 3, figsize=(15, 4))\n",
+    "for ax, name in zip(axes, corridors.data_vars):\n",
+    "    im = ax.imshow(corridors[name].values, cmap='magma', origin='upper')\n",
+    "    ax.set_title(name)\n",
+    "    # Mark source positions\n",
+    "    for r, c in positions:\n",
+    "        ax.plot(c, r, 'w*', markersize=12)\n",
+    "    plt.colorbar(im, ax=ax, shrink=0.8)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-20",
+   "metadata": {},
+   "source": [
+    "Each subplot shows the corridor between one pair of sources (marked with white stars). With uniform friction, corridors follow straight-line paths. With variable friction, each pair would route through different low-cost terrain.\n",
+    "\n",
+    "## Summary\n",
+    "\n",
+    "| Parameter | Effect |\n",
+    "|---|---|\n",
+    "| `friction` | Cost surface (NaN = barrier) |\n",
+    "| `source_a`, `source_b` | Two source rasters |\n",
+    "| `sources` + `pairwise=True` | Compute corridors for all pairs |\n",
+    "| `threshold` | Mask cells beyond this cost deviation |\n",
+    "| `relative=True` | Interpret threshold as a fraction of minimum corridor cost |\n",
+    "| `precomputed=True` | Skip internal cost_distance calls, use pre-computed surfaces |\n",
+    "\n",
+    "**When to use corridor analysis vs pathfinding:**\n",
+    "- Use `a_star_search` when you need a single optimal route (one cell wide).\n",
+    "- Use `least_cost_corridor` when you need a **zone** of low-cost connectivity between two regions.\n",
+    "\n",
+    "### References\n",
+    "- ArcGIS Corridor: https://pro.arcgis.com/en/pro-app/latest/tool-reference/spatial-analyst/corridor.htm\n",
+    "- Beier, P., Majka, D. R., & Spencer, W. D. (2008). Forks in the Road: Choices in Procedures for Designing Wildland Linkages. *Conservation Biology*, 22(4), 836-851."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/xrspatial/__init__.py
+++ b/xrspatial/__init__.py
@@ -1,6 +1,7 @@
 from xrspatial.aspect import aspect  # noqa
 from xrspatial.balanced_allocation import balanced_allocation  # noqa
 from xrspatial.bump import bump  # noqa
+from xrspatial.corridor import least_cost_corridor  # noqa
 from xrspatial.cost_distance import cost_distance  # noqa
 from xrspatial.dasymetric import disaggregate  # noqa
 from xrspatial.dasymetric import pycnophylactic  # noqa

--- a/xrspatial/corridor.py
+++ b/xrspatial/corridor.py
@@ -1,0 +1,192 @@
+"""Least-cost corridor analysis.
+
+Identifies zones of low cumulative traversal cost between two (or more)
+source locations on a friction surface.  Unlike a single-cell path, a
+corridor shows all cells within a cost threshold of the optimal route.
+
+Algorithm
+---------
+1. Compute ``cost_distance(friction, source_a)`` and
+   ``cost_distance(friction, source_b)``.
+2. Sum the two surfaces: ``corridor = cd_a + cd_b``.
+3. Normalize: ``corridor - corridor.min()``.
+4. Optionally threshold to produce a binary corridor mask.
+
+Because the function is pure arithmetic on ``cost_distance`` outputs,
+all four backends (NumPy, CuPy, Dask+NumPy, Dask+CuPy) are supported
+natively with no extra kernel code.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import numpy as np
+import xarray as xr
+
+from xrspatial.cost_distance import cost_distance
+from xrspatial.utils import _validate_raster
+
+
+def _compute_corridor(
+    cd_a: xr.DataArray,
+    cd_b: xr.DataArray,
+    threshold: float | None,
+    relative: bool,
+) -> xr.DataArray:
+    """Sum two cost-distance surfaces, normalize, and optionally threshold."""
+    corridor = cd_a + cd_b
+    corridor_min = float(corridor.min())
+
+    if not np.isfinite(corridor_min):
+        # Sources are mutually unreachable -- return all-NaN.
+        return corridor * np.nan
+
+    normalized = corridor - corridor_min
+
+    if threshold is not None:
+        if relative:
+            cutoff = threshold * corridor_min
+        else:
+            cutoff = threshold
+        normalized = normalized.where(normalized <= cutoff)
+
+    return normalized
+
+
+def least_cost_corridor(
+    friction: xr.DataArray,
+    source_a: xr.DataArray | None = None,
+    source_b: xr.DataArray | None = None,
+    *,
+    sources: list[xr.DataArray] | None = None,
+    pairwise: bool = False,
+    threshold: float | None = None,
+    relative: bool = False,
+    precomputed: bool = False,
+    x: str = "x",
+    y: str = "y",
+    connectivity: int = 8,
+    max_cost: float = np.inf,
+) -> xr.DataArray | xr.Dataset:
+    """Compute a least-cost corridor between two source regions.
+
+    A corridor surface is the sum of two cost-distance fields (one from
+    each source), normalized by the minimum corridor cost.  Cells where
+    the normalized value falls within *threshold* form the corridor.
+
+    Parameters
+    ----------
+    friction : xr.DataArray
+        2-D friction (cost) surface.  Positive finite values are
+        passable; NaN or ``<= 0`` marks barriers.  Ignored when
+        *precomputed* is True.
+    source_a, source_b : xr.DataArray, optional
+        Source rasters identifying start and end regions.  Non-zero
+        finite values mark source cells (same convention as
+        ``cost_distance``).  Required unless *sources* is given.
+        When *precomputed* is True these are treated as pre-computed
+        cost-distance surfaces.
+    sources : list of xr.DataArray, optional
+        Multiple source rasters for pairwise corridor computation.
+        Mutually exclusive with *source_a* / *source_b*.
+    pairwise : bool, default False
+        When True and *sources* has more than two entries, compute
+        corridors for every unique pair and return an ``xr.Dataset``
+        with one variable per pair (named ``corridor_i_j``).
+    threshold : float, optional
+        Cost threshold for masking the corridor.  Cells whose
+        normalized corridor cost exceeds this value are set to NaN.
+    relative : bool, default False
+        If True, *threshold* is a fraction of the minimum corridor
+        cost (e.g. 0.10 means within 10 % of optimal).  If False,
+        *threshold* is in absolute cost units.
+    precomputed : bool, default False
+        If True, *source_a* / *source_b* (or entries in *sources*)
+        are already cost-distance surfaces.  Skips the internal
+        ``cost_distance`` calls.
+    x, y : str
+        Coordinate names forwarded to ``cost_distance``.
+    connectivity : int, default 8
+        Pixel connectivity (4 or 8), forwarded to ``cost_distance``.
+    max_cost : float, default np.inf
+        Maximum cost budget, forwarded to ``cost_distance``.
+
+    Returns
+    -------
+    xr.DataArray or xr.Dataset
+        Normalized corridor surface (float).  Values start at 0 along
+        the optimal corridor and increase with deviation from it.
+        When *threshold* is set, cells beyond the cutoff are NaN.
+        With *pairwise=True* and multiple sources, returns a Dataset
+        keyed by pair indices (``corridor_0_1``, ``corridor_0_2``, ...).
+    """
+    # ------------------------------------------------------------------
+    # Input validation
+    # ------------------------------------------------------------------
+    if sources is not None and (source_a is not None or source_b is not None):
+        raise ValueError(
+            "Provide either (source_a, source_b) or sources, not both"
+        )
+
+    if sources is not None:
+        if len(sources) < 2:
+            raise ValueError("sources must contain at least 2 entries")
+        for i, s in enumerate(sources):
+            _validate_raster(
+                s, func_name="least_cost_corridor", name=f"sources[{i}]"
+            )
+    else:
+        if source_a is None or source_b is None:
+            raise ValueError(
+                "source_a and source_b are required when sources is not given"
+            )
+        _validate_raster(
+            source_a, func_name="least_cost_corridor", name="source_a"
+        )
+        _validate_raster(
+            source_b, func_name="least_cost_corridor", name="source_b"
+        )
+        sources = [source_a, source_b]
+
+    if not precomputed:
+        _validate_raster(
+            friction, func_name="least_cost_corridor", name="friction"
+        )
+
+    if threshold is not None and threshold < 0:
+        raise ValueError("threshold must be non-negative")
+
+    # ------------------------------------------------------------------
+    # Compute cost-distance surfaces (or use precomputed ones)
+    # ------------------------------------------------------------------
+    if precomputed:
+        cd_surfaces = list(sources)
+    else:
+        cd_surfaces = [
+            cost_distance(
+                src, friction,
+                x=x, y=y, connectivity=connectivity, max_cost=max_cost,
+            )
+            for src in sources
+        ]
+
+    # ------------------------------------------------------------------
+    # Two-source case: return a single DataArray
+    # ------------------------------------------------------------------
+    if len(cd_surfaces) == 2 and not pairwise:
+        return _compute_corridor(
+            cd_surfaces[0], cd_surfaces[1], threshold, relative
+        )
+
+    # ------------------------------------------------------------------
+    # Multi-source pairwise: return a Dataset
+    # ------------------------------------------------------------------
+    corridors = {}
+    for i, j in itertools.combinations(range(len(cd_surfaces)), 2):
+        name = f"corridor_{i}_{j}"
+        corridors[name] = _compute_corridor(
+            cd_surfaces[i], cd_surfaces[j], threshold, relative
+        )
+
+    return xr.Dataset(corridors)

--- a/xrspatial/tests/test_corridor.py
+++ b/xrspatial/tests/test_corridor.py
@@ -1,0 +1,376 @@
+"""Tests for xrspatial.corridor.least_cost_corridor."""
+
+try:
+    import dask.array as da
+except ImportError:
+    da = None
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from xrspatial.corridor import least_cost_corridor
+from xrspatial.cost_distance import cost_distance
+from xrspatial.utils import has_cuda_and_cupy
+
+
+def _make_raster(data, backend="numpy", chunks=(3, 3)):
+    """Build a DataArray with y/x coords, optionally dask/cupy-backed."""
+    h, w = data.shape
+    raster = xr.DataArray(
+        data.astype(np.float64),
+        dims=["y", "x"],
+        attrs={"res": (1.0, 1.0)},
+    )
+    raster["y"] = np.arange(h, dtype=np.float64)
+    raster["x"] = np.arange(w, dtype=np.float64)
+    if "dask" in backend and da is not None:
+        raster.data = da.from_array(raster.data, chunks=chunks)
+    if "cupy" in backend and has_cuda_and_cupy():
+        import cupy
+
+        if isinstance(raster.data, da.Array):
+            raster.data = raster.data.map_blocks(cupy.asarray)
+        else:
+            raster.data = cupy.asarray(raster.data)
+    return raster
+
+
+def _compute(arr):
+    """Extract numpy data from DataArray (works for numpy, dask, or cupy)."""
+    if da is not None and isinstance(arr.data, da.Array):
+        val = arr.data.compute()
+        if hasattr(val, "get"):
+            return val.get()
+        return val
+    if hasattr(arr.data, "get"):
+        return arr.data.get()
+    return arr.data
+
+
+# -----------------------------------------------------------------------
+# Basic corridor correctness
+# -----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "backend", ["numpy", "dask+numpy", "cupy", "dask+cupy"]
+)
+def test_basic_corridor_symmetry(backend):
+    """Corridor between two sources on uniform friction is symmetric."""
+    n = 7
+    friction_data = np.ones((n, n))
+
+    src_a = np.zeros((n, n))
+    src_a[3, 0] = 1.0  # left edge
+
+    src_b = np.zeros((n, n))
+    src_b[3, 6] = 1.0  # right edge
+
+    friction = _make_raster(friction_data, backend=backend, chunks=(7, 7))
+    sa = _make_raster(src_a, backend=backend, chunks=(7, 7))
+    sb = _make_raster(src_b, backend=backend, chunks=(7, 7))
+
+    result = least_cost_corridor(friction, sa, sb)
+    out = _compute(result)
+
+    # Minimum corridor cost should be 0 (after normalization)
+    assert np.nanmin(out) == pytest.approx(0.0, abs=1e-5)
+
+    # Corridor should be symmetric about the vertical midline
+    np.testing.assert_allclose(out[:, :3], out[:, -1:-4:-1], atol=1e-5)
+
+
+@pytest.mark.parametrize(
+    "backend", ["numpy", "dask+numpy", "cupy", "dask+cupy"]
+)
+def test_corridor_minimum_on_optimal_path(backend):
+    """Cells on the optimal path between sources have corridor value 0."""
+    n = 5
+    friction_data = np.ones((n, n))
+
+    src_a = np.zeros((n, n))
+    src_a[2, 0] = 1.0
+
+    src_b = np.zeros((n, n))
+    src_b[2, 4] = 1.0
+
+    friction = _make_raster(friction_data, backend=backend, chunks=(5, 5))
+    sa = _make_raster(src_a, backend=backend, chunks=(5, 5))
+    sb = _make_raster(src_b, backend=backend, chunks=(5, 5))
+
+    result = least_cost_corridor(friction, sa, sb)
+    out = _compute(result)
+
+    # The middle row (row 2) should be the optimal path on uniform friction.
+    # All cells on row 2 should have the minimum corridor value (0).
+    for col in range(n):
+        assert out[2, col] == pytest.approx(0.0, abs=1e-5)
+
+
+# -----------------------------------------------------------------------
+# Threshold tests
+# -----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "backend", ["numpy", "dask+numpy", "cupy", "dask+cupy"]
+)
+def test_absolute_threshold(backend):
+    """Absolute threshold masks cells with normalized cost > threshold."""
+    n = 7
+    friction_data = np.ones((n, n))
+
+    src_a = np.zeros((n, n))
+    src_a[3, 0] = 1.0
+
+    src_b = np.zeros((n, n))
+    src_b[3, 6] = 1.0
+
+    friction = _make_raster(friction_data, backend=backend, chunks=(7, 7))
+    sa = _make_raster(src_a, backend=backend, chunks=(7, 7))
+    sb = _make_raster(src_b, backend=backend, chunks=(7, 7))
+
+    result = least_cost_corridor(friction, sa, sb, threshold=0.5)
+    out = _compute(result)
+
+    # Cells with normalized cost > 0.5 should be NaN
+    assert np.all(np.isnan(out) | (out <= 0.5 + 1e-5))
+
+    # The optimal path (row 3) should not be masked
+    for col in range(n):
+        assert np.isfinite(out[3, col])
+
+
+@pytest.mark.parametrize(
+    "backend", ["numpy", "dask+numpy", "cupy", "dask+cupy"]
+)
+def test_relative_threshold(backend):
+    """Relative threshold uses fraction of minimum corridor cost."""
+    n = 7
+    friction_data = np.ones((n, n))
+
+    src_a = np.zeros((n, n))
+    src_a[3, 0] = 1.0
+
+    src_b = np.zeros((n, n))
+    src_b[3, 6] = 1.0
+
+    friction = _make_raster(friction_data, backend=backend, chunks=(7, 7))
+    sa = _make_raster(src_a, backend=backend, chunks=(7, 7))
+    sb = _make_raster(src_b, backend=backend, chunks=(7, 7))
+
+    # No threshold -- get full corridor
+    full = least_cost_corridor(friction, sa, sb)
+    full_out = _compute(full)
+
+    # Relative threshold of 50%
+    result = least_cost_corridor(
+        friction, sa, sb, threshold=0.5, relative=True
+    )
+    out = _compute(result)
+
+    # Count finite cells -- threshold version should have fewer
+    assert np.sum(np.isfinite(out)) < np.sum(np.isfinite(full_out))
+
+    # Optimal path cells should survive
+    for col in range(n):
+        assert np.isfinite(out[3, col])
+
+
+# -----------------------------------------------------------------------
+# Precomputed cost-distance surfaces
+# -----------------------------------------------------------------------
+
+
+def test_precomputed_matches_regular():
+    """Precomputed=True with manual cost_distance matches default path."""
+    n = 7
+    friction_data = np.ones((n, n))
+
+    src_a = np.zeros((n, n))
+    src_a[3, 0] = 1.0
+
+    src_b = np.zeros((n, n))
+    src_b[3, 6] = 1.0
+
+    friction = _make_raster(friction_data)
+    sa = _make_raster(src_a)
+    sb = _make_raster(src_b)
+
+    # Regular path
+    result_regular = least_cost_corridor(friction, sa, sb)
+
+    # Precomputed path
+    cd_a = cost_distance(sa, friction)
+    cd_b = cost_distance(sb, friction)
+    result_precomputed = least_cost_corridor(
+        friction, cd_a, cd_b, precomputed=True
+    )
+
+    np.testing.assert_allclose(
+        _compute(result_regular),
+        _compute(result_precomputed),
+        atol=1e-5,
+    )
+
+
+# -----------------------------------------------------------------------
+# Multi-source pairwise
+# -----------------------------------------------------------------------
+
+
+def test_pairwise_corridor():
+    """Pairwise mode with 3 sources returns Dataset with 3 corridors."""
+    n = 7
+    friction_data = np.ones((n, n))
+
+    sources = []
+    for r, c in [(0, 0), (0, 6), (6, 3)]:
+        s = np.zeros((n, n))
+        s[r, c] = 1.0
+        sources.append(_make_raster(s))
+
+    friction = _make_raster(friction_data)
+
+    result = least_cost_corridor(
+        friction, sources=sources, pairwise=True
+    )
+
+    assert isinstance(result, xr.Dataset)
+    assert set(result.data_vars) == {
+        "corridor_0_1",
+        "corridor_0_2",
+        "corridor_1_2",
+    }
+
+    # Each corridor should have minimum 0
+    for name in result.data_vars:
+        out = _compute(result[name])
+        assert np.nanmin(out) == pytest.approx(0.0, abs=1e-5)
+
+
+def test_pairwise_two_sources_returns_dataset():
+    """Pairwise=True with exactly 2 sources still returns a Dataset."""
+    n = 5
+    friction_data = np.ones((n, n))
+
+    s0 = np.zeros((n, n))
+    s0[0, 0] = 1.0
+    s1 = np.zeros((n, n))
+    s1[4, 4] = 1.0
+
+    friction = _make_raster(friction_data)
+    result = least_cost_corridor(
+        friction,
+        sources=[_make_raster(s0), _make_raster(s1)],
+        pairwise=True,
+    )
+
+    assert isinstance(result, xr.Dataset)
+    assert "corridor_0_1" in result.data_vars
+
+
+# -----------------------------------------------------------------------
+# NaN / barrier handling
+# -----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "backend", ["numpy", "dask+numpy", "cupy", "dask+cupy"]
+)
+def test_barrier_blocks_corridor(backend):
+    """NaN barrier between sources makes certain cells unreachable."""
+    n = 7
+    friction_data = np.ones((n, n))
+    # Wall of NaN except a gap at row 3
+    friction_data[:3, 3] = np.nan
+    friction_data[4:, 3] = np.nan
+
+    src_a = np.zeros((n, n))
+    src_a[3, 0] = 1.0
+
+    src_b = np.zeros((n, n))
+    src_b[3, 6] = 1.0
+
+    friction = _make_raster(friction_data, backend=backend, chunks=(7, 7))
+    sa = _make_raster(src_a, backend=backend, chunks=(7, 7))
+    sb = _make_raster(src_b, backend=backend, chunks=(7, 7))
+
+    result = least_cost_corridor(friction, sa, sb)
+    out = _compute(result)
+
+    # The gap row should still be reachable
+    assert np.isfinite(out[3, 3])
+
+
+@pytest.mark.parametrize(
+    "backend", ["numpy", "dask+numpy", "cupy", "dask+cupy"]
+)
+def test_unreachable_sources(backend):
+    """Full barrier between sources produces all-NaN corridor."""
+    n = 5
+    friction_data = np.ones((n, n))
+    friction_data[:, 2] = np.nan  # impenetrable wall
+
+    src_a = np.zeros((n, n))
+    src_a[2, 0] = 1.0
+
+    src_b = np.zeros((n, n))
+    src_b[2, 4] = 1.0
+
+    friction = _make_raster(friction_data, backend=backend, chunks=(5, 5))
+    sa = _make_raster(src_a, backend=backend, chunks=(5, 5))
+    sb = _make_raster(src_b, backend=backend, chunks=(5, 5))
+
+    result = least_cost_corridor(friction, sa, sb)
+    out = _compute(result)
+
+    assert np.all(np.isnan(out))
+
+
+# -----------------------------------------------------------------------
+# Edge cases and validation
+# -----------------------------------------------------------------------
+
+
+def test_single_cell_raster():
+    """1x1 raster where both sources are the same cell."""
+    friction = _make_raster(np.ones((1, 1)))
+    src = _make_raster(np.ones((1, 1)))
+
+    result = least_cost_corridor(friction, src, src)
+    out = _compute(result)
+
+    assert out[0, 0] == pytest.approx(0.0, abs=1e-5)
+
+
+def test_missing_sources_raises():
+    """Omitting both source_a/source_b and sources raises ValueError."""
+    friction = _make_raster(np.ones((3, 3)))
+    with pytest.raises(ValueError, match="source_a and source_b are required"):
+        least_cost_corridor(friction)
+
+
+def test_both_source_modes_raises():
+    """Providing source_a/source_b AND sources raises ValueError."""
+    friction = _make_raster(np.ones((3, 3)))
+    src = _make_raster(np.ones((3, 3)))
+    with pytest.raises(ValueError, match="not both"):
+        least_cost_corridor(friction, src, src, sources=[src, src])
+
+
+def test_negative_threshold_raises():
+    """Negative threshold raises ValueError."""
+    friction = _make_raster(np.ones((3, 3)))
+    src = _make_raster(np.ones((3, 3)))
+    with pytest.raises(ValueError, match="non-negative"):
+        least_cost_corridor(friction, src, src, threshold=-1.0)
+
+
+def test_single_source_in_list_raises():
+    """sources with fewer than 2 entries raises ValueError."""
+    friction = _make_raster(np.ones((3, 3)))
+    src = _make_raster(np.ones((3, 3)))
+    with pytest.raises(ValueError, match="at least 2"):
+        least_cost_corridor(friction, sources=[src])


### PR DESCRIPTION
## Summary
- Adds `least_cost_corridor()` -- sums two cost-distance surfaces, normalizes by the minimum, and optionally masks by a threshold
- Wraps existing `cost_distance` with no new kernels, so all four backends (NumPy, CuPy, Dask+NumPy, Dask+CuPy) work out of the box
- Supports absolute and relative thresholding, pre-computed cost-distance inputs, and multi-source pairwise mode

## Test plan
- [ ] `pytest xrspatial/tests/test_corridor.py` -- 20 tests: symmetry, optimal-path minimum, absolute/relative thresholds, precomputed surfaces, pairwise mode, barriers, unreachable sources, single-cell input, input validation
- [ ] Parametrized across numpy and dask+numpy backends
- [ ] Run notebook `20_Corridor_Analysis.ipynb` end-to-end

Closes #965