### PR TITLE
Fix 196 test-suite warnings (#1148)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -90,6 +90,17 @@ max-line-length = 100
 [tool:pytest]
 filterwarnings =
     ignore::numba.core.errors.NumbaPerformanceWarning
+    ignore::numba.core.errors.NumbaPendingDeprecationWarning
+    ignore:You will likely lose important projection information:UserWarning:pyproj
+    ignore:cost_distance. max_cost is infinite:UserWarning:xrspatial
+    ignore:surface_distance. max_distance is infinite:UserWarning:xrspatial
+    ignore:proximity. target coordinates exceed:ResourceWarning:xrspatial
+    ignore:Covariance of the parameters could not be estimated:scipy.optimize.OptimizeWarning
+    ignore:'oneOf' deprecated:DeprecationWarning:matplotlib
+    ignore:'parseString' deprecated:DeprecationWarning:matplotlib
+    ignore:'resetCache' deprecated:DeprecationWarning:matplotlib
+    ignore:'enablePackrat' deprecated:DeprecationWarning:matplotlib
+    ignore:'asyncio.AbstractEventLoopPolicy' is deprecated:DeprecationWarning:pytest_asyncio
 
 [isort]
 line_length = 100

--- a/xrspatial/classify.py
+++ b/xrspatial/classify.py
@@ -1382,7 +1382,7 @@ def _run_box_plot(agg, hinge, module):
         q3_l = da.percentile(finite_data, 75)
         max_l = da.nanmax(data_clean)
         q1, q2, q3, max_v = dask.compute(q1_l, q2_l, q3_l, max_l)
-        q1, q2, q3, max_v = float(q1), float(q2), float(q3), float(max_v)
+        q1, q2, q3, max_v = q1.item(), q2.item(), q3.item(), max_v.item()
     else:
         q1 = float(np.percentile(finite_data, 25))
         q2 = float(np.percentile(finite_data, 50))
@@ -1411,7 +1411,7 @@ def _run_dask_cupy_box_plot(agg, hinge):
     q3_l = da.percentile(finite_data, 75)
     max_l = da.nanmax(data_clean)
     q1, q2, q3, max_v = dask.compute(q1_l, q2_l, q3_l, max_l)
-    q1, q2, q3, max_v = float(q1), float(q2), float(q3), float(max_v)
+    q1, q2, q3, max_v = q1.item(), q2.item(), q3.item(), max_v.item()
 
     iqr = q3 - q1
     raw_bins = [q1 - hinge * iqr, q1, q2, q3, q3 + hinge * iqr, max_v]

--- a/xrspatial/preview.py
+++ b/xrspatial/preview.py
@@ -45,7 +45,9 @@ def _is_all_nan(block):
                 return bool(cupy.isnan(cupy.nanmax(block)))
     except ImportError:
         pass
-    with np.errstate(invalid='ignore'):
+    import warnings
+    with np.errstate(invalid='ignore'), warnings.catch_warnings():
+        warnings.simplefilter('ignore', RuntimeWarning)
         return bool(np.isnan(np.nanmax(block)))
 
 

--- a/xrspatial/rasterize.py
+++ b/xrspatial/rasterize.py
@@ -1036,7 +1036,10 @@ def _run_numpy(geometries, props_array, bounds, height, width, fill, dtype,
         _burn_points_cpu(out, written, prows, pcols, pt_idx,
                          point_props, merge_fn)
 
-    return out.astype(dtype)
+    import warnings
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', RuntimeWarning)
+        return out.astype(dtype)
 
 
 # ---------------------------------------------------------------------------

--- a/xrspatial/tests/test_zonal.py
+++ b/xrspatial/tests/test_zonal.py
@@ -1871,7 +1871,11 @@ class TestVectorZones:
     def test_apply_gdf(self):
         values, gdf, zones_raster = self._zones_raster_and_gdf()
         # rasterize produces float zones; apply needs int zones
-        zones_int = zones_raster.copy(data=zones_raster.values.astype(int))
+        import warnings
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
+            zones_int = zones_raster.copy(
+                data=zones_raster.values.astype(int))
         fn = lambda x: x * 2
         expected = apply(zones_int, values, fn)
         result = apply(gdf, values, fn, column='zone_id',

--- a/xrspatial/zonal.py
+++ b/xrspatial/zonal.py
@@ -208,7 +208,10 @@ def _nanreduce_preserve_allnan(blocks, func):
     ``np.nansum`` returns 0 for all-NaN input; we want NaN so that zones
     with no valid values propagate NaN, consistent with the numpy backend.
     """
-    result = func(blocks, axis=0)
+    import warnings
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', RuntimeWarning)
+        result = func(blocks, axis=0)
     all_nan = np.all(np.isnan(blocks), axis=0)
     result[all_nan] = np.nan
     return result
@@ -2217,7 +2220,7 @@ def trim(
     else:
         if is_cupy_array(data):
             data = data.get()
-        top, bottom, left, right = _trim(data, values)
+        top, bottom, left, right = _trim(data, np.asarray(values))
 
     arr = raster[top: bottom + 1, left: right + 1]
     arr.name = name
@@ -2493,7 +2496,7 @@ def crop(
     else:
         if is_cupy_array(data):
             data = data.get()
-        top, bottom, left, right = _crop(data, zones_ids)
+        top, bottom, left, right = _crop(data, np.asarray(zones_ids))
 
     arr = values[top: bottom + 1, left: right + 1]
     arr.name = name


### PR DESCRIPTION
## Summary
- Eliminates all 196 warnings from the test suite
- Fixes two deprecations that will become errors in future NumPy/Numba (0-d array `float()` cast in classify.py, reflected list in zonal.py `_crop`)
- Suppresses expected RuntimeWarnings at the source (all-NaN slices in preview/zonal, NaN-to-int cast in rasterize)
- Adds pytest filterwarnings for intentional warnings (iterative Dijkstra, memory guards) and third-party noise (pyproj, matplotlib, pytest_asyncio)

## Test plan
- [x] Full suite: 0 warnings, no new failures
- [ ] Verify classify box_plot still works on dask arrays
- [ ] Verify zonal trim/crop still works with list arguments
- [ ] Check that intentional warnings still appear for users (only suppressed in test output)

Closes #1148