### PR TITLE
Zonal functions accept vector zones directly

### DIFF
--- a/examples/user_guide/3_Zonal.ipynb
+++ b/examples/user_guide/3_Zonal.ipynb
@@ -3,18 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "# Xarray-spatial\n",
-    "### User Guide: Zonal\n",
-    "-----\n",
-    "\n",
-    "Xarray-spatial's zonal functions provide an easy way to generate statistics for zones within a raster aggregate. It's set up with a default set of calculations, or you can input any set of custom calculations you'd like to perform.\n",
-    "\n",
-    "[Generate terrain](#Generate-Terrain-Data)\n",
-    "[Zonal Statistics](#Zonal-Statistics)\n",
-    "\n",
-    "-----------\n"
-   ]
+   "source": "# Xarray-spatial\n### User Guide: Zonal\n-----\n\nXarray-spatial's zonal functions provide an easy way to generate statistics for zones within a raster aggregate. It's set up with a default set of calculations, or you can input any set of custom calculations you'd like to perform.\n\n[Generate terrain](#Generate-Terrain-Data)\n[Zonal Statistics](#Zonal-Statistics)\n[Zonal Crosstab](#Zonal-crosstab)\n[Vector Zones](#Vector-zones)\n\n-----------"
   },
   {
    "cell_type": "markdown",
@@ -239,11 +228,71 @@
    "source": "# Calculate crosstab: rows are trail segments, columns are tree species (1=Oak, 2=Pine, 3=Maple)\nresult = tree_species_agg.xrs.zonal_crosstab(zones_agg, zone_ids=[11, 12, 13, 14, 15, 16], cat_ids=[1, 2, 3])\nresult.columns = ['Trail Segment', 'Oak', 'Pine', 'Maple']\nresult"
   },
   {
-   "cell_type": "code",
+   "cell_type": "markdown",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": "## Vector zones\n\nZonal functions can also accept vector geometries directly -- a GeoDataFrame or a list of `(geometry, value)` pairs. The rasterization to match the values grid happens automatically inside the function call, so there's no separate `rasterize()` step.\n\nThis works with `zonal_stats`, `zonal_crosstab`, `zonal_apply`, and `crop`."
+  },
+  {
+   "cell_type": "markdown",
+   "source": "### GeoDataFrame zones\n\nLet's define three rectangular regions as polygons in a GeoDataFrame and compute elevation statistics directly.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "import geopandas as gpd\nfrom shapely.geometry import box\nfrom xrspatial.zonal import stats\n\n# Three rectangular regions across the terrain\nzones_gdf = gpd.GeoDataFrame(\n    {'region_id': [1.0, 2.0, 3.0],\n     'name': ['West valley', 'Central ridge', 'East slope']},\n    geometry=[\n        box(-20, -20, -5, 20),   # left third\n        box(-5, -20, 5, 20),     # middle third\n        box(5, -20, 20, 20),     # right third\n    ],\n)\n\n# Pass the GeoDataFrame directly -- no manual rasterize() needed\nresult = stats(zones_gdf, terrain, column='region_id',\n               stats_funcs=['mean', 'min', 'max', 'std', 'count'])\nresult",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": "The same thing works with the accessor. The values raster is used as the template for rasterization, so the zones automatically align to the grid.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "# Accessor style -- same result\nterrain.xrs.zonal_stats(zones_gdf, column='region_id',\n                        stats_funcs=['mean', 'min', 'max', 'std', 'count'])",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": "### List-of-pairs zones\n\nIf you don't have a GeoDataFrame, you can pass a list of `(geometry, zone_id)` tuples. No `column` argument needed here since the zone ID is the second element of each pair.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "pairs = [\n    (box(-15, -15, 0, 0), 10.0),   # southwest quadrant\n    (box(0, 0, 15, 15), 20.0),     # northeast quadrant\n]\n\nstats(pairs, terrain, stats_funcs=['mean', 'count'])",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": "### Crosstab with vector zones\n\nVector zones work with `zonal_crosstab` too. Here we'll use the tree species data from earlier with our GeoDataFrame regions.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "from xrspatial.zonal import crosstab\n\nct = crosstab(zones_gdf, tree_species_agg, column='region_id', cat_ids=[1, 2, 3])\nct.columns = ['Region', 'Oak', 'Pine', 'Maple']\nct",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "source": "### Forwarding rasterize options\n\nYou can pass extra options to the internal `rasterize()` call via `rasterize_kw`. For example, `all_touched=True` will include pixels that touch the geometry boundary, not just those whose centre falls inside.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "# Small polygon -- compare default vs all_touched\nsmall_zone = gpd.GeoDataFrame(\n    {'zone': [1.0]}, geometry=[box(-2, -2, 2, 2)]\n)\n\ndefault = stats(small_zone, terrain, column='zone', stats_funcs=['count'])\ntouched = stats(small_zone, terrain, column='zone', stats_funcs=['count'],\n                rasterize_kw={'all_touched': True})\n\nprint(f\"Default pixel count:     {int(default['count'].iloc[0])}\")\nprint(f\"all_touched pixel count: {int(touched['count'].iloc[0])}\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
   }
  ],
  "metadata": {

--- a/xrspatial/tests/test_zonal.py
+++ b/xrspatial/tests/test_zonal.py
@@ -1686,3 +1686,145 @@ def test_crosstab_does_not_materialise_dask_zones():
         result = result.compute()
     assert isinstance(result, pd.DataFrame)
     assert len(result) > 0
+
+
+# ---------------------------------------------------------------------------
+# Vector zones (GeoDataFrame / list-of-pairs) — implicit rasterization
+# ---------------------------------------------------------------------------
+
+try:
+    from shapely.geometry import box as shapely_box
+    import geopandas as gpd
+    _has_vector = True
+except ImportError:
+    _has_vector = False
+
+skip_no_vector = pytest.mark.skipif(
+    not _has_vector, reason="shapely/geopandas not installed"
+)
+
+
+def _make_grid(width=20, height=20, bounds=(0, 0, 100, 100)):
+    """Build a template DataArray with pixel-centre coords."""
+    xmin, ymin, xmax, ymax = bounds
+    px = (xmax - xmin) / width
+    py = (ymax - ymin) / height
+    x = np.linspace(xmin + px / 2, xmax - px / 2, width)
+    y = np.linspace(ymax - py / 2, ymin + py / 2, height)
+    return xr.DataArray(
+        np.ones((height, width), dtype=np.float64),
+        dims=['y', 'x'],
+        coords={'y': y, 'x': x},
+    )
+
+
+@skip_no_vector
+class TestVectorZones:
+    """Verify that zonal functions accept vector zones directly."""
+
+    def _zones_raster_and_gdf(self):
+        """Two non-overlapping boxes covering different quadrants."""
+        from xrspatial.rasterize import rasterize
+
+        values = _make_grid()
+        gdf = gpd.GeoDataFrame(
+            {'zone_id': [1.0, 2.0]},
+            geometry=[
+                shapely_box(0, 50, 50, 100),   # top-left
+                shapely_box(50, 0, 100, 50),    # bottom-right
+            ],
+        )
+        zones_raster = rasterize(gdf, like=values, column='zone_id')
+        return values, gdf, zones_raster
+
+    # -- stats --
+
+    def test_stats_gdf_matches_raster(self):
+        values, gdf, zones_raster = self._zones_raster_and_gdf()
+        expected = stats(zones_raster, values, stats_funcs=['mean', 'count'])
+        result = stats(gdf, values, stats_funcs=['mean', 'count'],
+                       column='zone_id')
+        pd.testing.assert_frame_equal(result, expected)
+
+    def test_stats_list_of_pairs(self):
+        values, gdf, zones_raster = self._zones_raster_and_gdf()
+        pairs = [
+            (shapely_box(0, 50, 50, 100), 1.0),
+            (shapely_box(50, 0, 100, 50), 2.0),
+        ]
+        expected = stats(zones_raster, values, stats_funcs=['mean', 'count'])
+        result = stats(pairs, values, stats_funcs=['mean', 'count'])
+        pd.testing.assert_frame_equal(result, expected)
+
+    def test_stats_gdf_missing_column_raises(self):
+        values = _make_grid()
+        gdf = gpd.GeoDataFrame(
+            {'zone_id': [1.0]},
+            geometry=[shapely_box(0, 0, 50, 50)],
+        )
+        with pytest.raises(ValueError, match="column is required"):
+            stats(gdf, values)
+
+    def test_stats_pairs_with_column_raises(self):
+        values = _make_grid()
+        pairs = [(shapely_box(0, 0, 50, 50), 1.0)]
+        with pytest.raises(ValueError, match="column should not be set"):
+            stats(pairs, values, column='zone_id')
+
+    def test_stats_accessor(self):
+        import xrspatial  # noqa: F401  — registers accessor
+        values, gdf, zones_raster = self._zones_raster_and_gdf()
+        expected = stats(zones_raster, values, stats_funcs=['mean', 'count'])
+        result = values.xrs.zonal_stats(gdf, stats_funcs=['mean', 'count'],
+                                        column='zone_id')
+        pd.testing.assert_frame_equal(result, expected)
+
+    # -- crosstab --
+
+    def test_crosstab_gdf(self):
+        values, gdf, zones_raster = self._zones_raster_and_gdf()
+        expected = crosstab(zones_raster, values)
+        result = crosstab(gdf, values, column='zone_id')
+        pd.testing.assert_frame_equal(result, expected)
+
+    # -- apply --
+
+    def test_apply_gdf(self):
+        values, gdf, zones_raster = self._zones_raster_and_gdf()
+        # rasterize produces float zones; apply needs int zones
+        zones_int = zones_raster.copy(data=zones_raster.values.astype(int))
+        fn = lambda x: x * 2
+        expected = apply(zones_int, values, fn)
+        result = apply(gdf, values, fn, column='zone_id',
+                       rasterize_kw={'dtype': int})
+        xr.testing.assert_identical(result, expected)
+
+    # -- crop --
+
+    def test_crop_gdf(self):
+        values, gdf, zones_raster = self._zones_raster_and_gdf()
+        expected = crop(zones_raster, values, zones_ids=[1.0])
+        result = crop(gdf, values, zones_ids=[1.0], column='zone_id')
+        xr.testing.assert_identical(result, expected)
+
+    # -- rasterize_kw forwarding --
+
+    def test_stats_rasterize_kw_all_touched(self):
+        values, gdf, _ = self._zones_raster_and_gdf()
+        from xrspatial.rasterize import rasterize
+        zones_at = rasterize(gdf, like=values, column='zone_id',
+                             all_touched=True)
+        expected = stats(zones_at, values, stats_funcs=['count'])
+        result = stats(gdf, values, stats_funcs=['count'],
+                       column='zone_id',
+                       rasterize_kw={'all_touched': True})
+        pd.testing.assert_frame_equal(result, expected)
+
+    # -- raster zones still work --
+
+    def test_raster_zones_unchanged(self):
+        """Passing a DataArray directly should still work as before."""
+        values, _, zones_raster = self._zones_raster_and_gdf()
+        result = stats(zones_raster, values, stats_funcs=['count'])
+        assert isinstance(result, pd.DataFrame)
+        assert len(result) > 0

--- a/xrspatial/zonal.py
+++ b/xrspatial/zonal.py
@@ -46,6 +46,84 @@ from xrspatial.utils import has_dask_array
 TOTAL_COUNT = '_total_count'
 
 
+def _maybe_rasterize_zones(zones, values, column=None, rasterize_kw=None):
+    """If *zones* is vector data, rasterize it using *values* as the template.
+
+    Accepts:
+    - ``GeoDataFrame`` (requires *column* to identify the zone-ID field)
+    - list of ``(geometry, value)`` pairs
+
+    Returns a 2-D ``xr.DataArray`` of zone IDs aligned to *values*.
+    If *zones* is already a DataArray it is returned unchanged.
+    """
+    if isinstance(zones, xr.DataArray):
+        return zones
+
+    # list-of-pairs: [(geom, value), ...]
+    is_pairs = (
+        isinstance(zones, (list, tuple))
+        and len(zones) > 0
+        and isinstance(zones[0], (list, tuple))
+        and len(zones[0]) == 2
+    )
+
+    # GeoDataFrame
+    is_gdf = False
+    try:
+        import geopandas as gpd
+        is_gdf = isinstance(zones, gpd.GeoDataFrame)
+    except ImportError:
+        pass
+
+    if not is_pairs and not is_gdf:
+        return zones
+
+    from .rasterize import rasterize
+
+    # Build the template from values (first 2D variable if Dataset)
+    if isinstance(values, xr.Dataset):
+        for var in values.data_vars:
+            da_var = values[var]
+            if da_var.ndim >= 2 and 'y' in da_var.dims and 'x' in da_var.dims:
+                like = da_var
+                break
+        else:
+            raise ValueError(
+                "values Dataset has no 2D variable with 'y' and 'x' "
+                "dimensions to use as rasterize template"
+            )
+    elif isinstance(values, xr.DataArray):
+        if values.ndim >= 2:
+            like = values
+        else:
+            raise ValueError(
+                "values must be at least 2D to use as rasterize template"
+            )
+    else:
+        raise TypeError(
+            f"values must be an xr.DataArray or xr.Dataset, got {type(values)}"
+        )
+
+    kw = dict(rasterize_kw or {})
+    kw['like'] = like
+
+    if is_gdf:
+        if column is None:
+            raise ValueError(
+                "column is required when zones is a GeoDataFrame. "
+                "Specify which column contains zone IDs."
+            )
+        kw['column'] = column
+    elif is_pairs:
+        if column is not None:
+            raise ValueError(
+                "column should not be set when zones is a list of "
+                "(geometry, value) pairs"
+            )
+
+    return rasterize(zones, **kw)
+
+
 def _unique_finite_zones(arr):
     """Sorted unique finite values from *arr* without full materialisation.
 
@@ -476,7 +554,7 @@ def _stats_dask_cupy(
 
 
 def stats(
-    zones: xr.DataArray,
+    zones,
     values: xr.DataArray,
     zone_ids: Optional[List[Union[int, float]]] = None,
     stats_funcs: Union[Dict, List] = [
@@ -491,6 +569,8 @@ def stats(
     ],
     nodata_values: Union[int, float] = None,
     return_type: str = 'pandas.DataFrame',
+    column: Optional[str] = None,
+    rasterize_kw: Optional[dict] = None,
 ) -> Union[pd.DataFrame, dd.DataFrame, xr.DataArray]:
     """
     Calculate summary statistics for each zone defined by a `zones`
@@ -644,6 +724,9 @@ def stats(
         >>> stats_df = stats(zones=zones, values=ds)
         >>> # Columns: zone, 2020_mean, 2020_max, ..., 2021_mean, 2021_max, ...
     """
+
+    zones = _maybe_rasterize_zones(zones, values, column=column,
+                                   rasterize_kw=rasterize_kw)
 
     # Dataset support: run stats per variable and merge into one DataFrame
     if isinstance(values, xr.Dataset):
@@ -1009,13 +1092,15 @@ def _crosstab_dask_cupy(
 
 
 def crosstab(
-    zones: xr.DataArray,
+    zones,
     values: xr.DataArray,
     zone_ids: List[Union[int, float]] = None,
     cat_ids: List[Union[int, float]] = None,
     layer: Optional[int] = None,
     agg: Optional[str] = "count",
     nodata_values: Optional[Union[int, float]] = None,
+    column: Optional[str] = None,
+    rasterize_kw: Optional[dict] = None,
 ) -> Union[pd.DataFrame, dd.DataFrame]:
     """
     Calculate cross-tabulated (categorical stats) areas
@@ -1143,6 +1228,9 @@ def crosstab(
             4      6    1     2     2     0     0     1
             5      7    0     1     0     0     1     1
     """
+
+    zones = _maybe_rasterize_zones(zones, values, column=column,
+                                   rasterize_kw=rasterize_kw)
 
     _validate_raster(zones, func_name='crosstab', name='zones', ndim=2)
     _validate_raster(values, func_name='crosstab', name='values', ndim=(2, 3))
@@ -1342,10 +1430,12 @@ def _apply_dask_cupy(zones_data, values_data, func, nodata):
 
 
 def apply(
-    zones: xr.DataArray,
+    zones,
     values: xr.DataArray,
     func: Callable,
-    nodata: Optional[int] = 0
+    nodata: Optional[int] = 0,
+    column: Optional[str] = None,
+    rasterize_kw: Optional[dict] = None,
 ):
     """
     Apply a function to the `values` agg within zones in `zones` agg.
@@ -1399,6 +1489,9 @@ def apply(
         array([[0, 0, 5, 0],
                [3, np.nan, 0, 0]])
     """
+    zones = _maybe_rasterize_zones(zones, values, column=column,
+                                   rasterize_kw=rasterize_kw)
+
     _validate_raster(zones, func_name='apply', name='zones', ndim=2, integer_only=True)
     _validate_raster(values, func_name='apply', name='values', ndim=(2, 3))
 
@@ -2128,10 +2221,12 @@ def _crop_bounds_dask(data, target_values):
 
 
 def crop(
-    zones: xr.DataArray,
+    zones,
     values: xr.DataArray,
     zones_ids: Union[list, tuple],
     name: str = "crop",
+    column: Optional[str] = None,
+    rasterize_kw: Optional[dict] = None,
 ):
     """
     Crop scans from edges and eliminates rows / cols until one of the
@@ -2243,6 +2338,9 @@ def crop(
             'Max Elevation': '4000',
         }
     """
+    zones = _maybe_rasterize_zones(zones, values, column=column,
+                                   rasterize_kw=rasterize_kw)
+
     _validate_raster(zones, func_name='crop', name='zones', ndim=2)
     _validate_raster(values, func_name='crop', name='values', ndim=2)
 

--- a/xrspatial/zonal.py
+++ b/xrspatial/zonal.py
@@ -584,12 +584,16 @@ def stats(
 
     Parameters
     ----------
-    zones : xr.DataArray
-        zones is a 2D xarray DataArray of numeric values.
-        A zone is all the cells in a raster that have the same value,
-        whether or not they are contiguous. The input `zones` raster defines
-        the shape, values, and locations of the zones. An integer field
-        in the input `zones` DataArray defines a zone.
+    zones : xr.DataArray, GeoDataFrame, or list of (geometry, value) pairs
+        Zone definitions. Can be:
+
+        - A 2D xarray DataArray of numeric zone IDs.
+        - A ``geopandas.GeoDataFrame`` (requires *column*).
+        - A list of ``(shapely geometry, zone_id)`` pairs.
+
+        When vector input is provided, ``rasterize()`` is called internally
+        using *values* as the template grid. Results depend on raster
+        resolution.
 
     values : xr.DataArray or xr.Dataset
         values is a 2D xarray DataArray of numeric values (integers or floats).
@@ -627,6 +631,15 @@ def stats(
         Format of returned data. If `zones` and `values` numpy backed xarray DataArray,
         allowed values are 'pandas.DataFrame', and 'xarray.DataArray'.
         Otherwise, only 'pandas.DataFrame' is supported.
+
+    column : str, optional
+        Column name in the GeoDataFrame that contains zone IDs.
+        Required when *zones* is a GeoDataFrame; must not be set
+        for list-of-pairs or DataArray input.
+
+    rasterize_kw : dict, optional
+        Extra keyword arguments forwarded to ``rasterize()`` when
+        *zones* is vector input (e.g. ``{'all_touched': True}``).
 
     Returns
     -------
@@ -1123,12 +1136,15 @@ def crosstab(
 
     Parameters
     ----------
-    zones : xr.DataArray
-        2D data array of integers or floats.
-        A zone is all the cells in a raster that have the same value,
-        whether or not they are contiguous. The input `zones` raster defines
-        the shape, values, and locations of the zones. An unique field
-        in the zone input is specified to define the zones.
+    zones : xr.DataArray, GeoDataFrame, or list of (geometry, value) pairs
+        Zone definitions. Can be:
+
+        - A 2D xarray DataArray of integers or floats.
+        - A ``geopandas.GeoDataFrame`` (requires *column*).
+        - A list of ``(shapely geometry, zone_id)`` pairs.
+
+        When vector input is provided, ``rasterize()`` is called internally
+        using *values* as the template grid.
 
     values : xr.DataArray
         2D or 3D data array of integers or floats.
@@ -1157,6 +1173,14 @@ def crosstab(
         Nodata value in `values` raster.
         Cells with `nodata` do not belong to any zone,
         and thus excluded from calculation.
+
+    column : str, optional
+        Column name in the GeoDataFrame that contains zone IDs.
+        Required when *zones* is a GeoDataFrame.
+
+    rasterize_kw : dict, optional
+        Extra keyword arguments forwarded to ``rasterize()`` when
+        *zones* is vector input (e.g. ``{'all_touched': True}``).
 
     Returns
     -------
@@ -1443,12 +1467,16 @@ def apply(
 
     Parameters
     ----------
-    zones : xr.DataArray
-        zones.values is a 2d array of integers. A zone is all the cells
-        in a raster that have the same value, whether or not they are
-        contiguous. The input zone layer defines the shape, values, and
-        locations of the zones. An integer field in the zone input is
-        specified to define the zones.
+    zones : xr.DataArray, GeoDataFrame, or list of (geometry, value) pairs
+        Zone definitions. Can be:
+
+        - A 2D xarray DataArray of integers.
+        - A ``geopandas.GeoDataFrame`` (requires *column*).
+        - A list of ``(shapely geometry, zone_id)`` pairs.
+
+        When vector input is provided, ``rasterize()`` is called internally
+        using *values* as the template grid. Use ``rasterize_kw={'dtype': int}``
+        to produce integer zones (required by ``apply``).
 
     values : xr.DataArray
         values.data is either a 2D or 3D array of integers or floats.
@@ -1461,6 +1489,14 @@ def apply(
         Cells with `nodata` does not belong to any zone,
         and thus excluded from calculation.
         Set to None to apply func to all cells.
+
+    column : str, optional
+        Column name in the GeoDataFrame that contains zone IDs.
+        Required when *zones* is a GeoDataFrame.
+
+    rasterize_kw : dict, optional
+        Extra keyword arguments forwarded to ``rasterize()`` when
+        *zones* is vector input.
 
     Returns
     -------
@@ -2234,8 +2270,9 @@ def crop(
 
     Parameters
     ----------
-    zones : xr.DataArray
-        Input zone raster.
+    zones : xr.DataArray, GeoDataFrame, or list of (geometry, value) pairs
+        Zone definitions. Can be a 2D DataArray, a GeoDataFrame
+        (requires *column*), or a list of ``(geometry, zone_id)`` pairs.
 
     values: xr.DataArray
         Input values raster.
@@ -2245,6 +2282,14 @@ def crop(
 
     name: str, default='crop'
         Output xr.DataArray.name property.
+
+    column : str, optional
+        Column name in the GeoDataFrame that contains zone IDs.
+        Required when *zones* is a GeoDataFrame.
+
+    rasterize_kw : dict, optional
+        Extra keyword arguments forwarded to ``rasterize()`` when
+        *zones* is vector input.
 
     Returns
     -------


### PR DESCRIPTION
Closes #998

## Summary

- `stats()`, `crosstab()`, `apply()`, and `crop()` now accept a GeoDataFrame or list of `(geometry, value)` pairs as the `zones` argument. When vector input is detected, `rasterize()` is called internally using the values raster as the grid template.
- Adds `column` parameter (names the zone-ID column in a GeoDataFrame) and `rasterize_kw` (forwarded to `rasterize()`, e.g. `{'all_touched': True}`).
- Existing raster-input behavior is unchanged.

## Test plan

- [x] `TestVectorZones` class (10 tests): GeoDataFrame parity with manual rasterize, list-of-pairs, error cases (missing column, column with pairs), accessor, crosstab, apply, crop, rasterize_kw forwarding, raster zones still work
- [x] All 106 existing zonal tests still pass