### PR TITLE
Add D-inf and MFD stream ordering and link segmentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,11 @@ In the GIS world, rasters are used for representing continuous phenomena (e.g. e
 | [Watershed](xrspatial/watershed.py) | Labels each cell with the pour point it drains to via D8 flow direction | ✅️ | ✅️ | ✅️ | ✅️ |
 | [Basins](xrspatial/watershed.py) | Delineates drainage basins by labeling each cell with its outlet ID | ✅️ | ✅️ | ✅️ | ✅️ |
 | [Stream Order](xrspatial/stream_order.py) | Assigns Strahler or Shreve stream order to cells in a drainage network | ✅️ | ✅️ | ✅️ | ✅️ |
+| [Stream Order (Dinf)](xrspatial/stream_order_dinf.py) | Strahler/Shreve stream ordering on D-infinity flow direction grids | ✅️ | ✅️ | ✅️ | ✅️ |
+| [Stream Order (MFD)](xrspatial/stream_order_mfd.py) | Strahler/Shreve stream ordering on MFD fraction grids | ✅️ | ✅️ | ✅️ | ✅️ |
 | [Stream Link](xrspatial/stream_link.py) | Assigns unique IDs to each stream segment between junctions | ✅️ | ✅️ | ✅️ | ✅️ |
+| [Stream Link (Dinf)](xrspatial/stream_link_dinf.py) | Stream link segmentation on D-infinity flow direction grids | ✅️ | ✅️ | ✅️ | ✅️ |
+| [Stream Link (MFD)](xrspatial/stream_link_mfd.py) | Stream link segmentation on MFD fraction grids | ✅️ | ✅️ | ✅️ | ✅️ |
 | [Snap Pour Point](xrspatial/snap_pour_point.py) | Snaps pour points to the highest-accumulation cell within a search radius | ✅️ | ✅️ | ✅️ | ✅️ |
 | [Flow Path](xrspatial/flow_path.py) | Traces downstream flow paths from start points through a D8 direction grid | ✅️ | ✅️ | 🔄 | 🔄 |
 | [HAND](xrspatial/hand.py) | Computes Height Above Nearest Drainage by tracing D8 flow to the nearest stream cell | ✅️ | ✅️ | 🔄 | 🔄 |

--- a/docs/source/reference/hydrology.rst
+++ b/docs/source/reference/hydrology.rst
@@ -96,12 +96,40 @@ Stream Link
 
     xrspatial.stream_link.stream_link
 
+Stream Link (D-infinity)
+========================
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.stream_link_dinf.stream_link_dinf
+
+Stream Link (MFD)
+=================
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.stream_link_mfd.stream_link_mfd
+
 Stream Order
 ============
 .. autosummary::
     :toctree: _autosummary
 
     xrspatial.stream_order.stream_order
+
+Stream Order (D-infinity)
+=========================
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.stream_order_dinf.stream_order_dinf
+
+Stream Order (MFD)
+==================
+.. autosummary::
+    :toctree: _autosummary
+
+    xrspatial.stream_order_mfd.stream_order_mfd
 
 Height Above Nearest Drainage (HAND)
 =====================================

--- a/examples/user_guide/25_Stream_Analysis_Dinf_MFD.ipynb
+++ b/examples/user_guide/25_Stream_Analysis_Dinf_MFD.ipynb
@@ -1,0 +1,249 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Stream ordering and link segmentation with D-inf and MFD routing\n",
+    "\n",
+    "xarray-spatial provides stream network analysis (ordering and link segmentation) for three flow routing models:\n",
+    "\n",
+    "- **D8**: single steepest-descent neighbor (existing `stream_order`, `stream_link`)\n",
+    "- **D-infinity**: continuous angle distributing flow between two neighbors (Tarboton 1997)\n",
+    "- **MFD**: flow fractions distributed to all downslope neighbors (Freeman/Quinn)\n",
+    "\n",
+    "This notebook shows how to use the D-inf and MFD variants."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import xarray as xr\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from xrspatial import generate_terrain\n",
+    "from xrspatial import flow_direction, flow_direction_dinf, flow_direction_mfd\n",
+    "from xrspatial import flow_accumulation, flow_accumulation_mfd\n",
+    "from xrspatial import stream_order, stream_link\n",
+    "from xrspatial import stream_order_dinf, stream_link_dinf\n",
+    "from xrspatial import stream_order_mfd, stream_link_mfd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generate synthetic terrain"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "W, H = 400, 400\n",
+    "cvs_x = np.linspace(0, 1000, W)\n",
+    "cvs_y = np.linspace(0, 1000, H)\n",
+    "\n",
+    "terrain = generate_terrain(x_range=(0, 1000), y_range=(0, 1000),\n",
+    "                           width=W, height=H)\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(6, 5))\n",
+    "terrain.plot(ax=ax, cmap='terrain')\n",
+    "ax.set_title('Synthetic elevation')\n",
+    "ax.set_aspect('equal')\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compute flow directions and accumulation\n",
+    "\n",
+    "We compute all three routing models from the same elevation surface."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# D8\n",
+    "fd_d8 = flow_direction(terrain)\n",
+    "fa_d8 = flow_accumulation(fd_d8)\n",
+    "\n",
+    "# D-infinity\n",
+    "fd_dinf = flow_direction_dinf(terrain)\n",
+    "\n",
+    "# MFD\n",
+    "fd_mfd = flow_direction_mfd(terrain)\n",
+    "fa_mfd = flow_accumulation_mfd(fd_mfd)\n",
+    "\n",
+    "print(f'D8 flow dir shape:   {fd_d8.shape}')\n",
+    "print(f'D-inf angles shape:  {fd_dinf.shape}')\n",
+    "print(f'MFD fractions shape: {fd_mfd.shape}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Stream ordering: D8 vs D-inf vs MFD\n",
+    "\n",
+    "We extract stream networks using a threshold and compare Strahler ordering across routing models."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "threshold = 200\n",
+    "\n",
+    "# D8 stream order (uses D8 accumulation)\n",
+    "so_d8 = stream_order(fd_d8, fa_d8, threshold=threshold, method='strahler')\n",
+    "\n",
+    "# D-inf stream order (uses D8 accumulation for thresholding)\n",
+    "so_dinf = stream_order_dinf(fd_dinf, fa_d8, threshold=threshold, method='strahler')\n",
+    "\n",
+    "# MFD stream order (uses MFD accumulation for thresholding)\n",
+    "so_mfd = stream_order_mfd(fd_mfd, fa_mfd, threshold=threshold, method='strahler')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = plt.subplots(1, 3, figsize=(15, 5))\n",
+    "\n",
+    "for ax, data, title in zip(axes,\n",
+    "                            [so_d8, so_dinf, so_mfd],\n",
+    "                            ['D8', 'D-infinity', 'MFD']):\n",
+    "    im = ax.imshow(np.where(np.isnan(data.values), 0, data.values),\n",
+    "                   cmap='Blues', interpolation='nearest',\n",
+    "                   vmin=0, vmax=max(np.nanmax(so_d8.values),\n",
+    "                                    np.nanmax(so_dinf.values),\n",
+    "                                    np.nanmax(so_mfd.values)))\n",
+    "    ax.set_title(f'Strahler order ({title})')\n",
+    "    ax.set_aspect('equal')\n",
+    "\n",
+    "fig.colorbar(im, ax=axes, shrink=0.6, label='Stream order')\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Shreve magnitude comparison"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sv_d8 = stream_order(fd_d8, fa_d8, threshold=threshold, method='shreve')\n",
+    "sv_dinf = stream_order_dinf(fd_dinf, fa_d8, threshold=threshold, method='shreve')\n",
+    "sv_mfd = stream_order_mfd(fd_mfd, fa_mfd, threshold=threshold, method='shreve')\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 3, figsize=(15, 5))\n",
+    "\n",
+    "for ax, data, title in zip(axes,\n",
+    "                            [sv_d8, sv_dinf, sv_mfd],\n",
+    "                            ['D8', 'D-infinity', 'MFD']):\n",
+    "    vals = np.where(np.isnan(data.values), 0, data.values)\n",
+    "    im = ax.imshow(np.log1p(vals), cmap='viridis', interpolation='nearest')\n",
+    "    ax.set_title(f'Shreve magnitude ({title})')\n",
+    "    ax.set_aspect('equal')\n",
+    "\n",
+    "fig.colorbar(im, ax=axes, shrink=0.6, label='log(1 + magnitude)')\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Stream link segmentation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sl_d8 = stream_link(fd_d8, fa_d8, threshold=threshold)\n",
+    "sl_dinf = stream_link_dinf(fd_dinf, fa_d8, threshold=threshold)\n",
+    "sl_mfd = stream_link_mfd(fd_mfd, fa_mfd, threshold=threshold)\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 3, figsize=(15, 5))\n",
+    "\n",
+    "for ax, data, title in zip(axes,\n",
+    "                            [sl_d8, sl_dinf, sl_mfd],\n",
+    "                            ['D8', 'D-infinity', 'MFD']):\n",
+    "    vals = data.values.copy()\n",
+    "    # Color by link ID mod a palette size for visibility\n",
+    "    vals_display = np.where(np.isnan(vals), 0,\n",
+    "                            np.mod(vals, 20) + 1)\n",
+    "    ax.imshow(vals_display, cmap='tab20', interpolation='nearest')\n",
+    "    ax.set_title(f'Stream links ({title})')\n",
+    "    ax.set_aspect('equal')\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Counting stream segments\n",
+    "\n",
+    "Each routing model produces a slightly different stream network topology.\n",
+    "MFD and D-inf can produce more junction points than D8 because flow\n",
+    "splits across multiple neighbors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for label, data in [('D8', sl_d8), ('D-inf', sl_dinf), ('MFD', sl_mfd)]:\n",
+    "    n_links = len(np.unique(data.values[~np.isnan(data.values)]))\n",
+    "    n_stream = int(np.sum(~np.isnan(data.values)))\n",
+    "    print(f'{label:6s}: {n_links:4d} links, {n_stream:6d} stream cells')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/xrspatial/__init__.py
+++ b/xrspatial/__init__.py
@@ -74,7 +74,11 @@ from xrspatial.proximity import proximity  # noqa
 from xrspatial.sink import sink  # noqa
 from xrspatial.snap_pour_point import snap_pour_point  # noqa
 from xrspatial.stream_link import stream_link  # noqa
+from xrspatial.stream_link_dinf import stream_link_dinf  # noqa
+from xrspatial.stream_link_mfd import stream_link_mfd  # noqa
 from xrspatial.stream_order import stream_order  # noqa
+from xrspatial.stream_order_dinf import stream_order_dinf  # noqa
+from xrspatial.stream_order_mfd import stream_order_mfd  # noqa
 from xrspatial.sky_view_factor import sky_view_factor  # noqa
 from xrspatial.slope import slope  # noqa
 from xrspatial.surface_distance import surface_allocation  # noqa

--- a/xrspatial/stream_link_dinf.py
+++ b/xrspatial/stream_link_dinf.py
@@ -1,0 +1,1227 @@
+"""Stream link segmentation for D-infinity flow direction grids.
+
+Assigns a unique positive integer ID to each stream "link" -- the
+contiguous segment of stream cells between junctions, headwaters, and
+outlets.  This is the D-inf counterpart to the D8 ``stream_link`` module.
+
+A **link-start cell** is either a headwater (in-degree 0 among stream
+cells) or a junction (in-degree >= 2).  Each link-start cell gets a
+position-based ID: ``row * width + col + 1``.  Downstream non-junction
+cells inherit their upstream neighbor's link_id via Kahn's BFS.
+
+Because D-inf angles can direct flow to two neighbours (the pair
+bracketing the continuous angle), a cell may have up to two downstream
+neighbours rather than exactly one as in D8.
+
+Algorithm
+---------
+CPU : Kahn's BFS topological sort among stream cells -- O(N_stream).
+GPU : iterative frontier peeling with pull-based kernels.
+Dask: iterative tile sweep with boundary propagation, same pattern
+      as ``stream_link.py``.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import xarray as xr
+from numba import cuda
+
+try:
+    import cupy
+except ImportError:
+    class cupy:  # type: ignore[no-redef]
+        ndarray = False
+
+try:
+    import dask.array as da
+except ImportError:
+    da = None
+
+from xrspatial.utils import (
+    _validate_raster,
+    cuda_args,
+    has_cuda_and_cupy,
+    is_cupy_array,
+    is_dask_cupy,
+    ngjit,
+)
+from xrspatial._boundary_store import BoundaryStore
+from xrspatial.dataset_support import supports_dataset
+from xrspatial.stream_order import _to_numpy_f64
+from xrspatial.stream_order_dinf import (
+    _dinf_downstream,
+    _NB_DY,
+    _NB_DX,
+    _preprocess_stream_tiles_dinf,
+    _make_stream_mask_np_dinf,
+)
+
+
+# =====================================================================
+# CPU kernel
+# =====================================================================
+
+@ngjit
+def _stream_link_dinf_cpu(angles, stream_mask, height, width):
+    """Kahn's BFS link ID assignment among stream cells (D-inf).
+
+    Parameters
+    ----------
+    angles : (H, W) float64 -- D-inf flow direction angles
+    stream_mask : (H, W) int8
+    height, width : int
+
+    Returns
+    -------
+    link_id : (H, W) float64
+    """
+    nb_dy = np.array([0, -1, -1, -1, 0, 1, 1, 1], dtype=np.int64)
+    nb_dx = np.array([1, 1, 0, -1, -1, -1, 0, 1], dtype=np.int64)
+    pi_over_4 = math.pi / 4.0
+
+    link_id = np.empty((height, width), dtype=np.float64)
+    in_degree = np.zeros((height, width), dtype=np.int32)
+
+    # Initialise
+    for r in range(height):
+        for c in range(width):
+            if stream_mask[r, c] == 0:
+                link_id[r, c] = np.nan
+            else:
+                link_id[r, c] = 0.0
+
+    # Compute in-degrees from D-inf angles
+    for r in range(height):
+        for c in range(width):
+            if stream_mask[r, c] == 0:
+                continue
+            theta = angles[r, c]
+            if theta != theta:  # NaN
+                continue
+            if theta < 0.0:  # pit
+                continue
+
+            k = int(theta / pi_over_4)
+            if k >= 8:
+                k = 7
+            k2 = (k + 1) % 8
+            alpha = theta - k * pi_over_4
+            frac1 = (pi_over_4 - alpha) / pi_over_4
+            frac2 = alpha / pi_over_4
+
+            if frac1 > 0.0:
+                nr = r + nb_dy[k]
+                nc = c + nb_dx[k]
+                if 0 <= nr < height and 0 <= nc < width:
+                    if stream_mask[nr, nc] == 1:
+                        in_degree[nr, nc] += 1
+
+            if frac2 > 0.0:
+                nr2 = r + nb_dy[k2]
+                nc2 = c + nb_dx[k2]
+                if 0 <= nr2 < height and 0 <= nc2 < width:
+                    if stream_mask[nr2, nc2] == 1:
+                        in_degree[nr2, nc2] += 1
+
+    # Store original in-degree to identify junctions
+    orig_indeg = np.empty((height, width), dtype=np.int32)
+    for r in range(height):
+        for c in range(width):
+            orig_indeg[r, c] = in_degree[r, c]
+
+    # BFS queue
+    queue_r = np.empty(height * width, dtype=np.int64)
+    queue_c = np.empty(height * width, dtype=np.int64)
+    head = np.int64(0)
+    tail = np.int64(0)
+
+    # Enqueue headwaters (stream cells with in_degree == 0)
+    for r in range(height):
+        for c in range(width):
+            if stream_mask[r, c] == 1 and in_degree[r, c] == 0:
+                link_id[r, c] = float(r * width + c + 1)
+                queue_r[tail] = r
+                queue_c[tail] = c
+                tail += 1
+
+    while head < tail:
+        r = queue_r[head]
+        c = queue_c[head]
+        head += 1
+
+        theta = angles[r, c]
+        if theta != theta:
+            continue
+        if theta < 0.0:
+            continue
+
+        k = int(theta / pi_over_4)
+        if k >= 8:
+            k = 7
+        k2 = (k + 1) % 8
+        alpha = theta - k * pi_over_4
+        frac1 = (pi_over_4 - alpha) / pi_over_4
+        frac2 = alpha / pi_over_4
+
+        # Propagate to neighbor k
+        if frac1 > 0.0:
+            nr = r + nb_dy[k]
+            nc = c + nb_dx[k]
+            if 0 <= nr < height and 0 <= nc < width:
+                if stream_mask[nr, nc] == 1:
+                    if orig_indeg[nr, nc] >= 2:
+                        in_degree[nr, nc] -= 1
+                        if in_degree[nr, nc] == 0:
+                            link_id[nr, nc] = float(nr * width + nc + 1)
+                            queue_r[tail] = nr
+                            queue_c[tail] = nc
+                            tail += 1
+                    else:
+                        if link_id[nr, nc] == 0.0:
+                            link_id[nr, nc] = link_id[r, c]
+                        in_degree[nr, nc] -= 1
+                        if in_degree[nr, nc] == 0:
+                            queue_r[tail] = nr
+                            queue_c[tail] = nc
+                            tail += 1
+
+        # Propagate to neighbor k2
+        if frac2 > 0.0:
+            nr2 = r + nb_dy[k2]
+            nc2 = c + nb_dx[k2]
+            if 0 <= nr2 < height and 0 <= nc2 < width:
+                if stream_mask[nr2, nc2] == 1:
+                    if orig_indeg[nr2, nc2] >= 2:
+                        in_degree[nr2, nc2] -= 1
+                        if in_degree[nr2, nc2] == 0:
+                            link_id[nr2, nc2] = float(
+                                nr2 * width + nc2 + 1)
+                            queue_r[tail] = nr2
+                            queue_c[tail] = nc2
+                            tail += 1
+                    else:
+                        if link_id[nr2, nc2] == 0.0:
+                            link_id[nr2, nc2] = link_id[r, c]
+                        in_degree[nr2, nc2] -= 1
+                        if in_degree[nr2, nc2] == 0:
+                            queue_r[tail] = nr2
+                            queue_c[tail] = nc2
+                            tail += 1
+
+    return link_id
+
+
+# =====================================================================
+# GPU kernels
+# =====================================================================
+
+@cuda.jit(device=True)
+def _dinf_nb_dy(k):
+    if k == 0:
+        return 0
+    elif k == 1:
+        return -1
+    elif k == 2:
+        return -1
+    elif k == 3:
+        return -1
+    elif k == 4:
+        return 0
+    elif k == 5:
+        return 1
+    elif k == 6:
+        return 1
+    else:
+        return 1
+
+
+@cuda.jit(device=True)
+def _dinf_nb_dx(k):
+    if k == 0:
+        return 1
+    elif k == 1:
+        return 1
+    elif k == 2:
+        return 0
+    elif k == 3:
+        return -1
+    elif k == 4:
+        return -1
+    elif k == 5:
+        return -1
+    elif k == 6:
+        return 0
+    else:
+        return 1
+
+
+@cuda.jit(device=True)
+def _dinf_angle_to_k(theta):
+    if theta != theta:  # NaN
+        return -1
+    if theta < 0.0:
+        return -1
+    pi_over_4 = 0.7853981633974483
+    k = int(theta / pi_over_4)
+    if k >= 8:
+        k = 7
+    return k
+
+
+@cuda.jit
+def _stream_link_dinf_init_gpu(angles, stream_mask, in_degree, state,
+                                link_id, H, W):
+    """Initialise GPU arrays and compute in-degrees from D-inf angles."""
+    i, j = cuda.grid(2)
+    if i >= H or j >= W:
+        return
+
+    if stream_mask[i, j] == 0:
+        state[i, j] = 0
+        link_id[i, j] = 0.0
+        return
+
+    state[i, j] = 1
+    link_id[i, j] = 0.0
+
+    theta = angles[i, j]
+    k = _dinf_angle_to_k(theta)
+    if k < 0:
+        return
+
+    pi_over_4 = 0.7853981633974483
+    k2 = (k + 1) % 8
+    alpha = theta - k * pi_over_4
+    frac1 = (pi_over_4 - alpha) / pi_over_4
+    frac2 = alpha / pi_over_4
+
+    if frac1 > 0.0:
+        ni = i + _dinf_nb_dy(k)
+        nj = j + _dinf_nb_dx(k)
+        if 0 <= ni < H and 0 <= nj < W and stream_mask[ni, nj] == 1:
+            cuda.atomic.add(in_degree, (ni, nj), 1)
+
+    if frac2 > 0.0:
+        ni2 = i + _dinf_nb_dy(k2)
+        nj2 = j + _dinf_nb_dx(k2)
+        if 0 <= ni2 < H and 0 <= nj2 < W and stream_mask[ni2, nj2] == 1:
+            cuda.atomic.add(in_degree, (ni2, nj2), 1)
+
+
+@cuda.jit
+def _stream_link_dinf_save_indeg(in_degree, orig_indeg, stream_mask, H, W):
+    """Copy in_degree to orig_indeg after init."""
+    i, j = cuda.grid(2)
+    if i >= H or j >= W:
+        return
+    if stream_mask[i, j] == 1:
+        orig_indeg[i, j] = in_degree[i, j]
+
+
+@cuda.jit
+def _stream_link_dinf_find_ready(in_degree, orig_indeg, state, link_id,
+                                  changed, H, W):
+    """Finalize previous frontier, mark new frontier cells."""
+    i, j = cuda.grid(2)
+    if i >= H or j >= W:
+        return
+
+    if state[i, j] == 2:
+        state[i, j] = 3
+
+    if state[i, j] == 1 and in_degree[i, j] == 0:
+        state[i, j] = 2
+        if orig_indeg[i, j] == 0 or orig_indeg[i, j] >= 2:
+            link_id[i, j] = float(i * W + j + 1)
+        cuda.atomic.add(changed, 0, 1)
+
+
+@cuda.jit
+def _stream_link_dinf_pull(angles, stream_mask, in_degree, orig_indeg,
+                            state, link_id, H, W):
+    """Active cells pull link_id from frontier D-inf neighbours."""
+    i, j = cuda.grid(2)
+    if i >= H or j >= W:
+        return
+    if state[i, j] != 1:
+        return
+
+    pi_over_4 = 0.7853981633974483
+
+    for nb in range(8):
+        dy = _dinf_nb_dy(nb)
+        dx = _dinf_nb_dx(nb)
+        ni = i + dy
+        nj = j + dx
+        if ni < 0 or ni >= H or nj < 0 or nj >= W:
+            continue
+        if state[ni, nj] != 2:
+            continue
+        if stream_mask[ni, nj] == 0:
+            continue
+
+        nb_theta = angles[ni, nj]
+        nb_k = _dinf_angle_to_k(nb_theta)
+        if nb_k < 0:
+            continue
+
+        nb_k2 = (nb_k + 1) % 8
+        nb_alpha = nb_theta - nb_k * pi_over_4
+        nb_frac1 = (pi_over_4 - nb_alpha) / pi_over_4
+        nb_frac2 = nb_alpha / pi_over_4
+
+        flows_to_us = False
+        if nb_frac1 > 0.0:
+            ti = ni + _dinf_nb_dy(nb_k)
+            tj = nj + _dinf_nb_dx(nb_k)
+            if ti == i and tj == j:
+                flows_to_us = True
+
+        if not flows_to_us and nb_frac2 > 0.0:
+            ti2 = ni + _dinf_nb_dy(nb_k2)
+            tj2 = nj + _dinf_nb_dx(nb_k2)
+            if ti2 == i and tj2 == j:
+                flows_to_us = True
+
+        if flows_to_us:
+            in_degree[i, j] -= 1
+            if orig_indeg[i, j] < 2 and link_id[i, j] == 0.0:
+                link_id[i, j] = link_id[ni, nj]
+
+
+def _stream_link_dinf_cupy(angles_data, stream_mask_data):
+    """GPU driver for D-inf stream link computation."""
+    import cupy as cp
+
+    H, W = angles_data.shape
+    angles_f64 = angles_data.astype(cp.float64)
+    stream_mask_i8 = stream_mask_data.astype(cp.int8)
+
+    in_degree = cp.zeros((H, W), dtype=cp.int32)
+    orig_indeg = cp.zeros((H, W), dtype=cp.int32)
+    state = cp.zeros((H, W), dtype=cp.int32)
+    link_id = cp.zeros((H, W), dtype=cp.float64)
+    changed = cp.zeros(1, dtype=cp.int32)
+
+    griddim, blockdim = cuda_args((H, W))
+
+    _stream_link_dinf_init_gpu[griddim, blockdim](
+        angles_f64, stream_mask_i8, in_degree, state, link_id, H, W)
+
+    _stream_link_dinf_save_indeg[griddim, blockdim](
+        in_degree, orig_indeg, stream_mask_i8, H, W)
+
+    max_iter = H * W
+    for _ in range(max_iter):
+        changed[0] = 0
+        _stream_link_dinf_find_ready[griddim, blockdim](
+            in_degree, orig_indeg, state, link_id, changed, H, W)
+
+        if int(changed[0]) == 0:
+            break
+
+        _stream_link_dinf_pull[griddim, blockdim](
+            angles_f64, stream_mask_i8, in_degree, orig_indeg,
+            state, link_id, H, W)
+
+    link_id = cp.where(stream_mask_i8 == 0, cp.nan, link_id)
+    return link_id
+
+
+# =====================================================================
+# GPU tile kernel for dask+cupy
+# =====================================================================
+
+@cuda.jit
+def _stream_link_dinf_find_ready_tile(in_degree, orig_indeg, state, link_id,
+                                       changed, H, W,
+                                       row_off, col_off, total_w):
+    """Tile-aware find_ready: uses global coordinates for link IDs."""
+    i, j = cuda.grid(2)
+    if i >= H or j >= W:
+        return
+
+    if state[i, j] == 2:
+        state[i, j] = 3
+
+    if state[i, j] == 1 and in_degree[i, j] == 0:
+        state[i, j] = 2
+        if orig_indeg[i, j] == 0 or orig_indeg[i, j] >= 2:
+            gi = row_off + i
+            gj = col_off + j
+            link_id[i, j] = float(gi * total_w + gj + 1)
+        cuda.atomic.add(changed, 0, 1)
+
+
+def _stream_link_dinf_tile_cupy(angles_data, stream_mask_data,
+                                 seed_id_top, seed_id_bottom,
+                                 seed_id_left, seed_id_right,
+                                 seed_ext_top, seed_ext_bottom,
+                                 seed_ext_left, seed_ext_right,
+                                 row_offset, col_offset, total_width):
+    """GPU seeded D-inf stream link for a single tile."""
+    import cupy as cp
+
+    H, W = angles_data.shape
+    angles_f64 = angles_data.astype(cp.float64)
+    stream_mask_i8 = stream_mask_data.astype(cp.int8)
+
+    in_degree = cp.zeros((H, W), dtype=cp.int32)
+    orig_indeg = cp.zeros((H, W), dtype=cp.int32)
+    state = cp.zeros((H, W), dtype=cp.int32)
+    link_id = cp.zeros((H, W), dtype=cp.float64)
+    changed = cp.zeros(1, dtype=cp.int32)
+
+    griddim, blockdim = cuda_args((H, W))
+
+    _stream_link_dinf_init_gpu[griddim, blockdim](
+        angles_f64, stream_mask_i8, in_degree, state, link_id, H, W)
+
+    _stream_link_dinf_save_indeg[griddim, blockdim](
+        in_degree, orig_indeg, stream_mask_i8, H, W)
+
+    # Add external in-degree counts to orig_indeg (for junction detection)
+    for r_idx, ext in [
+        ((0, slice(None)), seed_ext_top),
+        ((H - 1, slice(None)), seed_ext_bottom),
+        ((slice(None), 0), seed_ext_left),
+        ((slice(None), W - 1), seed_ext_right),
+    ]:
+        ext_cp = cp.asarray(ext).astype(cp.int32)
+        is_stream = stream_mask_i8[r_idx] == 1
+        orig_indeg[r_idx] += cp.where(is_stream, ext_cp, 0)
+
+    # Pre-set link_ids for non-junction boundary cells with seed values
+    for r_idx, s_id in [
+        ((0, slice(None)), seed_id_top),
+        ((H - 1, slice(None)), seed_id_bottom),
+        ((slice(None), 0), seed_id_left),
+        ((slice(None), W - 1), seed_id_right),
+    ]:
+        sid_cp = cp.asarray(s_id)
+        is_stream = stream_mask_i8[r_idx] == 1
+        non_junction = orig_indeg[r_idx] < 2
+        has_seed = sid_cp > 0
+        mask = is_stream & non_junction & has_seed
+        link_id[r_idx] = cp.where(mask, sid_cp, link_id[r_idx])
+
+    max_iter = H * W
+    for _ in range(max_iter):
+        changed[0] = 0
+        _stream_link_dinf_find_ready_tile[griddim, blockdim](
+            in_degree, orig_indeg, state, link_id, changed,
+            H, W, row_offset, col_offset, total_width)
+
+        if int(changed[0]) == 0:
+            break
+
+        _stream_link_dinf_pull[griddim, blockdim](
+            angles_f64, stream_mask_i8, in_degree, orig_indeg,
+            state, link_id, H, W)
+
+    link_id = cp.where(stream_mask_i8 == 0, cp.nan, link_id)
+    return link_id
+
+
+# =====================================================================
+# CPU tile kernel for dask
+# =====================================================================
+
+@ngjit
+def _stream_link_dinf_tile_kernel(angles, stream_mask, h, w,
+                                   seed_id_top, seed_id_bottom,
+                                   seed_id_left, seed_id_right,
+                                   seed_ext_top, seed_ext_bottom,
+                                   seed_ext_left, seed_ext_right,
+                                   row_offset, col_offset, total_width):
+    """Seeded BFS link assignment for a single D-inf tile.
+
+    Parameters
+    ----------
+    angles : (h, w) float64 -- D-inf flow direction angles for this tile
+    stream_mask : (h, w) int8
+    seed_id_*  : link_id values flowing in from neighbouring tiles.
+    seed_ext_* : count of external stream cells flowing into each
+                 boundary cell (to compute correct orig_indeg).
+    row_offset, col_offset : global pixel offsets of this tile.
+    total_width : total number of columns in the full raster.
+    """
+    nb_dy = np.array([0, -1, -1, -1, 0, 1, 1, 1], dtype=np.int64)
+    nb_dx = np.array([1, 1, 0, -1, -1, -1, 0, 1], dtype=np.int64)
+    pi_over_4 = math.pi / 4.0
+
+    link_id = np.empty((h, w), dtype=np.float64)
+    in_degree = np.zeros((h, w), dtype=np.int32)
+
+    # Initialise
+    for r in range(h):
+        for c in range(w):
+            if stream_mask[r, c] == 0:
+                link_id[r, c] = np.nan
+            else:
+                link_id[r, c] = 0.0
+
+    # Compute within-tile in-degrees
+    for r in range(h):
+        for c in range(w):
+            if stream_mask[r, c] == 0:
+                continue
+            theta = angles[r, c]
+            if theta != theta:
+                continue
+            if theta < 0.0:
+                continue
+
+            k = int(theta / pi_over_4)
+            if k >= 8:
+                k = 7
+            k2 = (k + 1) % 8
+            alpha = theta - k * pi_over_4
+            frac1 = (pi_over_4 - alpha) / pi_over_4
+            frac2 = alpha / pi_over_4
+
+            if frac1 > 0.0:
+                nr = r + nb_dy[k]
+                nc = c + nb_dx[k]
+                if 0 <= nr < h and 0 <= nc < w:
+                    if stream_mask[nr, nc] == 1:
+                        in_degree[nr, nc] += 1
+
+            if frac2 > 0.0:
+                nr2 = r + nb_dy[k2]
+                nc2 = c + nb_dx[k2]
+                if 0 <= nr2 < h and 0 <= nc2 < w:
+                    if stream_mask[nr2, nc2] == 1:
+                        in_degree[nr2, nc2] += 1
+
+    # orig_indeg = within-tile + external (for junction detection only)
+    orig_indeg = np.empty((h, w), dtype=np.int32)
+    for r in range(h):
+        for c in range(w):
+            orig_indeg[r, c] = in_degree[r, c]
+
+    for c in range(w):
+        if stream_mask[0, c] == 1:
+            orig_indeg[0, c] += int(seed_ext_top[c])
+        if stream_mask[h - 1, c] == 1:
+            orig_indeg[h - 1, c] += int(seed_ext_bottom[c])
+    for r in range(h):
+        if stream_mask[r, 0] == 1:
+            orig_indeg[r, 0] += int(seed_ext_left[r])
+        if stream_mask[r, w - 1] == 1:
+            orig_indeg[r, w - 1] += int(seed_ext_right[r])
+
+    # BFS queue
+    queue_r = np.empty(h * w, dtype=np.int64)
+    queue_c = np.empty(h * w, dtype=np.int64)
+    head = np.int64(0)
+    tail = np.int64(0)
+
+    # Assign initial link_ids and enqueue cells with in_degree == 0
+    for r in range(h):
+        for c in range(w):
+            if stream_mask[r, c] != 1:
+                continue
+            if in_degree[r, c] != 0:
+                continue
+            if orig_indeg[r, c] == 0 or orig_indeg[r, c] >= 2:
+                gr = row_offset + r
+                gc = col_offset + c
+                link_id[r, c] = float(gr * total_width + gc + 1)
+            queue_r[tail] = r
+            queue_c[tail] = c
+            tail += 1
+
+    # Seed non-junction, non-headwater boundary cells
+    for c in range(w):
+        if stream_mask[0, c] == 1 and seed_id_top[c] > 0:
+            if orig_indeg[0, c] < 2:
+                link_id[0, c] = seed_id_top[c]
+        if stream_mask[h - 1, c] == 1 and seed_id_bottom[c] > 0:
+            if orig_indeg[h - 1, c] < 2:
+                link_id[h - 1, c] = seed_id_bottom[c]
+    for r in range(h):
+        if stream_mask[r, 0] == 1 and seed_id_left[r] > 0:
+            if orig_indeg[r, 0] < 2:
+                link_id[r, 0] = seed_id_left[r]
+        if stream_mask[r, w - 1] == 1 and seed_id_right[r] > 0:
+            if orig_indeg[r, w - 1] < 2:
+                link_id[r, w - 1] = seed_id_right[r]
+
+    while head < tail:
+        r = queue_r[head]
+        c = queue_c[head]
+        head += 1
+
+        theta = angles[r, c]
+        if theta != theta:
+            continue
+        if theta < 0.0:
+            continue
+
+        k = int(theta / pi_over_4)
+        if k >= 8:
+            k = 7
+        k2 = (k + 1) % 8
+        alpha = theta - k * pi_over_4
+        frac1 = (pi_over_4 - alpha) / pi_over_4
+        frac2 = alpha / pi_over_4
+
+        if frac1 > 0.0:
+            nr = r + nb_dy[k]
+            nc = c + nb_dx[k]
+            if 0 <= nr < h and 0 <= nc < w:
+                if stream_mask[nr, nc] == 1:
+                    if orig_indeg[nr, nc] >= 2:
+                        in_degree[nr, nc] -= 1
+                        if in_degree[nr, nc] == 0:
+                            gnr = row_offset + nr
+                            gnc = col_offset + nc
+                            link_id[nr, nc] = float(
+                                gnr * total_width + gnc + 1)
+                            queue_r[tail] = nr
+                            queue_c[tail] = nc
+                            tail += 1
+                    else:
+                        if link_id[nr, nc] == 0.0:
+                            link_id[nr, nc] = link_id[r, c]
+                        in_degree[nr, nc] -= 1
+                        if in_degree[nr, nc] == 0:
+                            queue_r[tail] = nr
+                            queue_c[tail] = nc
+                            tail += 1
+
+        if frac2 > 0.0:
+            nr2 = r + nb_dy[k2]
+            nc2 = c + nb_dx[k2]
+            if 0 <= nr2 < h and 0 <= nc2 < w:
+                if stream_mask[nr2, nc2] == 1:
+                    if orig_indeg[nr2, nc2] >= 2:
+                        in_degree[nr2, nc2] -= 1
+                        if in_degree[nr2, nc2] == 0:
+                            gnr2 = row_offset + nr2
+                            gnc2 = col_offset + nc2
+                            link_id[nr2, nc2] = float(
+                                gnr2 * total_width + gnc2 + 1)
+                            queue_r[tail] = nr2
+                            queue_c[tail] = nc2
+                            tail += 1
+                    else:
+                        if link_id[nr2, nc2] == 0.0:
+                            link_id[nr2, nc2] = link_id[r, c]
+                        in_degree[nr2, nc2] -= 1
+                        if in_degree[nr2, nc2] == 0:
+                            queue_r[tail] = nr2
+                            queue_c[tail] = nc2
+                            tail += 1
+
+    return link_id
+
+
+# =====================================================================
+# Dask seed computation
+# =====================================================================
+
+def _compute_link_seeds_dinf(iy, ix, boundaries, flow_bdry, mask_bdry,
+                              chunks_y, chunks_x, n_tile_y, n_tile_x):
+    """Compute seed arrays for tile (iy, ix) from neighbour boundaries.
+
+    Returns (seed_id_top, seed_id_bottom, seed_id_left, seed_id_right,
+             seed_ext_top, seed_ext_bottom, seed_ext_left, seed_ext_right).
+
+    seed_id_*  : link_id propagated from the neighbouring tile.
+    seed_ext_* : count of external stream cells flowing into each
+                 boundary cell (needed to compute correct orig_indeg).
+    """
+    nb_dy = _NB_DY
+    nb_dx = _NB_DX
+
+    tile_h = chunks_y[iy]
+    tile_w = chunks_x[ix]
+
+    seed_id_top = np.zeros(tile_w, dtype=np.float64)
+    seed_id_bottom = np.zeros(tile_w, dtype=np.float64)
+    seed_id_left = np.zeros(tile_h, dtype=np.float64)
+    seed_id_right = np.zeros(tile_h, dtype=np.float64)
+
+    seed_ext_top = np.zeros(tile_w, dtype=np.float64)
+    seed_ext_bottom = np.zeros(tile_w, dtype=np.float64)
+    seed_ext_left = np.zeros(tile_h, dtype=np.float64)
+    seed_ext_right = np.zeros(tile_h, dtype=np.float64)
+
+    # Top edge: bottom row of tile above
+    if iy > 0:
+        nb_fdir = flow_bdry.get('bottom', iy - 1, ix)
+        nb_mask = mask_bdry.get('bottom', iy - 1, ix)
+        nb_link = boundaries.get('bottom', iy - 1, ix)
+        w = len(nb_fdir)
+        for j in range(w):
+            if nb_mask[j] == 0:
+                continue
+            theta = nb_fdir[j]
+            if theta != theta or theta < 0.0:
+                continue
+            k1, f1, k2, f2 = _dinf_downstream(theta)
+            if k1 < 0:
+                continue
+            for kk, frac in [(k1, f1), (k2, f2)]:
+                if frac <= 0.0:
+                    continue
+                dy = int(nb_dy[kk])
+                dx = int(nb_dx[kk])
+                if dy == 1:  # flows south into our tile
+                    tc = j + dx
+                    if 0 <= tc < tile_w:
+                        seed_ext_top[tc] += 1.0
+                        lid = nb_link[j]
+                        if lid > 0 and (seed_id_top[tc] == 0
+                                        or lid < seed_id_top[tc]):
+                            seed_id_top[tc] = lid
+
+    # Bottom edge: top row of tile below
+    if iy < n_tile_y - 1:
+        nb_fdir = flow_bdry.get('top', iy + 1, ix)
+        nb_mask = mask_bdry.get('top', iy + 1, ix)
+        nb_link = boundaries.get('top', iy + 1, ix)
+        w = len(nb_fdir)
+        for j in range(w):
+            if nb_mask[j] == 0:
+                continue
+            theta = nb_fdir[j]
+            if theta != theta or theta < 0.0:
+                continue
+            k1, f1, k2, f2 = _dinf_downstream(theta)
+            if k1 < 0:
+                continue
+            for kk, frac in [(k1, f1), (k2, f2)]:
+                if frac <= 0.0:
+                    continue
+                dy = int(nb_dy[kk])
+                dx = int(nb_dx[kk])
+                if dy == -1:  # flows north into our tile
+                    tc = j + dx
+                    if 0 <= tc < tile_w:
+                        seed_ext_bottom[tc] += 1.0
+                        lid = nb_link[j]
+                        if lid > 0 and (seed_id_bottom[tc] == 0
+                                        or lid < seed_id_bottom[tc]):
+                            seed_id_bottom[tc] = lid
+
+    # Left edge: right column of tile to the left
+    if ix > 0:
+        nb_fdir = flow_bdry.get('right', iy, ix - 1)
+        nb_mask = mask_bdry.get('right', iy, ix - 1)
+        nb_link = boundaries.get('right', iy, ix - 1)
+        h = len(nb_fdir)
+        for i in range(h):
+            if nb_mask[i] == 0:
+                continue
+            theta = nb_fdir[i]
+            if theta != theta or theta < 0.0:
+                continue
+            k1, f1, k2, f2 = _dinf_downstream(theta)
+            if k1 < 0:
+                continue
+            for kk, frac in [(k1, f1), (k2, f2)]:
+                if frac <= 0.0:
+                    continue
+                dy = int(nb_dy[kk])
+                dx = int(nb_dx[kk])
+                if dx == 1:  # flows east into our tile
+                    tr = i + dy
+                    if 0 <= tr < tile_h:
+                        seed_ext_left[tr] += 1.0
+                        lid = nb_link[i]
+                        if lid > 0 and (seed_id_left[tr] == 0
+                                        or lid < seed_id_left[tr]):
+                            seed_id_left[tr] = lid
+
+    # Right edge: left column of tile to the right
+    if ix < n_tile_x - 1:
+        nb_fdir = flow_bdry.get('left', iy, ix + 1)
+        nb_mask = mask_bdry.get('left', iy, ix + 1)
+        nb_link = boundaries.get('left', iy, ix + 1)
+        h = len(nb_fdir)
+        for i in range(h):
+            if nb_mask[i] == 0:
+                continue
+            theta = nb_fdir[i]
+            if theta != theta or theta < 0.0:
+                continue
+            k1, f1, k2, f2 = _dinf_downstream(theta)
+            if k1 < 0:
+                continue
+            for kk, frac in [(k1, f1), (k2, f2)]:
+                if frac <= 0.0:
+                    continue
+                dy = int(nb_dy[kk])
+                dx = int(nb_dx[kk])
+                if dx == -1:  # flows west into our tile
+                    tr = i + dy
+                    if 0 <= tr < tile_h:
+                        seed_ext_right[tr] += 1.0
+                        lid = nb_link[i]
+                        if lid > 0 and (seed_id_right[tr] == 0
+                                        or lid < seed_id_right[tr]):
+                            seed_id_right[tr] = lid
+
+    # Corner seeds from diagonal neighbour tiles
+    def _corner_link(nb_side, nb_iy, nb_ix, nb_idx,
+                     required_dy, required_dx,
+                     s_id, s_ext, target):
+        fdir = flow_bdry.get(nb_side, nb_iy, nb_ix)[nb_idx]
+        mask = mask_bdry.get(nb_side, nb_iy, nb_ix)[nb_idx]
+        if mask == 0:
+            return
+        if fdir != fdir or fdir < 0.0:
+            return
+        k1, f1, k2, f2 = _dinf_downstream(fdir)
+        if k1 < 0:
+            return
+        for kk, frac in [(k1, f1), (k2, f2)]:
+            if frac <= 0.0:
+                continue
+            dy = int(nb_dy[kk])
+            dx = int(nb_dx[kk])
+            if dy == required_dy and dx == required_dx:
+                s_ext[target] += 1.0
+                lid = float(boundaries.get(nb_side, nb_iy, nb_ix)[nb_idx])
+                if lid > 0 and (s_id[target] == 0
+                                or lid < s_id[target]):
+                    s_id[target] = lid
+
+    # Top-left corner: bottom-right cell of (iy-1, ix-1)
+    if iy > 0 and ix > 0:
+        _corner_link('bottom', iy - 1, ix - 1, -1,
+                     1, 1, seed_id_top, seed_ext_top, 0)
+    # Top-right corner: bottom-left cell of (iy-1, ix+1)
+    if iy > 0 and ix < n_tile_x - 1:
+        _corner_link('bottom', iy - 1, ix + 1, 0,
+                     1, -1, seed_id_top, seed_ext_top, tile_w - 1)
+    # Bottom-left corner: top-right cell of (iy+1, ix-1)
+    if iy < n_tile_y - 1 and ix > 0:
+        _corner_link('top', iy + 1, ix - 1, -1,
+                     -1, 1, seed_id_bottom, seed_ext_bottom, 0)
+    # Bottom-right corner: top-left cell of (iy+1, ix+1)
+    if iy < n_tile_y - 1 and ix < n_tile_x - 1:
+        _corner_link('top', iy + 1, ix + 1, 0,
+                     -1, -1, seed_id_bottom, seed_ext_bottom, tile_w - 1)
+
+    return (seed_id_top, seed_id_bottom, seed_id_left, seed_id_right,
+            seed_ext_top, seed_ext_bottom, seed_ext_left, seed_ext_right)
+
+
+# =====================================================================
+# Dask iterative tile sweep
+# =====================================================================
+
+def _process_link_tile_dinf(iy, ix, flow_dir_da, accum_da, threshold,
+                             boundaries, flow_bdry, mask_bdry,
+                             chunks_y, chunks_x, n_tile_y, n_tile_x,
+                             row_offsets, col_offsets, total_width):
+    """Run seeded BFS on one D-inf tile; update boundary stores."""
+    fd_chunk = np.asarray(
+        flow_dir_da.blocks[iy, ix].compute(), dtype=np.float64)
+    ac_chunk = np.asarray(
+        accum_da.blocks[iy, ix].compute(), dtype=np.float64)
+    sm = _make_stream_mask_np_dinf(ac_chunk, fd_chunk, threshold)
+    h, w = fd_chunk.shape
+
+    seeds = _compute_link_seeds_dinf(
+        iy, ix, boundaries, flow_bdry, mask_bdry,
+        chunks_y, chunks_x, n_tile_y, n_tile_x)
+
+    link = _stream_link_dinf_tile_kernel(
+        fd_chunk, sm, h, w, *seeds,
+        row_offsets[iy], col_offsets[ix], total_width)
+
+    change = 0.0
+    for side, strip in [('top', link[0, :]),
+                        ('bottom', link[-1, :]),
+                        ('left', link[:, 0]),
+                        ('right', link[:, -1])]:
+        new_vals = strip.copy()
+        new_vals = np.where(np.isnan(new_vals), 0.0, new_vals)
+        old = boundaries.get(side, iy, ix).copy()
+        with np.errstate(invalid='ignore'):
+            diff = np.abs(new_vals - old)
+        diff = np.where(np.isnan(diff), 0.0, diff)
+        m = float(np.max(diff))
+        if m > change:
+            change = m
+        boundaries.set(side, iy, ix, new_vals)
+
+    return change
+
+
+def _stream_link_dinf_dask(flow_dir_da, accum_da, threshold):
+    """Iterative boundary-propagation for D-inf dask arrays."""
+    chunks_y = flow_dir_da.chunks[0]
+    chunks_x = flow_dir_da.chunks[1]
+    n_tile_y = len(chunks_y)
+    n_tile_x = len(chunks_x)
+    total_width = sum(chunks_x)
+
+    row_offsets = np.zeros(n_tile_y, dtype=np.int64)
+    col_offsets = np.zeros(n_tile_x, dtype=np.int64)
+    if n_tile_y > 1:
+        np.cumsum(chunks_y[:-1], out=row_offsets[1:])
+    if n_tile_x > 1:
+        np.cumsum(chunks_x[:-1], out=col_offsets[1:])
+
+    flow_bdry, mask_bdry = _preprocess_stream_tiles_dinf(
+        flow_dir_da, accum_da, threshold, chunks_y, chunks_x)
+    flow_bdry = flow_bdry.snapshot()
+    mask_bdry = mask_bdry.snapshot()
+
+    boundaries = BoundaryStore(chunks_y, chunks_x, fill_value=0.0)
+
+    max_iterations = max(n_tile_y, n_tile_x) + 10
+    for _ in range(max_iterations):
+        max_change = 0.0
+        for iy in range(n_tile_y):
+            for ix in range(n_tile_x):
+                c = _process_link_tile_dinf(
+                    iy, ix, flow_dir_da, accum_da, threshold,
+                    boundaries, flow_bdry, mask_bdry,
+                    chunks_y, chunks_x, n_tile_y, n_tile_x,
+                    row_offsets, col_offsets, total_width)
+                if c > max_change:
+                    max_change = c
+        for iy in reversed(range(n_tile_y)):
+            for ix in reversed(range(n_tile_x)):
+                c = _process_link_tile_dinf(
+                    iy, ix, flow_dir_da, accum_da, threshold,
+                    boundaries, flow_bdry, mask_bdry,
+                    chunks_y, chunks_x, n_tile_y, n_tile_x,
+                    row_offsets, col_offsets, total_width)
+                if c > max_change:
+                    max_change = c
+        if max_change == 0.0:
+            break
+
+    _boundaries = boundaries.snapshot()
+    _flow_bdry = flow_bdry
+    _mask_bdry = mask_bdry
+    _threshold = threshold
+
+    def _tile_fn(block, accum_block, block_info=None):
+        if block_info is None or 0 not in block_info:
+            return np.full(block.shape, np.nan, dtype=np.float64)
+        iy, ix = block_info[0]['chunk-location']
+        fd = np.asarray(block, dtype=np.float64)
+        ac = np.asarray(accum_block, dtype=np.float64)
+        sm = _make_stream_mask_np_dinf(ac, fd, _threshold)
+        h, w = fd.shape
+        seeds = _compute_link_seeds_dinf(
+            iy, ix, _boundaries, _flow_bdry, _mask_bdry,
+            chunks_y, chunks_x, n_tile_y, n_tile_x)
+        return _stream_link_dinf_tile_kernel(
+            fd, sm, h, w, *seeds,
+            row_offsets[iy], col_offsets[ix], total_width)
+
+    return da.map_blocks(
+        _tile_fn, flow_dir_da, accum_da,
+        dtype=np.float64, meta=np.array((), dtype=np.float64))
+
+
+# =====================================================================
+# Dask + CuPy
+# =====================================================================
+
+def _process_link_tile_dinf_cupy(iy, ix, flow_dir_da, accum_da, threshold,
+                                  boundaries, flow_bdry, mask_bdry,
+                                  chunks_y, chunks_x, n_tile_y, n_tile_x,
+                                  row_offsets, col_offsets, total_width):
+    """Run seeded GPU D-inf stream link on one tile; update boundaries."""
+    import cupy as cp
+
+    fd_chunk = cp.asarray(
+        flow_dir_da.blocks[iy, ix].compute(), dtype=cp.float64)
+    ac_chunk = _to_numpy_f64(accum_da.blocks[iy, ix].compute())
+    fd_np = fd_chunk.get()
+    sm_np = _make_stream_mask_np_dinf(ac_chunk, fd_np, threshold)
+    sm_cp = cp.asarray(sm_np)
+
+    seeds = _compute_link_seeds_dinf(
+        iy, ix, boundaries, flow_bdry, mask_bdry,
+        chunks_y, chunks_x, n_tile_y, n_tile_x)
+
+    link = _stream_link_dinf_tile_cupy(
+        fd_chunk, sm_cp, *seeds,
+        row_offsets[iy], col_offsets[ix], total_width)
+
+    change = 0.0
+    for side, strip_cp in [('top', link[0, :]),
+                           ('bottom', link[-1, :]),
+                           ('left', link[:, 0]),
+                           ('right', link[:, -1])]:
+        new_vals = strip_cp.get().copy()
+        new_vals = np.where(np.isnan(new_vals), 0.0, new_vals)
+        old = boundaries.get(side, iy, ix).copy()
+        with np.errstate(invalid='ignore'):
+            diff = np.abs(new_vals - old)
+        diff = np.where(np.isnan(diff), 0.0, diff)
+        m = float(np.max(diff))
+        if m > change:
+            change = m
+        boundaries.set(side, iy, ix, new_vals)
+
+    return change
+
+
+def _stream_link_dinf_dask_cupy(flow_dir_da, accum_da, threshold):
+    """Dask+CuPy: native GPU processing per tile for D-inf stream link."""
+    import cupy as cp
+
+    chunks_y = flow_dir_da.chunks[0]
+    chunks_x = flow_dir_da.chunks[1]
+    n_tile_y = len(chunks_y)
+    n_tile_x = len(chunks_x)
+    total_width = sum(chunks_x)
+
+    row_offsets = np.zeros(n_tile_y, dtype=np.int64)
+    col_offsets = np.zeros(n_tile_x, dtype=np.int64)
+    if n_tile_y > 1:
+        np.cumsum(chunks_y[:-1], out=row_offsets[1:])
+    if n_tile_x > 1:
+        np.cumsum(chunks_x[:-1], out=col_offsets[1:])
+
+    flow_bdry, mask_bdry = _preprocess_stream_tiles_dinf(
+        flow_dir_da, accum_da, threshold, chunks_y, chunks_x)
+    flow_bdry = flow_bdry.snapshot()
+    mask_bdry = mask_bdry.snapshot()
+
+    boundaries = BoundaryStore(chunks_y, chunks_x, fill_value=0.0)
+
+    max_iterations = max(n_tile_y, n_tile_x) + 10
+    for _ in range(max_iterations):
+        max_change = 0.0
+        for iy in range(n_tile_y):
+            for ix in range(n_tile_x):
+                c = _process_link_tile_dinf_cupy(
+                    iy, ix, flow_dir_da, accum_da, threshold,
+                    boundaries, flow_bdry, mask_bdry,
+                    chunks_y, chunks_x, n_tile_y, n_tile_x,
+                    row_offsets, col_offsets, total_width)
+                if c > max_change:
+                    max_change = c
+        for iy in reversed(range(n_tile_y)):
+            for ix in reversed(range(n_tile_x)):
+                c = _process_link_tile_dinf_cupy(
+                    iy, ix, flow_dir_da, accum_da, threshold,
+                    boundaries, flow_bdry, mask_bdry,
+                    chunks_y, chunks_x, n_tile_y, n_tile_x,
+                    row_offsets, col_offsets, total_width)
+                if c > max_change:
+                    max_change = c
+        if max_change == 0.0:
+            break
+
+    _boundaries = boundaries.snapshot()
+
+    def _tile_fn(block, accum_block, block_info=None):
+        if block_info is None or 0 not in block_info:
+            return cp.full(block.shape, cp.nan, dtype=cp.float64)
+        iy, ix = block_info[0]['chunk-location']
+        fd = cp.asarray(block, dtype=cp.float64)
+        ac_np = _to_numpy_f64(accum_block)
+        fd_np = fd.get()
+        sm = cp.asarray(_make_stream_mask_np_dinf(ac_np, fd_np, threshold))
+        seeds = _compute_link_seeds_dinf(
+            iy, ix, _boundaries, flow_bdry, mask_bdry,
+            chunks_y, chunks_x, n_tile_y, n_tile_x)
+        return _stream_link_dinf_tile_cupy(
+            fd, sm, *seeds,
+            row_offsets[iy], col_offsets[ix], total_width)
+
+    return da.map_blocks(
+        _tile_fn, flow_dir_da, accum_da,
+        dtype=np.float64, meta=cp.array((), dtype=cp.float64))
+
+
+# =====================================================================
+# Public API
+# =====================================================================
+
+@supports_dataset
+def stream_link_dinf(flow_dir_dinf: xr.DataArray,
+                      flow_accum: xr.DataArray,
+                      threshold: float = 100,
+                      name: str = 'stream_link_dinf') -> xr.DataArray:
+    """Assign unique IDs to stream link segments (D-infinity).
+
+    Each contiguous stream segment between junctions, headwaters, and
+    outlets receives a distinct positive integer ID.  Non-stream cells
+    are NaN.
+
+    Parameters
+    ----------
+    flow_dir_dinf : xarray.DataArray or xr.Dataset
+        2D D-infinity flow direction grid.  Values are continuous
+        angles in radians in the range ``[0, 2*pi)``.  ``-1.0``
+        indicates a pit or flat.  ``NaN`` indicates nodata.
+    flow_accum : xarray.DataArray
+        2D flow accumulation grid.  Cells with
+        ``flow_accum >= threshold`` are stream cells.
+    threshold : float, default 100
+        Minimum accumulation for stream classification.
+    name : str, default 'stream_link_dinf'
+        Name of output DataArray.
+
+    Returns
+    -------
+    xarray.DataArray or xr.Dataset
+        2D float64 grid where each stream link has a unique positive
+        integer ID.  Non-stream cells are NaN.
+
+    References
+    ----------
+    Tarboton, D.G. (1997). A new method for the determination of flow
+    directions and upslope areas in grid digital elevation models.
+    Water Resources Research, 33(2), 309-319.
+    """
+    _validate_raster(flow_dir_dinf,
+                     func_name='stream_link_dinf',
+                     name='flow_dir_dinf')
+
+    fd_data = flow_dir_dinf.data
+    fa_data = flow_accum.data
+
+    if isinstance(fd_data, np.ndarray):
+        fd = fd_data.astype(np.float64)
+        fa = np.asarray(fa_data, dtype=np.float64)
+        stream_mask = np.where(fa >= threshold, 1, 0).astype(np.int8)
+        stream_mask = np.where(np.isnan(fa), 0, stream_mask).astype(np.int8)
+        stream_mask = np.where(np.isnan(fd), 0, stream_mask).astype(np.int8)
+        h, w = fd.shape
+        out = _stream_link_dinf_cpu(fd, stream_mask, h, w)
+
+    elif has_cuda_and_cupy() and is_cupy_array(fd_data):
+        import cupy as cp
+        fa_cp = cp.asarray(fa_data, dtype=cp.float64)
+        fd_cp = fd_data.astype(cp.float64)
+        stream_mask = cp.where(fa_cp >= threshold, 1, 0).astype(cp.int8)
+        stream_mask = cp.where(
+            cp.isnan(fa_cp), 0, stream_mask).astype(cp.int8)
+        stream_mask = cp.where(
+            cp.isnan(fd_cp), 0, stream_mask).astype(cp.int8)
+        out = _stream_link_dinf_cupy(fd_cp, stream_mask)
+
+    elif has_cuda_and_cupy() and is_dask_cupy(flow_dir_dinf):
+        out = _stream_link_dinf_dask_cupy(fd_data, fa_data, threshold)
+
+    elif da is not None and isinstance(fd_data, da.Array):
+        out = _stream_link_dinf_dask(fd_data, fa_data, threshold)
+
+    else:
+        raise TypeError(f"Unsupported array type: {type(fd_data)}")
+
+    return xr.DataArray(out,
+                        name=name,
+                        coords=flow_dir_dinf.coords,
+                        dims=flow_dir_dinf.dims,
+                        attrs=flow_dir_dinf.attrs)

--- a/xrspatial/stream_link_mfd.py
+++ b/xrspatial/stream_link_mfd.py
@@ -1,0 +1,978 @@
+"""Stream link segmentation for MFD (Multiple Flow Direction) grids.
+
+Assigns a unique positive integer ID to each stream "link" -- the
+contiguous segment of stream cells between junctions, headwaters, and
+outlets.  This is the MFD counterpart to the D8 ``stream_link`` module.
+
+A **link-start cell** is either a headwater (in-degree 0 among stream
+cells) or a junction (in-degree >= 2).  Each link-start cell gets a
+position-based ID: ``row * width + col + 1``.  Downstream non-junction
+cells inherit their upstream neighbor's link_id via Kahn's BFS.
+
+Because MFD allows a cell to flow to multiple downstream neighbors,
+a non-junction downstream cell may receive link_id from more than one
+upstream cell.  In that case it uses the first one that arrives in BFS
+order.
+
+Algorithm
+---------
+CPU : Kahn's BFS topological sort among stream cells -- O(N_stream).
+GPU : iterative frontier peeling with pull-based kernels.
+Dask: iterative tile sweep with boundary propagation, same pattern
+      as ``stream_link.py``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import xarray as xr
+from numba import cuda
+
+try:
+    import cupy
+except ImportError:
+    class cupy:  # type: ignore[no-redef]
+        ndarray = False
+
+try:
+    import dask.array as da
+except ImportError:
+    da = None
+
+from xrspatial.utils import (
+    _validate_raster,
+    cuda_args,
+    has_cuda_and_cupy,
+    is_cupy_array,
+    is_dask_cupy,
+    ngjit,
+)
+from xrspatial._boundary_store import BoundaryStore
+from xrspatial.dataset_support import supports_dataset
+from xrspatial.stream_order import _to_numpy_f64
+
+
+# =====================================================================
+# CPU kernel
+# =====================================================================
+
+@ngjit
+def _stream_link_mfd_cpu(fractions, stream_mask, height, width):
+    """Kahn's BFS link ID assignment among stream cells (MFD).
+
+    Parameters
+    ----------
+    fractions : (8, H, W) float64 -- MFD flow fractions
+    stream_mask : (H, W) int8
+    height, width : int
+
+    Returns
+    -------
+    link_id : (H, W) float64
+    """
+    dy = np.array([0, 1, 1, 1, 0, -1, -1, -1], dtype=np.int64)
+    dx = np.array([1, 1, 0, -1, -1, -1, 0, 1], dtype=np.int64)
+
+    link_id = np.empty((height, width), dtype=np.float64)
+    in_degree = np.zeros((height, width), dtype=np.int32)
+
+    # Initialise
+    for r in range(height):
+        for c in range(width):
+            if stream_mask[r, c] == 0:
+                link_id[r, c] = np.nan
+            else:
+                link_id[r, c] = 0.0
+
+    # Compute in-degrees (only among stream cells)
+    for r in range(height):
+        for c in range(width):
+            if stream_mask[r, c] == 0:
+                continue
+            for k in range(8):
+                if fractions[k, r, c] > 0.0:
+                    nr = r + dy[k]
+                    nc = c + dx[k]
+                    if 0 <= nr < height and 0 <= nc < width:
+                        if stream_mask[nr, nc] == 1:
+                            in_degree[nr, nc] += 1
+
+    # Store original in-degree to identify junctions
+    orig_indeg = np.empty((height, width), dtype=np.int32)
+    for r in range(height):
+        for c in range(width):
+            orig_indeg[r, c] = in_degree[r, c]
+
+    # BFS queue
+    queue_r = np.empty(height * width, dtype=np.int64)
+    queue_c = np.empty(height * width, dtype=np.int64)
+    head = np.int64(0)
+    tail = np.int64(0)
+
+    # Enqueue headwaters (stream cells with in_degree == 0)
+    for r in range(height):
+        for c in range(width):
+            if stream_mask[r, c] == 1 and in_degree[r, c] == 0:
+                link_id[r, c] = float(r * width + c + 1)
+                queue_r[tail] = r
+                queue_c[tail] = c
+                tail += 1
+
+    while head < tail:
+        r = queue_r[head]
+        c = queue_c[head]
+        head += 1
+
+        for k in range(8):
+            frac = fractions[k, r, c]
+            if frac <= 0.0:
+                continue
+            nr = r + dy[k]
+            nc = c + dx[k]
+            if not (0 <= nr < height and 0 <= nc < width
+                    and stream_mask[nr, nc] == 1):
+                continue
+
+            if orig_indeg[nr, nc] >= 2:
+                # Junction: decrement in-degree but don't propagate link_id.
+                # Junction gets its own position-based ID when ready.
+                in_degree[nr, nc] -= 1
+                if in_degree[nr, nc] == 0:
+                    link_id[nr, nc] = float(nr * width + nc + 1)
+                    queue_r[tail] = nr
+                    queue_c[tail] = nc
+                    tail += 1
+            else:
+                # Non-junction: inherit upstream link_id (first arrival wins)
+                if link_id[nr, nc] == 0.0:
+                    link_id[nr, nc] = link_id[r, c]
+                in_degree[nr, nc] -= 1
+                if in_degree[nr, nc] == 0:
+                    queue_r[tail] = nr
+                    queue_c[tail] = nc
+                    tail += 1
+
+    return link_id
+
+
+# =====================================================================
+# GPU kernels
+# =====================================================================
+
+@cuda.jit
+def _stream_link_mfd_init_gpu(fractions, stream_mask, in_degree, state,
+                               link_id, H, W):
+    """Initialise GPU arrays for MFD stream link computation."""
+    i, j = cuda.grid(2)
+    if i >= H or j >= W:
+        return
+
+    if stream_mask[i, j] == 0:
+        state[i, j] = 0
+        link_id[i, j] = 0.0
+        return
+
+    state[i, j] = 1
+    link_id[i, j] = 0.0
+
+    # Compute in-degree from fractions
+    for k in range(8):
+        frac = fractions[k, i, j]
+        if frac <= 0.0:
+            continue
+
+        if k == 0:
+            dy, dx = 0, 1
+        elif k == 1:
+            dy, dx = 1, 1
+        elif k == 2:
+            dy, dx = 1, 0
+        elif k == 3:
+            dy, dx = 1, -1
+        elif k == 4:
+            dy, dx = 0, -1
+        elif k == 5:
+            dy, dx = -1, -1
+        elif k == 6:
+            dy, dx = -1, 0
+        else:
+            dy, dx = -1, 1
+
+        ni = i + dy
+        nj = j + dx
+        if 0 <= ni < H and 0 <= nj < W and stream_mask[ni, nj] == 1:
+            cuda.atomic.add(in_degree, (ni, nj), 1)
+
+
+@cuda.jit
+def _stream_link_mfd_save_indeg(in_degree, orig_indeg, stream_mask, H, W):
+    """Copy in_degree to orig_indeg after init."""
+    i, j = cuda.grid(2)
+    if i >= H or j >= W:
+        return
+    if stream_mask[i, j] == 1:
+        orig_indeg[i, j] = in_degree[i, j]
+
+
+@cuda.jit
+def _stream_link_mfd_find_ready(in_degree, orig_indeg, state, link_id,
+                                 changed, H, W):
+    """Finalize previous frontier, mark new frontier cells."""
+    i, j = cuda.grid(2)
+    if i >= H or j >= W:
+        return
+
+    if state[i, j] == 2:
+        state[i, j] = 3
+
+    if state[i, j] == 1 and in_degree[i, j] == 0:
+        state[i, j] = 2
+        # Link-start cells get position-based ID
+        if orig_indeg[i, j] == 0 or orig_indeg[i, j] >= 2:
+            link_id[i, j] = float(i * W + j + 1)
+        cuda.atomic.add(changed, 0, 1)
+
+
+@cuda.jit
+def _stream_link_mfd_pull(fractions, stream_mask, in_degree, orig_indeg,
+                           state, link_id, H, W):
+    """Active cells pull link_id from frontier neighbours (MFD)."""
+    i, j = cuda.grid(2)
+    if i >= H or j >= W:
+        return
+    if state[i, j] != 1:
+        return
+
+    for nbr in range(8):
+        if nbr == 0:
+            dy, dx = 0, 1
+        elif nbr == 1:
+            dy, dx = 1, 1
+        elif nbr == 2:
+            dy, dx = 1, 0
+        elif nbr == 3:
+            dy, dx = 1, -1
+        elif nbr == 4:
+            dy, dx = 0, -1
+        elif nbr == 5:
+            dy, dx = -1, -1
+        elif nbr == 6:
+            dy, dx = -1, 0
+        else:
+            dy, dx = -1, 1
+
+        ni = i + dy
+        nj = j + dx
+        if ni < 0 or ni >= H or nj < 0 or nj >= W:
+            continue
+        if state[ni, nj] != 2:
+            continue
+        if stream_mask[ni, nj] == 0:
+            continue
+
+        # Check if the neighbor flows to us via the opposite direction
+        if nbr == 0:
+            opp = 4
+        elif nbr == 1:
+            opp = 5
+        elif nbr == 2:
+            opp = 6
+        elif nbr == 3:
+            opp = 7
+        elif nbr == 4:
+            opp = 0
+        elif nbr == 5:
+            opp = 1
+        elif nbr == 6:
+            opp = 2
+        else:
+            opp = 3
+
+        frac = fractions[opp, ni, nj]
+        if frac > 0.0:
+            in_degree[i, j] -= 1
+            # Non-junction cells inherit the upstream link_id
+            if orig_indeg[i, j] < 2 and link_id[i, j] == 0.0:
+                link_id[i, j] = link_id[ni, nj]
+
+
+def _stream_link_mfd_cupy(fractions_data, stream_mask_data):
+    """GPU driver for MFD stream link computation."""
+    import cupy as cp
+
+    _, H, W = fractions_data.shape
+    fractions_f64 = fractions_data.astype(cp.float64)
+    stream_mask_i8 = stream_mask_data.astype(cp.int8)
+
+    in_degree = cp.zeros((H, W), dtype=cp.int32)
+    orig_indeg = cp.zeros((H, W), dtype=cp.int32)
+    state = cp.zeros((H, W), dtype=cp.int32)
+    link_id = cp.zeros((H, W), dtype=cp.float64)
+    changed = cp.zeros(1, dtype=cp.int32)
+
+    griddim, blockdim = cuda_args((H, W))
+
+    _stream_link_mfd_init_gpu[griddim, blockdim](
+        fractions_f64, stream_mask_i8, in_degree, state, link_id, H, W)
+
+    # Save orig_indeg after atomic adds complete
+    _stream_link_mfd_save_indeg[griddim, blockdim](
+        in_degree, orig_indeg, stream_mask_i8, H, W)
+
+    max_iter = H * W
+    for _ in range(max_iter):
+        changed[0] = 0
+        _stream_link_mfd_find_ready[griddim, blockdim](
+            in_degree, orig_indeg, state, link_id, changed, H, W)
+
+        if int(changed[0]) == 0:
+            break
+
+        _stream_link_mfd_pull[griddim, blockdim](
+            fractions_f64, stream_mask_i8, in_degree, orig_indeg,
+            state, link_id, H, W)
+
+    link_id = cp.where(stream_mask_i8 == 0, cp.nan, link_id)
+    return link_id
+
+
+# =====================================================================
+# CPU tile kernel for dask
+# =====================================================================
+
+@ngjit
+def _stream_link_mfd_tile_kernel(fractions, stream_mask, h, w,
+                                  seed_id_top, seed_id_bottom,
+                                  seed_id_left, seed_id_right,
+                                  seed_ext_top, seed_ext_bottom,
+                                  seed_ext_left, seed_ext_right,
+                                  row_offset, col_offset, total_width):
+    """Seeded BFS link assignment for a single MFD tile.
+
+    Parameters
+    ----------
+    fractions : (8, h, w) float64 -- MFD flow fractions for this tile
+    stream_mask : (h, w) int8
+    seed_id_*  : link_id values flowing in from neighbouring tiles.
+    seed_ext_* : count of external stream cells flowing into each
+                 boundary cell (to compute correct orig_indeg).
+    row_offset, col_offset : global pixel offsets of this tile.
+    total_width : total number of columns in the full raster.
+    """
+    dy = np.array([0, 1, 1, 1, 0, -1, -1, -1], dtype=np.int64)
+    dx = np.array([1, 1, 0, -1, -1, -1, 0, 1], dtype=np.int64)
+
+    link_id = np.empty((h, w), dtype=np.float64)
+    in_degree = np.zeros((h, w), dtype=np.int32)
+
+    # Initialise
+    for r in range(h):
+        for c in range(w):
+            if stream_mask[r, c] == 0:
+                link_id[r, c] = np.nan
+            else:
+                link_id[r, c] = 0.0
+
+    # Compute within-tile in-degrees among stream cells
+    for r in range(h):
+        for c in range(w):
+            if stream_mask[r, c] == 0:
+                continue
+            for k in range(8):
+                if fractions[k, r, c] > 0.0:
+                    nr = r + dy[k]
+                    nc = c + dx[k]
+                    if 0 <= nr < h and 0 <= nc < w:
+                        if stream_mask[nr, nc] == 1:
+                            in_degree[nr, nc] += 1
+
+    # orig_indeg = within-tile + external (for junction detection only).
+    # Do NOT add external counts to in_degree -- external inflows are
+    # already "delivered" via seed_id values.
+    orig_indeg = np.empty((h, w), dtype=np.int32)
+    for r in range(h):
+        for c in range(w):
+            orig_indeg[r, c] = in_degree[r, c]
+
+    for c in range(w):
+        if stream_mask[0, c] == 1:
+            orig_indeg[0, c] += int(seed_ext_top[c])
+        if stream_mask[h - 1, c] == 1:
+            orig_indeg[h - 1, c] += int(seed_ext_bottom[c])
+    for r in range(h):
+        if stream_mask[r, 0] == 1:
+            orig_indeg[r, 0] += int(seed_ext_left[r])
+        if stream_mask[r, w - 1] == 1:
+            orig_indeg[r, w - 1] += int(seed_ext_right[r])
+
+    # BFS queue
+    queue_r = np.empty(h * w, dtype=np.int64)
+    queue_c = np.empty(h * w, dtype=np.int64)
+    head = np.int64(0)
+    tail = np.int64(0)
+
+    # Assign initial link_ids and enqueue cells with in_degree == 0
+    for r in range(h):
+        for c in range(w):
+            if stream_mask[r, c] != 1:
+                continue
+            if in_degree[r, c] != 0:
+                continue
+            # Headwater (orig_indeg == 0) or junction (orig_indeg >= 2):
+            # get position-based global ID
+            if orig_indeg[r, c] == 0 or orig_indeg[r, c] >= 2:
+                gr = row_offset + r
+                gc = col_offset + c
+                link_id[r, c] = float(gr * total_width + gc + 1)
+            queue_r[tail] = r
+            queue_c[tail] = c
+            tail += 1
+
+    # Seed non-junction, non-headwater boundary cells that receive
+    # a link_id from their external upstream neighbor.
+    # These cells have in_degree > 0 so they are NOT yet in the queue.
+    # We apply the seed_id so that when their in_degree drops to 0
+    # during BFS, they already have the right inherited link_id.
+    for c in range(w):
+        if stream_mask[0, c] == 1 and seed_id_top[c] > 0:
+            if orig_indeg[0, c] < 2:
+                link_id[0, c] = seed_id_top[c]
+        if stream_mask[h - 1, c] == 1 and seed_id_bottom[c] > 0:
+            if orig_indeg[h - 1, c] < 2:
+                link_id[h - 1, c] = seed_id_bottom[c]
+    for r in range(h):
+        if stream_mask[r, 0] == 1 and seed_id_left[r] > 0:
+            if orig_indeg[r, 0] < 2:
+                link_id[r, 0] = seed_id_left[r]
+        if stream_mask[r, w - 1] == 1 and seed_id_right[r] > 0:
+            if orig_indeg[r, w - 1] < 2:
+                link_id[r, w - 1] = seed_id_right[r]
+
+    while head < tail:
+        r = queue_r[head]
+        c = queue_c[head]
+        head += 1
+
+        for k in range(8):
+            frac = fractions[k, r, c]
+            if frac <= 0.0:
+                continue
+            nr = r + dy[k]
+            nc = c + dx[k]
+            if not (0 <= nr < h and 0 <= nc < w
+                    and stream_mask[nr, nc] == 1):
+                continue
+
+            if orig_indeg[nr, nc] >= 2:
+                in_degree[nr, nc] -= 1
+                if in_degree[nr, nc] == 0:
+                    gnr = row_offset + nr
+                    gnc = col_offset + nc
+                    link_id[nr, nc] = float(gnr * total_width + gnc + 1)
+                    queue_r[tail] = nr
+                    queue_c[tail] = nc
+                    tail += 1
+            else:
+                if link_id[nr, nc] == 0.0:
+                    link_id[nr, nc] = link_id[r, c]
+                in_degree[nr, nc] -= 1
+                if in_degree[nr, nc] == 0:
+                    queue_r[tail] = nr
+                    queue_c[tail] = nc
+                    tail += 1
+
+    return link_id
+
+
+# =====================================================================
+# Dask preprocessing: extract boundary fraction strips and stream masks
+# =====================================================================
+
+def _preprocess_mfd_stream_tiles(fractions_da, accum_da, threshold,
+                                  chunks_y, chunks_x):
+    """Extract boundary fraction strips (8-band) and stream masks.
+
+    Returns
+    -------
+    frac_bdry : dict mapping (side, iy, ix) -> (8, length) float64 array
+    mask_bdry : BoundaryStore with stream mask boundary strips
+    """
+    n_tile_y = len(chunks_y)
+    n_tile_x = len(chunks_x)
+
+    frac_bdry = {}
+    mask_bdry = BoundaryStore(chunks_y, chunks_x, fill_value=0.0)
+
+    for iy in range(n_tile_y):
+        for ix in range(n_tile_x):
+            y_start = sum(chunks_y[:iy])
+            y_end = y_start + chunks_y[iy]
+            x_start = sum(chunks_x[:ix])
+            x_end = x_start + chunks_x[ix]
+
+            chunk = np.asarray(
+                fractions_da[:, y_start:y_end, x_start:x_end].compute(),
+                dtype=np.float64)
+            ac_chunk = _to_numpy_f64(
+                accum_da[y_start:y_end, x_start:x_end].compute())
+
+            sm = np.where(ac_chunk >= threshold, 1.0, 0.0)
+            sm = np.where(np.isnan(ac_chunk), 0.0, sm)
+            # Also mark as non-stream if fractions are NaN
+            sm = np.where(np.isnan(chunk[0]), 0.0, sm)
+
+            # Store fraction strips: (8, length)
+            frac_bdry[('top', iy, ix)] = chunk[:, 0, :].copy()
+            frac_bdry[('bottom', iy, ix)] = chunk[:, -1, :].copy()
+            frac_bdry[('left', iy, ix)] = chunk[:, :, 0].copy()
+            frac_bdry[('right', iy, ix)] = chunk[:, :, -1].copy()
+
+            # Store stream mask strips
+            for side, strip in [('top', sm[0, :]),
+                                ('bottom', sm[-1, :]),
+                                ('left', sm[:, 0]),
+                                ('right', sm[:, -1])]:
+                mask_bdry.set(side, iy, ix,
+                              np.asarray(strip, dtype=np.float64))
+
+    return frac_bdry, mask_bdry
+
+
+# =====================================================================
+# Dask seed computation
+# =====================================================================
+
+def _compute_link_seeds_mfd(iy, ix, boundaries, frac_bdry, mask_bdry,
+                             chunks_y, chunks_x, n_tile_y, n_tile_x):
+    """Compute seed arrays for tile (iy, ix) from neighbour boundaries.
+
+    Returns (seed_id_top, seed_id_bottom, seed_id_left, seed_id_right,
+             seed_ext_top, seed_ext_bottom, seed_ext_left, seed_ext_right).
+
+    seed_id_*  : link_id propagated from the neighbouring tile.
+    seed_ext_* : count of external stream cells flowing into each
+                 boundary cell (needed to compute correct orig_indeg).
+    """
+    # Neighbor offsets: E(0), SE(1), S(2), SW(3), W(4), NW(5), N(6), NE(7)
+    dy_arr = np.array([0, 1, 1, 1, 0, -1, -1, -1], dtype=np.int64)
+    dx_arr = np.array([1, 1, 0, -1, -1, -1, 0, 1], dtype=np.int64)
+
+    tile_h = chunks_y[iy]
+    tile_w = chunks_x[ix]
+
+    seed_id_top = np.zeros(tile_w, dtype=np.float64)
+    seed_id_bottom = np.zeros(tile_w, dtype=np.float64)
+    seed_id_left = np.zeros(tile_h, dtype=np.float64)
+    seed_id_right = np.zeros(tile_h, dtype=np.float64)
+
+    seed_ext_top = np.zeros(tile_w, dtype=np.float64)
+    seed_ext_bottom = np.zeros(tile_w, dtype=np.float64)
+    seed_ext_left = np.zeros(tile_h, dtype=np.float64)
+    seed_ext_right = np.zeros(tile_h, dtype=np.float64)
+
+    # --- Top edge: bottom row of tile above ---
+    if iy > 0:
+        nb_frac = frac_bdry[('bottom', iy - 1, ix)]  # (8, tile_w)
+        nb_mask = mask_bdry.get('bottom', iy - 1, ix)
+        nb_link = boundaries.get('bottom', iy - 1, ix)
+        w = nb_frac.shape[1]
+        for c in range(w):
+            if nb_mask[c] == 0:
+                continue
+            for k in range(8):
+                if not (nb_frac[k, c] > 0.0):
+                    continue
+                ndy = dy_arr[k]
+                ndx = dx_arr[k]
+                if ndy == 1:  # flows south into our tile
+                    tc = c + ndx
+                    if 0 <= tc < tile_w:
+                        seed_ext_top[tc] += 1.0
+                        lid = nb_link[c]
+                        if lid > 0 and (seed_id_top[tc] == 0
+                                        or lid < seed_id_top[tc]):
+                            seed_id_top[tc] = lid
+
+    # --- Bottom edge: top row of tile below ---
+    if iy < n_tile_y - 1:
+        nb_frac = frac_bdry[('top', iy + 1, ix)]  # (8, tile_w)
+        nb_mask = mask_bdry.get('top', iy + 1, ix)
+        nb_link = boundaries.get('top', iy + 1, ix)
+        w = nb_frac.shape[1]
+        for c in range(w):
+            if nb_mask[c] == 0:
+                continue
+            for k in range(8):
+                if not (nb_frac[k, c] > 0.0):
+                    continue
+                ndy = dy_arr[k]
+                ndx = dx_arr[k]
+                if ndy == -1:  # flows north into our tile
+                    tc = c + ndx
+                    if 0 <= tc < tile_w:
+                        seed_ext_bottom[tc] += 1.0
+                        lid = nb_link[c]
+                        if lid > 0 and (seed_id_bottom[tc] == 0
+                                        or lid < seed_id_bottom[tc]):
+                            seed_id_bottom[tc] = lid
+
+    # --- Left edge: right column of tile to the left ---
+    if ix > 0:
+        nb_frac = frac_bdry[('right', iy, ix - 1)]  # (8, tile_h)
+        nb_mask = mask_bdry.get('right', iy, ix - 1)
+        nb_link = boundaries.get('right', iy, ix - 1)
+        h = nb_frac.shape[1]
+        for r in range(h):
+            if nb_mask[r] == 0:
+                continue
+            for k in range(8):
+                if not (nb_frac[k, r] > 0.0):
+                    continue
+                ndy = dy_arr[k]
+                ndx = dx_arr[k]
+                if ndx == 1:  # flows east into our tile
+                    tr = r + ndy
+                    if 0 <= tr < tile_h:
+                        seed_ext_left[tr] += 1.0
+                        lid = nb_link[r]
+                        if lid > 0 and (seed_id_left[tr] == 0
+                                        or lid < seed_id_left[tr]):
+                            seed_id_left[tr] = lid
+
+    # --- Right edge: left column of tile to the right ---
+    if ix < n_tile_x - 1:
+        nb_frac = frac_bdry[('left', iy, ix + 1)]  # (8, tile_h)
+        nb_mask = mask_bdry.get('left', iy, ix + 1)
+        nb_link = boundaries.get('left', iy, ix + 1)
+        h = nb_frac.shape[1]
+        for r in range(h):
+            if nb_mask[r] == 0:
+                continue
+            for k in range(8):
+                if not (nb_frac[k, r] > 0.0):
+                    continue
+                ndy = dy_arr[k]
+                ndx = dx_arr[k]
+                if ndx == -1:  # flows west into our tile
+                    tr = r + ndy
+                    if 0 <= tr < tile_h:
+                        seed_ext_right[tr] += 1.0
+                        lid = nb_link[r]
+                        if lid > 0 and (seed_id_right[tr] == 0
+                                        or lid < seed_id_right[tr]):
+                            seed_id_right[tr] = lid
+
+    # --- Diagonal corner seeds ---
+    # TL corner: bottom-right cell of (iy-1, ix-1) flows SE (k=1)
+    if iy > 0 and ix > 0:
+        nb_frac = frac_bdry[('bottom', iy - 1, ix - 1)]  # (8, w)
+        nb_mask = mask_bdry.get('bottom', iy - 1, ix - 1)
+        nb_link = boundaries.get('bottom', iy - 1, ix - 1)
+        if nb_mask[-1] == 1:
+            frac_se = nb_frac[1, -1]  # SE direction
+            if frac_se > 0.0:
+                seed_ext_top[0] += 1.0
+                lid = float(nb_link[-1])
+                if lid > 0 and (seed_id_top[0] == 0
+                                or lid < seed_id_top[0]):
+                    seed_id_top[0] = lid
+
+    # TR corner: bottom-left cell of (iy-1, ix+1) flows SW (k=3)
+    if iy > 0 and ix < n_tile_x - 1:
+        nb_frac = frac_bdry[('bottom', iy - 1, ix + 1)]  # (8, w)
+        nb_mask = mask_bdry.get('bottom', iy - 1, ix + 1)
+        nb_link = boundaries.get('bottom', iy - 1, ix + 1)
+        if nb_mask[0] == 1:
+            frac_sw = nb_frac[3, 0]  # SW direction
+            if frac_sw > 0.0:
+                seed_ext_top[tile_w - 1] += 1.0
+                lid = float(nb_link[0])
+                if lid > 0 and (seed_id_top[tile_w - 1] == 0
+                                or lid < seed_id_top[tile_w - 1]):
+                    seed_id_top[tile_w - 1] = lid
+
+    # BL corner: top-right cell of (iy+1, ix-1) flows NE (k=7)
+    if iy < n_tile_y - 1 and ix > 0:
+        nb_frac = frac_bdry[('top', iy + 1, ix - 1)]  # (8, w)
+        nb_mask = mask_bdry.get('top', iy + 1, ix - 1)
+        nb_link = boundaries.get('top', iy + 1, ix - 1)
+        if nb_mask[-1] == 1:
+            frac_ne = nb_frac[7, -1]  # NE direction
+            if frac_ne > 0.0:
+                seed_ext_bottom[0] += 1.0
+                lid = float(nb_link[-1])
+                if lid > 0 and (seed_id_bottom[0] == 0
+                                or lid < seed_id_bottom[0]):
+                    seed_id_bottom[0] = lid
+
+    # BR corner: top-left cell of (iy+1, ix+1) flows NW (k=5)
+    if iy < n_tile_y - 1 and ix < n_tile_x - 1:
+        nb_frac = frac_bdry[('top', iy + 1, ix + 1)]  # (8, w)
+        nb_mask = mask_bdry.get('top', iy + 1, ix + 1)
+        nb_link = boundaries.get('top', iy + 1, ix + 1)
+        if nb_mask[0] == 1:
+            frac_nw = nb_frac[5, 0]  # NW direction
+            if frac_nw > 0.0:
+                seed_ext_bottom[tile_w - 1] += 1.0
+                lid = float(nb_link[0])
+                if lid > 0 and (seed_id_bottom[tile_w - 1] == 0
+                                or lid < seed_id_bottom[tile_w - 1]):
+                    seed_id_bottom[tile_w - 1] = lid
+
+    return (seed_id_top, seed_id_bottom, seed_id_left, seed_id_right,
+            seed_ext_top, seed_ext_bottom, seed_ext_left, seed_ext_right)
+
+
+# =====================================================================
+# Dask iterative tile sweep
+# =====================================================================
+
+def _process_link_tile_mfd(iy, ix, fractions_da, accum_da, threshold,
+                            boundaries, frac_bdry, mask_bdry,
+                            chunks_y, chunks_x, n_tile_y, n_tile_x,
+                            row_offsets, col_offsets, total_width):
+    """Run seeded BFS on one MFD tile; update boundary stores."""
+    y_start = sum(chunks_y[:iy])
+    y_end = y_start + chunks_y[iy]
+    x_start = sum(chunks_x[:ix])
+    x_end = x_start + chunks_x[ix]
+
+    frac_chunk = np.asarray(
+        fractions_da[:, y_start:y_end, x_start:x_end].compute(),
+        dtype=np.float64)
+    ac_chunk = _to_numpy_f64(
+        accum_da[y_start:y_end, x_start:x_end].compute())
+
+    sm = np.where(ac_chunk >= threshold, 1, 0).astype(np.int8)
+    sm = np.where(np.isnan(ac_chunk), 0, sm).astype(np.int8)
+    sm = np.where(np.isnan(frac_chunk[0]), 0, sm).astype(np.int8)
+    _, h, w = frac_chunk.shape
+
+    seeds = _compute_link_seeds_mfd(
+        iy, ix, boundaries, frac_bdry, mask_bdry,
+        chunks_y, chunks_x, n_tile_y, n_tile_x)
+
+    link = _stream_link_mfd_tile_kernel(
+        frac_chunk, sm, h, w, *seeds,
+        row_offsets[iy], col_offsets[ix], total_width)
+
+    change = 0.0
+    for side, strip in [('top', link[0, :]),
+                        ('bottom', link[-1, :]),
+                        ('left', link[:, 0]),
+                        ('right', link[:, -1])]:
+        new_vals = strip.copy()
+        new_vals = np.where(np.isnan(new_vals), 0.0, new_vals)
+        old = boundaries.get(side, iy, ix).copy()
+        with np.errstate(invalid='ignore'):
+            diff = np.abs(new_vals - old)
+        diff = np.where(np.isnan(diff), 0.0, diff)
+        m = float(np.max(diff))
+        if m > change:
+            change = m
+        boundaries.set(side, iy, ix, new_vals)
+
+    return change
+
+
+def _stream_link_mfd_dask(fractions_da, accum_da, threshold):
+    """Iterative boundary-propagation for MFD dask arrays."""
+    chunks_y = fractions_da.chunks[1]
+    chunks_x = fractions_da.chunks[2]
+    n_tile_y = len(chunks_y)
+    n_tile_x = len(chunks_x)
+    total_width = sum(chunks_x)
+
+    # Precompute global pixel offsets for each tile
+    row_offsets = np.zeros(n_tile_y, dtype=np.int64)
+    col_offsets = np.zeros(n_tile_x, dtype=np.int64)
+    if n_tile_y > 1:
+        np.cumsum(chunks_y[:-1], out=row_offsets[1:])
+    if n_tile_x > 1:
+        np.cumsum(chunks_x[:-1], out=col_offsets[1:])
+
+    # Phase 0: extract boundary fraction strips and stream masks
+    frac_bdry, mask_bdry = _preprocess_mfd_stream_tiles(
+        fractions_da, accum_da, threshold, chunks_y, chunks_x)
+    mask_bdry = mask_bdry.snapshot()
+
+    # Phase 1: initialise boundary link_ids
+    boundaries = BoundaryStore(chunks_y, chunks_x, fill_value=0.0)
+
+    # Phase 2: iterative forward/backward sweeps
+    max_iterations = max(n_tile_y, n_tile_x) + 10
+    for _ in range(max_iterations):
+        max_change = 0.0
+        for iy in range(n_tile_y):
+            for ix in range(n_tile_x):
+                c = _process_link_tile_mfd(
+                    iy, ix, fractions_da, accum_da, threshold,
+                    boundaries, frac_bdry, mask_bdry,
+                    chunks_y, chunks_x, n_tile_y, n_tile_x,
+                    row_offsets, col_offsets, total_width)
+                if c > max_change:
+                    max_change = c
+        for iy in reversed(range(n_tile_y)):
+            for ix in reversed(range(n_tile_x)):
+                c = _process_link_tile_mfd(
+                    iy, ix, fractions_da, accum_da, threshold,
+                    boundaries, frac_bdry, mask_bdry,
+                    chunks_y, chunks_x, n_tile_y, n_tile_x,
+                    row_offsets, col_offsets, total_width)
+                if c > max_change:
+                    max_change = c
+        if max_change == 0.0:
+            break
+
+    # Snapshot converged boundaries before assembly
+    _boundaries = boundaries.snapshot()
+    _frac_bdry = frac_bdry
+    _mask_bdry = mask_bdry
+    _threshold = threshold
+
+    # Assemble result via da.block
+    rows = []
+    for iy in range(n_tile_y):
+        row = []
+        for ix in range(n_tile_x):
+            y_start = sum(chunks_y[:iy])
+            y_end = y_start + chunks_y[iy]
+            x_start = sum(chunks_x[:ix])
+            x_end = x_start + chunks_x[ix]
+
+            frac_chunk = np.asarray(
+                fractions_da[:, y_start:y_end, x_start:x_end].compute(),
+                dtype=np.float64)
+            ac_chunk = _to_numpy_f64(
+                accum_da[y_start:y_end, x_start:x_end].compute())
+
+            sm = np.where(ac_chunk >= _threshold, 1, 0).astype(np.int8)
+            sm = np.where(np.isnan(ac_chunk), 0, sm).astype(np.int8)
+            sm = np.where(np.isnan(frac_chunk[0]), 0, sm).astype(np.int8)
+            _, h, w = frac_chunk.shape
+
+            seeds = _compute_link_seeds_mfd(
+                iy, ix, _boundaries, _frac_bdry, _mask_bdry,
+                chunks_y, chunks_x, n_tile_y, n_tile_x)
+
+            tile_link = _stream_link_mfd_tile_kernel(
+                frac_chunk, sm, h, w, *seeds,
+                row_offsets[iy], col_offsets[ix], total_width)
+            row.append(da.from_array(tile_link, chunks=tile_link.shape))
+        rows.append(row)
+
+    return da.block(rows)
+
+
+def _stream_link_mfd_dask_cupy(fractions_da, accum_da, threshold):
+    """Dask+CuPy MFD: convert to numpy, run CPU dask path, convert back."""
+    import cupy as cp
+
+    fractions_np = fractions_da.map_blocks(
+        lambda b: b.get(), dtype=fractions_da.dtype,
+        meta=np.array((), dtype=fractions_da.dtype),
+    )
+    accum_np = accum_da.map_blocks(
+        lambda b: b.get(), dtype=accum_da.dtype,
+        meta=np.array((), dtype=accum_da.dtype),
+    )
+    result = _stream_link_mfd_dask(fractions_np, accum_np, threshold)
+    return result.map_blocks(
+        cp.asarray, dtype=result.dtype,
+        meta=cp.array((), dtype=result.dtype),
+    )
+
+
+# =====================================================================
+# Public API
+# =====================================================================
+
+@supports_dataset
+def stream_link_mfd(fractions: xr.DataArray,
+                     flow_accum: xr.DataArray,
+                     threshold: float = 100,
+                     name: str = 'stream_link_mfd') -> xr.DataArray:
+    """Assign unique IDs to stream link segments (MFD).
+
+    Each contiguous stream segment between junctions, headwaters, and
+    outlets receives a distinct positive integer ID.  Non-stream cells
+    are NaN.
+
+    Parameters
+    ----------
+    fractions : xarray.DataArray or xr.Dataset
+        3-D MFD flow direction array of shape ``(8, H, W)`` as returned
+        by ``flow_direction_mfd``.  Values are flow fractions in
+        ``[0, 1]`` that sum to 1.0 at each cell (NaN at nodata cells).
+        The neighbor order is:
+        E(0), SE(1), S(2), SW(3), W(4), NW(5), N(6), NE(7).
+    flow_accum : xarray.DataArray
+        2-D flow accumulation grid.  Cells with
+        ``flow_accum >= threshold`` are stream cells.
+    threshold : float, default 100
+        Minimum accumulation for stream classification.
+    name : str, default 'stream_link_mfd'
+        Name of output DataArray.
+
+    Returns
+    -------
+    xarray.DataArray or xr.Dataset
+        2-D float64 grid where each stream link has a unique positive
+        integer ID.  Non-stream cells are NaN.
+    """
+    _validate_raster(fractions, func_name='stream_link_mfd',
+                     name='fractions', ndim=3)
+
+    data = fractions.data
+
+    if data.ndim != 3 or data.shape[0] != 8:
+        raise ValueError(
+            "fractions must be a 3-D array of shape (8, H, W), "
+            f"got shape {data.shape}"
+        )
+
+    fa_data = flow_accum.data
+
+    if isinstance(data, np.ndarray):
+        frac = data.astype(np.float64)
+        fa = np.asarray(fa_data, dtype=np.float64)
+        stream_mask = np.where(fa >= threshold, 1, 0).astype(np.int8)
+        stream_mask = np.where(np.isnan(fa), 0, stream_mask).astype(np.int8)
+        stream_mask = np.where(
+            np.isnan(frac[0]), 0, stream_mask).astype(np.int8)
+        h, w = frac.shape[1], frac.shape[2]
+        out = _stream_link_mfd_cpu(frac, stream_mask, h, w)
+
+    elif has_cuda_and_cupy() and is_cupy_array(data):
+        import cupy as cp
+        fa_cp = cp.asarray(fa_data, dtype=cp.float64)
+        frac_cp = data.astype(cp.float64)
+        stream_mask = cp.where(fa_cp >= threshold, 1, 0).astype(cp.int8)
+        stream_mask = cp.where(
+            cp.isnan(fa_cp), 0, stream_mask).astype(cp.int8)
+        stream_mask = cp.where(
+            cp.isnan(frac_cp[0]), 0, stream_mask).astype(cp.int8)
+        out = _stream_link_mfd_cupy(frac_cp, stream_mask)
+
+    elif has_cuda_and_cupy() and is_dask_cupy(fractions):
+        out = _stream_link_mfd_dask_cupy(data, fa_data, threshold)
+
+    elif da is not None and isinstance(data, da.Array):
+        out = _stream_link_mfd_dask(data, fa_data, threshold)
+
+    else:
+        raise TypeError(f"Unsupported array type: {type(data)}")
+
+    # Build 2-D output coords (drop 'neighbor' dim)
+    spatial_dims = fractions.dims[1:]
+    coords = {k: v for k, v in fractions.coords.items()
+              if k != 'neighbor' and k not in fractions.dims[:1]}
+    for d in spatial_dims:
+        if d in fractions.coords:
+            coords[d] = fractions.coords[d]
+
+    return xr.DataArray(out,
+                        name=name,
+                        coords=coords,
+                        dims=spatial_dims,
+                        attrs=fractions.attrs)

--- a/xrspatial/stream_order_dinf.py
+++ b/xrspatial/stream_order_dinf.py
@@ -1,0 +1,1891 @@
+"""Stream order extraction for D-infinity flow direction grids.
+
+Assigns hierarchical order values to stream cells derived from a
+D-infinity (continuous angle) flow direction grid and a flow
+accumulation grid.  Cells with accumulation below a user-defined
+threshold are non-stream and receive NaN.  Two methods are supported:
+
+* **Strahler**: headwaters = 1; when two streams of equal order meet
+  the downstream order increments by 1; otherwise the higher order
+  propagates.
+* **Shreve**: headwaters = 1; at each confluence the downstream
+  magnitude equals the sum of all incoming magnitudes.
+
+Unlike the D8 variant, D-inf flow directions are continuous angles in
+[0, 2*pi).  Each cell flows to at most two downstream neighbours
+(the pair bracketing the angle), with proportional fractions.  The
+topology (in-degree, upstream/downstream relationship) is derived from
+these angles rather than from discrete D8 codes.
+
+Algorithm
+---------
+CPU : Kahn's BFS topological sort among stream cells -- O(N_stream).
+GPU : iterative frontier peeling with pull-based kernels.
+Dask: iterative tile sweep with boundary propagation, same pattern
+      as ``stream_order.py``.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import xarray as xr
+from numba import cuda
+
+try:
+    import cupy
+except ImportError:
+    class cupy:  # type: ignore[no-redef]
+        ndarray = False
+
+try:
+    import dask.array as da
+except ImportError:
+    da = None
+
+from xrspatial.utils import (
+    _validate_raster,
+    cuda_args,
+    has_cuda_and_cupy,
+    is_cupy_array,
+    is_dask_cupy,
+    ngjit,
+)
+from xrspatial._boundary_store import BoundaryStore
+from xrspatial.dataset_support import supports_dataset
+from xrspatial.stream_order import _to_numpy_f64
+
+
+# Neighbor offsets: counterclockwise from East
+# E, NE, N, NW, W, SW, S, SE
+_NB_DY = np.array([0, -1, -1, -1, 0, 1, 1, 1], dtype=np.int64)
+_NB_DX = np.array([1, 1, 0, -1, -1, -1, 0, 1], dtype=np.int64)
+
+_PI_OVER_4 = math.pi / 4.0
+_TWO_PI = 2.0 * math.pi
+
+
+# =====================================================================
+# Helper: angle -> two downstream neighbors + fractions
+# =====================================================================
+
+def _dinf_downstream(theta):
+    """Return (k1, frac1, k2, frac2) for a D-inf angle theta.
+
+    k1/k2 are neighbor indices (0..7 into the E,NE,N,...,SE convention).
+    frac1 is the proportion of flow to neighbor k1, frac2 to k2.
+    Returns (-1, 0, -1, 0) if theta is NaN or < 0 (pit/nodata).
+    """
+    if theta != theta:  # NaN
+        return -1, 0.0, -1, 0.0
+    if theta < 0.0:
+        return -1, 0.0, -1, 0.0
+
+    k = int(theta / _PI_OVER_4)
+    if k >= 8:
+        k = 7
+    k2 = (k + 1) % 8
+    alpha = theta - k * _PI_OVER_4
+    frac1 = (_PI_OVER_4 - alpha) / _PI_OVER_4
+    frac2 = alpha / _PI_OVER_4
+    return k, frac1, k2, frac2
+
+
+# =====================================================================
+# CPU kernels
+# =====================================================================
+
+@ngjit
+def _strahler_dinf_cpu(angles, stream_mask, height, width):
+    """Kahn's BFS Strahler ordering for D-inf flow directions."""
+    nb_dy = np.array([0, -1, -1, -1, 0, 1, 1, 1], dtype=np.int64)
+    nb_dx = np.array([1, 1, 0, -1, -1, -1, 0, 1], dtype=np.int64)
+    pi_over_4 = math.pi / 4.0
+
+    order = np.empty((height, width), dtype=np.float64)
+    in_degree = np.zeros((height, width), dtype=np.int32)
+    max_in = np.zeros((height, width), dtype=np.float64)
+    cnt_max = np.zeros((height, width), dtype=np.int32)
+
+    # Initialise
+    for r in range(height):
+        for c in range(width):
+            if stream_mask[r, c] == 0:
+                order[r, c] = np.nan
+            else:
+                order[r, c] = 0.0
+
+    # Compute in-degrees: each stream cell's angle gives 2 downstream
+    # neighbors; increment their in-degree if they are stream cells.
+    for r in range(height):
+        for c in range(width):
+            if stream_mask[r, c] == 0:
+                continue
+            theta = angles[r, c]
+            if theta != theta:  # NaN
+                continue
+            if theta < 0.0:  # pit
+                continue
+
+            k = int(theta / pi_over_4)
+            if k >= 8:
+                k = 7
+            k2 = (k + 1) % 8
+            alpha = theta - k * pi_over_4
+            frac1 = (pi_over_4 - alpha) / pi_over_4
+            frac2 = alpha / pi_over_4
+
+            if frac1 > 0.0:
+                nr = r + nb_dy[k]
+                nc = c + nb_dx[k]
+                if 0 <= nr < height and 0 <= nc < width:
+                    if stream_mask[nr, nc] == 1:
+                        in_degree[nr, nc] += 1
+
+            if frac2 > 0.0:
+                nr2 = r + nb_dy[k2]
+                nc2 = c + nb_dx[k2]
+                if 0 <= nr2 < height and 0 <= nc2 < width:
+                    if stream_mask[nr2, nc2] == 1:
+                        in_degree[nr2, nc2] += 1
+
+    # BFS queue
+    queue_r = np.empty(height * width, dtype=np.int64)
+    queue_c = np.empty(height * width, dtype=np.int64)
+    head = np.int64(0)
+    tail = np.int64(0)
+
+    # Enqueue headwaters (stream cells with in_degree == 0)
+    for r in range(height):
+        for c in range(width):
+            if stream_mask[r, c] == 1 and in_degree[r, c] == 0:
+                order[r, c] = 1.0
+                queue_r[tail] = r
+                queue_c[tail] = c
+                tail += 1
+
+    while head < tail:
+        r = queue_r[head]
+        c = queue_c[head]
+        head += 1
+
+        theta = angles[r, c]
+        if theta != theta:
+            continue
+        if theta < 0.0:
+            continue
+
+        k = int(theta / pi_over_4)
+        if k >= 8:
+            k = 7
+        k2 = (k + 1) % 8
+        alpha = theta - k * pi_over_4
+        frac1 = (pi_over_4 - alpha) / pi_over_4
+        frac2 = alpha / pi_over_4
+        cur_ord = order[r, c]
+
+        # Propagate to neighbor k
+        if frac1 > 0.0:
+            nr = r + nb_dy[k]
+            nc = c + nb_dx[k]
+            if 0 <= nr < height and 0 <= nc < width:
+                if stream_mask[nr, nc] == 1:
+                    if cur_ord > max_in[nr, nc]:
+                        max_in[nr, nc] = cur_ord
+                        cnt_max[nr, nc] = 1
+                    elif cur_ord == max_in[nr, nc]:
+                        cnt_max[nr, nc] += 1
+
+                    in_degree[nr, nc] -= 1
+                    if in_degree[nr, nc] == 0:
+                        if cnt_max[nr, nc] >= 2:
+                            order[nr, nc] = max_in[nr, nc] + 1.0
+                        else:
+                            order[nr, nc] = max_in[nr, nc]
+                        queue_r[tail] = nr
+                        queue_c[tail] = nc
+                        tail += 1
+
+        # Propagate to neighbor k2
+        if frac2 > 0.0:
+            nr2 = r + nb_dy[k2]
+            nc2 = c + nb_dx[k2]
+            if 0 <= nr2 < height and 0 <= nc2 < width:
+                if stream_mask[nr2, nc2] == 1:
+                    if cur_ord > max_in[nr2, nc2]:
+                        max_in[nr2, nc2] = cur_ord
+                        cnt_max[nr2, nc2] = 1
+                    elif cur_ord == max_in[nr2, nc2]:
+                        cnt_max[nr2, nc2] += 1
+
+                    in_degree[nr2, nc2] -= 1
+                    if in_degree[nr2, nc2] == 0:
+                        if cnt_max[nr2, nc2] >= 2:
+                            order[nr2, nc2] = max_in[nr2, nc2] + 1.0
+                        else:
+                            order[nr2, nc2] = max_in[nr2, nc2]
+                        queue_r[tail] = nr2
+                        queue_c[tail] = nc2
+                        tail += 1
+
+    return order
+
+
+@ngjit
+def _shreve_dinf_cpu(angles, stream_mask, height, width):
+    """Kahn's BFS Shreve ordering for D-inf flow directions."""
+    nb_dy = np.array([0, -1, -1, -1, 0, 1, 1, 1], dtype=np.int64)
+    nb_dx = np.array([1, 1, 0, -1, -1, -1, 0, 1], dtype=np.int64)
+    pi_over_4 = math.pi / 4.0
+
+    order = np.empty((height, width), dtype=np.float64)
+    in_degree = np.zeros((height, width), dtype=np.int32)
+
+    for r in range(height):
+        for c in range(width):
+            if stream_mask[r, c] == 0:
+                order[r, c] = np.nan
+            else:
+                order[r, c] = 0.0
+
+    # Compute in-degrees
+    for r in range(height):
+        for c in range(width):
+            if stream_mask[r, c] == 0:
+                continue
+            theta = angles[r, c]
+            if theta != theta:
+                continue
+            if theta < 0.0:
+                continue
+
+            k = int(theta / pi_over_4)
+            if k >= 8:
+                k = 7
+            k2 = (k + 1) % 8
+            alpha = theta - k * pi_over_4
+            frac1 = (pi_over_4 - alpha) / pi_over_4
+            frac2 = alpha / pi_over_4
+
+            if frac1 > 0.0:
+                nr = r + nb_dy[k]
+                nc = c + nb_dx[k]
+                if 0 <= nr < height and 0 <= nc < width:
+                    if stream_mask[nr, nc] == 1:
+                        in_degree[nr, nc] += 1
+
+            if frac2 > 0.0:
+                nr2 = r + nb_dy[k2]
+                nc2 = c + nb_dx[k2]
+                if 0 <= nr2 < height and 0 <= nc2 < width:
+                    if stream_mask[nr2, nc2] == 1:
+                        in_degree[nr2, nc2] += 1
+
+    queue_r = np.empty(height * width, dtype=np.int64)
+    queue_c = np.empty(height * width, dtype=np.int64)
+    head = np.int64(0)
+    tail = np.int64(0)
+
+    for r in range(height):
+        for c in range(width):
+            if stream_mask[r, c] == 1 and in_degree[r, c] == 0:
+                order[r, c] = 1.0
+                queue_r[tail] = r
+                queue_c[tail] = c
+                tail += 1
+
+    while head < tail:
+        r = queue_r[head]
+        c = queue_c[head]
+        head += 1
+
+        theta = angles[r, c]
+        if theta != theta:
+            continue
+        if theta < 0.0:
+            continue
+
+        k = int(theta / pi_over_4)
+        if k >= 8:
+            k = 7
+        k2 = (k + 1) % 8
+        alpha = theta - k * pi_over_4
+        frac1 = (pi_over_4 - alpha) / pi_over_4
+        frac2 = alpha / pi_over_4
+        cur_ord = order[r, c]
+
+        if frac1 > 0.0:
+            nr = r + nb_dy[k]
+            nc = c + nb_dx[k]
+            if 0 <= nr < height and 0 <= nc < width:
+                if stream_mask[nr, nc] == 1:
+                    order[nr, nc] += cur_ord
+                    in_degree[nr, nc] -= 1
+                    if in_degree[nr, nc] == 0:
+                        queue_r[tail] = nr
+                        queue_c[tail] = nc
+                        tail += 1
+
+        if frac2 > 0.0:
+            nr2 = r + nb_dy[k2]
+            nc2 = c + nb_dx[k2]
+            if 0 <= nr2 < height and 0 <= nc2 < width:
+                if stream_mask[nr2, nc2] == 1:
+                    order[nr2, nc2] += cur_ord
+                    in_degree[nr2, nc2] -= 1
+                    if in_degree[nr2, nc2] == 0:
+                        queue_r[tail] = nr2
+                        queue_c[tail] = nc2
+                        tail += 1
+
+    return order
+
+
+# =====================================================================
+# GPU kernels
+# =====================================================================
+
+@cuda.jit(device=True)
+def _dinf_nb_dy(k):
+    """Return row offset for neighbor k (0..7)."""
+    if k == 0:
+        return 0
+    elif k == 1:
+        return -1
+    elif k == 2:
+        return -1
+    elif k == 3:
+        return -1
+    elif k == 4:
+        return 0
+    elif k == 5:
+        return 1
+    elif k == 6:
+        return 1
+    else:
+        return 1
+
+
+@cuda.jit(device=True)
+def _dinf_nb_dx(k):
+    """Return column offset for neighbor k (0..7)."""
+    if k == 0:
+        return 1
+    elif k == 1:
+        return 1
+    elif k == 2:
+        return 0
+    elif k == 3:
+        return -1
+    elif k == 4:
+        return -1
+    elif k == 5:
+        return -1
+    elif k == 6:
+        return 0
+    else:
+        return 1
+
+
+@cuda.jit(device=True)
+def _dinf_angle_to_k(theta):
+    """Convert angle to primary neighbor index k (0..7).
+
+    Returns -1 if theta is NaN or < 0 (pit/nodata).
+    """
+    if theta != theta:  # NaN
+        return -1
+    if theta < 0.0:
+        return -1
+    pi_over_4 = 0.7853981633974483
+    k = int(theta / pi_over_4)
+    if k >= 8:
+        k = 7
+    return k
+
+
+@cuda.jit
+def _stream_order_dinf_init_gpu(angles, stream_mask, in_degree, state,
+                                 order, max_in, cnt_max, H, W):
+    """Initialise GPU arrays and compute in-degrees from D-inf angles."""
+    i, j = cuda.grid(2)
+    if i >= H or j >= W:
+        return
+
+    if stream_mask[i, j] == 0:
+        state[i, j] = 0
+        order[i, j] = 0.0
+        max_in[i, j] = 0.0
+        cnt_max[i, j] = 0
+        return
+
+    state[i, j] = 1
+    order[i, j] = 0.0
+    max_in[i, j] = 0.0
+    cnt_max[i, j] = 0
+
+    theta = angles[i, j]
+    k = _dinf_angle_to_k(theta)
+    if k < 0:
+        return
+
+    pi_over_4 = 0.7853981633974483
+    k2 = (k + 1) % 8
+    alpha = theta - k * pi_over_4
+    frac1 = (pi_over_4 - alpha) / pi_over_4
+    frac2 = alpha / pi_over_4
+
+    if frac1 > 0.0:
+        ni = i + _dinf_nb_dy(k)
+        nj = j + _dinf_nb_dx(k)
+        if 0 <= ni < H and 0 <= nj < W and stream_mask[ni, nj] == 1:
+            cuda.atomic.add(in_degree, (ni, nj), 1)
+
+    if frac2 > 0.0:
+        ni2 = i + _dinf_nb_dy(k2)
+        nj2 = j + _dinf_nb_dx(k2)
+        if 0 <= ni2 < H and 0 <= nj2 < W and stream_mask[ni2, nj2] == 1:
+            cuda.atomic.add(in_degree, (ni2, nj2), 1)
+
+
+@cuda.jit
+def _stream_order_dinf_find_ready(in_degree, state, order, changed, H, W):
+    """Finalize previous frontier, mark new frontier cells."""
+    i, j = cuda.grid(2)
+    if i >= H or j >= W:
+        return
+
+    if state[i, j] == 2:
+        state[i, j] = 3
+
+    if state[i, j] == 1 and in_degree[i, j] == 0:
+        state[i, j] = 2
+        if order[i, j] == 0.0:
+            order[i, j] = 1.0  # headwater
+        cuda.atomic.add(changed, 0, 1)
+
+
+@cuda.jit
+def _stream_order_dinf_pull_strahler(angles, stream_mask, in_degree, state,
+                                      order, max_in, cnt_max, H, W):
+    """Active cells pull Strahler info from frontier D-inf neighbours."""
+    i, j = cuda.grid(2)
+    if i >= H or j >= W:
+        return
+    if state[i, j] != 1:
+        return
+
+    pi_over_4 = 0.7853981633974483
+
+    # Check each of the 8 neighbors to see if it is on the frontier
+    # and flows to us.
+    for nb in range(8):
+        dy = _dinf_nb_dy(nb)
+        dx = _dinf_nb_dx(nb)
+        ni = i + dy
+        nj = j + dx
+        if ni < 0 or ni >= H or nj < 0 or nj >= W:
+            continue
+        if state[ni, nj] != 2:
+            continue
+        if stream_mask[ni, nj] == 0:
+            continue
+
+        # Check if the neighbor's angle points to us.
+        nb_theta = angles[ni, nj]
+        nb_k = _dinf_angle_to_k(nb_theta)
+        if nb_k < 0:
+            continue
+
+        nb_k2 = (nb_k + 1) % 8
+        nb_alpha = nb_theta - nb_k * pi_over_4
+        nb_frac1 = (pi_over_4 - nb_alpha) / pi_over_4
+        nb_frac2 = nb_alpha / pi_over_4
+
+        flows_to_us = False
+        if nb_frac1 > 0.0:
+            ti = ni + _dinf_nb_dy(nb_k)
+            tj = nj + _dinf_nb_dx(nb_k)
+            if ti == i and tj == j:
+                flows_to_us = True
+
+        if not flows_to_us and nb_frac2 > 0.0:
+            ti2 = ni + _dinf_nb_dy(nb_k2)
+            tj2 = nj + _dinf_nb_dx(nb_k2)
+            if ti2 == i and tj2 == j:
+                flows_to_us = True
+
+        if flows_to_us:
+            nb_ord = order[ni, nj]
+            if nb_ord > max_in[i, j]:
+                max_in[i, j] = nb_ord
+                cnt_max[i, j] = 1
+            elif nb_ord == max_in[i, j]:
+                cnt_max[i, j] += 1
+            in_degree[i, j] -= 1
+
+    if in_degree[i, j] == 0:
+        if cnt_max[i, j] >= 2:
+            order[i, j] = max_in[i, j] + 1.0
+        else:
+            order[i, j] = max_in[i, j]
+
+
+@cuda.jit
+def _stream_order_dinf_pull_shreve(angles, stream_mask, in_degree, state,
+                                    order, H, W):
+    """Active cells pull Shreve magnitudes from frontier D-inf neighbours."""
+    i, j = cuda.grid(2)
+    if i >= H or j >= W:
+        return
+    if state[i, j] != 1:
+        return
+
+    pi_over_4 = 0.7853981633974483
+
+    for nb in range(8):
+        dy = _dinf_nb_dy(nb)
+        dx = _dinf_nb_dx(nb)
+        ni = i + dy
+        nj = j + dx
+        if ni < 0 or ni >= H or nj < 0 or nj >= W:
+            continue
+        if state[ni, nj] != 2:
+            continue
+        if stream_mask[ni, nj] == 0:
+            continue
+
+        nb_theta = angles[ni, nj]
+        nb_k = _dinf_angle_to_k(nb_theta)
+        if nb_k < 0:
+            continue
+
+        nb_k2 = (nb_k + 1) % 8
+        nb_alpha = nb_theta - nb_k * pi_over_4
+        nb_frac1 = (pi_over_4 - nb_alpha) / pi_over_4
+        nb_frac2 = nb_alpha / pi_over_4
+
+        flows_to_us = False
+        if nb_frac1 > 0.0:
+            ti = ni + _dinf_nb_dy(nb_k)
+            tj = nj + _dinf_nb_dx(nb_k)
+            if ti == i and tj == j:
+                flows_to_us = True
+
+        if not flows_to_us and nb_frac2 > 0.0:
+            ti2 = ni + _dinf_nb_dy(nb_k2)
+            tj2 = nj + _dinf_nb_dx(nb_k2)
+            if ti2 == i and tj2 == j:
+                flows_to_us = True
+
+        if flows_to_us:
+            order[i, j] += order[ni, nj]
+            in_degree[i, j] -= 1
+
+
+# =====================================================================
+# CuPy driver
+# =====================================================================
+
+def _stream_order_dinf_cupy(angles_data, stream_mask_data, method):
+    """GPU driver for D-inf stream order computation."""
+    import cupy as cp
+
+    H, W = angles_data.shape
+    angles_f64 = angles_data.astype(cp.float64)
+    stream_mask_i8 = stream_mask_data.astype(cp.int8)
+
+    in_degree = cp.zeros((H, W), dtype=cp.int32)
+    state = cp.zeros((H, W), dtype=cp.int32)
+    order = cp.zeros((H, W), dtype=cp.float64)
+    max_in = cp.zeros((H, W), dtype=cp.float64)
+    cnt_max = cp.zeros((H, W), dtype=cp.int32)
+    changed = cp.zeros(1, dtype=cp.int32)
+
+    griddim, blockdim = cuda_args((H, W))
+
+    _stream_order_dinf_init_gpu[griddim, blockdim](
+        angles_f64, stream_mask_i8, in_degree, state,
+        order, max_in, cnt_max, H, W)
+
+    max_iter = H * W
+    for _ in range(max_iter):
+        changed[0] = 0
+        _stream_order_dinf_find_ready[griddim, blockdim](
+            in_degree, state, order, changed, H, W)
+
+        if int(changed[0]) == 0:
+            break
+
+        if method == 'strahler':
+            _stream_order_dinf_pull_strahler[griddim, blockdim](
+                angles_f64, stream_mask_i8, in_degree, state,
+                order, max_in, cnt_max, H, W)
+        else:
+            _stream_order_dinf_pull_shreve[griddim, blockdim](
+                angles_f64, stream_mask_i8, in_degree, state,
+                order, H, W)
+
+    order = cp.where(stream_mask_i8 == 0, cp.nan, order)
+    return order
+
+
+# =====================================================================
+# CPU tile kernels for Dask
+# =====================================================================
+
+@ngjit
+def _strahler_dinf_tile_kernel(angles, stream_mask, h, w,
+                                seed_max_top, seed_cnt_top,
+                                seed_max_bottom, seed_cnt_bottom,
+                                seed_max_left, seed_cnt_left,
+                                seed_max_right, seed_cnt_right):
+    """Seeded Strahler BFS for a single tile (D-inf)."""
+    nb_dy = np.array([0, -1, -1, -1, 0, 1, 1, 1], dtype=np.int64)
+    nb_dx = np.array([1, 1, 0, -1, -1, -1, 0, 1], dtype=np.int64)
+    pi_over_4 = math.pi / 4.0
+
+    order = np.empty((h, w), dtype=np.float64)
+    in_degree = np.zeros((h, w), dtype=np.int32)
+    max_in = np.zeros((h, w), dtype=np.float64)
+    cnt_max = np.zeros((h, w), dtype=np.int32)
+
+    for r in range(h):
+        for c in range(w):
+            if stream_mask[r, c] == 0:
+                order[r, c] = np.nan
+            else:
+                order[r, c] = 0.0
+
+    # Apply seeds: set max_in / cnt_max from boundary info
+    for c in range(w):
+        if stream_mask[0, c] == 1 and seed_max_top[c] > 0:
+            if seed_max_top[c] > max_in[0, c]:
+                max_in[0, c] = seed_max_top[c]
+                cnt_max[0, c] = int(seed_cnt_top[c])
+            elif seed_max_top[c] == max_in[0, c]:
+                cnt_max[0, c] += int(seed_cnt_top[c])
+        if stream_mask[h - 1, c] == 1 and seed_max_bottom[c] > 0:
+            if seed_max_bottom[c] > max_in[h - 1, c]:
+                max_in[h - 1, c] = seed_max_bottom[c]
+                cnt_max[h - 1, c] = int(seed_cnt_bottom[c])
+            elif seed_max_bottom[c] == max_in[h - 1, c]:
+                cnt_max[h - 1, c] += int(seed_cnt_bottom[c])
+    for r in range(h):
+        if stream_mask[r, 0] == 1 and seed_max_left[r] > 0:
+            if seed_max_left[r] > max_in[r, 0]:
+                max_in[r, 0] = seed_max_left[r]
+                cnt_max[r, 0] = int(seed_cnt_left[r])
+            elif seed_max_left[r] == max_in[r, 0]:
+                cnt_max[r, 0] += int(seed_cnt_left[r])
+        if stream_mask[r, w - 1] == 1 and seed_max_right[r] > 0:
+            if seed_max_right[r] > max_in[r, w - 1]:
+                max_in[r, w - 1] = seed_max_right[r]
+                cnt_max[r, w - 1] = int(seed_cnt_right[r])
+            elif seed_max_right[r] == max_in[r, w - 1]:
+                cnt_max[r, w - 1] += int(seed_cnt_right[r])
+
+    # Compute in-degrees among stream cells within tile
+    for r in range(h):
+        for c in range(w):
+            if stream_mask[r, c] == 0:
+                continue
+            theta = angles[r, c]
+            if theta != theta:
+                continue
+            if theta < 0.0:
+                continue
+
+            k = int(theta / pi_over_4)
+            if k >= 8:
+                k = 7
+            k2 = (k + 1) % 8
+            alpha = theta - k * pi_over_4
+            frac1 = (pi_over_4 - alpha) / pi_over_4
+            frac2 = alpha / pi_over_4
+
+            if frac1 > 0.0:
+                nr = r + nb_dy[k]
+                nc = c + nb_dx[k]
+                if 0 <= nr < h and 0 <= nc < w:
+                    if stream_mask[nr, nc] == 1:
+                        in_degree[nr, nc] += 1
+
+            if frac2 > 0.0:
+                nr2 = r + nb_dy[k2]
+                nc2 = c + nb_dx[k2]
+                if 0 <= nr2 < h and 0 <= nc2 < w:
+                    if stream_mask[nr2, nc2] == 1:
+                        in_degree[nr2, nc2] += 1
+
+    # BFS
+    queue_r = np.empty(h * w, dtype=np.int64)
+    queue_c = np.empty(h * w, dtype=np.int64)
+    head = np.int64(0)
+    tail = np.int64(0)
+
+    for r in range(h):
+        for c in range(w):
+            if stream_mask[r, c] != 1:
+                continue
+            if in_degree[r, c] != 0:
+                continue
+            # Headwater or seeded cell
+            if max_in[r, c] > 0:
+                if cnt_max[r, c] >= 2:
+                    order[r, c] = max_in[r, c] + 1.0
+                else:
+                    order[r, c] = max_in[r, c]
+            else:
+                order[r, c] = 1.0
+            queue_r[tail] = r
+            queue_c[tail] = c
+            tail += 1
+
+    while head < tail:
+        r = queue_r[head]
+        c = queue_c[head]
+        head += 1
+
+        theta = angles[r, c]
+        if theta != theta:
+            continue
+        if theta < 0.0:
+            continue
+
+        k = int(theta / pi_over_4)
+        if k >= 8:
+            k = 7
+        k2 = (k + 1) % 8
+        alpha = theta - k * pi_over_4
+        frac1 = (pi_over_4 - alpha) / pi_over_4
+        frac2 = alpha / pi_over_4
+        cur_ord = order[r, c]
+
+        if frac1 > 0.0:
+            nr = r + nb_dy[k]
+            nc = c + nb_dx[k]
+            if 0 <= nr < h and 0 <= nc < w:
+                if stream_mask[nr, nc] == 1:
+                    if cur_ord > max_in[nr, nc]:
+                        max_in[nr, nc] = cur_ord
+                        cnt_max[nr, nc] = 1
+                    elif cur_ord == max_in[nr, nc]:
+                        cnt_max[nr, nc] += 1
+
+                    in_degree[nr, nc] -= 1
+                    if in_degree[nr, nc] == 0:
+                        if cnt_max[nr, nc] >= 2:
+                            order[nr, nc] = max_in[nr, nc] + 1.0
+                        else:
+                            order[nr, nc] = max_in[nr, nc]
+                        queue_r[tail] = nr
+                        queue_c[tail] = nc
+                        tail += 1
+
+        if frac2 > 0.0:
+            nr2 = r + nb_dy[k2]
+            nc2 = c + nb_dx[k2]
+            if 0 <= nr2 < h and 0 <= nc2 < w:
+                if stream_mask[nr2, nc2] == 1:
+                    if cur_ord > max_in[nr2, nc2]:
+                        max_in[nr2, nc2] = cur_ord
+                        cnt_max[nr2, nc2] = 1
+                    elif cur_ord == max_in[nr2, nc2]:
+                        cnt_max[nr2, nc2] += 1
+
+                    in_degree[nr2, nc2] -= 1
+                    if in_degree[nr2, nc2] == 0:
+                        if cnt_max[nr2, nc2] >= 2:
+                            order[nr2, nc2] = max_in[nr2, nc2] + 1.0
+                        else:
+                            order[nr2, nc2] = max_in[nr2, nc2]
+                        queue_r[tail] = nr2
+                        queue_c[tail] = nc2
+                        tail += 1
+
+    return order
+
+
+@ngjit
+def _shreve_dinf_tile_kernel(angles, stream_mask, h, w,
+                              seed_top, seed_bottom,
+                              seed_left, seed_right):
+    """Seeded Shreve BFS for a single tile (D-inf)."""
+    nb_dy = np.array([0, -1, -1, -1, 0, 1, 1, 1], dtype=np.int64)
+    nb_dx = np.array([1, 1, 0, -1, -1, -1, 0, 1], dtype=np.int64)
+    pi_over_4 = math.pi / 4.0
+
+    order = np.empty((h, w), dtype=np.float64)
+    in_degree = np.zeros((h, w), dtype=np.int32)
+
+    for r in range(h):
+        for c in range(w):
+            if stream_mask[r, c] == 0:
+                order[r, c] = np.nan
+            else:
+                order[r, c] = 0.0
+
+    # Apply additive seeds
+    for c in range(w):
+        if stream_mask[0, c] == 1:
+            order[0, c] += seed_top[c]
+        if stream_mask[h - 1, c] == 1:
+            order[h - 1, c] += seed_bottom[c]
+    for r in range(h):
+        if stream_mask[r, 0] == 1:
+            order[r, 0] += seed_left[r]
+        if stream_mask[r, w - 1] == 1:
+            order[r, w - 1] += seed_right[r]
+
+    # In-degrees
+    for r in range(h):
+        for c in range(w):
+            if stream_mask[r, c] == 0:
+                continue
+            theta = angles[r, c]
+            if theta != theta:
+                continue
+            if theta < 0.0:
+                continue
+
+            k = int(theta / pi_over_4)
+            if k >= 8:
+                k = 7
+            k2 = (k + 1) % 8
+            alpha = theta - k * pi_over_4
+            frac1 = (pi_over_4 - alpha) / pi_over_4
+            frac2 = alpha / pi_over_4
+
+            if frac1 > 0.0:
+                nr = r + nb_dy[k]
+                nc = c + nb_dx[k]
+                if 0 <= nr < h and 0 <= nc < w:
+                    if stream_mask[nr, nc] == 1:
+                        in_degree[nr, nc] += 1
+
+            if frac2 > 0.0:
+                nr2 = r + nb_dy[k2]
+                nc2 = c + nb_dx[k2]
+                if 0 <= nr2 < h and 0 <= nc2 < w:
+                    if stream_mask[nr2, nc2] == 1:
+                        in_degree[nr2, nc2] += 1
+
+    queue_r = np.empty(h * w, dtype=np.int64)
+    queue_c = np.empty(h * w, dtype=np.int64)
+    head = np.int64(0)
+    tail = np.int64(0)
+
+    for r in range(h):
+        for c in range(w):
+            if stream_mask[r, c] == 1 and in_degree[r, c] == 0:
+                if order[r, c] == 0.0:
+                    order[r, c] = 1.0  # headwater
+                queue_r[tail] = r
+                queue_c[tail] = c
+                tail += 1
+
+    while head < tail:
+        r = queue_r[head]
+        c = queue_c[head]
+        head += 1
+
+        theta = angles[r, c]
+        if theta != theta:
+            continue
+        if theta < 0.0:
+            continue
+
+        k = int(theta / pi_over_4)
+        if k >= 8:
+            k = 7
+        k2 = (k + 1) % 8
+        alpha = theta - k * pi_over_4
+        frac1 = (pi_over_4 - alpha) / pi_over_4
+        frac2 = alpha / pi_over_4
+        cur_ord = order[r, c]
+
+        if frac1 > 0.0:
+            nr = r + nb_dy[k]
+            nc = c + nb_dx[k]
+            if 0 <= nr < h and 0 <= nc < w:
+                if stream_mask[nr, nc] == 1:
+                    order[nr, nc] += cur_ord
+                    in_degree[nr, nc] -= 1
+                    if in_degree[nr, nc] == 0:
+                        queue_r[tail] = nr
+                        queue_c[tail] = nc
+                        tail += 1
+
+        if frac2 > 0.0:
+            nr2 = r + nb_dy[k2]
+            nc2 = c + nb_dx[k2]
+            if 0 <= nr2 < h and 0 <= nc2 < w:
+                if stream_mask[nr2, nc2] == 1:
+                    order[nr2, nc2] += cur_ord
+                    in_degree[nr2, nc2] -= 1
+                    if in_degree[nr2, nc2] == 0:
+                        queue_r[tail] = nr2
+                        queue_c[tail] = nc2
+                        tail += 1
+
+    return order
+
+
+# =====================================================================
+# Dask preprocessing and seed computation
+# =====================================================================
+
+def _preprocess_stream_tiles_dinf(flow_dir_da, accum_da, threshold,
+                                   chunks_y, chunks_x):
+    """Extract boundary strips for D-inf angles and stream mask."""
+    n_tile_y = len(chunks_y)
+    n_tile_x = len(chunks_x)
+
+    flow_bdry = BoundaryStore(chunks_y, chunks_x, fill_value=np.nan)
+    mask_bdry = BoundaryStore(chunks_y, chunks_x, fill_value=0.0)
+
+    for iy in range(n_tile_y):
+        for ix in range(n_tile_x):
+            fd_chunk = _to_numpy_f64(
+                flow_dir_da.blocks[iy, ix].compute())
+            ac_chunk = _to_numpy_f64(
+                accum_da.blocks[iy, ix].compute())
+            sm = np.where(ac_chunk >= threshold, 1.0, 0.0)
+            sm = np.where(np.isnan(ac_chunk), 0.0, sm)
+
+            for side, row_data_fd, row_data_sm in [
+                ('top', fd_chunk[0, :], sm[0, :]),
+                ('bottom', fd_chunk[-1, :], sm[-1, :]),
+                ('left', fd_chunk[:, 0], sm[:, 0]),
+                ('right', fd_chunk[:, -1], sm[:, -1]),
+            ]:
+                flow_bdry.set(side, iy, ix,
+                              np.asarray(row_data_fd, dtype=np.float64))
+                mask_bdry.set(side, iy, ix,
+                              np.asarray(row_data_sm, dtype=np.float64))
+
+    return flow_bdry, mask_bdry
+
+
+def _compute_shreve_seeds_dinf(iy, ix, boundaries, flow_bdry, mask_bdry,
+                                chunks_y, chunks_x, n_tile_y, n_tile_x):
+    """Compute additive Shreve seeds from D-inf neighbour tiles."""
+    nb_dy = _NB_DY
+    nb_dx = _NB_DX
+
+    tile_h = chunks_y[iy]
+    tile_w = chunks_x[ix]
+
+    seed_top = np.zeros(tile_w, dtype=np.float64)
+    seed_bottom = np.zeros(tile_w, dtype=np.float64)
+    seed_left = np.zeros(tile_h, dtype=np.float64)
+    seed_right = np.zeros(tile_h, dtype=np.float64)
+
+    # Top edge: bottom row of tile above flows south into our top row
+    if iy > 0:
+        nb_fdir = flow_bdry.get('bottom', iy - 1, ix)
+        nb_mask = mask_bdry.get('bottom', iy - 1, ix)
+        nb_order = boundaries.get('bottom', iy - 1, ix)
+        w = len(nb_fdir)
+        for j in range(w):
+            if nb_mask[j] == 0:
+                continue
+            theta = nb_fdir[j]
+            if theta != theta or theta < 0.0:
+                continue
+            k1, f1, k2, f2 = _dinf_downstream(theta)
+            if k1 < 0:
+                continue
+            for kk, frac in [(k1, f1), (k2, f2)]:
+                if frac <= 0.0:
+                    continue
+                dy = int(nb_dy[kk])
+                dx = int(nb_dx[kk])
+                if dy == 1:  # flows south into our tile
+                    tc = j + dx
+                    if 0 <= tc < tile_w:
+                        seed_top[tc] += nb_order[j] * frac
+
+    # Bottom edge: top row of tile below flows north into our bottom row
+    if iy < n_tile_y - 1:
+        nb_fdir = flow_bdry.get('top', iy + 1, ix)
+        nb_mask = mask_bdry.get('top', iy + 1, ix)
+        nb_order = boundaries.get('top', iy + 1, ix)
+        w = len(nb_fdir)
+        for j in range(w):
+            if nb_mask[j] == 0:
+                continue
+            theta = nb_fdir[j]
+            if theta != theta or theta < 0.0:
+                continue
+            k1, f1, k2, f2 = _dinf_downstream(theta)
+            if k1 < 0:
+                continue
+            for kk, frac in [(k1, f1), (k2, f2)]:
+                if frac <= 0.0:
+                    continue
+                dy = int(nb_dy[kk])
+                dx = int(nb_dx[kk])
+                if dy == -1:  # flows north into our tile
+                    tc = j + dx
+                    if 0 <= tc < tile_w:
+                        seed_bottom[tc] += nb_order[j] * frac
+
+    # Left edge: right column of tile to the left flows east into us
+    if ix > 0:
+        nb_fdir = flow_bdry.get('right', iy, ix - 1)
+        nb_mask = mask_bdry.get('right', iy, ix - 1)
+        nb_order = boundaries.get('right', iy, ix - 1)
+        h = len(nb_fdir)
+        for i in range(h):
+            if nb_mask[i] == 0:
+                continue
+            theta = nb_fdir[i]
+            if theta != theta or theta < 0.0:
+                continue
+            k1, f1, k2, f2 = _dinf_downstream(theta)
+            if k1 < 0:
+                continue
+            for kk, frac in [(k1, f1), (k2, f2)]:
+                if frac <= 0.0:
+                    continue
+                dy = int(nb_dy[kk])
+                dx = int(nb_dx[kk])
+                if dx == 1:  # flows east into our tile
+                    tr = i + dy
+                    if 0 <= tr < tile_h:
+                        seed_left[tr] += nb_order[i] * frac
+
+    # Right edge: left column of tile to the right flows west into us
+    if ix < n_tile_x - 1:
+        nb_fdir = flow_bdry.get('left', iy, ix + 1)
+        nb_mask = mask_bdry.get('left', iy, ix + 1)
+        nb_order = boundaries.get('left', iy, ix + 1)
+        h = len(nb_fdir)
+        for i in range(h):
+            if nb_mask[i] == 0:
+                continue
+            theta = nb_fdir[i]
+            if theta != theta or theta < 0.0:
+                continue
+            k1, f1, k2, f2 = _dinf_downstream(theta)
+            if k1 < 0:
+                continue
+            for kk, frac in [(k1, f1), (k2, f2)]:
+                if frac <= 0.0:
+                    continue
+                dy = int(nb_dy[kk])
+                dx = int(nb_dx[kk])
+                if dx == -1:  # flows west into our tile
+                    tr = i + dy
+                    if 0 <= tr < tile_h:
+                        seed_right[tr] += nb_order[i] * frac
+
+    # Corner seeds from diagonal neighbour tiles.
+    def _corner_shreve(nb_side, nb_iy, nb_ix, nb_idx,
+                       required_dy, required_dx,
+                       s_arr, target):
+        fdir = flow_bdry.get(nb_side, nb_iy, nb_ix)[nb_idx]
+        mask = mask_bdry.get(nb_side, nb_iy, nb_ix)[nb_idx]
+        if mask == 0:
+            return
+        if fdir != fdir or fdir < 0.0:
+            return
+        k1, f1, k2, f2 = _dinf_downstream(fdir)
+        if k1 < 0:
+            return
+        for kk, frac in [(k1, f1), (k2, f2)]:
+            if frac <= 0.0:
+                continue
+            dy = int(nb_dy[kk])
+            dx = int(nb_dx[kk])
+            if dy == required_dy and dx == required_dx:
+                order_val = boundaries.get(nb_side, nb_iy, nb_ix)[nb_idx]
+                s_arr[target] += order_val * frac
+
+    # Top-left corner: bottom-right cell of tile (iy-1, ix-1)
+    if iy > 0 and ix > 0:
+        _corner_shreve('bottom', iy - 1, ix - 1, -1,
+                       1, 1, seed_top, 0)
+    # Top-right corner: bottom-left cell of tile (iy-1, ix+1)
+    if iy > 0 and ix < n_tile_x - 1:
+        _corner_shreve('bottom', iy - 1, ix + 1, 0,
+                       1, -1, seed_top, tile_w - 1)
+    # Bottom-left corner: top-right cell of tile (iy+1, ix-1)
+    if iy < n_tile_y - 1 and ix > 0:
+        _corner_shreve('top', iy + 1, ix - 1, -1,
+                       -1, 1, seed_bottom, 0)
+    # Bottom-right corner: top-left cell of tile (iy+1, ix+1)
+    if iy < n_tile_y - 1 and ix < n_tile_x - 1:
+        _corner_shreve('top', iy + 1, ix + 1, 0,
+                       -1, -1, seed_bottom, tile_w - 1)
+
+    return seed_top, seed_bottom, seed_left, seed_right
+
+
+def _compute_strahler_seeds_dinf(iy, ix, bdry_max, bdry_cnt,
+                                  flow_bdry, mask_bdry,
+                                  chunks_y, chunks_x,
+                                  n_tile_y, n_tile_x):
+    """Compute Strahler (max, cnt) seeds from D-inf neighbour tiles."""
+    nb_dy = _NB_DY
+    nb_dx = _NB_DX
+
+    tile_h = chunks_y[iy]
+    tile_w = chunks_x[ix]
+
+    smax_top = np.zeros(tile_w, dtype=np.float64)
+    scnt_top = np.zeros(tile_w, dtype=np.float64)
+    smax_bottom = np.zeros(tile_w, dtype=np.float64)
+    scnt_bottom = np.zeros(tile_w, dtype=np.float64)
+    smax_left = np.zeros(tile_h, dtype=np.float64)
+    scnt_left = np.zeros(tile_h, dtype=np.float64)
+    smax_right = np.zeros(tile_h, dtype=np.float64)
+    scnt_right = np.zeros(tile_h, dtype=np.float64)
+
+    def _update_max_cnt(cur_max, cur_cnt, new_val, idx):
+        if new_val > cur_max[idx]:
+            cur_max[idx] = new_val
+            cur_cnt[idx] = 1.0
+        elif new_val == cur_max[idx] and new_val > 0:
+            cur_cnt[idx] += 1.0
+
+    def _reconstruct_order(nm, nc):
+        """Reconstruct the order from stored max/cnt."""
+        if nc >= 2:
+            return nm + 1.0
+        return nm
+
+    # Top edge: bottom row of tile above
+    if iy > 0:
+        nb_fdir = flow_bdry.get('bottom', iy - 1, ix)
+        nb_mask = mask_bdry.get('bottom', iy - 1, ix)
+        nb_max = bdry_max.get('bottom', iy - 1, ix)
+        nb_cnt = bdry_cnt.get('bottom', iy - 1, ix)
+        w = len(nb_fdir)
+        for j in range(w):
+            if nb_mask[j] == 0 or nb_max[j] == 0:
+                continue
+            theta = nb_fdir[j]
+            if theta != theta or theta < 0.0:
+                continue
+            k1, f1, k2, f2 = _dinf_downstream(theta)
+            if k1 < 0:
+                continue
+            val = _reconstruct_order(nb_max[j], nb_cnt[j])
+            for kk, frac in [(k1, f1), (k2, f2)]:
+                if frac <= 0.0:
+                    continue
+                dy = int(nb_dy[kk])
+                dx = int(nb_dx[kk])
+                if dy == 1:  # flows south
+                    tc = j + dx
+                    if 0 <= tc < tile_w:
+                        _update_max_cnt(smax_top, scnt_top, val, tc)
+
+    # Bottom edge: top row of tile below
+    if iy < n_tile_y - 1:
+        nb_fdir = flow_bdry.get('top', iy + 1, ix)
+        nb_mask = mask_bdry.get('top', iy + 1, ix)
+        nb_max = bdry_max.get('top', iy + 1, ix)
+        nb_cnt = bdry_cnt.get('top', iy + 1, ix)
+        w = len(nb_fdir)
+        for j in range(w):
+            if nb_mask[j] == 0 or nb_max[j] == 0:
+                continue
+            theta = nb_fdir[j]
+            if theta != theta or theta < 0.0:
+                continue
+            k1, f1, k2, f2 = _dinf_downstream(theta)
+            if k1 < 0:
+                continue
+            val = _reconstruct_order(nb_max[j], nb_cnt[j])
+            for kk, frac in [(k1, f1), (k2, f2)]:
+                if frac <= 0.0:
+                    continue
+                dy = int(nb_dy[kk])
+                dx = int(nb_dx[kk])
+                if dy == -1:  # flows north
+                    tc = j + dx
+                    if 0 <= tc < tile_w:
+                        _update_max_cnt(smax_bottom, scnt_bottom, val, tc)
+
+    # Left edge: right column of tile to the left
+    if ix > 0:
+        nb_fdir = flow_bdry.get('right', iy, ix - 1)
+        nb_mask = mask_bdry.get('right', iy, ix - 1)
+        nb_max = bdry_max.get('right', iy, ix - 1)
+        nb_cnt = bdry_cnt.get('right', iy, ix - 1)
+        h = len(nb_fdir)
+        for i in range(h):
+            if nb_mask[i] == 0 or nb_max[i] == 0:
+                continue
+            theta = nb_fdir[i]
+            if theta != theta or theta < 0.0:
+                continue
+            k1, f1, k2, f2 = _dinf_downstream(theta)
+            if k1 < 0:
+                continue
+            val = _reconstruct_order(nb_max[i], nb_cnt[i])
+            for kk, frac in [(k1, f1), (k2, f2)]:
+                if frac <= 0.0:
+                    continue
+                dy = int(nb_dy[kk])
+                dx = int(nb_dx[kk])
+                if dx == 1:  # flows east
+                    tr = i + dy
+                    if 0 <= tr < tile_h:
+                        _update_max_cnt(smax_left, scnt_left, val, tr)
+
+    # Right edge: left column of tile to the right
+    if ix < n_tile_x - 1:
+        nb_fdir = flow_bdry.get('left', iy, ix + 1)
+        nb_mask = mask_bdry.get('left', iy, ix + 1)
+        nb_max = bdry_max.get('left', iy, ix + 1)
+        nb_cnt = bdry_cnt.get('left', iy, ix + 1)
+        h = len(nb_fdir)
+        for i in range(h):
+            if nb_mask[i] == 0 or nb_max[i] == 0:
+                continue
+            theta = nb_fdir[i]
+            if theta != theta or theta < 0.0:
+                continue
+            k1, f1, k2, f2 = _dinf_downstream(theta)
+            if k1 < 0:
+                continue
+            val = _reconstruct_order(nb_max[i], nb_cnt[i])
+            for kk, frac in [(k1, f1), (k2, f2)]:
+                if frac <= 0.0:
+                    continue
+                dy = int(nb_dy[kk])
+                dx = int(nb_dx[kk])
+                if dx == -1:  # flows west
+                    tr = i + dy
+                    if 0 <= tr < tile_h:
+                        _update_max_cnt(smax_right, scnt_right, val, tr)
+
+    # Corner seeds
+    def _corner_strahler(nb_side, nb_iy, nb_ix, nb_idx,
+                         required_dy, required_dx,
+                         s_max, s_cnt, target):
+        fdir = flow_bdry.get(nb_side, nb_iy, nb_ix)[nb_idx]
+        mask = mask_bdry.get(nb_side, nb_iy, nb_ix)[nb_idx]
+        if mask == 0:
+            return
+        nm = bdry_max.get(nb_side, nb_iy, nb_ix)[nb_idx]
+        if nm == 0:
+            return
+        if fdir != fdir or fdir < 0.0:
+            return
+        k1, f1, k2, f2 = _dinf_downstream(fdir)
+        if k1 < 0:
+            return
+        nc = bdry_cnt.get(nb_side, nb_iy, nb_ix)[nb_idx]
+        val = _reconstruct_order(nm, nc)
+        for kk, frac in [(k1, f1), (k2, f2)]:
+            if frac <= 0.0:
+                continue
+            dy = int(nb_dy[kk])
+            dx = int(nb_dx[kk])
+            if dy == required_dy and dx == required_dx:
+                _update_max_cnt(s_max, s_cnt, val, target)
+
+    # Top-left corner
+    if iy > 0 and ix > 0:
+        _corner_strahler('bottom', iy - 1, ix - 1, -1,
+                         1, 1, smax_top, scnt_top, 0)
+    # Top-right corner
+    if iy > 0 and ix < n_tile_x - 1:
+        _corner_strahler('bottom', iy - 1, ix + 1, 0,
+                         1, -1, smax_top, scnt_top, tile_w - 1)
+    # Bottom-left corner
+    if iy < n_tile_y - 1 and ix > 0:
+        _corner_strahler('top', iy + 1, ix - 1, -1,
+                         -1, 1, smax_bottom, scnt_bottom, 0)
+    # Bottom-right corner
+    if iy < n_tile_y - 1 and ix < n_tile_x - 1:
+        _corner_strahler('top', iy + 1, ix + 1, 0,
+                         -1, -1, smax_bottom, scnt_bottom, tile_w - 1)
+
+    return (smax_top, scnt_top, smax_bottom, scnt_bottom,
+            smax_left, scnt_left, smax_right, scnt_right)
+
+
+# =====================================================================
+# Dask iterative tile sweep
+# =====================================================================
+
+def _make_stream_mask_np_dinf(ac_chunk, fd_chunk, threshold):
+    """Build stream mask as numpy int8 from accumulation and D-inf angles."""
+    sm = np.where(ac_chunk >= threshold, 1, 0).astype(np.int8)
+    sm = np.where(np.isnan(ac_chunk), 0, sm).astype(np.int8)
+    sm = np.where(np.isnan(fd_chunk), 0, sm).astype(np.int8)
+    return sm
+
+
+def _process_strahler_tile_dinf(iy, ix, flow_dir_da, accum_da, threshold,
+                                 bdry_max, bdry_cnt, flow_bdry, mask_bdry,
+                                 chunks_y, chunks_x, n_tile_y, n_tile_x):
+    """Run seeded Strahler BFS on one D-inf tile; update boundary stores."""
+    fd_chunk = np.asarray(
+        flow_dir_da.blocks[iy, ix].compute(), dtype=np.float64)
+    ac_chunk = np.asarray(
+        accum_da.blocks[iy, ix].compute(), dtype=np.float64)
+    sm = _make_stream_mask_np_dinf(ac_chunk, fd_chunk, threshold)
+    h, w = fd_chunk.shape
+
+    seeds = _compute_strahler_seeds_dinf(
+        iy, ix, bdry_max, bdry_cnt, flow_bdry, mask_bdry,
+        chunks_y, chunks_x, n_tile_y, n_tile_x)
+
+    order = _strahler_dinf_tile_kernel(fd_chunk, sm, h, w, *seeds)
+
+    change = 0.0
+    for side, strip in [('top', order[0, :]),
+                        ('bottom', order[-1, :]),
+                        ('left', order[:, 0]),
+                        ('right', order[:, -1])]:
+        new_vals = strip.copy()
+        new_max = np.where(np.isnan(new_vals), 0.0, new_vals)
+        new_cnt = np.where(new_max > 0, 1.0, 0.0)
+
+        old_max = bdry_max.get(side, iy, ix).copy()
+        with np.errstate(invalid='ignore'):
+            diff = np.abs(new_max - old_max)
+        diff = np.where(np.isnan(diff), 0.0, diff)
+        m = float(np.max(diff))
+        if m > change:
+            change = m
+
+        bdry_max.set(side, iy, ix, new_max)
+        bdry_cnt.set(side, iy, ix, new_cnt)
+
+    return change
+
+
+def _process_shreve_tile_dinf(iy, ix, flow_dir_da, accum_da, threshold,
+                               boundaries, flow_bdry, mask_bdry,
+                               chunks_y, chunks_x, n_tile_y, n_tile_x):
+    """Run seeded Shreve BFS on one D-inf tile; update boundaries."""
+    fd_chunk = np.asarray(
+        flow_dir_da.blocks[iy, ix].compute(), dtype=np.float64)
+    ac_chunk = np.asarray(
+        accum_da.blocks[iy, ix].compute(), dtype=np.float64)
+    sm = _make_stream_mask_np_dinf(ac_chunk, fd_chunk, threshold)
+    h, w = fd_chunk.shape
+
+    seeds = _compute_shreve_seeds_dinf(
+        iy, ix, boundaries, flow_bdry, mask_bdry,
+        chunks_y, chunks_x, n_tile_y, n_tile_x)
+
+    order = _shreve_dinf_tile_kernel(fd_chunk, sm, h, w, *seeds)
+
+    change = 0.0
+    for side, strip in [('top', order[0, :]),
+                        ('bottom', order[-1, :]),
+                        ('left', order[:, 0]),
+                        ('right', order[:, -1])]:
+        new_vals = strip.copy()
+        new_vals = np.where(np.isnan(new_vals), 0.0, new_vals)
+        old = boundaries.get(side, iy, ix).copy()
+        with np.errstate(invalid='ignore'):
+            diff = np.abs(new_vals - old)
+        diff = np.where(np.isnan(diff), 0.0, diff)
+        m = float(np.max(diff))
+        if m > change:
+            change = m
+        boundaries.set(side, iy, ix, new_vals)
+
+    return change
+
+
+def _stream_order_dinf_dask_strahler(flow_dir_da, accum_da, threshold):
+    """Dask iterative sweep for D-inf Strahler ordering."""
+    chunks_y = flow_dir_da.chunks[0]
+    chunks_x = flow_dir_da.chunks[1]
+    n_tile_y = len(chunks_y)
+    n_tile_x = len(chunks_x)
+
+    flow_bdry, mask_bdry = _preprocess_stream_tiles_dinf(
+        flow_dir_da, accum_da, threshold, chunks_y, chunks_x)
+    flow_bdry = flow_bdry.snapshot()
+    mask_bdry = mask_bdry.snapshot()
+
+    bdry_max = BoundaryStore(chunks_y, chunks_x, fill_value=0.0)
+    bdry_cnt = BoundaryStore(chunks_y, chunks_x, fill_value=0.0)
+
+    max_iterations = max(n_tile_y, n_tile_x) + 10
+    for _ in range(max_iterations):
+        max_change = 0.0
+        for iy in range(n_tile_y):
+            for ix in range(n_tile_x):
+                c = _process_strahler_tile_dinf(
+                    iy, ix, flow_dir_da, accum_da, threshold,
+                    bdry_max, bdry_cnt, flow_bdry, mask_bdry,
+                    chunks_y, chunks_x, n_tile_y, n_tile_x)
+                if c > max_change:
+                    max_change = c
+        for iy in reversed(range(n_tile_y)):
+            for ix in reversed(range(n_tile_x)):
+                c = _process_strahler_tile_dinf(
+                    iy, ix, flow_dir_da, accum_da, threshold,
+                    bdry_max, bdry_cnt, flow_bdry, mask_bdry,
+                    chunks_y, chunks_x, n_tile_y, n_tile_x)
+                if c > max_change:
+                    max_change = c
+        if max_change == 0.0:
+            break
+
+    _bdry_max = bdry_max.snapshot()
+    _bdry_cnt = bdry_cnt.snapshot()
+    _flow_bdry = flow_bdry
+    _mask_bdry = mask_bdry
+    _threshold = threshold
+
+    def _tile_fn(block, accum_block, block_info=None):
+        if block_info is None or 0 not in block_info:
+            return np.full(block.shape, np.nan, dtype=np.float64)
+        iy, ix = block_info[0]['chunk-location']
+        fd = np.asarray(block, dtype=np.float64)
+        ac = np.asarray(accum_block, dtype=np.float64)
+        sm = _make_stream_mask_np_dinf(ac, fd, _threshold)
+        h, w = fd.shape
+        seeds = _compute_strahler_seeds_dinf(
+            iy, ix, _bdry_max, _bdry_cnt, _flow_bdry, _mask_bdry,
+            chunks_y, chunks_x, n_tile_y, n_tile_x)
+        return _strahler_dinf_tile_kernel(fd, sm, h, w, *seeds)
+
+    return da.map_blocks(
+        _tile_fn, flow_dir_da, accum_da,
+        dtype=np.float64, meta=np.array((), dtype=np.float64))
+
+
+def _stream_order_dinf_dask_shreve(flow_dir_da, accum_da, threshold):
+    """Dask iterative sweep for D-inf Shreve ordering."""
+    chunks_y = flow_dir_da.chunks[0]
+    chunks_x = flow_dir_da.chunks[1]
+    n_tile_y = len(chunks_y)
+    n_tile_x = len(chunks_x)
+
+    flow_bdry, mask_bdry = _preprocess_stream_tiles_dinf(
+        flow_dir_da, accum_da, threshold, chunks_y, chunks_x)
+    flow_bdry = flow_bdry.snapshot()
+    mask_bdry = mask_bdry.snapshot()
+
+    boundaries = BoundaryStore(chunks_y, chunks_x, fill_value=0.0)
+
+    max_iterations = max(n_tile_y, n_tile_x) + 10
+    for _ in range(max_iterations):
+        max_change = 0.0
+        for iy in range(n_tile_y):
+            for ix in range(n_tile_x):
+                c = _process_shreve_tile_dinf(
+                    iy, ix, flow_dir_da, accum_da, threshold,
+                    boundaries, flow_bdry, mask_bdry,
+                    chunks_y, chunks_x, n_tile_y, n_tile_x)
+                if c > max_change:
+                    max_change = c
+        for iy in reversed(range(n_tile_y)):
+            for ix in reversed(range(n_tile_x)):
+                c = _process_shreve_tile_dinf(
+                    iy, ix, flow_dir_da, accum_da, threshold,
+                    boundaries, flow_bdry, mask_bdry,
+                    chunks_y, chunks_x, n_tile_y, n_tile_x)
+                if c > max_change:
+                    max_change = c
+        if max_change == 0.0:
+            break
+
+    _boundaries = boundaries.snapshot()
+    _flow_bdry = flow_bdry
+    _mask_bdry = mask_bdry
+    _threshold = threshold
+
+    def _tile_fn(block, accum_block, block_info=None):
+        if block_info is None or 0 not in block_info:
+            return np.full(block.shape, np.nan, dtype=np.float64)
+        iy, ix = block_info[0]['chunk-location']
+        fd = np.asarray(block, dtype=np.float64)
+        ac = np.asarray(accum_block, dtype=np.float64)
+        sm = _make_stream_mask_np_dinf(ac, fd, _threshold)
+        h, w = fd.shape
+        seeds = _compute_shreve_seeds_dinf(
+            iy, ix, _boundaries, _flow_bdry, _mask_bdry,
+            chunks_y, chunks_x, n_tile_y, n_tile_x)
+        return _shreve_dinf_tile_kernel(fd, sm, h, w, *seeds)
+
+    return da.map_blocks(
+        _tile_fn, flow_dir_da, accum_da,
+        dtype=np.float64, meta=np.array((), dtype=np.float64))
+
+
+# =====================================================================
+# Dask + CuPy
+# =====================================================================
+
+def _stream_order_dinf_tile_cupy(angles_data, stream_mask_data, method,
+                                  seeds):
+    """GPU seeded D-inf stream order for a single tile.
+
+    Uses GPU frontier peeling with seeds injected after initialisation.
+    For Strahler, seeds are (max_top, cnt_top, max_bot, cnt_bot, ...).
+    For Shreve, seeds are (top, bot, left, right).
+    """
+    import cupy as cp
+
+    H, W = angles_data.shape
+    angles_f64 = angles_data.astype(cp.float64)
+    stream_mask_i8 = stream_mask_data.astype(cp.int8)
+
+    in_degree = cp.zeros((H, W), dtype=cp.int32)
+    state = cp.zeros((H, W), dtype=cp.int32)
+    order = cp.zeros((H, W), dtype=cp.float64)
+    max_in = cp.zeros((H, W), dtype=cp.float64)
+    cnt_max = cp.zeros((H, W), dtype=cp.int32)
+    changed = cp.zeros(1, dtype=cp.int32)
+
+    griddim, blockdim = cuda_args((H, W))
+
+    _stream_order_dinf_init_gpu[griddim, blockdim](
+        angles_f64, stream_mask_i8, in_degree, state,
+        order, max_in, cnt_max, H, W)
+
+    if method == 'strahler':
+        (smax_top, scnt_top, smax_bot, scnt_bot,
+         smax_left, scnt_left, smax_right, scnt_right) = seeds
+        for r_idx, s_max, s_cnt in [
+            ((0, slice(None)), smax_top, scnt_top),
+            ((H - 1, slice(None)), smax_bot, scnt_bot),
+            ((slice(None), 0), smax_left, scnt_left),
+            ((slice(None), W - 1), smax_right, scnt_right),
+        ]:
+            sm_cp = cp.asarray(s_max)
+            sc_cp = cp.asarray(s_cnt).astype(cp.int32)
+            is_stream = stream_mask_i8[r_idx] == 1
+            has_seed = sm_cp > 0
+            mask = is_stream & has_seed
+            max_in[r_idx] = cp.where(mask, sm_cp, max_in[r_idx])
+            cnt_max[r_idx] = cp.where(mask, sc_cp, cnt_max[r_idx])
+    else:
+        (seed_top, seed_bot, seed_left, seed_right) = seeds
+        order[0, :] += cp.asarray(seed_top)
+        order[H - 1, :] += cp.asarray(seed_bot)
+        order[:, 0] += cp.asarray(seed_left)
+        order[:, W - 1] += cp.asarray(seed_right)
+
+    max_iter = H * W
+    for _ in range(max_iter):
+        changed[0] = 0
+        _stream_order_dinf_find_ready[griddim, blockdim](
+            in_degree, state, order, changed, H, W)
+
+        if int(changed[0]) == 0:
+            break
+
+        if method == 'strahler':
+            _stream_order_dinf_pull_strahler[griddim, blockdim](
+                angles_f64, stream_mask_i8, in_degree, state,
+                order, max_in, cnt_max, H, W)
+        else:
+            _stream_order_dinf_pull_shreve[griddim, blockdim](
+                angles_f64, stream_mask_i8, in_degree, state,
+                order, H, W)
+
+    order = cp.where(stream_mask_i8 == 0, cp.nan, order)
+    return order
+
+
+def _process_strahler_tile_dinf_cupy(iy, ix, flow_dir_da, accum_da,
+                                      threshold,
+                                      bdry_max, bdry_cnt,
+                                      flow_bdry, mask_bdry,
+                                      chunks_y, chunks_x,
+                                      n_tile_y, n_tile_x):
+    """Run seeded GPU D-inf Strahler on one tile; update boundaries."""
+    import cupy as cp
+
+    fd_chunk = cp.asarray(
+        flow_dir_da.blocks[iy, ix].compute(), dtype=cp.float64)
+    ac_chunk = _to_numpy_f64(accum_da.blocks[iy, ix].compute())
+    fd_np = fd_chunk.get()
+    sm_np = _make_stream_mask_np_dinf(ac_chunk, fd_np, threshold)
+    sm_cp = cp.asarray(sm_np)
+
+    seeds = _compute_strahler_seeds_dinf(
+        iy, ix, bdry_max, bdry_cnt, flow_bdry, mask_bdry,
+        chunks_y, chunks_x, n_tile_y, n_tile_x)
+
+    order = _stream_order_dinf_tile_cupy(fd_chunk, sm_cp, 'strahler', seeds)
+
+    change = 0.0
+    for side, strip_cp in [('top', order[0, :]),
+                           ('bottom', order[-1, :]),
+                           ('left', order[:, 0]),
+                           ('right', order[:, -1])]:
+        new_vals = strip_cp.get().copy()
+        new_max = np.where(np.isnan(new_vals), 0.0, new_vals)
+        new_cnt = np.where(new_max > 0, 1.0, 0.0)
+
+        old_max = bdry_max.get(side, iy, ix).copy()
+        with np.errstate(invalid='ignore'):
+            diff = np.abs(new_max - old_max)
+        diff = np.where(np.isnan(diff), 0.0, diff)
+        m = float(np.max(diff))
+        if m > change:
+            change = m
+
+        bdry_max.set(side, iy, ix, new_max)
+        bdry_cnt.set(side, iy, ix, new_cnt)
+
+    return change
+
+
+def _process_shreve_tile_dinf_cupy(iy, ix, flow_dir_da, accum_da,
+                                    threshold,
+                                    boundaries, flow_bdry, mask_bdry,
+                                    chunks_y, chunks_x,
+                                    n_tile_y, n_tile_x):
+    """Run seeded GPU D-inf Shreve on one tile; update boundaries."""
+    import cupy as cp
+
+    fd_chunk = cp.asarray(
+        flow_dir_da.blocks[iy, ix].compute(), dtype=cp.float64)
+    ac_chunk = _to_numpy_f64(accum_da.blocks[iy, ix].compute())
+    fd_np = fd_chunk.get()
+    sm_np = _make_stream_mask_np_dinf(ac_chunk, fd_np, threshold)
+    sm_cp = cp.asarray(sm_np)
+
+    seeds = _compute_shreve_seeds_dinf(
+        iy, ix, boundaries, flow_bdry, mask_bdry,
+        chunks_y, chunks_x, n_tile_y, n_tile_x)
+
+    order = _stream_order_dinf_tile_cupy(fd_chunk, sm_cp, 'shreve', seeds)
+
+    change = 0.0
+    for side, strip_cp in [('top', order[0, :]),
+                           ('bottom', order[-1, :]),
+                           ('left', order[:, 0]),
+                           ('right', order[:, -1])]:
+        new_vals = strip_cp.get().copy()
+        new_vals = np.where(np.isnan(new_vals), 0.0, new_vals)
+        old = boundaries.get(side, iy, ix).copy()
+        with np.errstate(invalid='ignore'):
+            diff = np.abs(new_vals - old)
+        diff = np.where(np.isnan(diff), 0.0, diff)
+        m = float(np.max(diff))
+        if m > change:
+            change = m
+        boundaries.set(side, iy, ix, new_vals)
+
+    return change
+
+
+def _stream_order_dinf_dask_cupy(flow_dir_da, accum_da, threshold, method):
+    """Dask+CuPy: native GPU processing per tile for D-inf stream order."""
+    import cupy as cp
+
+    chunks_y = flow_dir_da.chunks[0]
+    chunks_x = flow_dir_da.chunks[1]
+    n_tile_y = len(chunks_y)
+    n_tile_x = len(chunks_x)
+
+    flow_bdry, mask_bdry = _preprocess_stream_tiles_dinf(
+        flow_dir_da, accum_da, threshold, chunks_y, chunks_x)
+    flow_bdry = flow_bdry.snapshot()
+    mask_bdry = mask_bdry.snapshot()
+
+    max_iterations = max(n_tile_y, n_tile_x) + 10
+
+    if method == 'strahler':
+        bdry_max = BoundaryStore(chunks_y, chunks_x, fill_value=0.0)
+        bdry_cnt = BoundaryStore(chunks_y, chunks_x, fill_value=0.0)
+
+        for _ in range(max_iterations):
+            max_change = 0.0
+            for iy in range(n_tile_y):
+                for ix in range(n_tile_x):
+                    c = _process_strahler_tile_dinf_cupy(
+                        iy, ix, flow_dir_da, accum_da, threshold,
+                        bdry_max, bdry_cnt, flow_bdry, mask_bdry,
+                        chunks_y, chunks_x, n_tile_y, n_tile_x)
+                    if c > max_change:
+                        max_change = c
+            for iy in reversed(range(n_tile_y)):
+                for ix in reversed(range(n_tile_x)):
+                    c = _process_strahler_tile_dinf_cupy(
+                        iy, ix, flow_dir_da, accum_da, threshold,
+                        bdry_max, bdry_cnt, flow_bdry, mask_bdry,
+                        chunks_y, chunks_x, n_tile_y, n_tile_x)
+                    if c > max_change:
+                        max_change = c
+            if max_change == 0.0:
+                break
+
+        _bdry_max = bdry_max.snapshot()
+        _bdry_cnt = bdry_cnt.snapshot()
+
+        def _tile_fn(block, accum_block, block_info=None):
+            if block_info is None or 0 not in block_info:
+                return cp.full(block.shape, cp.nan, dtype=cp.float64)
+            iy, ix = block_info[0]['chunk-location']
+            fd = cp.asarray(block, dtype=cp.float64)
+            ac_np = _to_numpy_f64(accum_block)
+            fd_np = fd.get()
+            sm = cp.asarray(_make_stream_mask_np_dinf(ac_np, fd_np, threshold))
+            seeds = _compute_strahler_seeds_dinf(
+                iy, ix, _bdry_max, _bdry_cnt, flow_bdry, mask_bdry,
+                chunks_y, chunks_x, n_tile_y, n_tile_x)
+            return _stream_order_dinf_tile_cupy(
+                fd, sm, 'strahler', seeds)
+
+    else:  # shreve
+        boundaries = BoundaryStore(chunks_y, chunks_x, fill_value=0.0)
+
+        for _ in range(max_iterations):
+            max_change = 0.0
+            for iy in range(n_tile_y):
+                for ix in range(n_tile_x):
+                    c = _process_shreve_tile_dinf_cupy(
+                        iy, ix, flow_dir_da, accum_da, threshold,
+                        boundaries, flow_bdry, mask_bdry,
+                        chunks_y, chunks_x, n_tile_y, n_tile_x)
+                    if c > max_change:
+                        max_change = c
+            for iy in reversed(range(n_tile_y)):
+                for ix in reversed(range(n_tile_x)):
+                    c = _process_shreve_tile_dinf_cupy(
+                        iy, ix, flow_dir_da, accum_da, threshold,
+                        boundaries, flow_bdry, mask_bdry,
+                        chunks_y, chunks_x, n_tile_y, n_tile_x)
+                    if c > max_change:
+                        max_change = c
+            if max_change == 0.0:
+                break
+
+        _boundaries = boundaries.snapshot()
+
+        def _tile_fn(block, accum_block, block_info=None):
+            if block_info is None or 0 not in block_info:
+                return cp.full(block.shape, cp.nan, dtype=cp.float64)
+            iy, ix = block_info[0]['chunk-location']
+            fd = cp.asarray(block, dtype=cp.float64)
+            ac_np = _to_numpy_f64(accum_block)
+            fd_np = fd.get()
+            sm = cp.asarray(_make_stream_mask_np_dinf(ac_np, fd_np, threshold))
+            seeds = _compute_shreve_seeds_dinf(
+                iy, ix, _boundaries, flow_bdry, mask_bdry,
+                chunks_y, chunks_x, n_tile_y, n_tile_x)
+            return _stream_order_dinf_tile_cupy(
+                fd, sm, 'shreve', seeds)
+
+    return da.map_blocks(
+        _tile_fn, flow_dir_da, accum_da,
+        dtype=np.float64, meta=cp.array((), dtype=cp.float64))
+
+
+# =====================================================================
+# Public API
+# =====================================================================
+
+@supports_dataset
+def stream_order_dinf(flow_dir_dinf: xr.DataArray,
+                      flow_accum: xr.DataArray,
+                      threshold: float = 100,
+                      method: str = 'strahler',
+                      name: str = 'stream_order_dinf') -> xr.DataArray:
+    """Compute stream order from D-infinity flow direction and accumulation.
+
+    Parameters
+    ----------
+    flow_dir_dinf : xarray.DataArray or xr.Dataset
+        2D D-infinity flow direction grid.  Values are continuous
+        angles in radians in the range ``[0, 2*pi)``.  ``-1.0``
+        indicates a pit or flat.  ``NaN`` indicates nodata.
+    flow_accum : xarray.DataArray
+        2D flow accumulation grid.  Cells with
+        ``flow_accum >= threshold`` are considered stream cells.
+    threshold : float, default 100
+        Minimum accumulation to classify a cell as part of the
+        stream network.
+    method : str, default 'strahler'
+        ``'strahler'`` for Strahler branching hierarchy or
+        ``'shreve'`` for Shreve cumulative magnitude.
+    name : str, default 'stream_order_dinf'
+        Name of output DataArray.
+
+    Returns
+    -------
+    xarray.DataArray or xr.Dataset
+        2D float64 array of stream order values.  Non-stream cells
+        (accumulation below threshold) are NaN.
+
+    References
+    ----------
+    Tarboton, D.G. (1997). A new method for the determination of flow
+    directions and upslope areas in grid digital elevation models.
+    Water Resources Research, 33(2), 309-319.
+
+    Strahler, A.N. (1957). Quantitative analysis of watershed
+    geomorphology. Transactions of the American Geophysical Union,
+    38(6), 913-920.
+
+    Shreve, R.L. (1966). Statistical law of stream numbers. Journal
+    of Geology, 74(1), 17-37.
+    """
+    _validate_raster(flow_dir_dinf,
+                     func_name='stream_order_dinf',
+                     name='flow_dir_dinf')
+
+    method = method.lower()
+    if method not in ('strahler', 'shreve'):
+        raise ValueError(
+            f"method must be 'strahler' or 'shreve', got {method!r}")
+
+    fd_data = flow_dir_dinf.data
+    fa_data = flow_accum.data
+
+    if isinstance(fd_data, np.ndarray):
+        fd = fd_data.astype(np.float64)
+        fa = np.asarray(fa_data, dtype=np.float64)
+        stream_mask = np.where(fa >= threshold, 1, 0).astype(np.int8)
+        stream_mask = np.where(np.isnan(fa), 0, stream_mask).astype(np.int8)
+        stream_mask = np.where(np.isnan(fd), 0, stream_mask).astype(np.int8)
+        h, w = fd.shape
+        if method == 'strahler':
+            out = _strahler_dinf_cpu(fd, stream_mask, h, w)
+        else:
+            out = _shreve_dinf_cpu(fd, stream_mask, h, w)
+
+    elif has_cuda_and_cupy() and is_cupy_array(fd_data):
+        import cupy as cp
+        fa_cp = cp.asarray(fa_data, dtype=cp.float64)
+        fd_cp = fd_data.astype(cp.float64)
+        stream_mask = cp.where(fa_cp >= threshold, 1, 0).astype(cp.int8)
+        stream_mask = cp.where(
+            cp.isnan(fa_cp), 0, stream_mask).astype(cp.int8)
+        stream_mask = cp.where(
+            cp.isnan(fd_cp), 0, stream_mask).astype(cp.int8)
+        out = _stream_order_dinf_cupy(fd_cp, stream_mask, method)
+
+    elif has_cuda_and_cupy() and is_dask_cupy(flow_dir_dinf):
+        out = _stream_order_dinf_dask_cupy(
+            fd_data, fa_data, threshold, method)
+
+    elif da is not None and isinstance(fd_data, da.Array):
+        if method == 'strahler':
+            out = _stream_order_dinf_dask_strahler(
+                fd_data, fa_data, threshold)
+        else:
+            out = _stream_order_dinf_dask_shreve(
+                fd_data, fa_data, threshold)
+
+    else:
+        raise TypeError(f"Unsupported array type: {type(fd_data)}")
+
+    return xr.DataArray(out,
+                        name=name,
+                        coords=flow_dir_dinf.coords,
+                        dims=flow_dir_dinf.dims,
+                        attrs=flow_dir_dinf.attrs)

--- a/xrspatial/stream_order_mfd.py
+++ b/xrspatial/stream_order_mfd.py
@@ -1,0 +1,1455 @@
+"""Stream order extraction for MFD (Multiple Flow Direction) grids.
+
+Assigns hierarchical order values to stream cells derived from an MFD
+flow direction grid (8, H, W) and a flow accumulation grid.  Cells with
+accumulation below a user-defined threshold are non-stream and receive
+NaN.  Two methods are supported:
+
+* **Strahler**: headwaters = 1; when two streams of equal order meet
+  the downstream order increments by 1; otherwise the higher order
+  propagates.
+* **Shreve**: headwaters = 1; at each confluence the downstream
+  magnitude equals the sum of all incoming magnitudes.
+
+Algorithm
+---------
+CPU : Kahn's BFS topological sort among stream cells -- O(N_stream).
+GPU : iterative frontier peeling with pull-based kernels.
+Dask: iterative tile sweep with boundary propagation, same pattern
+      as ``flow_accumulation_mfd.py``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import xarray as xr
+from numba import cuda
+
+try:
+    import cupy
+except ImportError:
+    class cupy:  # type: ignore[no-redef]
+        ndarray = False
+
+try:
+    import dask.array as da
+except ImportError:
+    da = None
+
+from xrspatial.utils import (
+    _validate_raster,
+    cuda_args,
+    has_cuda_and_cupy,
+    is_cupy_array,
+    is_dask_cupy,
+    ngjit,
+)
+from xrspatial._boundary_store import BoundaryStore
+from xrspatial.dataset_support import supports_dataset
+
+# Neighbor offsets: E, SE, S, SW, W, NW, N, NE
+_DY = np.array([0, 1, 1, 1, 0, -1, -1, -1], dtype=np.int64)
+_DX = np.array([1, 1, 0, -1, -1, -1, 0, 1], dtype=np.int64)
+
+# Opposite neighbor index (who points back at me?)
+# E(0)->W(4), SE(1)->NW(5), S(2)->N(6), SW(3)->NE(7), ...
+_OPPOSITE = np.array([4, 5, 6, 7, 0, 1, 2, 3], dtype=np.int64)
+
+
+def _to_numpy_f64(arr):
+    """Convert *arr* to a contiguous numpy float64 array (handles CuPy)."""
+    if hasattr(arr, 'get'):
+        arr = arr.get()
+    return np.asarray(arr, dtype=np.float64)
+
+
+# =====================================================================
+# CPU kernels
+# =====================================================================
+
+@ngjit
+def _strahler_mfd_cpu(fractions, stream_mask, height, width):
+    """Kahn's BFS Strahler ordering among stream cells (MFD topology)."""
+    dy = np.array([0, 1, 1, 1, 0, -1, -1, -1], dtype=np.int64)
+    dx = np.array([1, 1, 0, -1, -1, -1, 0, 1], dtype=np.int64)
+
+    order = np.empty((height, width), dtype=np.float64)
+    in_degree = np.zeros((height, width), dtype=np.int32)
+    max_in = np.zeros((height, width), dtype=np.float64)
+    cnt_max = np.zeros((height, width), dtype=np.int32)
+
+    # Initialise
+    for r in range(height):
+        for c in range(width):
+            if stream_mask[r, c] == 0:
+                order[r, c] = np.nan
+            else:
+                order[r, c] = 0.0
+
+    # Compute in-degrees (only among stream cells)
+    for r in range(height):
+        for c in range(width):
+            if stream_mask[r, c] == 0:
+                continue
+            for k in range(8):
+                if fractions[k, r, c] > 0.0:
+                    nr = r + dy[k]
+                    nc = c + dx[k]
+                    if 0 <= nr < height and 0 <= nc < width:
+                        if stream_mask[nr, nc] == 1:
+                            in_degree[nr, nc] += 1
+
+    # BFS queue
+    queue_r = np.empty(height * width, dtype=np.int64)
+    queue_c = np.empty(height * width, dtype=np.int64)
+    head = np.int64(0)
+    tail = np.int64(0)
+
+    # Enqueue headwaters (stream cells with in_degree == 0)
+    for r in range(height):
+        for c in range(width):
+            if stream_mask[r, c] == 1 and in_degree[r, c] == 0:
+                order[r, c] = 1.0
+                queue_r[tail] = r
+                queue_c[tail] = c
+                tail += 1
+
+    while head < tail:
+        r = queue_r[head]
+        c = queue_c[head]
+        head += 1
+
+        cur_ord = order[r, c]
+
+        for k in range(8):
+            if fractions[k, r, c] > 0.0:
+                nr = r + dy[k]
+                nc = c + dx[k]
+                if not (0 <= nr < height and 0 <= nc < width
+                        and stream_mask[nr, nc] == 1):
+                    continue
+
+                if cur_ord > max_in[nr, nc]:
+                    max_in[nr, nc] = cur_ord
+                    cnt_max[nr, nc] = 1
+                elif cur_ord == max_in[nr, nc]:
+                    cnt_max[nr, nc] += 1
+
+                in_degree[nr, nc] -= 1
+                if in_degree[nr, nc] == 0:
+                    if cnt_max[nr, nc] >= 2:
+                        order[nr, nc] = max_in[nr, nc] + 1.0
+                    else:
+                        order[nr, nc] = max_in[nr, nc]
+                    queue_r[tail] = nr
+                    queue_c[tail] = nc
+                    tail += 1
+
+    return order
+
+
+@ngjit
+def _shreve_mfd_cpu(fractions, stream_mask, height, width):
+    """Kahn's BFS Shreve ordering among stream cells (MFD topology)."""
+    dy = np.array([0, 1, 1, 1, 0, -1, -1, -1], dtype=np.int64)
+    dx = np.array([1, 1, 0, -1, -1, -1, 0, 1], dtype=np.int64)
+
+    order = np.empty((height, width), dtype=np.float64)
+    in_degree = np.zeros((height, width), dtype=np.int32)
+
+    for r in range(height):
+        for c in range(width):
+            if stream_mask[r, c] == 0:
+                order[r, c] = np.nan
+            else:
+                order[r, c] = 0.0
+
+    for r in range(height):
+        for c in range(width):
+            if stream_mask[r, c] == 0:
+                continue
+            for k in range(8):
+                if fractions[k, r, c] > 0.0:
+                    nr = r + dy[k]
+                    nc = c + dx[k]
+                    if 0 <= nr < height and 0 <= nc < width:
+                        if stream_mask[nr, nc] == 1:
+                            in_degree[nr, nc] += 1
+
+    queue_r = np.empty(height * width, dtype=np.int64)
+    queue_c = np.empty(height * width, dtype=np.int64)
+    head = np.int64(0)
+    tail = np.int64(0)
+
+    for r in range(height):
+        for c in range(width):
+            if stream_mask[r, c] == 1 and in_degree[r, c] == 0:
+                order[r, c] = 1.0
+                queue_r[tail] = r
+                queue_c[tail] = c
+                tail += 1
+
+    while head < tail:
+        r = queue_r[head]
+        c = queue_c[head]
+        head += 1
+
+        for k in range(8):
+            if fractions[k, r, c] > 0.0:
+                nr = r + dy[k]
+                nc = c + dx[k]
+                if not (0 <= nr < height and 0 <= nc < width
+                        and stream_mask[nr, nc] == 1):
+                    continue
+
+                order[nr, nc] += order[r, c]
+                in_degree[nr, nc] -= 1
+                if in_degree[nr, nc] == 0:
+                    queue_r[tail] = nr
+                    queue_c[tail] = nc
+                    tail += 1
+
+    return order
+
+
+# =====================================================================
+# GPU kernels
+# =====================================================================
+
+@cuda.jit
+def _stream_order_mfd_init_gpu(fractions, stream_mask, in_degree, state,
+                                order, max_in, cnt_max, H, W):
+    """Initialise GPU arrays for MFD stream order computation."""
+    i, j = cuda.grid(2)
+    if i >= H or j >= W:
+        return
+
+    if stream_mask[i, j] == 0:
+        state[i, j] = 0
+        order[i, j] = 0.0
+        max_in[i, j] = 0.0
+        cnt_max[i, j] = 0
+        return
+
+    state[i, j] = 1
+    order[i, j] = 0.0
+    max_in[i, j] = 0.0
+    cnt_max[i, j] = 0
+
+    # Count in-degree: iterate over 8 directions, check fraction > 0
+    for k in range(8):
+        frac = fractions[k, i, j]
+        if frac <= 0.0:
+            continue
+
+        if k == 0:
+            dy, dx = 0, 1
+        elif k == 1:
+            dy, dx = 1, 1
+        elif k == 2:
+            dy, dx = 1, 0
+        elif k == 3:
+            dy, dx = 1, -1
+        elif k == 4:
+            dy, dx = 0, -1
+        elif k == 5:
+            dy, dx = -1, -1
+        elif k == 6:
+            dy, dx = -1, 0
+        else:
+            dy, dx = -1, 1
+
+        ni = i + dy
+        nj = j + dx
+        if 0 <= ni < H and 0 <= nj < W and stream_mask[ni, nj] == 1:
+            cuda.atomic.add(in_degree, (ni, nj), 1)
+
+
+@cuda.jit
+def _stream_order_mfd_find_ready(in_degree, state, order, changed, H, W):
+    """Finalize previous frontier (2->3), mark new frontier (1->2).
+
+    Identical logic to D8 ``_stream_order_find_ready``: headwater cells
+    get order=1 when in_degree reaches 0.
+    """
+    i, j = cuda.grid(2)
+    if i >= H or j >= W:
+        return
+
+    if state[i, j] == 2:
+        state[i, j] = 3
+
+    if state[i, j] == 1 and in_degree[i, j] == 0:
+        state[i, j] = 2
+        if order[i, j] == 0.0:
+            order[i, j] = 1.0  # headwater
+        cuda.atomic.add(changed, 0, 1)
+
+
+@cuda.jit
+def _stream_order_mfd_pull_strahler(fractions, stream_mask, in_degree, state,
+                                     order, max_in, cnt_max, H, W):
+    """Active cells pull Strahler info from frontier neighbours (MFD).
+
+    For each of 8 neighbours, check if the neighbour is on the frontier
+    (state==2) and flows to us (fractions[opposite[k], ni, nj] > 0).
+    """
+    i, j = cuda.grid(2)
+    if i >= H or j >= W:
+        return
+    if state[i, j] != 1:
+        return
+
+    for nbr in range(8):
+        if nbr == 0:
+            dy, dx = 0, 1
+        elif nbr == 1:
+            dy, dx = 1, 1
+        elif nbr == 2:
+            dy, dx = 1, 0
+        elif nbr == 3:
+            dy, dx = 1, -1
+        elif nbr == 4:
+            dy, dx = 0, -1
+        elif nbr == 5:
+            dy, dx = -1, -1
+        elif nbr == 6:
+            dy, dx = -1, 0
+        else:
+            dy, dx = -1, 1
+
+        ni = i + dy
+        nj = j + dx
+        if ni < 0 or ni >= H or nj < 0 or nj >= W:
+            continue
+        if state[ni, nj] != 2:
+            continue
+        if stream_mask[ni, nj] == 0:
+            continue
+
+        # Opposite of nbr: the direction from neighbor back to me
+        if nbr == 0:
+            opp = 4
+        elif nbr == 1:
+            opp = 5
+        elif nbr == 2:
+            opp = 6
+        elif nbr == 3:
+            opp = 7
+        elif nbr == 4:
+            opp = 0
+        elif nbr == 5:
+            opp = 1
+        elif nbr == 6:
+            opp = 2
+        else:
+            opp = 3
+
+        frac = fractions[opp, ni, nj]
+        if frac > 0.0:
+            nb_ord = order[ni, nj]
+            if nb_ord > max_in[i, j]:
+                max_in[i, j] = nb_ord
+                cnt_max[i, j] = 1
+            elif nb_ord == max_in[i, j]:
+                cnt_max[i, j] += 1
+            in_degree[i, j] -= 1
+
+    if in_degree[i, j] == 0:
+        if cnt_max[i, j] >= 2:
+            order[i, j] = max_in[i, j] + 1.0
+        else:
+            order[i, j] = max_in[i, j]
+
+
+@cuda.jit
+def _stream_order_mfd_pull_shreve(fractions, stream_mask, in_degree, state,
+                                   order, H, W):
+    """Active cells pull Shreve magnitudes from frontier neighbours (MFD)."""
+    i, j = cuda.grid(2)
+    if i >= H or j >= W:
+        return
+    if state[i, j] != 1:
+        return
+
+    for nbr in range(8):
+        if nbr == 0:
+            dy, dx = 0, 1
+        elif nbr == 1:
+            dy, dx = 1, 1
+        elif nbr == 2:
+            dy, dx = 1, 0
+        elif nbr == 3:
+            dy, dx = 1, -1
+        elif nbr == 4:
+            dy, dx = 0, -1
+        elif nbr == 5:
+            dy, dx = -1, -1
+        elif nbr == 6:
+            dy, dx = -1, 0
+        else:
+            dy, dx = -1, 1
+
+        ni = i + dy
+        nj = j + dx
+        if ni < 0 or ni >= H or nj < 0 or nj >= W:
+            continue
+        if state[ni, nj] != 2:
+            continue
+        if stream_mask[ni, nj] == 0:
+            continue
+
+        if nbr == 0:
+            opp = 4
+        elif nbr == 1:
+            opp = 5
+        elif nbr == 2:
+            opp = 6
+        elif nbr == 3:
+            opp = 7
+        elif nbr == 4:
+            opp = 0
+        elif nbr == 5:
+            opp = 1
+        elif nbr == 6:
+            opp = 2
+        else:
+            opp = 3
+
+        frac = fractions[opp, ni, nj]
+        if frac > 0.0:
+            order[i, j] += order[ni, nj]
+            in_degree[i, j] -= 1
+
+
+# =====================================================================
+# CuPy driver
+# =====================================================================
+
+def _stream_order_mfd_cupy(fractions_data, stream_mask_data, method):
+    """GPU driver for MFD stream order computation."""
+    import cupy as cp
+
+    _, H, W = fractions_data.shape
+    fractions_f64 = fractions_data.astype(cp.float64)
+    stream_mask_i8 = stream_mask_data.astype(cp.int8)
+
+    in_degree = cp.zeros((H, W), dtype=cp.int32)
+    state = cp.zeros((H, W), dtype=cp.int32)
+    order = cp.zeros((H, W), dtype=cp.float64)
+    max_in = cp.zeros((H, W), dtype=cp.float64)
+    cnt_max = cp.zeros((H, W), dtype=cp.int32)
+    changed = cp.zeros(1, dtype=cp.int32)
+
+    griddim, blockdim = cuda_args((H, W))
+
+    _stream_order_mfd_init_gpu[griddim, blockdim](
+        fractions_f64, stream_mask_i8, in_degree, state,
+        order, max_in, cnt_max, H, W)
+
+    max_iter = H * W
+    for _ in range(max_iter):
+        changed[0] = 0
+        _stream_order_mfd_find_ready[griddim, blockdim](
+            in_degree, state, order, changed, H, W)
+
+        if int(changed[0]) == 0:
+            break
+
+        if method == 'strahler':
+            _stream_order_mfd_pull_strahler[griddim, blockdim](
+                fractions_f64, stream_mask_i8, in_degree, state,
+                order, max_in, cnt_max, H, W)
+        else:
+            _stream_order_mfd_pull_shreve[griddim, blockdim](
+                fractions_f64, stream_mask_i8, in_degree, state,
+                order, H, W)
+
+    order = cp.where(stream_mask_i8 == 0, cp.nan, order)
+    return order
+
+
+# =====================================================================
+# CPU tile kernels for dask
+# =====================================================================
+
+@ngjit
+def _strahler_mfd_tile_kernel(fractions, stream_mask, h, w,
+                               seed_max_top, seed_cnt_top,
+                               seed_max_bottom, seed_cnt_bottom,
+                               seed_max_left, seed_cnt_left,
+                               seed_max_right, seed_cnt_right):
+    """Seeded Strahler BFS for a single MFD tile."""
+    dy = np.array([0, 1, 1, 1, 0, -1, -1, -1], dtype=np.int64)
+    dx = np.array([1, 1, 0, -1, -1, -1, 0, 1], dtype=np.int64)
+
+    order = np.empty((h, w), dtype=np.float64)
+    in_degree = np.zeros((h, w), dtype=np.int32)
+    max_in = np.zeros((h, w), dtype=np.float64)
+    cnt_max = np.zeros((h, w), dtype=np.int32)
+
+    for r in range(h):
+        for c in range(w):
+            if stream_mask[r, c] == 0:
+                order[r, c] = np.nan
+            else:
+                order[r, c] = 0.0
+
+    # Apply seeds: set max_in / cnt_max from boundary info
+    for c in range(w):
+        if stream_mask[0, c] == 1 and seed_max_top[c] > 0:
+            if seed_max_top[c] > max_in[0, c]:
+                max_in[0, c] = seed_max_top[c]
+                cnt_max[0, c] = int(seed_cnt_top[c])
+            elif seed_max_top[c] == max_in[0, c]:
+                cnt_max[0, c] += int(seed_cnt_top[c])
+        if stream_mask[h - 1, c] == 1 and seed_max_bottom[c] > 0:
+            if seed_max_bottom[c] > max_in[h - 1, c]:
+                max_in[h - 1, c] = seed_max_bottom[c]
+                cnt_max[h - 1, c] = int(seed_cnt_bottom[c])
+            elif seed_max_bottom[c] == max_in[h - 1, c]:
+                cnt_max[h - 1, c] += int(seed_cnt_bottom[c])
+    for r in range(h):
+        if stream_mask[r, 0] == 1 and seed_max_left[r] > 0:
+            if seed_max_left[r] > max_in[r, 0]:
+                max_in[r, 0] = seed_max_left[r]
+                cnt_max[r, 0] = int(seed_cnt_left[r])
+            elif seed_max_left[r] == max_in[r, 0]:
+                cnt_max[r, 0] += int(seed_cnt_left[r])
+        if stream_mask[r, w - 1] == 1 and seed_max_right[r] > 0:
+            if seed_max_right[r] > max_in[r, w - 1]:
+                max_in[r, w - 1] = seed_max_right[r]
+                cnt_max[r, w - 1] = int(seed_cnt_right[r])
+            elif seed_max_right[r] == max_in[r, w - 1]:
+                cnt_max[r, w - 1] += int(seed_cnt_right[r])
+
+    # Compute in-degrees among stream cells within tile
+    for r in range(h):
+        for c in range(w):
+            if stream_mask[r, c] == 0:
+                continue
+            for k in range(8):
+                if fractions[k, r, c] > 0.0:
+                    nr = r + dy[k]
+                    nc = c + dx[k]
+                    if 0 <= nr < h and 0 <= nc < w and stream_mask[nr, nc] == 1:
+                        in_degree[nr, nc] += 1
+
+    # BFS
+    queue_r = np.empty(h * w, dtype=np.int64)
+    queue_c = np.empty(h * w, dtype=np.int64)
+    head = np.int64(0)
+    tail = np.int64(0)
+
+    for r in range(h):
+        for c in range(w):
+            if stream_mask[r, c] != 1:
+                continue
+            if in_degree[r, c] != 0:
+                continue
+            # Headwater or seeded cell
+            if max_in[r, c] > 0:
+                if cnt_max[r, c] >= 2:
+                    order[r, c] = max_in[r, c] + 1.0
+                else:
+                    order[r, c] = max_in[r, c]
+            else:
+                order[r, c] = 1.0
+            queue_r[tail] = r
+            queue_c[tail] = c
+            tail += 1
+
+    while head < tail:
+        r = queue_r[head]
+        c = queue_c[head]
+        head += 1
+
+        cur_ord = order[r, c]
+
+        for k in range(8):
+            if fractions[k, r, c] > 0.0:
+                nr = r + dy[k]
+                nc = c + dx[k]
+                if not (0 <= nr < h and 0 <= nc < w
+                        and stream_mask[nr, nc] == 1):
+                    continue
+
+                if cur_ord > max_in[nr, nc]:
+                    max_in[nr, nc] = cur_ord
+                    cnt_max[nr, nc] = 1
+                elif cur_ord == max_in[nr, nc]:
+                    cnt_max[nr, nc] += 1
+
+                in_degree[nr, nc] -= 1
+                if in_degree[nr, nc] == 0:
+                    if cnt_max[nr, nc] >= 2:
+                        order[nr, nc] = max_in[nr, nc] + 1.0
+                    else:
+                        order[nr, nc] = max_in[nr, nc]
+                    queue_r[tail] = nr
+                    queue_c[tail] = nc
+                    tail += 1
+
+    return order
+
+
+@ngjit
+def _shreve_mfd_tile_kernel(fractions, stream_mask, h, w,
+                             seed_top, seed_bottom,
+                             seed_left, seed_right):
+    """Seeded Shreve BFS for a single MFD tile."""
+    dy = np.array([0, 1, 1, 1, 0, -1, -1, -1], dtype=np.int64)
+    dx = np.array([1, 1, 0, -1, -1, -1, 0, 1], dtype=np.int64)
+
+    order = np.empty((h, w), dtype=np.float64)
+    in_degree = np.zeros((h, w), dtype=np.int32)
+
+    for r in range(h):
+        for c in range(w):
+            if stream_mask[r, c] == 0:
+                order[r, c] = np.nan
+            else:
+                order[r, c] = 0.0
+
+    # Apply additive seeds
+    for c in range(w):
+        if stream_mask[0, c] == 1:
+            order[0, c] += seed_top[c]
+        if stream_mask[h - 1, c] == 1:
+            order[h - 1, c] += seed_bottom[c]
+    for r in range(h):
+        if stream_mask[r, 0] == 1:
+            order[r, 0] += seed_left[r]
+        if stream_mask[r, w - 1] == 1:
+            order[r, w - 1] += seed_right[r]
+
+    # In-degrees
+    for r in range(h):
+        for c in range(w):
+            if stream_mask[r, c] == 0:
+                continue
+            for k in range(8):
+                if fractions[k, r, c] > 0.0:
+                    nr = r + dy[k]
+                    nc = c + dx[k]
+                    if 0 <= nr < h and 0 <= nc < w and stream_mask[nr, nc] == 1:
+                        in_degree[nr, nc] += 1
+
+    queue_r = np.empty(h * w, dtype=np.int64)
+    queue_c = np.empty(h * w, dtype=np.int64)
+    head = np.int64(0)
+    tail = np.int64(0)
+
+    for r in range(h):
+        for c in range(w):
+            if stream_mask[r, c] == 1 and in_degree[r, c] == 0:
+                if order[r, c] == 0.0:
+                    order[r, c] = 1.0  # headwater
+                queue_r[tail] = r
+                queue_c[tail] = c
+                tail += 1
+
+    while head < tail:
+        r = queue_r[head]
+        c = queue_c[head]
+        head += 1
+
+        for k in range(8):
+            if fractions[k, r, c] > 0.0:
+                nr = r + dy[k]
+                nc = c + dx[k]
+                if not (0 <= nr < h and 0 <= nc < w
+                        and stream_mask[nr, nc] == 1):
+                    continue
+
+                order[nr, nc] += order[r, c]
+                in_degree[nr, nc] -= 1
+                if in_degree[nr, nc] == 0:
+                    queue_r[tail] = nr
+                    queue_c[tail] = nc
+                    tail += 1
+
+    return order
+
+
+# =====================================================================
+# Dask preprocessing
+# =====================================================================
+
+def _preprocess_mfd_stream_tiles(fractions_da, accum_da, threshold,
+                                  chunks_y, chunks_x):
+    """Extract boundary fraction strips and stream masks into dicts.
+
+    For MFD we need the full 8-band fractions at each boundary cell,
+    so we store them as (8, length) arrays.  Stream masks are stored
+    as 1-D float64 arrays (1.0 = stream, 0.0 = not stream).
+    """
+    n_tile_y = len(chunks_y)
+    n_tile_x = len(chunks_x)
+
+    frac_bdry = {}
+    mask_bdry = BoundaryStore(chunks_y, chunks_x, fill_value=0.0)
+
+    for iy in range(n_tile_y):
+        for ix in range(n_tile_x):
+            y_start = sum(chunks_y[:iy])
+            y_end = y_start + chunks_y[iy]
+            x_start = sum(chunks_x[:ix])
+            x_end = x_start + chunks_x[ix]
+
+            frac_chunk = np.asarray(
+                fractions_da[:, y_start:y_end, x_start:x_end].compute(),
+                dtype=np.float64)
+            ac_chunk = _to_numpy_f64(
+                accum_da[y_start:y_end, x_start:x_end].compute())
+
+            # Build stream mask for this tile
+            sm = np.where(ac_chunk >= threshold, 1.0, 0.0)
+            sm = np.where(np.isnan(ac_chunk), 0.0, sm)
+            # NaN fractions -> not stream
+            frac0 = frac_chunk[0]
+            sm = np.where(frac0 != frac0, 0.0, sm)  # NaN check
+
+            # Store fraction boundary strips: (8, length)
+            frac_bdry[('top', iy, ix)] = frac_chunk[:, 0, :].copy()
+            frac_bdry[('bottom', iy, ix)] = frac_chunk[:, -1, :].copy()
+            frac_bdry[('left', iy, ix)] = frac_chunk[:, :, 0].copy()
+            frac_bdry[('right', iy, ix)] = frac_chunk[:, :, -1].copy()
+
+            # Store stream mask boundary strips
+            for side, row_data_sm in [
+                ('top', sm[0, :]),
+                ('bottom', sm[-1, :]),
+                ('left', sm[:, 0]),
+                ('right', sm[:, -1]),
+            ]:
+                mask_bdry.set(side, iy, ix,
+                              np.asarray(row_data_sm, dtype=np.float64))
+
+    return frac_bdry, mask_bdry
+
+
+# =====================================================================
+# Dask seed computation
+# =====================================================================
+
+def _compute_shreve_seeds_mfd(iy, ix, boundaries, frac_bdry, mask_bdry,
+                               chunks_y, chunks_x, n_tile_y, n_tile_x):
+    """Compute additive Shreve seeds from neighbours for MFD tile (iy, ix).
+
+    For MFD, a neighbour cell flows into the current tile if its fraction
+    for the direction pointing into our tile is > 0.  The seed contribution
+    is ``boundary_order[cell] * fraction``.
+    """
+    dy_arr = np.array([0, 1, 1, 1, 0, -1, -1, -1], dtype=np.int64)
+    dx_arr = np.array([1, 1, 0, -1, -1, -1, 0, 1], dtype=np.int64)
+
+    tile_h = chunks_y[iy]
+    tile_w = chunks_x[ix]
+
+    seed_top = np.zeros(tile_w, dtype=np.float64)
+    seed_bottom = np.zeros(tile_w, dtype=np.float64)
+    seed_left = np.zeros(tile_h, dtype=np.float64)
+    seed_right = np.zeros(tile_h, dtype=np.float64)
+
+    # --- Top edge: bottom row of tile above ---
+    if iy > 0:
+        nb_frac = frac_bdry[('bottom', iy - 1, ix)]  # (8, tile_w)
+        nb_mask = mask_bdry.get('bottom', iy - 1, ix)
+        nb_order = boundaries.get('bottom', iy - 1, ix)
+        w = nb_frac.shape[1]
+        for c in range(w):
+            if nb_mask[c] == 0:
+                continue
+            for k in range(8):
+                if not (nb_frac[k, c] > 0.0):
+                    continue
+                ndy = dy_arr[k]
+                ndx = dx_arr[k]
+                if ndy == 1:  # flows south into our tile
+                    tc = c + ndx
+                    if 0 <= tc < tile_w:
+                        seed_top[tc] += nb_order[c] * nb_frac[k, c]
+
+    # --- Bottom edge: top row of tile below ---
+    if iy < n_tile_y - 1:
+        nb_frac = frac_bdry[('top', iy + 1, ix)]  # (8, tile_w)
+        nb_mask = mask_bdry.get('top', iy + 1, ix)
+        nb_order = boundaries.get('top', iy + 1, ix)
+        w = nb_frac.shape[1]
+        for c in range(w):
+            if nb_mask[c] == 0:
+                continue
+            for k in range(8):
+                if not (nb_frac[k, c] > 0.0):
+                    continue
+                ndy = dy_arr[k]
+                ndx = dx_arr[k]
+                if ndy == -1:  # flows north into our tile
+                    tc = c + ndx
+                    if 0 <= tc < tile_w:
+                        seed_bottom[tc] += nb_order[c] * nb_frac[k, c]
+
+    # --- Left edge: right column of tile to the left ---
+    if ix > 0:
+        nb_frac = frac_bdry[('right', iy, ix - 1)]  # (8, tile_h)
+        nb_mask = mask_bdry.get('right', iy, ix - 1)
+        nb_order = boundaries.get('right', iy, ix - 1)
+        h = nb_frac.shape[1]
+        for r in range(h):
+            if nb_mask[r] == 0:
+                continue
+            for k in range(8):
+                if not (nb_frac[k, r] > 0.0):
+                    continue
+                ndy = dy_arr[k]
+                ndx = dx_arr[k]
+                if ndx == 1:  # flows east into our tile
+                    tr = r + ndy
+                    if 0 <= tr < tile_h:
+                        seed_left[tr] += nb_order[r] * nb_frac[k, r]
+
+    # --- Right edge: left column of tile to the right ---
+    if ix < n_tile_x - 1:
+        nb_frac = frac_bdry[('left', iy, ix + 1)]  # (8, tile_h)
+        nb_mask = mask_bdry.get('left', iy, ix + 1)
+        nb_order = boundaries.get('left', iy, ix + 1)
+        h = nb_frac.shape[1]
+        for r in range(h):
+            if nb_mask[r] == 0:
+                continue
+            for k in range(8):
+                if not (nb_frac[k, r] > 0.0):
+                    continue
+                ndy = dy_arr[k]
+                ndx = dx_arr[k]
+                if ndx == -1:  # flows west into our tile
+                    tr = r + ndy
+                    if 0 <= tr < tile_h:
+                        seed_right[tr] += nb_order[r] * nb_frac[k, r]
+
+    # --- Diagonal corner seeds ---
+    # TL: bottom-right cell of (iy-1, ix-1) flows SE (dy=1, dx=1 -> k=1)
+    if iy > 0 and ix > 0:
+        nb_frac = frac_bdry[('bottom', iy - 1, ix - 1)]  # (8, w)
+        nb_mask = mask_bdry.get('bottom', iy - 1, ix - 1)
+        if nb_mask[-1] == 1:
+            frac_se = nb_frac[1, -1]  # SE direction
+            if frac_se > 0.0:
+                av = float(boundaries.get('bottom', iy - 1, ix - 1)[-1])
+                seed_top[0] += av * frac_se
+
+    # TR: bottom-left cell of (iy-1, ix+1) flows SW (dy=1, dx=-1 -> k=3)
+    if iy > 0 and ix < n_tile_x - 1:
+        nb_frac = frac_bdry[('bottom', iy - 1, ix + 1)]  # (8, w)
+        nb_mask = mask_bdry.get('bottom', iy - 1, ix + 1)
+        if nb_mask[0] == 1:
+            frac_sw = nb_frac[3, 0]  # SW direction
+            if frac_sw > 0.0:
+                av = float(boundaries.get('bottom', iy - 1, ix + 1)[0])
+                seed_top[tile_w - 1] += av * frac_sw
+
+    # BL: top-right cell of (iy+1, ix-1) flows NE (dy=-1, dx=1 -> k=7)
+    if iy < n_tile_y - 1 and ix > 0:
+        nb_frac = frac_bdry[('top', iy + 1, ix - 1)]  # (8, w)
+        nb_mask = mask_bdry.get('top', iy + 1, ix - 1)
+        if nb_mask[-1] == 1:
+            frac_ne = nb_frac[7, -1]  # NE direction
+            if frac_ne > 0.0:
+                av = float(boundaries.get('top', iy + 1, ix - 1)[-1])
+                seed_bottom[0] += av * frac_ne
+
+    # BR: top-left cell of (iy+1, ix+1) flows NW (dy=-1, dx=-1 -> k=5)
+    if iy < n_tile_y - 1 and ix < n_tile_x - 1:
+        nb_frac = frac_bdry[('top', iy + 1, ix + 1)]  # (8, w)
+        nb_mask = mask_bdry.get('top', iy + 1, ix + 1)
+        if nb_mask[0] == 1:
+            frac_nw = nb_frac[5, 0]  # NW direction
+            if frac_nw > 0.0:
+                av = float(boundaries.get('top', iy + 1, ix + 1)[0])
+                seed_bottom[tile_w - 1] += av * frac_nw
+
+    return seed_top, seed_bottom, seed_left, seed_right
+
+
+def _compute_strahler_seeds_mfd(iy, ix, bdry_max, bdry_cnt,
+                                 frac_bdry, mask_bdry,
+                                 chunks_y, chunks_x, n_tile_y, n_tile_x):
+    """Compute Strahler (max, cnt) seeds from neighbours for MFD tile.
+
+    For Strahler ordering, the seed is the order value of the boundary
+    cell (not multiplied by fraction).
+    """
+    dy_arr = np.array([0, 1, 1, 1, 0, -1, -1, -1], dtype=np.int64)
+    dx_arr = np.array([1, 1, 0, -1, -1, -1, 0, 1], dtype=np.int64)
+
+    tile_h = chunks_y[iy]
+    tile_w = chunks_x[ix]
+
+    smax_top = np.zeros(tile_w, dtype=np.float64)
+    scnt_top = np.zeros(tile_w, dtype=np.float64)
+    smax_bottom = np.zeros(tile_w, dtype=np.float64)
+    scnt_bottom = np.zeros(tile_w, dtype=np.float64)
+    smax_left = np.zeros(tile_h, dtype=np.float64)
+    scnt_left = np.zeros(tile_h, dtype=np.float64)
+    smax_right = np.zeros(tile_h, dtype=np.float64)
+    scnt_right = np.zeros(tile_h, dtype=np.float64)
+
+    def _update_max_cnt(cur_max, cur_cnt, new_val, idx):
+        if new_val > cur_max[idx]:
+            cur_max[idx] = new_val
+            cur_cnt[idx] = 1.0
+        elif new_val == cur_max[idx] and new_val > 0:
+            cur_cnt[idx] += 1.0
+
+    # --- Top edge: bottom row of tile above ---
+    if iy > 0:
+        nb_frac = frac_bdry[('bottom', iy - 1, ix)]  # (8, tile_w)
+        nb_mask = mask_bdry.get('bottom', iy - 1, ix)
+        nb_max = bdry_max.get('bottom', iy - 1, ix)
+        nb_cnt = bdry_cnt.get('bottom', iy - 1, ix)
+        w = nb_frac.shape[1]
+        for c in range(w):
+            if nb_mask[c] == 0 or nb_max[c] == 0:
+                continue
+            for k in range(8):
+                if not (nb_frac[k, c] > 0.0):
+                    continue
+                ndy = dy_arr[k]
+                ndx = dx_arr[k]
+                if ndy == 1:  # flows south into our tile
+                    tc = c + ndx
+                    if 0 <= tc < tile_w:
+                        # Reconstruct the order of the boundary cell
+                        if nb_cnt[c] >= 2:
+                            val = nb_max[c] + 1.0
+                        else:
+                            val = nb_max[c]
+                        _update_max_cnt(smax_top, scnt_top, val, tc)
+
+    # --- Bottom edge: top row of tile below ---
+    if iy < n_tile_y - 1:
+        nb_frac = frac_bdry[('top', iy + 1, ix)]  # (8, tile_w)
+        nb_mask = mask_bdry.get('top', iy + 1, ix)
+        nb_max = bdry_max.get('top', iy + 1, ix)
+        nb_cnt = bdry_cnt.get('top', iy + 1, ix)
+        w = nb_frac.shape[1]
+        for c in range(w):
+            if nb_mask[c] == 0 or nb_max[c] == 0:
+                continue
+            for k in range(8):
+                if not (nb_frac[k, c] > 0.0):
+                    continue
+                ndy = dy_arr[k]
+                ndx = dx_arr[k]
+                if ndy == -1:  # flows north into our tile
+                    tc = c + ndx
+                    if 0 <= tc < tile_w:
+                        if nb_cnt[c] >= 2:
+                            val = nb_max[c] + 1.0
+                        else:
+                            val = nb_max[c]
+                        _update_max_cnt(smax_bottom, scnt_bottom, val, tc)
+
+    # --- Left edge: right column of tile to the left ---
+    if ix > 0:
+        nb_frac = frac_bdry[('right', iy, ix - 1)]  # (8, tile_h)
+        nb_mask = mask_bdry.get('right', iy, ix - 1)
+        nb_max = bdry_max.get('right', iy, ix - 1)
+        nb_cnt = bdry_cnt.get('right', iy, ix - 1)
+        h = nb_frac.shape[1]
+        for r in range(h):
+            if nb_mask[r] == 0 or nb_max[r] == 0:
+                continue
+            for k in range(8):
+                if not (nb_frac[k, r] > 0.0):
+                    continue
+                ndy = dy_arr[k]
+                ndx = dx_arr[k]
+                if ndx == 1:  # flows east into our tile
+                    tr = r + ndy
+                    if 0 <= tr < tile_h:
+                        if nb_cnt[r] >= 2:
+                            val = nb_max[r] + 1.0
+                        else:
+                            val = nb_max[r]
+                        _update_max_cnt(smax_left, scnt_left, val, tr)
+
+    # --- Right edge: left column of tile to the right ---
+    if ix < n_tile_x - 1:
+        nb_frac = frac_bdry[('left', iy, ix + 1)]  # (8, tile_h)
+        nb_mask = mask_bdry.get('left', iy, ix + 1)
+        nb_max = bdry_max.get('left', iy, ix + 1)
+        nb_cnt = bdry_cnt.get('left', iy, ix + 1)
+        h = nb_frac.shape[1]
+        for r in range(h):
+            if nb_mask[r] == 0 or nb_max[r] == 0:
+                continue
+            for k in range(8):
+                if not (nb_frac[k, r] > 0.0):
+                    continue
+                ndy = dy_arr[k]
+                ndx = dx_arr[k]
+                if ndx == -1:  # flows west into our tile
+                    tr = r + ndy
+                    if 0 <= tr < tile_h:
+                        if nb_cnt[r] >= 2:
+                            val = nb_max[r] + 1.0
+                        else:
+                            val = nb_max[r]
+                        _update_max_cnt(smax_right, scnt_right, val, tr)
+
+    # --- Diagonal corner seeds ---
+    # TL: bottom-right cell of (iy-1, ix-1) flows SE (k=1)
+    if iy > 0 and ix > 0:
+        nb_frac = frac_bdry[('bottom', iy - 1, ix - 1)]
+        nb_mask = mask_bdry.get('bottom', iy - 1, ix - 1)
+        if nb_mask[-1] == 1:
+            frac_se = nb_frac[1, -1]
+            if frac_se > 0.0:
+                nm = bdry_max.get('bottom', iy - 1, ix - 1)[-1]
+                nc = bdry_cnt.get('bottom', iy - 1, ix - 1)[-1]
+                if nm > 0:
+                    val = nm + 1.0 if nc >= 2 else nm
+                    _update_max_cnt(smax_top, scnt_top, val, 0)
+
+    # TR: bottom-left cell of (iy-1, ix+1) flows SW (k=3)
+    if iy > 0 and ix < n_tile_x - 1:
+        nb_frac = frac_bdry[('bottom', iy - 1, ix + 1)]
+        nb_mask = mask_bdry.get('bottom', iy - 1, ix + 1)
+        if nb_mask[0] == 1:
+            frac_sw = nb_frac[3, 0]
+            if frac_sw > 0.0:
+                nm = bdry_max.get('bottom', iy - 1, ix + 1)[0]
+                nc = bdry_cnt.get('bottom', iy - 1, ix + 1)[0]
+                if nm > 0:
+                    val = nm + 1.0 if nc >= 2 else nm
+                    _update_max_cnt(smax_top, scnt_top, val, tile_w - 1)
+
+    # BL: top-right cell of (iy+1, ix-1) flows NE (k=7)
+    if iy < n_tile_y - 1 and ix > 0:
+        nb_frac = frac_bdry[('top', iy + 1, ix - 1)]
+        nb_mask = mask_bdry.get('top', iy + 1, ix - 1)
+        if nb_mask[-1] == 1:
+            frac_ne = nb_frac[7, -1]
+            if frac_ne > 0.0:
+                nm = bdry_max.get('top', iy + 1, ix - 1)[-1]
+                nc = bdry_cnt.get('top', iy + 1, ix - 1)[-1]
+                if nm > 0:
+                    val = nm + 1.0 if nc >= 2 else nm
+                    _update_max_cnt(smax_bottom, scnt_bottom, val, 0)
+
+    # BR: top-left cell of (iy+1, ix+1) flows NW (k=5)
+    if iy < n_tile_y - 1 and ix < n_tile_x - 1:
+        nb_frac = frac_bdry[('top', iy + 1, ix + 1)]
+        nb_mask = mask_bdry.get('top', iy + 1, ix + 1)
+        if nb_mask[0] == 1:
+            frac_nw = nb_frac[5, 0]
+            if frac_nw > 0.0:
+                nm = bdry_max.get('top', iy + 1, ix + 1)[0]
+                nc = bdry_cnt.get('top', iy + 1, ix + 1)[0]
+                if nm > 0:
+                    val = nm + 1.0 if nc >= 2 else nm
+                    _update_max_cnt(smax_bottom, scnt_bottom, val,
+                                    tile_w - 1)
+
+    return (smax_top, scnt_top, smax_bottom, scnt_bottom,
+            smax_left, scnt_left, smax_right, scnt_right)
+
+
+# =====================================================================
+# Dask iterative tile sweep
+# =====================================================================
+
+def _make_stream_mask_mfd_np(ac_chunk, frac_chunk, threshold):
+    """Build stream mask as numpy int8 from accumulation and MFD fractions."""
+    sm = np.where(ac_chunk >= threshold, 1, 0).astype(np.int8)
+    sm = np.where(np.isnan(ac_chunk), 0, sm).astype(np.int8)
+    # NaN fractions -> not stream
+    frac0 = frac_chunk[0]
+    sm = np.where(np.isnan(frac0), 0, sm).astype(np.int8)
+    return sm
+
+
+def _process_strahler_tile_mfd(iy, ix, fractions_da, accum_da, threshold,
+                                bdry_max, bdry_cnt, frac_bdry, mask_bdry,
+                                chunks_y, chunks_x, n_tile_y, n_tile_x):
+    """Run seeded Strahler BFS on one MFD tile; update boundary stores."""
+    y_start = sum(chunks_y[:iy])
+    y_end = y_start + chunks_y[iy]
+    x_start = sum(chunks_x[:ix])
+    x_end = x_start + chunks_x[ix]
+
+    frac_chunk = np.asarray(
+        fractions_da[:, y_start:y_end, x_start:x_end].compute(),
+        dtype=np.float64)
+    ac_chunk = _to_numpy_f64(
+        accum_da[y_start:y_end, x_start:x_end].compute())
+    sm = _make_stream_mask_mfd_np(ac_chunk, frac_chunk, threshold)
+    _, h, w = frac_chunk.shape
+
+    seeds = _compute_strahler_seeds_mfd(
+        iy, ix, bdry_max, bdry_cnt, frac_bdry, mask_bdry,
+        chunks_y, chunks_x, n_tile_y, n_tile_x)
+
+    order = _strahler_mfd_tile_kernel(frac_chunk, sm, h, w, *seeds)
+
+    # Extract boundary order values and recompute max/cnt for boundaries
+    change = 0.0
+    for side, strip in [('top', order[0, :]),
+                        ('bottom', order[-1, :]),
+                        ('left', order[:, 0]),
+                        ('right', order[:, -1])]:
+        new_vals = strip.copy()
+        new_max = np.where(np.isnan(new_vals), 0.0, new_vals)
+        new_cnt = np.where(new_max > 0, 1.0, 0.0)
+
+        old_max = bdry_max.get(side, iy, ix).copy()
+        with np.errstate(invalid='ignore'):
+            diff = np.abs(new_max - old_max)
+        diff = np.where(np.isnan(diff), 0.0, diff)
+        m = float(np.max(diff))
+        if m > change:
+            change = m
+
+        bdry_max.set(side, iy, ix, new_max)
+        bdry_cnt.set(side, iy, ix, new_cnt)
+
+    return change
+
+
+def _process_shreve_tile_mfd(iy, ix, fractions_da, accum_da, threshold,
+                              boundaries, frac_bdry, mask_bdry,
+                              chunks_y, chunks_x, n_tile_y, n_tile_x):
+    """Run seeded Shreve BFS on one MFD tile; update boundaries."""
+    y_start = sum(chunks_y[:iy])
+    y_end = y_start + chunks_y[iy]
+    x_start = sum(chunks_x[:ix])
+    x_end = x_start + chunks_x[ix]
+
+    frac_chunk = np.asarray(
+        fractions_da[:, y_start:y_end, x_start:x_end].compute(),
+        dtype=np.float64)
+    ac_chunk = _to_numpy_f64(
+        accum_da[y_start:y_end, x_start:x_end].compute())
+    sm = _make_stream_mask_mfd_np(ac_chunk, frac_chunk, threshold)
+    _, h, w = frac_chunk.shape
+
+    seeds = _compute_shreve_seeds_mfd(
+        iy, ix, boundaries, frac_bdry, mask_bdry,
+        chunks_y, chunks_x, n_tile_y, n_tile_x)
+
+    order = _shreve_mfd_tile_kernel(frac_chunk, sm, h, w, *seeds)
+
+    change = 0.0
+    for side, strip in [('top', order[0, :]),
+                        ('bottom', order[-1, :]),
+                        ('left', order[:, 0]),
+                        ('right', order[:, -1])]:
+        new_vals = strip.copy()
+        new_vals = np.where(np.isnan(new_vals), 0.0, new_vals)
+        old = boundaries.get(side, iy, ix).copy()
+        with np.errstate(invalid='ignore'):
+            diff = np.abs(new_vals - old)
+        diff = np.where(np.isnan(diff), 0.0, diff)
+        m = float(np.max(diff))
+        if m > change:
+            change = m
+        boundaries.set(side, iy, ix, new_vals)
+
+    return change
+
+
+def _stream_order_mfd_dask_strahler(fractions_da, accum_da, threshold):
+    """Dask iterative sweep for MFD Strahler ordering."""
+    chunks_y = fractions_da.chunks[1]
+    chunks_x = fractions_da.chunks[2]
+    n_tile_y = len(chunks_y)
+    n_tile_x = len(chunks_x)
+
+    frac_bdry, mask_bdry = _preprocess_mfd_stream_tiles(
+        fractions_da, accum_da, threshold, chunks_y, chunks_x)
+    mask_bdry = mask_bdry.snapshot()
+
+    bdry_max = BoundaryStore(chunks_y, chunks_x, fill_value=0.0)
+    bdry_cnt = BoundaryStore(chunks_y, chunks_x, fill_value=0.0)
+
+    max_iterations = max(n_tile_y, n_tile_x) + 10
+    for _ in range(max_iterations):
+        max_change = 0.0
+        for iy in range(n_tile_y):
+            for ix in range(n_tile_x):
+                c = _process_strahler_tile_mfd(
+                    iy, ix, fractions_da, accum_da, threshold,
+                    bdry_max, bdry_cnt, frac_bdry, mask_bdry,
+                    chunks_y, chunks_x, n_tile_y, n_tile_x)
+                if c > max_change:
+                    max_change = c
+        for iy in reversed(range(n_tile_y)):
+            for ix in reversed(range(n_tile_x)):
+                c = _process_strahler_tile_mfd(
+                    iy, ix, fractions_da, accum_da, threshold,
+                    bdry_max, bdry_cnt, frac_bdry, mask_bdry,
+                    chunks_y, chunks_x, n_tile_y, n_tile_x)
+                if c > max_change:
+                    max_change = c
+        if max_change == 0.0:
+            break
+
+    _bdry_max = bdry_max.snapshot()
+    _bdry_cnt = bdry_cnt.snapshot()
+    _frac_bdry = frac_bdry
+    _mask_bdry = mask_bdry
+    _threshold = threshold
+
+    # Assemble result by re-running each tile with converged seeds
+    rows = []
+    for iy in range(n_tile_y):
+        row = []
+        for ix in range(n_tile_x):
+            y_start = sum(chunks_y[:iy])
+            y_end = y_start + chunks_y[iy]
+            x_start = sum(chunks_x[:ix])
+            x_end = x_start + chunks_x[ix]
+
+            frac_chunk = np.asarray(
+                fractions_da[:, y_start:y_end, x_start:x_end].compute(),
+                dtype=np.float64)
+            ac_chunk = _to_numpy_f64(
+                accum_da[y_start:y_end, x_start:x_end].compute())
+            sm = _make_stream_mask_mfd_np(ac_chunk, frac_chunk, _threshold)
+            _, h, w = frac_chunk.shape
+
+            seeds = _compute_strahler_seeds_mfd(
+                iy, ix, _bdry_max, _bdry_cnt, _frac_bdry, _mask_bdry,
+                chunks_y, chunks_x, n_tile_y, n_tile_x)
+
+            tile_order = _strahler_mfd_tile_kernel(
+                frac_chunk, sm, h, w, *seeds)
+            row.append(da.from_array(tile_order, chunks=tile_order.shape))
+        rows.append(row)
+
+    return da.block(rows)
+
+
+def _stream_order_mfd_dask_shreve(fractions_da, accum_da, threshold):
+    """Dask iterative sweep for MFD Shreve ordering."""
+    chunks_y = fractions_da.chunks[1]
+    chunks_x = fractions_da.chunks[2]
+    n_tile_y = len(chunks_y)
+    n_tile_x = len(chunks_x)
+
+    frac_bdry, mask_bdry = _preprocess_mfd_stream_tiles(
+        fractions_da, accum_da, threshold, chunks_y, chunks_x)
+    mask_bdry = mask_bdry.snapshot()
+
+    boundaries = BoundaryStore(chunks_y, chunks_x, fill_value=0.0)
+
+    max_iterations = max(n_tile_y, n_tile_x) + 10
+    for _ in range(max_iterations):
+        max_change = 0.0
+        for iy in range(n_tile_y):
+            for ix in range(n_tile_x):
+                c = _process_shreve_tile_mfd(
+                    iy, ix, fractions_da, accum_da, threshold,
+                    boundaries, frac_bdry, mask_bdry,
+                    chunks_y, chunks_x, n_tile_y, n_tile_x)
+                if c > max_change:
+                    max_change = c
+        for iy in reversed(range(n_tile_y)):
+            for ix in reversed(range(n_tile_x)):
+                c = _process_shreve_tile_mfd(
+                    iy, ix, fractions_da, accum_da, threshold,
+                    boundaries, frac_bdry, mask_bdry,
+                    chunks_y, chunks_x, n_tile_y, n_tile_x)
+                if c > max_change:
+                    max_change = c
+        if max_change == 0.0:
+            break
+
+    _boundaries = boundaries.snapshot()
+    _frac_bdry = frac_bdry
+    _mask_bdry = mask_bdry
+    _threshold = threshold
+
+    # Assemble result
+    rows = []
+    for iy in range(n_tile_y):
+        row = []
+        for ix in range(n_tile_x):
+            y_start = sum(chunks_y[:iy])
+            y_end = y_start + chunks_y[iy]
+            x_start = sum(chunks_x[:ix])
+            x_end = x_start + chunks_x[ix]
+
+            frac_chunk = np.asarray(
+                fractions_da[:, y_start:y_end, x_start:x_end].compute(),
+                dtype=np.float64)
+            ac_chunk = _to_numpy_f64(
+                accum_da[y_start:y_end, x_start:x_end].compute())
+            sm = _make_stream_mask_mfd_np(ac_chunk, frac_chunk, _threshold)
+            _, h, w = frac_chunk.shape
+
+            seeds = _compute_shreve_seeds_mfd(
+                iy, ix, _boundaries, _frac_bdry, _mask_bdry,
+                chunks_y, chunks_x, n_tile_y, n_tile_x)
+
+            tile_order = _shreve_mfd_tile_kernel(
+                frac_chunk, sm, h, w, *seeds)
+            row.append(da.from_array(tile_order, chunks=tile_order.shape))
+        rows.append(row)
+
+    return da.block(rows)
+
+
+# =====================================================================
+# Dask+CuPy
+# =====================================================================
+
+def _stream_order_mfd_dask_cupy(fractions_da, accum_da, threshold, method):
+    """Dask+CuPy MFD: convert to numpy, run iterative, convert back."""
+    import cupy as cp
+
+    # Convert dask+cupy to dask+numpy for processing
+    fractions_np = fractions_da.map_blocks(
+        lambda b: b.get(), dtype=fractions_da.dtype,
+        meta=np.array((), dtype=fractions_da.dtype),
+    )
+    accum_np = accum_da.map_blocks(
+        lambda b: b.get(), dtype=accum_da.dtype,
+        meta=np.array((), dtype=accum_da.dtype),
+    )
+
+    if method == 'strahler':
+        result = _stream_order_mfd_dask_strahler(
+            fractions_np, accum_np, threshold)
+    else:
+        result = _stream_order_mfd_dask_shreve(
+            fractions_np, accum_np, threshold)
+
+    return result.map_blocks(
+        cp.asarray, dtype=result.dtype,
+        meta=cp.array((), dtype=result.dtype),
+    )
+
+
+# =====================================================================
+# Public API
+# =====================================================================
+
+@supports_dataset
+def stream_order_mfd(fractions: xr.DataArray,
+                     flow_accum: xr.DataArray,
+                     threshold: float = 100,
+                     method: str = 'strahler',
+                     name: str = 'stream_order_mfd') -> xr.DataArray:
+    """Compute stream order from MFD flow direction and accumulation grids.
+
+    Parameters
+    ----------
+    fractions : xarray.DataArray or xr.Dataset
+        3-D MFD flow direction array of shape ``(8, H, W)`` as returned
+        by ``flow_direction_mfd``.  Values are flow fractions in
+        ``[0, 1]`` that sum to 1.0 at each cell (0.0 at pits/flats,
+        NaN at edges or nodata cells).
+        Supported backends: NumPy, CuPy, NumPy-backed Dask,
+        CuPy-backed Dask.
+        If a Dataset is passed, the operation is applied to each
+        data variable independently.
+    flow_accum : xarray.DataArray
+        2-D flow accumulation grid.  Cells with
+        ``flow_accum >= threshold`` are considered stream cells.
+    threshold : float, default 100
+        Minimum accumulation to classify a cell as part of the
+        stream network.
+    method : str, default 'strahler'
+        ``'strahler'`` for Strahler branching hierarchy or
+        ``'shreve'`` for Shreve cumulative magnitude.
+    name : str, default 'stream_order_mfd'
+        Name of output DataArray.
+
+    Returns
+    -------
+    xarray.DataArray or xr.Dataset
+        2-D float64 array of stream order values.  Non-stream cells
+        (accumulation below threshold) are NaN.
+
+    References
+    ----------
+    Strahler, A.N. (1957). Quantitative analysis of watershed
+    geomorphology. Transactions of the American Geophysical Union,
+    38(6), 913-920.
+
+    Shreve, R.L. (1966). Statistical law of stream numbers. Journal
+    of Geology, 74(1), 17-37.
+    """
+    _validate_raster(fractions, func_name='stream_order_mfd',
+                     name='fractions', ndim=3)
+
+    method = method.lower()
+    if method not in ('strahler', 'shreve'):
+        raise ValueError(
+            f"method must be 'strahler' or 'shreve', got {method!r}")
+
+    frac_data = fractions.data
+    fa_data = flow_accum.data
+
+    if frac_data.ndim != 3 or frac_data.shape[0] != 8:
+        raise ValueError(
+            "fractions must be a 3-D array of shape (8, H, W), "
+            f"got shape {frac_data.shape}"
+        )
+
+    if isinstance(frac_data, np.ndarray):
+        frac = frac_data.astype(np.float64)
+        fa = np.asarray(fa_data, dtype=np.float64)
+        stream_mask = np.where(fa >= threshold, 1, 0).astype(np.int8)
+        stream_mask = np.where(np.isnan(fa), 0, stream_mask).astype(np.int8)
+        # NaN fractions -> not stream
+        stream_mask = np.where(
+            np.isnan(frac[0]), 0, stream_mask).astype(np.int8)
+        h, w = frac.shape[1], frac.shape[2]
+        if method == 'strahler':
+            out = _strahler_mfd_cpu(frac, stream_mask, h, w)
+        else:
+            out = _shreve_mfd_cpu(frac, stream_mask, h, w)
+
+    elif has_cuda_and_cupy() and is_cupy_array(frac_data):
+        import cupy as cp
+        fa_cp = cp.asarray(fa_data, dtype=cp.float64)
+        frac_cp = frac_data.astype(cp.float64)
+        stream_mask = cp.where(fa_cp >= threshold, 1, 0).astype(cp.int8)
+        stream_mask = cp.where(
+            cp.isnan(fa_cp), 0, stream_mask).astype(cp.int8)
+        stream_mask = cp.where(
+            cp.isnan(frac_cp[0]), 0, stream_mask).astype(cp.int8)
+        out = _stream_order_mfd_cupy(frac_cp, stream_mask, method)
+
+    elif has_cuda_and_cupy() and is_dask_cupy(fractions):
+        out = _stream_order_mfd_dask_cupy(
+            frac_data, fa_data, threshold, method)
+
+    elif da is not None and isinstance(frac_data, da.Array):
+        if method == 'strahler':
+            out = _stream_order_mfd_dask_strahler(
+                frac_data, fa_data, threshold)
+        else:
+            out = _stream_order_mfd_dask_shreve(
+                frac_data, fa_data, threshold)
+
+    else:
+        raise TypeError(f"Unsupported array type: {type(frac_data)}")
+
+    # Build 2-D output coords (drop 'neighbor' dim)
+    spatial_dims = fractions.dims[1:]
+    coords = {k: v for k, v in fractions.coords.items()
+              if k != 'neighbor' and k not in fractions.dims[:1]}
+    for d in spatial_dims:
+        if d in fractions.coords:
+            coords[d] = fractions.coords[d]
+
+    return xr.DataArray(out,
+                        name=name,
+                        coords=coords,
+                        dims=spatial_dims,
+                        attrs=fractions.attrs)

--- a/xrspatial/tests/test_stream_link_dinf.py
+++ b/xrspatial/tests/test_stream_link_dinf.py
@@ -1,0 +1,168 @@
+import math
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from xrspatial.stream_link_dinf import stream_link_dinf
+from xrspatial.tests.general_checks import (
+    create_test_raster,
+    cuda_and_cupy_available,
+    dask_array_available,
+)
+
+# D-inf angle convention (counterclockwise from East):
+PI4 = math.pi / 4.0
+ANGLE_E  = 0.0
+ANGLE_NE = PI4
+ANGLE_N  = 2 * PI4
+ANGLE_NW = 3 * PI4
+ANGLE_W  = 4 * PI4
+ANGLE_SW = 5 * PI4
+ANGLE_S  = 6 * PI4
+ANGLE_SE = 7 * PI4
+PIT = -1.0
+
+
+# ====================================================================
+# Helpers
+# ====================================================================
+
+def _call(angles, accum, threshold=0, **kwargs):
+    """Wrap raw arrays and call stream_link_dinf."""
+    a_da = create_test_raster(angles)
+    fa_da = create_test_raster(accum)
+    return stream_link_dinf(a_da, fa_da, threshold=threshold, **kwargs)
+
+
+# ====================================================================
+# Tests
+# ====================================================================
+
+def test_linear_chain():
+    """Single stream, no junctions -> all one link_id."""
+    angles = np.array([[ANGLE_E, ANGLE_E, ANGLE_E, ANGLE_E, PIT]],
+                      dtype=np.float64)
+    accum = np.array([[1.0, 2.0, 3.0, 4.0, 5.0]], dtype=np.float64)
+    result = _call(angles, accum, threshold=1)
+    vals = result.data
+    assert not np.any(np.isnan(vals))
+    unique = np.unique(vals)
+    assert len(unique) == 1
+    assert unique[0] == 1.0  # headwater at (0,0)
+
+
+def test_y_confluence():
+    """Two headwaters merge -> 3 link IDs."""
+    angles = np.array([
+        [ANGLE_SE, np.nan, ANGLE_SW],
+        [np.nan,   ANGLE_S, np.nan],
+        [np.nan,   PIT,     np.nan],
+    ], dtype=np.float64)
+    accum = np.array([
+        [1.0, 0.0, 1.0],
+        [0.0, 3.0, 0.0],
+        [0.0, 4.0, 0.0],
+    ], dtype=np.float64)
+    result = _call(angles, accum, threshold=1)
+    vals = result.data
+
+    assert np.isnan(vals[0, 1])
+    assert np.isnan(vals[1, 0])
+    # (0,0) headwater: ID = 0*3 + 0 + 1 = 1
+    assert vals[0, 0] == 1.0
+    # (0,2) headwater: ID = 0*3 + 2 + 1 = 3
+    assert vals[0, 2] == 3.0
+    # (1,1) junction: ID = 1*3 + 1 + 1 = 5
+    assert vals[1, 1] == 5.0
+    # (2,1) inherits from junction: ID = 5
+    assert vals[2, 1] == 5.0
+    stream_vals = vals[~np.isnan(vals)]
+    assert len(np.unique(stream_vals)) == 3
+
+
+def test_cascade_junctions():
+    """Sequential junctions."""
+    # A(0,0)->E, C(1,0)->NE => B(0,1) junction
+    # B(0,1)->E, E(1,2)->N  => D(0,2) junction
+    # D(0,2)->E              => F(0,3) pit
+    angles = np.array([
+        [ANGLE_E, ANGLE_E, ANGLE_E, PIT],
+        [ANGLE_NE, np.nan, ANGLE_N, np.nan],
+    ], dtype=np.float64)
+    accum = np.array([
+        [1.0, 3.0, 5.0, 6.0],
+        [1.0, 0.0, 1.0, 0.0],
+    ], dtype=np.float64)
+    result = _call(angles, accum, threshold=1)
+    vals = result.data
+
+    assert vals[0, 0] == 1.0       # headwater
+    assert vals[1, 0] == 5.0       # headwater: 1*4 + 0 + 1
+    assert vals[0, 1] == 2.0       # junction: 0*4 + 1 + 1
+    assert vals[1, 2] == 7.0       # headwater: 1*4 + 2 + 1
+    assert vals[0, 2] == 3.0       # junction: 0*4 + 2 + 1
+    assert vals[0, 3] == 3.0       # inherits from D
+
+
+# ====================================================================
+# Edge cases
+# ====================================================================
+
+def test_nan_handling():
+    """NaN angles -> NaN output."""
+    angles = np.full((2, 2), np.nan, dtype=np.float64)
+    angles[0, 0] = PIT
+    accum = np.array([[5.0, 0.0], [0.0, 0.0]], dtype=np.float64)
+    result = _call(angles, accum, threshold=1)
+    assert not np.isnan(result.data[0, 0])
+    assert np.isnan(result.data[0, 1])
+
+
+def test_pit_as_stream():
+    """Pit with high accum is headwater link."""
+    angles = np.array([[PIT]], dtype=np.float64)
+    accum = np.array([[10.0]], dtype=np.float64)
+    result = _call(angles, accum, threshold=1)
+    assert result.data[0, 0] == 1.0
+
+
+def test_single_cell():
+    """Single cell -> headwater ID."""
+    angles = np.array([[PIT]], dtype=np.float64)
+    accum = np.array([[5.0]], dtype=np.float64)
+    result = _call(angles, accum, threshold=1)
+    assert result.data[0, 0] == 1.0
+
+
+@dask_array_available
+def test_dask_matches_numpy():
+    """Dask result matches numpy."""
+    import dask.array as da
+
+    angles = np.array([
+        [ANGLE_SE, np.nan, ANGLE_SW],
+        [np.nan,   ANGLE_S, np.nan],
+        [np.nan,   PIT,     np.nan],
+    ], dtype=np.float64)
+    accum = np.array([
+        [1.0, 0.0, 1.0],
+        [0.0, 3.0, 0.0],
+        [0.0, 4.0, 0.0],
+    ], dtype=np.float64)
+
+    a_np = create_test_raster(angles)
+    fa_np = create_test_raster(accum)
+    np_result = stream_link_dinf(a_np, fa_np, threshold=1)
+
+    a_dask = xr.DataArray(
+        da.from_array(angles, chunks=(2, 2)),
+        dims=['y', 'x'])
+    fa_dask = xr.DataArray(
+        da.from_array(accum, chunks=(2, 2)),
+        dims=['y', 'x'])
+    dask_result = stream_link_dinf(a_dask, fa_dask, threshold=1)
+
+    np.testing.assert_array_equal(
+        np.nan_to_num(np_result.values, nan=-999),
+        np.nan_to_num(dask_result.values, nan=-999))

--- a/xrspatial/tests/test_stream_link_mfd.py
+++ b/xrspatial/tests/test_stream_link_mfd.py
@@ -1,0 +1,183 @@
+import numpy as np
+import pytest
+import xarray as xr
+
+from xrspatial.stream_link_mfd import stream_link_mfd
+from xrspatial.tests.general_checks import (
+    create_test_raster,
+    cuda_and_cupy_available,
+    dask_array_available,
+)
+
+
+# ====================================================================
+# Helpers
+# ====================================================================
+
+def _make_fractions(dirs, shape):
+    """Build (8, H, W) fractions from a dict of {(r,c): [(k, frac), ...]}.
+
+    Cells not in *dirs* get NaN (nodata).  Cells with empty lists are
+    pits (all-zero fractions).
+    """
+    H, W = shape
+    fracs = np.full((8, H, W), np.nan, dtype=np.float64)
+    for (r, c), entries in dirs.items():
+        fracs[:, r, c] = 0.0
+        for k, f in entries:
+            fracs[k, r, c] = f
+    return fracs
+
+
+def _call(fracs, accum, threshold=0, **kwargs):
+    """Wrap raw arrays and call stream_link_mfd."""
+    frac_da = xr.DataArray(fracs, dims=['neighbor', 'y', 'x'])
+    fa_da = create_test_raster(accum)
+    return stream_link_mfd(frac_da, fa_da, threshold=threshold, **kwargs)
+
+
+# ====================================================================
+# Tests
+# ====================================================================
+
+def test_linear_chain():
+    """Single stream, no junctions -> all one link_id."""
+    fracs = _make_fractions({
+        (0, 0): [(0, 1.0)],  # E
+        (0, 1): [(0, 1.0)],  # E
+        (0, 2): [(0, 1.0)],  # E
+        (0, 3): [(0, 1.0)],  # E
+        (0, 4): [],           # pit
+    }, (1, 5))
+    accum = np.array([[1.0, 2.0, 3.0, 4.0, 5.0]], dtype=np.float64)
+    result = _call(fracs, accum, threshold=1)
+    vals = result.data
+    assert not np.any(np.isnan(vals))
+    unique = np.unique(vals[~np.isnan(vals)])
+    assert len(unique) == 1
+    # Headwater at (0,0), width=5 -> ID = 0*5 + 0 + 1 = 1
+    assert unique[0] == 1.0
+
+
+def test_y_confluence():
+    """Two headwaters merge at junction -> 3 distinct link_ids."""
+    fracs = _make_fractions({
+        (0, 0): [(1, 1.0)],   # SE
+        (0, 2): [(3, 1.0)],   # SW
+        (1, 1): [(2, 1.0)],   # S
+        (2, 1): [],            # pit
+    }, (3, 3))
+    accum = np.array([
+        [1.0, 0.0, 1.0],
+        [0.0, 3.0, 0.0],
+        [0.0, 4.0, 0.0],
+    ], dtype=np.float64)
+    result = _call(fracs, accum, threshold=1)
+    vals = result.data
+
+    # Non-stream cells are NaN
+    assert np.isnan(vals[0, 1])
+    assert np.isnan(vals[1, 0])
+    # (0,0) headwater: ID = 0*3 + 0 + 1 = 1
+    assert vals[0, 0] == 1.0
+    # (0,2) headwater: ID = 0*3 + 2 + 1 = 3
+    assert vals[0, 2] == 3.0
+    # (1,1) junction (in_degree=2): ID = 1*3 + 1 + 1 = 5
+    assert vals[1, 1] == 5.0
+    # (2,1) inherits from (1,1): ID = 5
+    assert vals[2, 1] == 5.0
+    # 3 distinct IDs
+    stream_vals = vals[~np.isnan(vals)]
+    assert len(np.unique(stream_vals)) == 3
+
+
+def test_cascade_junctions():
+    """Sequential junctions -> each segment has distinct ID.
+
+    A(0,0)->E, C(1,0)->NE(7) => B(0,1) is junction
+    B(0,1)->E, E(1,2)->N(6)  => D(0,2) is junction
+    D(0,2)->E                => F(0,3) pit
+    """
+    fracs = _make_fractions({
+        (0, 0): [(0, 1.0)],   # E to (0,1)
+        (0, 1): [(0, 1.0)],   # E to (0,2)
+        (0, 2): [(0, 1.0)],   # E to (0,3)
+        (0, 3): [],            # pit
+        (1, 0): [(7, 1.0)],   # NE to (0,1)
+        (1, 2): [(6, 1.0)],   # N to (0,2)
+    }, (2, 4))
+    accum = np.array([
+        [1.0, 3.0, 5.0, 6.0],
+        [1.0, 0.0, 1.0, 0.0],
+    ], dtype=np.float64)
+    result = _call(fracs, accum, threshold=1)
+    vals = result.data
+
+    # A(0,0) headwater: link_id = 0*4 + 0 + 1 = 1
+    assert vals[0, 0] == 1.0
+    # C(1,0) headwater: link_id = 1*4 + 0 + 1 = 5
+    assert vals[1, 0] == 5.0
+    # B(0,1) junction: link_id = 0*4 + 1 + 1 = 2
+    assert vals[0, 1] == 2.0
+    # E(1,2) headwater: link_id = 1*4 + 2 + 1 = 7
+    assert vals[1, 2] == 7.0
+    # D(0,2) junction: link_id = 0*4 + 2 + 1 = 3
+    assert vals[0, 2] == 3.0
+    # F(0,3) inherits from D: link_id = 3
+    assert vals[0, 3] == 3.0
+
+
+# ====================================================================
+# Edge cases
+# ====================================================================
+
+def test_nan_handling():
+    """NaN fractions -> NaN output."""
+    fracs = np.full((8, 2, 2), np.nan, dtype=np.float64)
+    fracs[:, 0, 0] = 0.0  # valid pit
+    accum = np.array([[5.0, 0.0], [0.0, 0.0]], dtype=np.float64)
+    result = _call(fracs, accum, threshold=1)
+    assert not np.isnan(result.data[0, 0])
+    assert np.isnan(result.data[0, 1])
+
+
+def test_single_cell():
+    """Single cell -> headwater with position-based ID."""
+    fracs = np.zeros((8, 1, 1), dtype=np.float64)
+    accum = np.array([[5.0]], dtype=np.float64)
+    result = _call(fracs, accum, threshold=1)
+    assert result.data[0, 0] == 1.0  # 0*1 + 0 + 1
+
+
+@dask_array_available
+def test_dask_matches_numpy():
+    """Dask result matches numpy."""
+    import dask.array as da
+
+    fracs = _make_fractions({
+        (0, 0): [(1, 1.0)],
+        (0, 2): [(3, 1.0)],
+        (1, 1): [(2, 1.0)],
+        (2, 1): [],
+    }, (3, 3))
+    accum = np.array([
+        [1.0, 0.0, 1.0],
+        [0.0, 3.0, 0.0],
+        [0.0, 4.0, 0.0],
+    ], dtype=np.float64)
+
+    frac_np = xr.DataArray(fracs, dims=['neighbor', 'y', 'x'])
+    fa_np = create_test_raster(accum)
+    np_result = stream_link_mfd(frac_np, fa_np, threshold=1)
+
+    frac_dask = xr.DataArray(
+        da.from_array(fracs, chunks=(8, 2, 2)),
+        dims=['neighbor', 'y', 'x'])
+    fa_dask = xr.DataArray(
+        da.from_array(accum, chunks=(2, 2)),
+        dims=['y', 'x'])
+    dask_result = stream_link_mfd(frac_dask, fa_dask, threshold=1)
+
+    np.testing.assert_array_equal(
+        np.nan_to_num(np_result.values, nan=-999),
+        np.nan_to_num(dask_result.values, nan=-999))

--- a/xrspatial/tests/test_stream_order_dinf.py
+++ b/xrspatial/tests/test_stream_order_dinf.py
@@ -1,0 +1,203 @@
+import math
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from xrspatial.stream_order_dinf import stream_order_dinf
+from xrspatial.tests.general_checks import (
+    create_test_raster,
+    cuda_and_cupy_available,
+    dask_array_available,
+)
+
+# D-inf angle convention (counterclockwise from East):
+#   E=0, NE=pi/4, N=pi/2, NW=3pi/4, W=pi, SW=5pi/4, S=3pi/2, SE=7pi/4
+PI4 = math.pi / 4.0
+ANGLE_E  = 0.0
+ANGLE_NE = PI4
+ANGLE_N  = 2 * PI4
+ANGLE_NW = 3 * PI4
+ANGLE_W  = 4 * PI4
+ANGLE_SW = 5 * PI4
+ANGLE_S  = 6 * PI4
+ANGLE_SE = 7 * PI4
+PIT = -1.0
+
+
+# ====================================================================
+# Helpers
+# ====================================================================
+
+def _call(angles, accum, threshold=0, **kwargs):
+    """Wrap raw arrays in DataArrays and call stream_order_dinf."""
+    a_da = create_test_raster(angles)
+    fa_da = create_test_raster(accum)
+    return stream_order_dinf(a_da, fa_da, threshold=threshold, **kwargs)
+
+
+# ====================================================================
+# Strahler tests
+# ====================================================================
+
+def test_y_confluence_strahler():
+    """Two order-1 streams merge -> order 2 downstream.
+
+    Same topology as D8 test but with D-inf angles.
+    (0,0)->SE to (1,1), (0,2)->SW to (1,1), (1,1)->S to (2,1), (2,1) pit
+    """
+    angles = np.array([
+        [ANGLE_SE, PIT, ANGLE_SW],
+        [PIT,      ANGLE_S, PIT],
+        [PIT,      PIT,     PIT],
+    ], dtype=np.float64)
+    accum = np.array([
+        [1.0, 1.0, 1.0],
+        [1.0, 3.0, 1.0],
+        [1.0, 4.0, 1.0],
+    ], dtype=np.float64)
+    result = _call(angles, accum, threshold=1, method='strahler')
+    assert result.data[0, 0] == 1.0
+    assert result.data[0, 2] == 1.0
+    assert result.data[1, 1] == 2.0
+    assert result.data[2, 1] == 2.0
+
+
+def test_unequal_confluence_strahler():
+    """Order 1 meets order 2 -> stays order 2."""
+    angles = np.array([
+        [ANGLE_SE, PIT, ANGLE_SW],
+        [PIT,      ANGLE_S, PIT],
+        [ANGLE_E,  PIT,     PIT],
+    ], dtype=np.float64)
+    accum = np.array([
+        [1.0, 1.0, 1.0],
+        [1.0, 3.0, 1.0],
+        [1.0, 5.0, 1.0],
+    ], dtype=np.float64)
+    result = _call(angles, accum, threshold=1, method='strahler')
+    assert result.data[0, 0] == 1.0
+    assert result.data[0, 2] == 1.0
+    assert result.data[1, 1] == 2.0
+    assert result.data[2, 1] == 2.0
+
+
+# ====================================================================
+# Shreve tests
+# ====================================================================
+
+def test_y_confluence_shreve():
+    """Two headwaters merge -> Shreve magnitude = 2."""
+    angles = np.array([
+        [ANGLE_SE, PIT, ANGLE_SW],
+        [PIT,      ANGLE_S, PIT],
+        [PIT,      PIT,     PIT],
+    ], dtype=np.float64)
+    accum = np.array([
+        [1.0, 1.0, 1.0],
+        [1.0, 3.0, 1.0],
+        [1.0, 4.0, 1.0],
+    ], dtype=np.float64)
+    result = _call(angles, accum, threshold=1, method='shreve')
+    assert result.data[0, 0] == 1.0
+    assert result.data[0, 2] == 1.0
+    assert result.data[1, 1] == 2.0
+    assert result.data[2, 1] == 2.0
+
+
+# ====================================================================
+# D-inf specific: split angle
+# ====================================================================
+
+def test_split_angle_strahler():
+    """Cell with angle between two cardinals flows to both neighbors.
+
+    H(0,0) has angle pi/8 (between E and NE), so it flows to both
+    (0,1) via E and (-1,1) via NE.  Only (0,1) is in bounds.
+    So effectively one downstream neighbor -> (0,1) gets order 1.
+    """
+    # angle = pi/8 means between E(0) and NE(pi/4)
+    # k=0 (E), k2=1 (NE), frac1=0.5, frac2=0.5
+    # Neighbor E: (0, 0+1) = (0, 1) -- in bounds
+    # Neighbor NE: (0-1, 0+1) = (-1, 1) -- out of bounds
+    angles = np.array([
+        [math.pi / 8.0, PIT],
+    ], dtype=np.float64)
+    accum = np.array([[5.0, 5.0]], dtype=np.float64)
+    result = _call(angles, accum, threshold=1, method='strahler')
+    assert result.data[0, 0] == 1.0  # headwater
+    assert result.data[0, 1] == 1.0  # single inflow
+
+
+# ====================================================================
+# Edge cases
+# ====================================================================
+
+def test_nan_handling():
+    """NaN angles -> non-stream (NaN output)."""
+    angles = np.full((2, 2), np.nan, dtype=np.float64)
+    angles[0, 0] = PIT  # valid pit
+    accum = np.array([[5.0, 0.0], [0.0, 0.0]], dtype=np.float64)
+    result = _call(angles, accum, threshold=1, method='strahler')
+    assert result.data[0, 0] == 1.0
+    assert np.isnan(result.data[0, 1])
+    assert np.isnan(result.data[1, 0])
+
+
+def test_pit_handling():
+    """Pit cells (angle=-1) with high accum are headwaters."""
+    angles = np.array([[PIT]], dtype=np.float64)
+    accum = np.array([[10.0]], dtype=np.float64)
+    result = _call(angles, accum, threshold=1, method='strahler')
+    assert result.data[0, 0] == 1.0
+
+
+def test_threshold_excludes():
+    """Cells below threshold are NaN."""
+    angles = np.array([[ANGLE_E, PIT]], dtype=np.float64)
+    accum = np.array([[1.0, 100.0]], dtype=np.float64)
+    result = _call(angles, accum, threshold=50, method='strahler')
+    assert np.isnan(result.data[0, 0])
+    assert result.data[0, 1] == 1.0
+
+
+def test_invalid_method():
+    """Invalid method raises ValueError."""
+    angles = np.array([[PIT]], dtype=np.float64)
+    accum = np.array([[1.0]], dtype=np.float64)
+    with pytest.raises(ValueError, match="method must be"):
+        _call(angles, accum, threshold=0, method='bogus')
+
+
+@dask_array_available
+def test_dask_matches_numpy():
+    """Dask result matches numpy."""
+    import dask.array as da
+
+    angles = np.array([
+        [ANGLE_SE, PIT, ANGLE_SW],
+        [PIT,      ANGLE_S, PIT],
+        [ANGLE_E,  PIT,     PIT],
+    ], dtype=np.float64)
+    accum = np.array([
+        [1.0, 1.0, 1.0],
+        [1.0, 3.0, 1.0],
+        [1.0, 5.0, 1.0],
+    ], dtype=np.float64)
+
+    a_np = create_test_raster(angles)
+    fa_np = create_test_raster(accum)
+    np_result = stream_order_dinf(a_np, fa_np, threshold=1, method='strahler')
+
+    a_dask = xr.DataArray(
+        da.from_array(angles, chunks=(2, 2)),
+        dims=['y', 'x'])
+    fa_dask = xr.DataArray(
+        da.from_array(accum, chunks=(2, 2)),
+        dims=['y', 'x'])
+    dask_result = stream_order_dinf(a_dask, fa_dask, threshold=1,
+                                     method='strahler')
+
+    np.testing.assert_array_equal(
+        np.nan_to_num(np_result.values, nan=-999),
+        np.nan_to_num(dask_result.values, nan=-999))

--- a/xrspatial/tests/test_stream_order_mfd.py
+++ b/xrspatial/tests/test_stream_order_mfd.py
@@ -1,0 +1,238 @@
+import numpy as np
+import pytest
+import xarray as xr
+
+from xrspatial.stream_order_mfd import stream_order_mfd
+from xrspatial.tests.general_checks import (
+    create_test_raster,
+    cuda_and_cupy_available,
+    dask_array_available,
+)
+
+
+# ====================================================================
+# Helpers
+# ====================================================================
+
+def _make_fractions(dirs, shape):
+    """Build (8, H, W) fractions from a dict of {(r,c): [(k, frac), ...]}.
+
+    Cells not in *dirs* get NaN (nodata).  Cells with empty lists are
+    pits (all-zero fractions).
+    """
+    H, W = shape
+    fracs = np.full((8, H, W), np.nan, dtype=np.float64)
+    for (r, c), entries in dirs.items():
+        fracs[:, r, c] = 0.0
+        for k, f in entries:
+            fracs[k, r, c] = f
+    return fracs
+
+
+def _call(fracs, accum, threshold=0, **kwargs):
+    """Wrap raw arrays in DataArrays and call stream_order_mfd."""
+    frac_da = xr.DataArray(fracs, dims=['neighbor', 'y', 'x'])
+    fa_da = create_test_raster(accum)
+    return stream_order_mfd(frac_da, fa_da, threshold=threshold, **kwargs)
+
+
+# ====================================================================
+# Strahler tests
+# ====================================================================
+
+def test_y_confluence_strahler():
+    """Two order-1 streams merge -> order 2 downstream."""
+    # (0,0)->SE(1) to (1,1), (0,2)->SW(3) to (1,1)
+    # (1,1)->S(2) to (2,1), (2,1) pit
+    fracs = _make_fractions({
+        (0, 0): [(1, 1.0)],   # SE
+        (0, 1): [],
+        (0, 2): [(3, 1.0)],   # SW
+        (1, 0): [],
+        (1, 1): [(2, 1.0)],   # S
+        (1, 2): [],
+        (2, 0): [],
+        (2, 1): [],            # pit
+        (2, 2): [],
+    }, (3, 3))
+    accum = np.array([
+        [1.0, 1.0, 1.0],
+        [1.0, 3.0, 1.0],
+        [1.0, 4.0, 1.0],
+    ], dtype=np.float64)
+    result = _call(fracs, accum, threshold=1, method='strahler')
+    assert result.data[0, 0] == 1.0
+    assert result.data[0, 2] == 1.0
+    assert result.data[1, 1] == 2.0
+    assert result.data[2, 1] == 2.0
+
+
+def test_unequal_confluence_strahler():
+    """Order 1 meets order 2 -> stays order 2."""
+    fracs = _make_fractions({
+        (0, 0): [(1, 1.0)],   # SE
+        (0, 1): [],
+        (0, 2): [(3, 1.0)],   # SW
+        (1, 0): [],
+        (1, 1): [(2, 1.0)],   # S
+        (1, 2): [],
+        (2, 0): [(0, 1.0)],   # E
+        (2, 1): [],            # pit
+        (2, 2): [],
+    }, (3, 3))
+    accum = np.array([
+        [1.0, 1.0, 1.0],
+        [1.0, 3.0, 1.0],
+        [1.0, 5.0, 1.0],
+    ], dtype=np.float64)
+    result = _call(fracs, accum, threshold=1, method='strahler')
+    assert result.data[0, 0] == 1.0
+    assert result.data[0, 2] == 1.0
+    assert result.data[1, 1] == 2.0
+    # (2,1): max=2 from (1,1), cnt_max=1, also gets 1 from (2,0)
+    # max stays 2, cnt stays 1 -> order 2
+    assert result.data[2, 1] == 2.0
+
+
+# ====================================================================
+# Shreve tests
+# ====================================================================
+
+def test_y_confluence_shreve():
+    """Two headwaters merge -> Shreve magnitude = 2."""
+    fracs = _make_fractions({
+        (0, 0): [(1, 1.0)],   # SE
+        (0, 1): [],
+        (0, 2): [(3, 1.0)],   # SW
+        (1, 0): [],
+        (1, 1): [(2, 1.0)],   # S
+        (1, 2): [],
+        (2, 0): [],
+        (2, 1): [],            # pit
+        (2, 2): [],
+    }, (3, 3))
+    accum = np.array([
+        [1.0, 1.0, 1.0],
+        [1.0, 3.0, 1.0],
+        [1.0, 4.0, 1.0],
+    ], dtype=np.float64)
+    result = _call(fracs, accum, threshold=1, method='shreve')
+    assert result.data[0, 0] == 1.0
+    assert result.data[0, 2] == 1.0
+    assert result.data[1, 1] == 2.0
+    assert result.data[2, 1] == 2.0
+
+
+# ====================================================================
+# MFD-specific: split flow
+# ====================================================================
+
+def test_split_flow_strahler():
+    """Cell sends flow to two neighbors via MFD fractions.
+
+    H(0,1) sends 50% SE and 50% S.  Both targets are stream cells
+    that are pits.  H has in-degree 0 (headwater, order 1).
+    Both targets have in-degree 1 (from H), so they get order 1.
+    """
+    fracs = _make_fractions({
+        (0, 0): [],
+        (0, 1): [(1, 0.5), (2, 0.5)],   # SE + S
+        (0, 2): [],
+        (1, 0): [],
+        (1, 1): [],            # pit, receives from H via S
+        (1, 2): [],            # pit, receives from H via SE
+    }, (2, 3))
+    accum = np.array([
+        [1.0, 2.0, 1.0],
+        [1.0, 2.0, 2.0],
+    ], dtype=np.float64)
+    result = _call(fracs, accum, threshold=1, method='strahler')
+    assert result.data[0, 1] == 1.0  # headwater
+    assert result.data[1, 1] == 1.0  # single inflow
+    assert result.data[1, 2] == 1.0  # single inflow
+
+
+# ====================================================================
+# Edge cases
+# ====================================================================
+
+def test_nan_handling():
+    """NaN in fractions -> non-stream cell (NaN output)."""
+    fracs = np.full((8, 2, 2), np.nan, dtype=np.float64)
+    # Only (0,0) is valid, pit
+    fracs[:, 0, 0] = 0.0
+    accum = np.array([[5.0, 0.0], [0.0, 0.0]], dtype=np.float64)
+    result = _call(fracs, accum, threshold=1, method='strahler')
+    assert result.data[0, 0] == 1.0  # isolated headwater
+    assert np.isnan(result.data[0, 1])
+    assert np.isnan(result.data[1, 0])
+    assert np.isnan(result.data[1, 1])
+
+
+def test_threshold_excludes_cells():
+    """Cells below threshold are NaN even if valid fractions exist."""
+    fracs = _make_fractions({
+        (0, 0): [(0, 1.0)],  # E
+        (0, 1): [],           # pit
+    }, (1, 2))
+    accum = np.array([[1.0, 100.0]], dtype=np.float64)
+    result = _call(fracs, accum, threshold=50, method='strahler')
+    assert np.isnan(result.data[0, 0])   # below threshold
+    assert result.data[0, 1] == 1.0       # above threshold, headwater
+
+
+def test_single_cell():
+    """Single-cell raster -> headwater order 1."""
+    fracs = np.zeros((8, 1, 1), dtype=np.float64)
+    accum = np.array([[5.0]], dtype=np.float64)
+    result = _call(fracs, accum, threshold=1, method='strahler')
+    assert result.data[0, 0] == 1.0
+
+
+def test_invalid_method():
+    """Invalid method raises ValueError."""
+    fracs = np.zeros((8, 1, 1), dtype=np.float64)
+    accum = np.array([[1.0]], dtype=np.float64)
+    with pytest.raises(ValueError, match="method must be"):
+        _call(fracs, accum, threshold=0, method='bogus')
+
+
+@dask_array_available
+def test_dask_matches_numpy():
+    """Dask result matches numpy for a small grid."""
+    import dask.array as da
+
+    fracs = _make_fractions({
+        (0, 0): [(1, 1.0)],
+        (0, 1): [],
+        (0, 2): [(3, 1.0)],
+        (1, 0): [],
+        (1, 1): [(2, 1.0)],
+        (1, 2): [],
+        (2, 0): [(0, 1.0)],
+        (2, 1): [],
+        (2, 2): [],
+    }, (3, 3))
+    accum = np.array([
+        [1.0, 1.0, 1.0],
+        [1.0, 3.0, 1.0],
+        [1.0, 5.0, 1.0],
+    ], dtype=np.float64)
+
+    frac_da_np = xr.DataArray(fracs, dims=['neighbor', 'y', 'x'])
+    fa_da_np = create_test_raster(accum)
+    np_result = stream_order_mfd(frac_da_np, fa_da_np, threshold=1,
+                                  method='strahler')
+
+    frac_dask = xr.DataArray(
+        da.from_array(fracs, chunks=(8, 2, 2)),
+        dims=['neighbor', 'y', 'x'])
+    fa_dask = xr.DataArray(
+        da.from_array(accum, chunks=(2, 2)),
+        dims=['y', 'x'])
+    dask_result = stream_order_mfd(frac_dask, fa_dask, threshold=1,
+                                    method='strahler')
+
+    np.testing.assert_array_equal(
+        np.nan_to_num(np_result.values, nan=-999),
+        np.nan_to_num(dask_result.values, nan=-999))


### PR DESCRIPTION
Closes #983.

## Summary

- `stream_order_dinf` and `stream_link_dinf` for D-infinity (Tarboton 1997) flow direction grids
- `stream_order_mfd` and `stream_link_mfd` for Multiple Flow Direction fraction grids
- All four functions support NumPy, CuPy, Dask+NumPy, and Dask+CuPy backends
- Strahler and Shreve methods for both ordering functions

## What changed

**New modules** (4):
- `xrspatial/stream_order_dinf.py` -- D-inf angle -> two bracketing neighbors with fractional weights, then Kahn's BFS same as D8
- `xrspatial/stream_order_mfd.py` -- MFD (8, H, W) fraction grid -> all downslope neighbors, then Kahn's BFS
- `xrspatial/stream_link_dinf.py` -- link segmentation using D-inf topology
- `xrspatial/stream_link_mfd.py` -- link segmentation using MFD topology

**Tests** (4 files, 31 tests):
- Y-confluence, cascade junctions, split-flow/split-angle, NaN handling, threshold filtering, single-cell, dask-vs-numpy parity

**Docs and examples**:
- `hydrology.rst` updated with 4 new API entries
- `README.md` feature matrix updated
- New user guide notebook: `25_Stream_Analysis_Dinf_MFD.ipynb`

## Design notes

The topology construction differs per routing model, but the BFS ordering and link segmentation logic is identical to the existing D8 implementations. D-inf decomposes each angle into two bracketing neighbors. MFD reads directly from the 8-band fraction array. Once the flow graph is built, Strahler/Shreve ordering and link ID assignment work the same way.

## Test plan

- [x] 31 new tests pass (`pytest xrspatial/tests/test_stream_{order,link}_{dinf,mfd}.py`)
- [x] 47 existing D8 stream tests still pass (no regressions)
- [ ] GPU tests (need CUDA hardware)