### PR TITLE
Add section index to README feature matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ In the GIS world, rasters are used for representing continuous phenomena (e.g. e
 
 ✅ = native backend &nbsp;&nbsp; 🔄 = accepted (CPU fallback)
 
+[Classification](#classification) · [Diffusion](#diffusion) · [Focal](#focal) · [Morphological](#morphological) · [Fire](#fire) · [Multispectral](#multispectral) · [Multivariate](#multivariate) · [Pathfinding](#pathfinding) · [Proximity](#proximity) · [Reproject / Merge](#reproject--merge) · [Raster / Vector Conversion](#raster--vector-conversion) · [Surface](#surface) · [Hydrology](#hydrology) · [Flood](#flood) · [Interpolation](#interpolation) · [Dasymetric](#dasymetric) · [Zonal](#zonal) · [Utilities](#utilities)
+
 -------
 
 ### **Classification**


### PR DESCRIPTION
Closes #1033

## Summary
- Adds a single line of anchor links at the top of the feature matrix, right below the backend legend
- Covers all 18 category sections (Classification through Utilities)
- Middot-separated inline links keep it compact and visually low-key

## Test plan
- [ ] Verify anchor links resolve correctly on the rendered GitHub README