### PR TITLE
Fix stale full pipeline benchmark numbers in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,10 +262,10 @@ Built-in Numba JIT and CUDA projection kernels bypass pyproj for per-pixel coord
 
 | Backend | Time |
 |:---|---:|
-| NumPy | 2.7s |
+| NumPy | 784ms |
 | CuPy GPU | 348ms |
 | Dask+CuPy GPU | 343ms |
-| rioxarray (GDAL) | 418ms |
+| rioxarray (GDAL) | 749ms |
 
 **Merge performance** (4 overlapping same-CRS tiles, vs rioxarray):
 


### PR DESCRIPTION
## Summary

- NumPy pipeline time updated from 2.7s to 784ms (was 3.4x too slow, predates reproject/geotiff optimizations)
- rioxarray pipeline time updated from 418ms to 749ms (hardware/version drift)
- GPU rows left unchanged (no GPU available to re-measure)

Closes #1077

## Test plan

- [ ] Verify numbers by running the pipeline benchmark (read 3600x3600 Copernicus DEM + reproject to EPSG:3857 + write GeoTIFF)