### PR TITLE
Update rockout skill and performance sweep state

### DIFF
--- a/.claude/commands/rockout.md
+++ b/.claude/commands/rockout.md
@@ -71,19 +71,10 @@ through all seven steps below. The prompt is: $ARGUMENTS
 
 ## Step 6 -- Create a User Guide Notebook
 
-The project has an `examples/user_guide/` directory with numbered notebooks.
-
-1. Determine the next available notebook number by listing the directory.
-2. Create a new `.ipynb` notebook following the established pattern:
-   - Markdown cell with title and explanation of the feature
-   - Import cell
-   - Synthetic data generation with visualization
-   - Demonstrate each mode/option of the feature
-   - Show a practical use case or comparison
-3. Use `matplotlib` for plots, consistent with existing notebooks.
-4. Keep the notebook self-contained (no external data dependencies).
-
 **Skip this step** if the change is a pure bug fix with no new user-facing API.
+
+Run the `/user-guide-notebook` skill to create the notebook. It handles structure,
+plotting conventions, GIS alert boxes, preview images, and humanizer passes.
 
 ## Step 7 -- Update the README Feature Matrix
 

--- a/.claude/performance-sweep-state.json
+++ b/.claude/performance-sweep-state.json
@@ -1,10 +1,11 @@
 {
-  "last_triage": "2026-03-31T18:00:00Z",
+  "last_triage": "2026-04-05T12:00:00Z",
   "modules": {
     "reproject": { "last_inspected": "2026-03-31T18:00:00Z", "oom_verdict": "RISKY", "bottleneck": "compute-bound", "high_count": 1, "issue": null },
     "geotiff": { "last_inspected": "2026-03-31T18:00:00Z", "oom_verdict": "SAFE", "bottleneck": "IO-bound", "high_count": 0, "issue": null, "notes": "False positive. open_geotiff(chunks=N) returns lazy dask array. to_geotiff auto-routes dask inputs to write_streaming. Eager paths are by design for numpy/cupy." },
     "zonal": { "last_inspected": "2026-03-31T18:00:00Z", "oom_verdict": "WILL OOM", "bottleneck": "memory-bound", "high_count": 4, "issue": 1110, "notes": "Memory guards improved, iterrows replaced with isin. da.unique().compute() confirmed safe (small result). regions() is inherently global - documented limitation." },
-    "viewshed": { "last_inspected": "2026-03-31T18:00:00Z", "oom_verdict": "SAFE", "bottleneck": "memory-bound", "high_count": 1, "issue": null },
+    "viewshed": { "last_inspected": "2026-04-05T12:00:00Z", "oom_verdict": "SAFE", "bottleneck": "memory-bound", "high_count": 0, "issue": "fixed-in-tree", "notes": "Tier B memory estimate tightened from 280 to 368 bytes/pixel (accounts for lexsort double-alloc + computed raster). astype copy=False avoids needless float64 copy." },
+    "visibility": { "last_inspected": "2026-04-05T12:00:00Z", "oom_verdict": "SAFE", "bottleneck": "memory-bound", "high_count": 0, "issue": "fixed-in-tree", "notes": "Fixed: _extract_transect uses vindex for point extraction, cumulative_viewshed accumulates lazily with da.zeros + da.Array addition. All 3 HIGH findings resolved." },
     "rasterize": { "last_inspected": "2026-03-31T18:00:00Z", "oom_verdict": "SAFE", "bottleneck": "graph-bound", "high_count": 1, "issue": null },
     "bump": { "last_inspected": "2026-03-31T18:00:00Z", "oom_verdict": "WILL OOM", "bottleneck": "memory-bound", "high_count": 0, "issue": null },
     "normalize": { "last_inspected": "2026-03-31T18:00:00Z", "oom_verdict": "SAFE", "bottleneck": "compute-bound", "high_count": 0, "issue": 1124, "notes": "Boolean indexing replaced with lazy nanmin/nanmax/nanmean/nanstd." },


### PR DESCRIPTION
## Summary
- Simplify rockout Step 6 (user guide notebook) to delegate to the `/user-guide-notebook` skill instead of inlining instructions
- Update performance-sweep-state.json with viewshed/visibility fixes from #1167

## Test plan
- [ ] CI passes