### PR TITLE
Add geometry simplification to polygonize()

### DIFF
--- a/docs/superpowers/plans/2026-04-06-polygonize-simplification.md
+++ b/docs/superpowers/plans/2026-04-06-polygonize-simplification.md
@@ -1,0 +1,916 @@
+# Polygonize Geometry Simplification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add topology-preserving Douglas-Peucker simplification to `polygonize()` via shared-edge decomposition.
+
+**Architecture:** New `simplify_tolerance` and `simplify_method` parameters on `polygonize()`. Simplification runs after boundary tracing / chunk merging but before output conversion. A shared-edge approach decomposes all polygon rings into unique edge chains at junction vertices, simplifies each chain once with numba-compiled Douglas-Peucker, then reassembles rings. This guarantees adjacent polygons share identical simplified boundaries (no gaps/overlaps).
+
+**Tech Stack:** Python, numba (`@ngjit`), numpy, xarray, pytest. Optional: shapely (for topology tests only).
+
+---
+
+### Task 1: Douglas-Peucker kernel
+
+**Files:**
+- Modify: `xrspatial/polygonize.py` (insert after `_group_rings_into_polygons` ~line 920)
+- Test: `xrspatial/tests/test_polygonize.py`
+
+- [ ] **Step 1: Write the failing test for `_douglas_peucker`**
+
+Add at the end of `xrspatial/tests/test_polygonize.py`:
+
+```python
+class TestSimplifyHelpers:
+    """Tests for internal simplification helper functions."""
+
+    def test_douglas_peucker_straight_line(self):
+        """DP on a straight line should reduce to just endpoints."""
+        from ..polygonize import _douglas_peucker
+        coords = np.array([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0],
+                           [3.0, 0.0], [4.0, 0.0]], dtype=np.float64)
+        result = _douglas_peucker(coords, 0.1)
+        expected = np.array([[0.0, 0.0], [4.0, 0.0]], dtype=np.float64)
+        assert_allclose(result, expected)
+
+    def test_douglas_peucker_preserves_bend(self):
+        """DP should keep a vertex that exceeds tolerance."""
+        from ..polygonize import _douglas_peucker
+        coords = np.array([[0.0, 0.0], [2.0, 3.0], [4.0, 0.0]],
+                          dtype=np.float64)
+        # Distance of (2,3) from line (0,0)-(4,0) is 3.0
+        result = _douglas_peucker(coords, 2.0)
+        assert len(result) == 3  # all points kept
+
+    def test_douglas_peucker_removes_below_tolerance(self):
+        """DP should remove a vertex within tolerance."""
+        from ..polygonize import _douglas_peucker
+        coords = np.array([[0.0, 0.0], [2.0, 0.5], [4.0, 0.0]],
+                          dtype=np.float64)
+        # Distance of (2,0.5) from line (0,0)-(4,0) is 0.5
+        result = _douglas_peucker(coords, 1.0)
+        expected = np.array([[0.0, 0.0], [4.0, 0.0]], dtype=np.float64)
+        assert_allclose(result, expected)
+
+    def test_douglas_peucker_two_points(self):
+        """DP on two points should return them unchanged."""
+        from ..polygonize import _douglas_peucker
+        coords = np.array([[0.0, 0.0], [4.0, 0.0]], dtype=np.float64)
+        result = _douglas_peucker(coords, 1.0)
+        assert_allclose(result, coords)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest xrspatial/tests/test_polygonize.py::TestSimplifyHelpers -v`
+Expected: FAIL with ImportError (`_douglas_peucker` not found)
+
+- [ ] **Step 3: Implement `_douglas_peucker`**
+
+Add to `xrspatial/polygonize.py` after `_group_rings_into_polygons` (~line 920), before `_merge_polygon_rings`:
+
+```python
+@ngjit
+def _perpendicular_distance(px, py, ax, ay, bx, by):
+    """Perpendicular distance from point (px,py) to line (ax,ay)-(bx,by)."""
+    dx = bx - ax
+    dy = by - ay
+    len_sq = dx * dx + dy * dy
+    if len_sq == 0.0:
+        return np.sqrt((px - ax) ** 2 + (py - ay) ** 2)
+    t = ((px - ax) * dx + (py - ay) * dy) / len_sq
+    t = max(0.0, min(1.0, t))
+    proj_x = ax + t * dx
+    proj_y = ay + t * dy
+    return np.sqrt((px - proj_x) ** 2 + (py - proj_y) ** 2)
+
+
+@ngjit
+def _douglas_peucker(coords, tolerance):
+    """Douglas-Peucker line simplification on an Nx2 float64 array.
+
+    Endpoints are always preserved. Returns a new Nx2 array with
+    only the retained vertices.
+    """
+    n = len(coords)
+    if n <= 2:
+        return coords.copy()
+
+    # Iterative DP using an explicit stack to avoid recursion depth issues.
+    keep = np.zeros(n, dtype=nb.boolean)
+    keep[0] = True
+    keep[n - 1] = True
+
+    # Stack of (start, end) index pairs.
+    stack = [(np.int64(0), np.int64(n - 1))]
+    while len(stack) > 0:
+        start, end = stack.pop()
+        if end - start < 2:
+            continue
+
+        ax, ay = coords[start, 0], coords[start, 1]
+        bx, by = coords[end, 0], coords[end, 1]
+
+        max_dist = 0.0
+        max_idx = start
+        for i in range(start + 1, end):
+            d = _perpendicular_distance(
+                coords[i, 0], coords[i, 1], ax, ay, bx, by)
+            if d > max_dist:
+                max_dist = d
+                max_idx = i
+
+        if max_dist > tolerance:
+            keep[max_idx] = True
+            stack.append((start, max_idx))
+            stack.append((max_idx, end))
+
+    count = 0
+    for i in range(n):
+        if keep[i]:
+            count += 1
+
+    result = np.empty((count, 2), dtype=np.float64)
+    j = 0
+    for i in range(n):
+        if keep[i]:
+            result[j, 0] = coords[i, 0]
+            result[j, 1] = coords[i, 1]
+            j += 1
+
+    return result
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest xrspatial/tests/test_polygonize.py::TestSimplifyHelpers -v`
+Expected: PASS (all 4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add xrspatial/polygonize.py xrspatial/tests/test_polygonize.py
+git commit -m "Add Douglas-Peucker kernel for polygonize simplification (#1151)"
+```
+
+---
+
+### Task 2: Shared-edge simplification orchestrator
+
+**Files:**
+- Modify: `xrspatial/polygonize.py` (insert after `_douglas_peucker`)
+- Test: `xrspatial/tests/test_polygonize.py`
+
+- [ ] **Step 1: Write the failing test for `_simplify_polygons`**
+
+Add to the `TestSimplifyHelpers` class in `xrspatial/tests/test_polygonize.py`:
+
+```python
+    def test_simplify_polygons_reduces_vertices(self):
+        """Simplification should reduce vertex count on staircase edges."""
+        from ..polygonize import _simplify_polygons
+
+        # L-shaped polygon (exterior only, staircase boundary).
+        # 3x3 grid, value in top-left 2x2 block.
+        raster = np.array([[1, 1, 0],
+                           [1, 1, 0],
+                           [0, 0, 0]], dtype=np.int64)
+        data = xr.DataArray(raster)
+        column_orig, pp_orig = polygonize(data, return_type="numpy")
+
+        from ..polygonize import _simplify_polygons
+        pp_simplified = _simplify_polygons(pp_orig, tolerance=0.5)
+
+        # Area must be preserved.
+        for orig_rings, simp_rings in zip(pp_orig, pp_simplified):
+            orig_area = sum(calc_boundary_area(r) for r in orig_rings)
+            simp_area = sum(calc_boundary_area(r) for r in simp_rings)
+            assert_allclose(simp_area, orig_area, atol=1e-10)
+
+    def test_simplify_polygons_topology_preserved(self):
+        """Adjacent simplified polygons should not create gaps."""
+        from ..polygonize import _simplify_polygons
+
+        # Checkerboard-ish: two adjacent rectangles sharing an edge.
+        raster = np.array([[1, 1, 2, 2],
+                           [1, 1, 2, 2],
+                           [1, 1, 2, 2],
+                           [1, 1, 2, 2]], dtype=np.int64)
+        data = xr.DataArray(raster)
+        column, pp = polygonize(data, return_type="numpy")
+
+        pp_simplified = _simplify_polygons(pp, tolerance=0.0)
+
+        # With tolerance=0, no vertices should be removed; output
+        # should match input exactly.
+        for orig_rings, simp_rings in zip(pp, pp_simplified):
+            assert len(orig_rings) == len(simp_rings)
+            for orig_ring, simp_ring in zip(orig_rings, simp_rings):
+                assert_allclose(simp_ring, orig_ring)
+
+    def test_simplify_polygons_shared_edge_identical(self):
+        """Two polygons sharing an edge must have identical simplified edges."""
+        from ..polygonize import _simplify_polygons
+
+        # Create a raster where two regions share a staircase boundary.
+        raster = np.array([
+            [1, 1, 1, 2, 2, 2],
+            [1, 1, 2, 2, 2, 2],
+            [1, 2, 2, 2, 2, 2],
+            [1, 1, 2, 2, 2, 2],
+            [1, 1, 1, 2, 2, 2],
+        ], dtype=np.int64)
+        data = xr.DataArray(raster)
+        column, pp = polygonize(data, return_type="numpy")
+
+        pp_simplified = _simplify_polygons(pp, tolerance=1.5)
+
+        # Extract edge vertices of each polygon. The shared boundary
+        # should appear in both polygons with identical coordinates.
+        # Check total area is preserved (which requires no gaps/overlaps).
+        total_orig = sum(
+            sum(calc_boundary_area(r) for r in rings) for rings in pp)
+        total_simp = sum(
+            sum(calc_boundary_area(r) for r in rings) for rings in pp_simplified)
+        assert_allclose(total_simp, total_orig, atol=1e-10)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest xrspatial/tests/test_polygonize.py::TestSimplifyHelpers::test_simplify_polygons_reduces_vertices -v`
+Expected: FAIL with ImportError (`_simplify_polygons` not found)
+
+- [ ] **Step 3: Implement shared-edge orchestrator functions**
+
+Add to `xrspatial/polygonize.py` after `_douglas_peucker`:
+
+```python
+def _find_junctions(all_rings):
+    """Find junction vertices where 3+ ring boundaries meet.
+
+    A junction is any (x, y) coordinate that appears in 3 or more
+    distinct rings.  These vertices are pinned during simplification.
+
+    Parameters
+    ----------
+    all_rings : list of list of np.ndarray
+        polygon_points structure: list of polygons, each polygon is
+        a list of rings (Nx2 arrays, closed).
+
+    Returns
+    -------
+    set of (float, float)
+    """
+    vertex_ring_count = {}  # (x, y) -> set of ring identifiers
+    ring_id = 0
+    for rings in all_rings:
+        for ring in rings:
+            for k in range(len(ring) - 1):  # skip closing duplicate
+                pt = (ring[k, 0], ring[k, 1])
+                if pt not in vertex_ring_count:
+                    vertex_ring_count[pt] = set()
+                vertex_ring_count[pt].add(ring_id)
+            ring_id += 1
+
+    return {pt for pt, ids in vertex_ring_count.items() if len(ids) >= 3}
+
+
+def _split_ring_at_junctions(ring, junctions):
+    """Split a closed ring into chains at junction vertices.
+
+    Each chain starts and ends at a junction vertex (endpoints included
+    in the chain).  If the ring contains no junctions, the entire ring
+    is returned as a single chain.
+
+    Parameters
+    ----------
+    ring : np.ndarray, shape (N, 2)
+        Closed ring (first == last vertex).
+    junctions : set of (float, float)
+
+    Returns
+    -------
+    list of np.ndarray
+        Each array is an Mx2 chain.  Consecutive chains share their
+        endpoint/startpoint.
+    """
+    n = len(ring) - 1  # number of unique vertices
+
+    # Find indices of junction vertices within this ring.
+    junction_indices = []
+    for k in range(n):
+        if (ring[k, 0], ring[k, 1]) in junctions:
+            junction_indices.append(k)
+
+    if len(junction_indices) == 0:
+        # No junctions: return the whole ring as a single chain.
+        return [ring.copy()]
+
+    # Rotate ring so that the first junction is at index 0.
+    first = junction_indices[0]
+    if first > 0:
+        # Rotate unique vertices, then re-close.
+        rotated = np.empty_like(ring)
+        rotated[:n - first] = ring[first:n]
+        rotated[n - first:n] = ring[:first]
+        rotated[n] = rotated[0]
+        ring = rotated
+        junction_indices = [(ji - first) % n for ji in junction_indices]
+        junction_indices.sort()
+
+    # Split at each junction.
+    chains = []
+    for i in range(len(junction_indices)):
+        start = junction_indices[i]
+        if i + 1 < len(junction_indices):
+            end = junction_indices[i + 1]
+        else:
+            end = n  # wrap back to first junction (index 0 after rotation)
+        chains.append(ring[start:end + 1].copy())
+
+    return chains
+
+
+def _chain_key(chain):
+    """Canonical key for deduplicating shared edge chains.
+
+    Two chains that connect the same pair of junctions but are traversed
+    in opposite directions should map to the same key.  We use the sorted
+    endpoint pair plus the frozenset of interior vertices.
+    """
+    start = (chain[0, 0], chain[0, 1])
+    end = (chain[-1, 0], chain[-1, 1])
+    if start > end:
+        start, end = end, start
+    # Include chain length to disambiguate chains between the same
+    # junction pair with different paths.
+    interior = tuple(
+        (chain[k, 0], chain[k, 1]) for k in range(1, len(chain) - 1))
+    # For reversed chains, interior order is reversed.
+    interior_rev = interior[::-1]
+    interior = min(interior, interior_rev)
+    return (start, end, interior)
+
+
+def _simplify_polygons(polygon_points, tolerance):
+    """Topology-preserving simplification of all polygons.
+
+    Uses shared-edge decomposition: finds junction vertices, splits
+    rings into chains at junctions, simplifies each unique chain once
+    with Douglas-Peucker, then reassembles rings.
+
+    Parameters
+    ----------
+    polygon_points : list of list of np.ndarray
+        Output of polygonize backend: list of polygons, each polygon
+        is [exterior_ring, *hole_rings].
+    tolerance : float
+        Douglas-Peucker tolerance in coordinate units.
+
+    Returns
+    -------
+    list of list of np.ndarray
+        Same structure as input, with simplified coordinates.
+    """
+    if tolerance <= 0:
+        return polygon_points
+
+    # Step 1: Find junctions.
+    junctions = _find_junctions(polygon_points)
+
+    # Step 2 & 3: Split rings into chains, deduplicate, simplify.
+    simplified_chains = {}  # chain_key -> simplified np.ndarray
+
+    # We also need to track how to reassemble each ring.
+    # ring_info[poly_idx][ring_idx] = list of (chain_key, is_reversed)
+    ring_info = []
+
+    for poly_idx, rings in enumerate(polygon_points):
+        poly_info = []
+        for ring in rings:
+            chains = _split_ring_at_junctions(ring, junctions)
+            chain_refs = []
+            for chain in chains:
+                key = _chain_key(chain)
+                if key not in simplified_chains:
+                    simplified_chains[key] = _douglas_peucker(chain, tolerance)
+                # Determine if this chain was reversed relative to canonical.
+                start = (chain[0, 0], chain[0, 1])
+                canonical_start = (simplified_chains[key][0, 0],
+                                   simplified_chains[key][0, 1])
+                is_reversed = (start != canonical_start)
+                chain_refs.append((key, is_reversed))
+            poly_info.append(chain_refs)
+        ring_info.append(poly_info)
+
+    # Step 4: Reassemble rings.
+    result = []
+    for poly_idx, rings in enumerate(polygon_points):
+        new_rings = []
+        for ring_idx, chain_refs in enumerate(ring_info[poly_idx]):
+            if len(chain_refs) == 1 and len(chain_refs[0]) == 2:
+                key, is_reversed = chain_refs[0]
+                simplified = simplified_chains[key]
+                if is_reversed:
+                    simplified = simplified[::-1].copy()
+                # Ensure ring is closed.
+                if not (simplified[0, 0] == simplified[-1, 0] and
+                        simplified[0, 1] == simplified[-1, 1]):
+                    simplified = np.vstack([simplified, simplified[:1]])
+                new_rings.append(simplified)
+            else:
+                # Multiple chains: concatenate (drop duplicate junction points).
+                parts = []
+                for key, is_reversed in chain_refs:
+                    simplified = simplified_chains[key]
+                    if is_reversed:
+                        simplified = simplified[::-1].copy()
+                    if parts:
+                        # Skip first point (same as last of previous chain).
+                        parts.append(simplified[1:])
+                    else:
+                        parts.append(simplified)
+                assembled = np.vstack(parts)
+                # Ensure ring is closed.
+                if not (assembled[0, 0] == assembled[-1, 0] and
+                        assembled[0, 1] == assembled[-1, 1]):
+                    assembled = np.vstack([assembled, assembled[:1]])
+                new_rings.append(assembled)
+
+        # Drop degenerate rings (fewer than 4 vertices = triangle minimum).
+        filtered = []
+        for ring in new_rings:
+            if len(ring) >= 4:
+                filtered.append(ring)
+            elif len(new_rings) > 0 and ring is new_rings[0]:
+                # Keep exterior even if degenerate (shouldn't happen with
+                # reasonable tolerances, but better than losing the polygon).
+                filtered.append(ring)
+        if filtered:
+            result.append(filtered)
+        else:
+            result.append(new_rings)
+
+    return result
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest xrspatial/tests/test_polygonize.py::TestSimplifyHelpers -v`
+Expected: PASS (all 7 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add xrspatial/polygonize.py xrspatial/tests/test_polygonize.py
+git commit -m "Add shared-edge simplification orchestrator (#1151)"
+```
+
+---
+
+### Task 3: Wire into `polygonize()` public API
+
+**Files:**
+- Modify: `xrspatial/polygonize.py` (function signature + body at ~line 1021)
+- Test: `xrspatial/tests/test_polygonize.py`
+
+- [ ] **Step 1: Write failing tests for the public API**
+
+Add to `xrspatial/tests/test_polygonize.py`:
+
+```python
+class TestPolygonizeSimplify:
+    """Tests for simplify_tolerance and simplify_method parameters."""
+
+    def test_tolerance_none_no_change(self):
+        """tolerance=None should produce identical output to no-arg call."""
+        raster = np.array([[1, 1, 2, 2],
+                           [1, 1, 2, 2]], dtype=np.int64)
+        data = xr.DataArray(raster)
+        col1, pp1 = polygonize(data)
+        col2, pp2 = polygonize(data, simplify_tolerance=None)
+        assert col1 == col2
+        for r1, r2 in zip(pp1, pp2):
+            for a, b in zip(r1, r2):
+                assert_allclose(a, b)
+
+    def test_tolerance_zero_no_change(self):
+        """tolerance=0.0 should produce identical output."""
+        raster = np.array([[1, 1, 2, 2],
+                           [1, 1, 2, 2]], dtype=np.int64)
+        data = xr.DataArray(raster)
+        col1, pp1 = polygonize(data)
+        col2, pp2 = polygonize(data, simplify_tolerance=0.0)
+        assert col1 == col2
+        for r1, r2 in zip(pp1, pp2):
+            for a, b in zip(r1, r2):
+                assert_allclose(a, b)
+
+    def test_negative_tolerance_raises(self):
+        """Negative tolerance should raise ValueError."""
+        raster = np.array([[1, 1], [1, 1]], dtype=np.int64)
+        data = xr.DataArray(raster)
+        with pytest.raises(ValueError, match="simplify_tolerance"):
+            polygonize(data, simplify_tolerance=-1.0)
+
+    def test_visvalingam_not_implemented(self):
+        """Visvalingam-Whyatt should raise NotImplementedError."""
+        raster = np.array([[1, 1], [1, 1]], dtype=np.int64)
+        data = xr.DataArray(raster)
+        with pytest.raises(NotImplementedError):
+            polygonize(data, simplify_tolerance=1.0,
+                       simplify_method="visvalingam-whyatt")
+
+    def test_invalid_method_raises(self):
+        """Unknown method should raise ValueError."""
+        raster = np.array([[1, 1], [1, 1]], dtype=np.int64)
+        data = xr.DataArray(raster)
+        with pytest.raises(ValueError, match="simplify_method"):
+            polygonize(data, simplify_tolerance=1.0,
+                       simplify_method="invalid")
+
+    def test_simplify_reduces_vertices(self):
+        """Simplification should reduce total vertex count."""
+        # Staircase boundary between two values.
+        raster = np.array([
+            [1, 1, 1, 2, 2, 2],
+            [1, 1, 2, 2, 2, 2],
+            [1, 2, 2, 2, 2, 2],
+            [1, 1, 2, 2, 2, 2],
+            [1, 1, 1, 2, 2, 2],
+        ], dtype=np.int64)
+        data = xr.DataArray(raster)
+        _, pp_orig = polygonize(data)
+        _, pp_simp = polygonize(data, simplify_tolerance=1.5)
+
+        orig_verts = sum(len(r) for rings in pp_orig for r in rings)
+        simp_verts = sum(len(r) for rings in pp_simp for r in rings)
+        assert simp_verts < orig_verts
+
+    def test_simplify_preserves_area(self):
+        """Total area must be preserved after simplification."""
+        raster = np.array([
+            [1, 1, 1, 2, 2, 2],
+            [1, 1, 2, 2, 2, 2],
+            [1, 2, 2, 2, 2, 2],
+            [1, 1, 2, 2, 2, 2],
+            [1, 1, 1, 2, 2, 2],
+        ], dtype=np.int64)
+        data = xr.DataArray(raster)
+        _, pp_orig = polygonize(data)
+        _, pp_simp = polygonize(data, simplify_tolerance=1.5)
+
+        total_orig = sum(
+            sum(calc_boundary_area(r) for r in rings) for rings in pp_orig)
+        total_simp = sum(
+            sum(calc_boundary_area(r) for r in rings) for rings in pp_simp)
+        assert_allclose(total_simp, total_orig, atol=1e-10)
+
+    def test_simplify_with_geopandas(self):
+        """Simplification should work with geopandas return type."""
+        pytest.importorskip("geopandas")
+        raster = np.array([
+            [1, 1, 2, 2],
+            [1, 1, 2, 2],
+            [1, 1, 2, 2],
+        ], dtype=np.int64)
+        data = xr.DataArray(raster)
+        gdf = polygonize(data, simplify_tolerance=0.5,
+                         return_type="geopandas")
+        assert len(gdf) == 2  # two polygons
+        assert gdf.geometry.is_valid.all()
+
+    def test_simplify_with_geojson(self):
+        """Simplification should work with geojson return type."""
+        raster = np.array([
+            [1, 1, 2, 2],
+            [1, 1, 2, 2],
+        ], dtype=np.int64)
+        data = xr.DataArray(raster)
+        fc = polygonize(data, simplify_tolerance=0.5,
+                        return_type="geojson")
+        assert fc["type"] == "FeatureCollection"
+        assert len(fc["features"]) == 2
+
+
+@pytest.mark.skipif(da is None, reason="dask not installed")
+class TestPolygonizeSimplifyDask:
+    """Simplification with dask backend."""
+
+    def test_simplify_dask_matches_numpy(self):
+        """Dask simplification should produce same areas as numpy."""
+        raster = np.array([
+            [1, 1, 1, 2, 2, 2],
+            [1, 1, 2, 2, 2, 2],
+            [1, 2, 2, 2, 2, 2],
+            [1, 1, 2, 2, 2, 2],
+            [1, 1, 1, 2, 2, 2],
+        ], dtype=np.int64)
+
+        data_np = xr.DataArray(raster)
+        data_dask = xr.DataArray(da.from_array(raster, chunks=(3, 3)))
+
+        _, pp_np = polygonize(data_np, simplify_tolerance=1.5)
+        _, pp_dask = polygonize(data_dask, simplify_tolerance=1.5)
+
+        # Compare per-value area sums.
+        col_np, _ = polygonize(data_np, simplify_tolerance=1.5)
+        col_dask, _ = polygonize(data_dask, simplify_tolerance=1.5)
+
+        areas_np = {}
+        for val, rings in zip(col_np, pp_np):
+            a = sum(calc_boundary_area(r) for r in rings)
+            areas_np[val] = areas_np.get(val, 0.0) + a
+
+        areas_dask = {}
+        for val, rings in zip(col_dask, pp_dask):
+            a = sum(calc_boundary_area(r) for r in rings)
+            areas_dask[val] = areas_dask.get(val, 0.0) + a
+
+        for val in areas_np:
+            assert_allclose(areas_dask[val], areas_np[val], atol=1e-10)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest xrspatial/tests/test_polygonize.py::TestPolygonizeSimplify::test_negative_tolerance_raises -v`
+Expected: FAIL with TypeError (unexpected keyword argument)
+
+- [ ] **Step 3: Modify `polygonize()` signature and body**
+
+In `xrspatial/polygonize.py`, update the `polygonize` function:
+
+**Signature** — add the two new parameters:
+
+```python
+def polygonize(
+    raster: xr.DataArray,
+    mask: Optional[xr.DataArray] = None,
+    connectivity: int = 4,
+    transform: Optional[np.ndarray] = None,
+    column_name: str = "DN",
+    return_type: str = "numpy",
+    simplify_tolerance: Optional[float] = None,
+    simplify_method: str = "douglas-peucker",
+):
+```
+
+**Docstring** — add parameter descriptions after the `return_type` entry:
+
+```
+    simplify_tolerance: float, optional
+        Douglas-Peucker simplification tolerance in coordinate units.
+        When set, polygon boundaries are simplified using shared-edge
+        decomposition to preserve topology between adjacent polygons.
+        Default is None (no simplification).
+
+    simplify_method: str, default="douglas-peucker"
+        Simplification algorithm.  Currently only "douglas-peucker" is
+        supported.  "visvalingam-whyatt" is reserved for future use.
+```
+
+**Validation** — add after the transform check block (~line 1112):
+
+```python
+    # Check simplification parameters.
+    if simplify_tolerance is not None and simplify_tolerance < 0:
+        raise ValueError(
+            "simplify_tolerance must be non-negative, "
+            f"got {simplify_tolerance}")
+    if simplify_method not in ("douglas-peucker", "visvalingam-whyatt"):
+        raise ValueError(
+            f"simplify_method must be 'douglas-peucker' or "
+            f"'visvalingam-whyatt', got '{simplify_method}'")
+    if (simplify_method == "visvalingam-whyatt"
+            and simplify_tolerance is not None
+            and simplify_tolerance > 0):
+        raise NotImplementedError(
+            "Visvalingam-Whyatt simplification is not yet implemented")
+```
+
+**Simplification call** — add after the `mapper(raster)(...)` call and before the return-type conversion block:
+
+```python
+    # Apply simplification if requested.
+    if simplify_tolerance is not None and simplify_tolerance > 0:
+        polygon_points = _simplify_polygons(polygon_points, simplify_tolerance)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest xrspatial/tests/test_polygonize.py::TestPolygonizeSimplify xrspatial/tests/test_polygonize.py::TestPolygonizeSimplifyDask -v`
+Expected: PASS (all tests)
+
+- [ ] **Step 5: Run the full test suite to check for regressions**
+
+Run: `pytest xrspatial/tests/test_polygonize.py -v`
+Expected: All existing tests PASS (new parameters have defaults so no breakage)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add xrspatial/polygonize.py xrspatial/tests/test_polygonize.py
+git commit -m "Wire simplify_tolerance into polygonize() public API (#1151)"
+```
+
+---
+
+### Task 4: Update documentation
+
+**Files:**
+- Modify: `docs/source/reference/utilities.rst` (no changes needed — autodoc picks up new params)
+- Verify: docstring is complete and renders correctly
+
+- [ ] **Step 1: Verify docstring has the new parameters**
+
+Read `xrspatial/polygonize.py` and confirm `simplify_tolerance` and `simplify_method` are documented in the `polygonize` docstring.
+
+- [ ] **Step 2: Test docs build (if sphinx is available)**
+
+Run: `cd docs && make html 2>&1 | tail -20`
+If sphinx is not set up, skip. The autodoc entry in `utilities.rst` already points to `xrspatial.polygonize.polygonize`, so new params will appear automatically.
+
+- [ ] **Step 3: Commit (if any doc changes were needed)**
+
+Only commit if manual changes were required. Autodoc should handle it.
+
+---
+
+### Task 5: Create user guide notebook
+
+**Files:**
+- Create: `examples/user_guide/50_Polygonize_Simplification.ipynb`
+
+- [ ] **Step 1: Create the notebook**
+
+Create `examples/user_guide/50_Polygonize_Simplification.ipynb` with these cells:
+
+**Cell 1 (markdown):**
+```markdown
+# Polygonize with Geometry Simplification
+
+`polygonize()` converts raster regions into vector polygons. On high-resolution rasters, the resulting geometries can have thousands of vertices per polygon, making them unwieldy for rendering, file export, and spatial joins.
+
+The `simplify_tolerance` parameter applies Douglas-Peucker simplification during polygonization. Topology is preserved: adjacent polygons share identical simplified boundaries, so no gaps or overlaps appear between neighbors.
+```
+
+**Cell 2 (code):**
+```python
+import numpy as np
+import xarray as xr
+import matplotlib.pyplot as plt
+from matplotlib.patches import Polygon as MplPolygon
+from matplotlib.collections import PatchCollection
+
+from xrspatial import polygonize
+```
+
+**Cell 3 (markdown):**
+```markdown
+## Generate a sample classified raster
+
+We'll create a synthetic land-cover raster with irregular region boundaries — the kind of output you'd get from a classification or segmentation step.
+```
+
+**Cell 4 (code):**
+```python
+rng = np.random.default_rng(42)
+shape = (80, 120)
+
+# Start with smooth noise, then classify into 4 land-cover types.
+from scipy.ndimage import gaussian_filter
+noise = rng.standard_normal(shape)
+smooth = gaussian_filter(noise, sigma=8)
+classified = np.digitize(smooth, bins=[-0.5, 0.0, 0.5]) + 1  # values 1-4
+
+raster = xr.DataArray(classified.astype(np.int32))
+
+fig, ax = plt.subplots(figsize=(10, 6))
+raster.plot(ax=ax, cmap="Set2", add_colorbar=True)
+ax.set_title("Classified raster (4 land-cover types)")
+ax.set_aspect("equal")
+plt.tight_layout()
+plt.show()
+```
+
+**Cell 5 (markdown):**
+```markdown
+## Polygonize without simplification
+
+First, let's see what the raw pixel-boundary polygons look like.
+```
+
+**Cell 6 (code):**
+```python
+col_raw, pp_raw = polygonize(raster)
+total_verts_raw = sum(len(r) for rings in pp_raw for r in rings)
+print(f"Polygons: {len(pp_raw)}, Total vertices: {total_verts_raw}")
+```
+
+**Cell 7 (code):**
+```python
+def plot_polygons(polygon_points, column, title, ax):
+    """Plot polygons colored by value."""
+    cmap = plt.cm.Set2
+    vals = sorted(set(column))
+    val_to_color = {v: cmap(i / max(len(vals) - 1, 1)) for i, v in enumerate(vals)}
+
+    patches = []
+    colors = []
+    for val, rings in zip(column, polygon_points):
+        ext = rings[0]
+        patches.append(MplPolygon(ext[:, :2], closed=True))
+        colors.append(val_to_color[val])
+
+    pc = PatchCollection(patches, facecolors=colors, edgecolors="black",
+                         linewidths=0.3)
+    ax.add_collection(pc)
+    ax.set_xlim(0, 120)
+    ax.set_ylim(0, 80)
+    ax.set_aspect("equal")
+    ax.set_title(title)
+    ax.invert_yaxis()
+
+fig, ax = plt.subplots(figsize=(10, 6))
+plot_polygons(pp_raw, col_raw, f"Raw polygons ({total_verts_raw} vertices)", ax)
+plt.tight_layout()
+plt.show()
+```
+
+**Cell 8 (markdown):**
+```markdown
+## Polygonize with simplification
+
+Now apply Douglas-Peucker simplification with increasing tolerances. The `simplify_tolerance` is in the raster's coordinate units (pixels here, but would be meters or degrees with a georeferenced raster).
+
+Topology is preserved: adjacent polygons share identical simplified edges, so no gaps appear between them.
+```
+
+**Cell 9 (code):**
+```python
+fig, axes = plt.subplots(1, 3, figsize=(18, 6))
+
+for ax, tol in zip(axes, [0.5, 1.5, 3.0]):
+    col, pp = polygonize(raster, simplify_tolerance=tol)
+    n_verts = sum(len(r) for rings in pp for r in rings)
+    reduction = 100 * (1 - n_verts / total_verts_raw)
+    plot_polygons(pp, col,
+                  f"tolerance={tol}  ({n_verts} verts, {reduction:.0f}% reduction)",
+                  ax)
+
+plt.tight_layout()
+plt.show()
+```
+
+**Cell 10 (markdown):**
+```markdown
+## GeoDataFrame output
+
+`simplify_tolerance` works with all return types. Here's a GeoDataFrame:
+```
+
+**Cell 11 (code):**
+```python
+gdf = polygonize(raster, simplify_tolerance=1.5, return_type="geopandas",
+                 column_name="landcover")
+print(gdf.head())
+print(f"\nAll geometries valid: {gdf.geometry.is_valid.all()}")
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add examples/user_guide/50_Polygonize_Simplification.ipynb
+git commit -m "Add polygonize simplification user guide notebook (#1151)"
+```
+
+---
+
+### Task 6: Update README feature matrix
+
+**Files:**
+- Modify: `README.md` (~line 514)
+
+- [ ] **Step 1: Verify no README change is needed**
+
+The simplification feature adds parameters to the existing `polygonize()` function. No new function is created, and backend support does not change. The existing README row:
+
+```
+| [Polygonize](xrspatial/polygonize.py) | Converts contiguous regions of equal value into vector polygons | Standard (CCL) | ✅️ | ✅️ | ✅️ | 🔄 |
+```
+
+is still accurate. **No change needed.** Skip this task.
+
+---
+
+### Task 7: Final integration check
+
+- [ ] **Step 1: Run the full polygonize test suite**
+
+Run: `pytest xrspatial/tests/test_polygonize.py -v --tb=short`
+Expected: All tests pass, including new simplification tests.
+
+- [ ] **Step 2: Verify backward compatibility**
+
+Run: `python -c "from xrspatial import polygonize; import xarray as xr, numpy as np; d = xr.DataArray(np.array([[1,2],[3,4]])); c, p = polygonize(d); print(f'{len(c)} polygons')"`
+Expected: `4 polygons` (no error, same behavior as before)

--- a/docs/superpowers/specs/2026-04-06-polygonize-simplification-design.md
+++ b/docs/superpowers/specs/2026-04-06-polygonize-simplification-design.md
@@ -1,0 +1,138 @@
+# Polygonize Geometry Simplification
+
+**Issue:** #1151
+**Date:** 2026-04-06
+
+## Problem
+
+`polygonize()` produces exact pixel-boundary polygons. On high-resolution
+rasters this creates dense geometries with thousands of vertices per polygon,
+making output slow to render, large on disk, and unwieldy for spatial joins.
+
+The current workaround chains GDAL's `gdal_polygonize.py` with
+`ogr2ogr -simplify`, adding an external dependency and intermediate file.
+
+## API
+
+Two new parameters on `polygonize()`:
+
+```python
+def polygonize(
+    raster, mask=None, connectivity=4, transform=None,
+    column_name="DN", return_type="numpy",
+    simplify_tolerance=None,            # float, coordinate units
+    simplify_method="douglas-peucker",  # str
+):
+```
+
+- `simplify_tolerance=None` or `0.0`: no simplification (backward compatible).
+- `simplify_tolerance > 0`: apply Douglas-Peucker with given tolerance.
+- `simplify_method="visvalingam-whyatt"`: raises `NotImplementedError`.
+- Negative tolerance raises `ValueError`.
+
+## Algorithm: Shared-Edge Douglas-Peucker
+
+Topology-preserving simplification via shared-edge decomposition, same
+approach used by TopoJSON and GRASS `v.generalize`.
+
+### Pipeline position
+
+Simplification runs between boundary tracing and output conversion:
+
+```
+CCL -> boundary tracing -> [simplification] -> output conversion
+```
+
+For dask backends, simplification runs after chunk merging.
+
+### Steps
+
+1. **Find junctions.** Scan all ring vertices. A junction is any coordinate
+   that appears as a vertex in 3 or more distinct rings. These points are
+   pinned and never removed by simplification.
+
+2. **Split rings into edge chains.** Walk each ring and split at junction
+   vertices. Each resulting chain connects two junctions (or forms a closed
+   loop when the ring contains no junctions). Each chain is shared by at
+   most 2 adjacent polygons.
+
+3. **Deduplicate chains.** Normalize each chain by its sorted endpoint pair
+   so shared edges between adjacent polygons are identified and simplified
+   only once.
+
+4. **Simplify each chain.** Apply Douglas-Peucker to each unique chain.
+   Junction endpoints are fixed. The DP implementation is numba-compiled
+   (`@ngjit`) for performance on large coordinate arrays.
+
+5. **Reassemble rings.** Replace each ring's chain segments with their
+   simplified versions and rebuild the ring coordinate arrays.
+
+### Why this preserves topology
+
+Adjacent polygons reference the same physical edge chain. Simplifying
+each chain once means both neighbors get identical simplified boundaries.
+No gaps or overlaps can arise because there is no independent simplification
+of shared geometry.
+
+## Implementation
+
+All new code lives in `xrspatial/polygonize.py` as internal functions.
+
+### New functions
+
+| Function | Decorator | Purpose |
+|---|---|---|
+| `_find_junctions(all_rings)` | pure Python | Scan rings, return set of junction coords |
+| `_split_ring_at_junctions(ring, junctions)` | pure Python | Break one ring into chains at junctions |
+| `_normalize_chain(chain)` | pure Python | Canonical key for deduplication |
+| `_douglas_peucker(coords, tolerance)` | `@ngjit` | DP simplification on Nx2 array |
+| `_simplify_polygons(polygon_points, tolerance)` | pure Python | Orchestrator: junctions -> split -> DP -> reassemble |
+
+### Integration point
+
+In `polygonize()`, after the `mapper(raster)(...)` call returns
+`(column, polygon_points)` and before the return-type conversion block:
+
+```python
+if simplify_tolerance and simplify_tolerance > 0:
+    polygon_points = _simplify_polygons(polygon_points, simplify_tolerance)
+```
+
+### Backend behavior
+
+- **NumPy / CuPy:** simplification runs on CPU-side coordinate arrays
+  returned by boundary tracing (CuPy already transfers to CPU for tracing).
+- **Dask:** simplification runs after `_merge_chunk_polygons()`, on the
+  fully merged result.
+- No GPU-side simplification. Boundary tracing is already CPU-bound;
+  simplification follows the same pattern.
+
+## Constraints
+
+- No Visvalingam-Whyatt yet. The `simplify_method` parameter is present
+  in the API for forward compatibility; passing `"visvalingam-whyatt"`
+  raises `NotImplementedError`.
+- No streaming simplification. The full polygon set must fit in memory,
+  same constraint as existing boundary tracing.
+- Minimum ring size after simplification: exterior rings keep at least 4
+  vertices (3 unique + closing). Degenerate rings (area below tolerance
+  squared) are dropped.
+
+## Testing
+
+- Correctness: known 4x4 raster, verify simplified polygon areas match
+  originals (simplification must not change topology, only vertex count).
+- Vertex reduction: verify output has fewer vertices than unsimplified.
+- Topology: verify no gaps between adjacent polygons (union of simplified
+  polygons equals union of originals, within floating-point tolerance).
+- Edge cases: tolerance=0, tolerance=None, negative tolerance, single-pixel
+  raster, raster with one uniform value.
+- Backend parity: numpy and dask produce same results.
+- Return types: simplification works with all five return types.
+
+## Out of scope
+
+- Visvalingam-Whyatt implementation (future PR).
+- GPU-accelerated simplification.
+- Per-chunk simplification for dask (simplification is post-merge only).
+- Area-weighted simplification or other adaptive tolerance schemes.

--- a/examples/user_guide/50_Polygonize_Simplification.ipynb
+++ b/examples/user_guide/50_Polygonize_Simplification.ipynb
@@ -1,0 +1,213 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Polygonize with Geometry Simplification\n",
+    "\n",
+    "`polygonize()` converts raster regions into vector polygons. On high-resolution rasters the result can have thousands of vertices per polygon, which slows rendering and inflates file size.\n",
+    "\n",
+    "The `simplify_tolerance` parameter simplifies polygon boundaries during polygonization. Two algorithms are available:\n",
+    "- `simplify_method=\"douglas-peucker\"` (default): distance-based, removes vertices that deviate less than the tolerance from the simplified line\n",
+    "- `simplify_method=\"visvalingam-whyatt\"`: area-based, removes vertices that form triangles smaller than the tolerance threshold\n",
+    "\n",
+    "Adjacent polygons share identical simplified boundaries, so no gaps or overlaps are introduced."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import xarray as xr\n",
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib.patches import Polygon as MplPolygon\n",
+    "from matplotlib.collections import PatchCollection\n",
+    "\n",
+    "from xrspatial import polygonize"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generate a classified raster\n",
+    "\n",
+    "A synthetic land-cover raster with irregular region boundaries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rng = np.random.default_rng(42)\n",
+    "shape = (80, 120)\n",
+    "\n",
+    "from scipy.ndimage import gaussian_filter\n",
+    "noise = rng.standard_normal(shape)\n",
+    "smooth = gaussian_filter(noise, sigma=8)\n",
+    "classified = np.digitize(smooth, bins=[-0.5, 0.0, 0.5]) + 1\n",
+    "\n",
+    "raster = xr.DataArray(classified.astype(np.int32))\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(10, 6))\n",
+    "raster.plot(ax=ax, cmap=\"Set2\", add_colorbar=True)\n",
+    "ax.set_title(\"Classified raster (4 land-cover types)\")\n",
+    "ax.set_aspect(\"equal\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Polygonize without simplification"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "col_raw, pp_raw = polygonize(raster)\n",
+    "total_verts_raw = sum(len(r) for rings in pp_raw for r in rings)\n",
+    "print(f\"Polygons: {len(pp_raw)}, Total vertices: {total_verts_raw}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_polygons(polygon_points, column, title, ax):\n",
+    "    cmap = plt.cm.Set2\n",
+    "    vals = sorted(set(column))\n",
+    "    val_to_color = {v: cmap(i / max(len(vals) - 1, 1)) for i, v in enumerate(vals)}\n",
+    "\n",
+    "    patches = []\n",
+    "    colors = []\n",
+    "    for val, rings in zip(column, polygon_points):\n",
+    "        ext = rings[0]\n",
+    "        patches.append(MplPolygon(ext[:, :2], closed=True))\n",
+    "        colors.append(val_to_color[val])\n",
+    "\n",
+    "    pc = PatchCollection(patches, facecolors=colors, edgecolors=\"black\",\n",
+    "                         linewidths=0.3)\n",
+    "    ax.add_collection(pc)\n",
+    "    ax.set_xlim(0, 120)\n",
+    "    ax.set_ylim(0, 80)\n",
+    "    ax.set_aspect(\"equal\")\n",
+    "    ax.set_title(title)\n",
+    "    ax.invert_yaxis()\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(10, 6))\n",
+    "plot_polygons(pp_raw, col_raw, f\"Raw polygons ({total_verts_raw} vertices)\", ax)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Douglas-Peucker simplification\n",
+    "\n",
+    "Increasing tolerance values show the trade-off between fidelity and vertex count. The tolerance is in coordinate units (pixels here)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = plt.subplots(1, 3, figsize=(18, 6))\n",
+    "\n",
+    "for ax, tol in zip(axes, [0.5, 1.5, 3.0]):\n",
+    "    col, pp = polygonize(raster, simplify_tolerance=tol)\n",
+    "    n_verts = sum(len(r) for rings in pp for r in rings)\n",
+    "    reduction = 100 * (1 - n_verts / total_verts_raw)\n",
+    "    plot_polygons(pp, col,\n",
+    "                  f\"tolerance={tol}  ({n_verts} verts, {reduction:.0f}% reduction)\",\n",
+    "                  ax)\n",
+    "\n",
+    "plt.suptitle(\"Douglas-Peucker simplification\", fontsize=14, y=1.02)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visvalingam-Whyatt simplification\n",
+    "\n",
+    "Area-based simplification removes vertices that contribute the least area change. The tolerance is a minimum triangle area threshold."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = plt.subplots(1, 3, figsize=(18, 6))\n",
+    "\n",
+    "for ax, tol in zip(axes, [0.25, 1.0, 3.0]):\n",
+    "    col, pp = polygonize(raster, simplify_tolerance=tol,\n",
+    "                         simplify_method=\"visvalingam-whyatt\")\n",
+    "    n_verts = sum(len(r) for rings in pp for r in rings)\n",
+    "    reduction = 100 * (1 - n_verts / total_verts_raw)\n",
+    "    plot_polygons(pp, col,\n",
+    "                  f\"tolerance={tol}  ({n_verts} verts, {reduction:.0f}% reduction)\",\n",
+    "                  ax)\n",
+    "\n",
+    "plt.suptitle(\"Visvalingam-Whyatt simplification\", fontsize=14, y=1.02)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## GeoDataFrame output\n",
+    "\n",
+    "`simplify_tolerance` works with all return types including GeoDataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdf = polygonize(raster, simplify_tolerance=1.5, return_type=\"geopandas\",\n",
+    "                 column_name=\"landcover\")\n",
+    "print(gdf.head(10))\n",
+    "print(f\"\\nAll geometries valid: {gdf.geometry.is_valid.all()}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/xrspatial/polygonize.py
+++ b/xrspatial/polygonize.py
@@ -1364,17 +1364,14 @@ def _simplify_polygons(polygon_points, tolerance, method="douglas-peucker"):
                 new_rings.append(assembled)
 
         # Drop degenerate rings (fewer than 4 vertices = triangle minimum).
-        filtered = []
-        for ring in new_rings:
+        # If the exterior ring is degenerate, drop the entire polygon.
+        if len(new_rings) == 0 or len(new_rings[0]) < 4:
+            continue
+        filtered = [new_rings[0]]  # exterior is valid
+        for ring in new_rings[1:]:
             if len(ring) >= 4:
                 filtered.append(ring)
-            elif len(new_rings) > 0 and ring is new_rings[0]:
-                # Keep exterior even if degenerate.
-                filtered.append(ring)
-        if filtered:
-            result.append(filtered)
-        else:
-            result.append(new_rings)
+        result.append(filtered)
 
     return result
 

--- a/xrspatial/polygonize.py
+++ b/xrspatial/polygonize.py
@@ -1002,6 +1002,274 @@ def _douglas_peucker(coords, tolerance):
     return result
 
 
+def _find_junctions(all_rings):
+    """Find junction vertices that must be pinned during simplification.
+
+    A junction is any vertex where the topology of shared edges changes.
+    This includes:
+    - Vertices where 3+ distinct rings meet (true topological junctions).
+    - Endpoints of shared edge chains between pairs of rings (where a
+      shared boundary starts or ends).
+
+    These vertices are pinned so that shared edges are simplified
+    identically for all rings that use them.
+
+    Parameters
+    ----------
+    all_rings : list of list of np.ndarray
+        polygon_points structure: list of polygons, each polygon is
+        a list of rings (Nx2 arrays, closed).
+
+    Returns
+    -------
+    set of (float, float)
+    """
+    # Build a set of directed edges per ring, and track which rings
+    # each vertex belongs to.
+    vertex_ring_count = {}  # (x, y) -> set of ring identifiers
+    # Track directed edges: (pt_a, pt_b) -> set of ring_ids
+    edge_rings = {}
+    ring_id = 0
+    for rings in all_rings:
+        for ring in rings:
+            n = len(ring) - 1  # unique vertices (ring is closed)
+            for k in range(n):
+                pt = (ring[k, 0], ring[k, 1])
+                if pt not in vertex_ring_count:
+                    vertex_ring_count[pt] = set()
+                vertex_ring_count[pt].add(ring_id)
+
+                pt_next = (ring[k + 1, 0], ring[k + 1, 1])
+                edge = (pt, pt_next)
+                if edge not in edge_rings:
+                    edge_rings[edge] = set()
+                edge_rings[edge].add(ring_id)
+            ring_id += 1
+
+    # An edge is "shared" if its reverse also exists (in a different ring).
+    # Shared edges connect two polygons along a boundary.
+    shared_edges = set()
+    for (a, b), rids in edge_rings.items():
+        rev = (b, a)
+        if rev in edge_rings:
+            # The forward and reverse edges exist (potentially in different rings).
+            shared_edges.add((min(a, b), max(a, b)))
+
+    # Build set of vertices on shared edges.
+    shared_vertices = set()
+    for a, b in shared_edges:
+        shared_vertices.add(a)
+        shared_vertices.add(b)
+
+    # Find junctions: vertices in 3+ rings, OR shared vertices that
+    # are adjacent to at least one non-shared edge in some ring.
+    junctions = set()
+
+    # Type 1: vertices in 3+ rings.
+    for pt, ids in vertex_ring_count.items():
+        if len(ids) >= 3:
+            junctions.add(pt)
+
+    # Type 2: endpoints of shared chains. A shared vertex is a chain
+    # endpoint if, in any ring, it has an adjacent edge that is NOT shared.
+    ring_id = 0
+    for rings in all_rings:
+        for ring in rings:
+            n = len(ring) - 1
+            for k in range(n):
+                pt = (ring[k, 0], ring[k, 1])
+                if pt not in shared_vertices:
+                    continue
+                # Check the edge leaving this vertex.
+                pt_next = (ring[(k + 1) % n, 0], ring[(k + 1) % n, 1])
+                edge_fwd = (min(pt, pt_next), max(pt, pt_next))
+                # Check the edge arriving at this vertex.
+                pt_prev = (ring[(k - 1) % n, 0], ring[(k - 1) % n, 1])
+                edge_bwd = (min(pt, pt_prev), max(pt, pt_prev))
+
+                if edge_fwd not in shared_edges or edge_bwd not in shared_edges:
+                    junctions.add(pt)
+            ring_id += 1
+
+    return junctions
+
+
+def _split_ring_at_junctions(ring, junctions):
+    """Split a closed ring into chains at junction vertices.
+
+    Each chain starts and ends at a junction vertex (endpoints included
+    in the chain).  If the ring contains no junctions, the entire ring
+    is returned as a single chain.
+
+    Parameters
+    ----------
+    ring : np.ndarray, shape (N, 2)
+        Closed ring (first == last vertex).
+    junctions : set of (float, float)
+
+    Returns
+    -------
+    list of np.ndarray
+        Each array is an Mx2 chain.  Consecutive chains share their
+        endpoint/startpoint.
+    """
+    n = len(ring) - 1  # number of unique vertices
+
+    # Find indices of junction vertices within this ring.
+    junction_indices = []
+    for k in range(n):
+        if (ring[k, 0], ring[k, 1]) in junctions:
+            junction_indices.append(k)
+
+    if len(junction_indices) == 0:
+        # No junctions: return the whole ring as a single chain.
+        return [ring.copy()]
+
+    # Rotate ring so that the first junction is at index 0.
+    first = junction_indices[0]
+    if first > 0:
+        # Rotate unique vertices, then re-close.
+        rotated = np.empty_like(ring)
+        rotated[:n - first] = ring[first:n]
+        rotated[n - first:n] = ring[:first]
+        rotated[n] = rotated[0]
+        ring = rotated
+        junction_indices = [(ji - first) % n for ji in junction_indices]
+        junction_indices.sort()
+
+    # Split at each junction.
+    chains = []
+    for i in range(len(junction_indices)):
+        start = junction_indices[i]
+        if i + 1 < len(junction_indices):
+            end = junction_indices[i + 1]
+        else:
+            end = n  # wrap back to first junction (index 0 after rotation)
+        chains.append(ring[start:end + 1].copy())
+
+    return chains
+
+
+def _chain_key(chain):
+    """Canonical key for deduplicating shared edge chains.
+
+    Two chains that connect the same pair of junctions but are traversed
+    in opposite directions should map to the same key.  We use the sorted
+    endpoint pair plus the frozenset of interior vertices.
+    """
+    start = (chain[0, 0], chain[0, 1])
+    end = (chain[-1, 0], chain[-1, 1])
+    if start > end:
+        start, end = end, start
+    # Include interior points for disambiguation.
+    interior = tuple(
+        (chain[k, 0], chain[k, 1]) for k in range(1, len(chain) - 1))
+    interior_rev = interior[::-1]
+    interior = min(interior, interior_rev)
+    return (start, end, interior)
+
+
+def _simplify_polygons(polygon_points, tolerance):
+    """Topology-preserving simplification of all polygons.
+
+    Uses shared-edge decomposition: finds junction vertices, splits
+    rings into chains at junctions, simplifies each unique chain once
+    with Douglas-Peucker, then reassembles rings.
+
+    Parameters
+    ----------
+    polygon_points : list of list of np.ndarray
+        Output of polygonize backend: list of polygons, each polygon
+        is [exterior_ring, *hole_rings].
+    tolerance : float
+        Douglas-Peucker tolerance in coordinate units.
+
+    Returns
+    -------
+    list of list of np.ndarray
+        Same structure as input, with simplified coordinates.
+    """
+    if tolerance <= 0:
+        return polygon_points
+
+    # Step 1: Find junctions.
+    junctions = _find_junctions(polygon_points)
+
+    # Step 2 & 3: Split rings into chains, deduplicate, simplify.
+    simplified_chains = {}  # chain_key -> simplified np.ndarray
+
+    # Track how to reassemble each ring.
+    # ring_info[poly_idx][ring_idx] = list of (chain_key, is_reversed)
+    ring_info = []
+
+    for poly_idx, rings in enumerate(polygon_points):
+        poly_info = []
+        for ring in rings:
+            chains = _split_ring_at_junctions(ring, junctions)
+            chain_refs = []
+            for chain in chains:
+                key = _chain_key(chain)
+                if key not in simplified_chains:
+                    simplified_chains[key] = _douglas_peucker(chain, tolerance)
+                # Determine if this chain was reversed relative to canonical.
+                start = (chain[0, 0], chain[0, 1])
+                canonical_start = (simplified_chains[key][0, 0],
+                                   simplified_chains[key][0, 1])
+                is_reversed = (start != canonical_start)
+                chain_refs.append((key, is_reversed))
+            poly_info.append(chain_refs)
+        ring_info.append(poly_info)
+
+    # Step 4: Reassemble rings.
+    result = []
+    for poly_idx, rings in enumerate(polygon_points):
+        new_rings = []
+        for ring_idx, chain_refs in enumerate(ring_info[poly_idx]):
+            if len(chain_refs) == 1:
+                key, is_reversed = chain_refs[0]
+                simplified = simplified_chains[key]
+                if is_reversed:
+                    simplified = simplified[::-1].copy()
+                # Ensure ring is closed.
+                if not (simplified[0, 0] == simplified[-1, 0] and
+                        simplified[0, 1] == simplified[-1, 1]):
+                    simplified = np.vstack([simplified, simplified[:1]])
+                new_rings.append(simplified)
+            else:
+                # Multiple chains: concatenate (drop duplicate junction points).
+                parts = []
+                for key, is_reversed in chain_refs:
+                    simplified = simplified_chains[key]
+                    if is_reversed:
+                        simplified = simplified[::-1].copy()
+                    if parts:
+                        # Skip first point (same as last of previous chain).
+                        parts.append(simplified[1:])
+                    else:
+                        parts.append(simplified)
+                assembled = np.vstack(parts)
+                # Ensure ring is closed.
+                if not (assembled[0, 0] == assembled[-1, 0] and
+                        assembled[0, 1] == assembled[-1, 1]):
+                    assembled = np.vstack([assembled, assembled[:1]])
+                new_rings.append(assembled)
+
+        # Drop degenerate rings (fewer than 4 vertices = triangle minimum).
+        filtered = []
+        for ring in new_rings:
+            if len(ring) >= 4:
+                filtered.append(ring)
+            elif len(new_rings) > 0 and ring is new_rings[0]:
+                # Keep exterior even if degenerate.
+                filtered.append(ring)
+        if filtered:
+            result.append(filtered)
+        else:
+            result.append(new_rings)
+
+    return result
+
+
 def _merge_polygon_rings(polys_list):
     """Merge polygon ring sets that share chunk-boundary edges.
 

--- a/xrspatial/polygonize.py
+++ b/xrspatial/polygonize.py
@@ -1002,6 +1002,109 @@ def _douglas_peucker(coords, tolerance):
     return result
 
 
+@ngjit
+def _visvalingam_whyatt(coords, tolerance):
+    """Visvalingam-Whyatt area-based line simplification.
+
+    Iteratively removes the vertex that forms the smallest triangle
+    area with its neighbors, until no triangle area is below tolerance.
+    Endpoints are always preserved.
+
+    Parameters
+    ----------
+    coords : np.ndarray, shape (N, 2)
+        Input coordinate array.
+    tolerance : float
+        Minimum triangle area threshold. Vertices forming triangles
+        with area below this value are removed.
+
+    Returns
+    -------
+    np.ndarray, shape (M, 2)
+        Simplified coordinate array.
+    """
+    n = len(coords)
+    if n <= 2:
+        return coords.copy()
+
+    # Use a doubly-linked list via prev/next index arrays.
+    prev_idx = np.empty(n, dtype=np.int64)
+    next_idx = np.empty(n, dtype=np.int64)
+    for i in range(n):
+        prev_idx[i] = i - 1
+        next_idx[i] = i + 1
+    # Endpoints are never removed (sentinel values).
+    prev_idx[0] = -1
+    next_idx[n - 1] = -1
+
+    # Compute triangle areas for interior vertices.
+    areas = np.full(n, np.inf, dtype=np.float64)
+    for i in range(1, n - 1):
+        ax, ay = coords[prev_idx[i], 0], coords[prev_idx[i], 1]
+        bx, by = coords[i, 0], coords[i, 1]
+        cx, cy = coords[next_idx[i], 0], coords[next_idx[i], 1]
+        areas[i] = abs((ax * (by - cy) + bx * (cy - ay) + cx * (ay - by)) / 2.0)
+
+    removed = np.zeros(n, dtype=np.bool_)
+    remaining = n
+
+    while remaining > 2:
+        # Find vertex with minimum area.
+        min_area = np.inf
+        min_idx = -1
+        for i in range(1, n - 1):
+            if not removed[i] and areas[i] < min_area:
+                min_area = areas[i]
+                min_idx = i
+
+        if min_idx == -1 or min_area >= tolerance:
+            break
+
+        # Remove vertex.
+        removed[min_idx] = True
+        remaining -= 1
+
+        # Update linked list.
+        p = prev_idx[min_idx]
+        nx_i = next_idx[min_idx]
+        if p >= 0:
+            next_idx[p] = nx_i
+        if nx_i >= 0 and nx_i < n:
+            prev_idx[nx_i] = p
+
+        # Recompute areas for affected neighbors.
+        if p > 0 and prev_idx[p] >= 0:
+            ax, ay = coords[prev_idx[p], 0], coords[prev_idx[p], 1]
+            bx, by = coords[p, 0], coords[p, 1]
+            cx, cy = coords[next_idx[p], 0], coords[next_idx[p], 1]
+            new_area = abs((ax * (by - cy) + bx * (cy - ay) + cx * (ay - by)) / 2.0)
+            # Enforce monotonicity: area can only increase.
+            areas[p] = max(new_area, min_area)
+
+        if nx_i >= 0 and nx_i < n - 1 and next_idx[nx_i] >= 0:
+            ax, ay = coords[prev_idx[nx_i], 0], coords[prev_idx[nx_i], 1]
+            bx, by = coords[nx_i, 0], coords[nx_i, 1]
+            cx, cy = coords[next_idx[nx_i], 0], coords[next_idx[nx_i], 1]
+            new_area = abs((ax * (by - cy) + bx * (cy - ay) + cx * (ay - by)) / 2.0)
+            areas[nx_i] = max(new_area, min_area)
+
+    # Collect remaining vertices.
+    count = 0
+    for i in range(n):
+        if not removed[i]:
+            count += 1
+
+    result = np.empty((count, 2), dtype=np.float64)
+    j = 0
+    for i in range(n):
+        if not removed[i]:
+            result[j, 0] = coords[i, 0]
+            result[j, 1] = coords[i, 1]
+            j += 1
+
+    return result
+
+
 def _find_junctions(all_rings):
     """Find junction vertices that must be pinned during simplification.
 
@@ -1169,12 +1272,12 @@ def _chain_key(chain):
     return (start, end, interior)
 
 
-def _simplify_polygons(polygon_points, tolerance):
+def _simplify_polygons(polygon_points, tolerance, method="douglas-peucker"):
     """Topology-preserving simplification of all polygons.
 
     Uses shared-edge decomposition: finds junction vertices, splits
     rings into chains at junctions, simplifies each unique chain once
-    with Douglas-Peucker, then reassembles rings.
+    with the chosen algorithm, then reassembles rings.
 
     Parameters
     ----------
@@ -1182,7 +1285,10 @@ def _simplify_polygons(polygon_points, tolerance):
         Output of polygonize backend: list of polygons, each polygon
         is [exterior_ring, *hole_rings].
     tolerance : float
-        Douglas-Peucker tolerance in coordinate units.
+        Simplification tolerance in coordinate units.
+    method : str, default="douglas-peucker"
+        Simplification algorithm: ``"douglas-peucker"`` or
+        ``"visvalingam-whyatt"``.
 
     Returns
     -------
@@ -1210,7 +1316,10 @@ def _simplify_polygons(polygon_points, tolerance):
             for chain in chains:
                 key = _chain_key(chain)
                 if key not in simplified_chains:
-                    simplified_chains[key] = _douglas_peucker(chain, tolerance)
+                    if method == "douglas-peucker":
+                        simplified_chains[key] = _douglas_peucker(chain, tolerance)
+                    else:
+                        simplified_chains[key] = _visvalingam_whyatt(chain, tolerance)
                 # Determine if this chain was reversed relative to canonical.
                 start = (chain[0, 0], chain[0, 1])
                 canonical_start = (simplified_chains[key][0, 0],
@@ -1376,6 +1485,8 @@ def polygonize(
     transform: Optional[np.ndarray] = None,  # shape (6,)
     column_name: str = "DN",
     return_type: str = "numpy",
+    simplify_tolerance: Optional[float] = None,
+    simplify_method: str = "douglas-peucker",
 ):
     """
     Polygonize creates vector polygons for connected regions of pixels in a
@@ -1415,6 +1526,23 @@ def polygonize(
         Format of returned data.  Allowed values are "numpy", "spatialpandas",
         "geopandas", "awkward" and "geojson".  "numpy" and "geojson" are
         always available, the others require optional dependencies.
+
+    simplify_tolerance: float, optional
+        Simplification tolerance in coordinate units. When set, polygon
+        boundaries are simplified using shared-edge decomposition to
+        preserve topology between adjacent polygons. Default is None
+        (no simplification).
+
+        For ``"douglas-peucker"``, this is the maximum perpendicular
+        distance a vertex may deviate from the simplified line.
+
+        For ``"visvalingam-whyatt"``, this is the minimum triangle area
+        threshold; vertices forming triangles smaller than this are removed.
+
+    simplify_method: str, default="douglas-peucker"
+        Simplification algorithm. Options are ``"douglas-peucker"``
+        (distance-based, good for general use) and ``"visvalingam-whyatt"``
+        (area-based, tends to produce better cartographic results).
 
     Returns
     -------
@@ -1462,6 +1590,16 @@ def polygonize(
             raise ValueError(
                 f"Incorrect transform length of {len(transform)} instead of 6")
 
+    # Check simplification parameters.
+    if simplify_tolerance is not None and simplify_tolerance < 0:
+        raise ValueError(
+            "simplify_tolerance must be non-negative, "
+            f"got {simplify_tolerance}")
+    if simplify_method not in ("douglas-peucker", "visvalingam-whyatt"):
+        raise ValueError(
+            f"simplify_method must be 'douglas-peucker' or "
+            f"'visvalingam-whyatt', got '{simplify_method}'")
+
     mapper = ArrayTypeFunctionMapping(
         numpy_func=_polygonize_numpy,
         cupy_func=_polygonize_cupy,
@@ -1470,6 +1608,11 @@ def polygonize(
     )
     column, polygon_points = mapper(raster)(
         raster.data, mask_data, connectivity_8, transform)
+
+    # Apply simplification if requested.
+    if simplify_tolerance is not None and simplify_tolerance > 0:
+        polygon_points = _simplify_polygons(
+            polygon_points, simplify_tolerance, method=simplify_method)
 
     # Convert to requested return_type.
     if return_type == "numpy":

--- a/xrspatial/polygonize.py
+++ b/xrspatial/polygonize.py
@@ -1272,7 +1272,8 @@ def _chain_key(chain):
     return (start, end, interior)
 
 
-def _simplify_polygons(polygon_points, tolerance, method="douglas-peucker"):
+def _simplify_polygons(column, polygon_points, tolerance,
+                       method="douglas-peucker"):
     """Topology-preserving simplification of all polygons.
 
     Uses shared-edge decomposition: finds junction vertices, splits
@@ -1281,6 +1282,8 @@ def _simplify_polygons(polygon_points, tolerance, method="douglas-peucker"):
 
     Parameters
     ----------
+    column : list
+        Pixel values corresponding to each polygon.
     polygon_points : list of list of np.ndarray
         Output of polygonize backend: list of polygons, each polygon
         is [exterior_ring, *hole_rings].
@@ -1292,11 +1295,12 @@ def _simplify_polygons(polygon_points, tolerance, method="douglas-peucker"):
 
     Returns
     -------
-    list of list of np.ndarray
-        Same structure as input, with simplified coordinates.
+    (list, list of list of np.ndarray)
+        Filtered column and simplified polygon_points.  Polygons whose
+        exterior ring collapses below 4 vertices are dropped from both.
     """
     if tolerance <= 0:
-        return polygon_points
+        return column, polygon_points
 
     # Step 1: Find junctions.
     junctions = _find_junctions(polygon_points)
@@ -1330,6 +1334,7 @@ def _simplify_polygons(polygon_points, tolerance, method="douglas-peucker"):
         ring_info.append(poly_info)
 
     # Step 4: Reassemble rings.
+    result_column = []
     result = []
     for poly_idx, rings in enumerate(polygon_points):
         new_rings = []
@@ -1371,9 +1376,10 @@ def _simplify_polygons(polygon_points, tolerance, method="douglas-peucker"):
         for ring in new_rings[1:]:
             if len(ring) >= 4:
                 filtered.append(ring)
+        result_column.append(column[poly_idx])
         result.append(filtered)
 
-    return result
+    return result_column, result
 
 
 def _merge_polygon_rings(polys_list):
@@ -1608,8 +1614,9 @@ def polygonize(
 
     # Apply simplification if requested.
     if simplify_tolerance is not None and simplify_tolerance > 0:
-        polygon_points = _simplify_polygons(
-            polygon_points, simplify_tolerance, method=simplify_method)
+        column, polygon_points = _simplify_polygons(
+            column, polygon_points, simplify_tolerance,
+            method=simplify_method)
 
     # Convert to requested return_type.
     if return_type == "numpy":

--- a/xrspatial/polygonize.py
+++ b/xrspatial/polygonize.py
@@ -919,6 +919,89 @@ def _group_rings_into_polygons(rings):
     return result
 
 
+@ngjit
+def _perpendicular_distance(px, py, ax, ay, bx, by):
+    """Perpendicular distance from point (px,py) to line (ax,ay)-(bx,by)."""
+    dx = bx - ax
+    dy = by - ay
+    len_sq = dx * dx + dy * dy
+    if len_sq == 0.0:
+        return np.sqrt((px - ax) ** 2 + (py - ay) ** 2)
+    t = ((px - ax) * dx + (py - ay) * dy) / len_sq
+    t = max(0.0, min(1.0, t))
+    proj_x = ax + t * dx
+    proj_y = ay + t * dy
+    return np.sqrt((px - proj_x) ** 2 + (py - proj_y) ** 2)
+
+
+@ngjit
+def _douglas_peucker(coords, tolerance):
+    """Douglas-Peucker line simplification on an Nx2 float64 array.
+
+    Endpoints are always preserved. Returns a new Nx2 array with
+    only the retained vertices.
+    """
+    n = len(coords)
+    if n <= 2:
+        return coords.copy()
+
+    # Iterative DP using an explicit numpy array stack to avoid recursion
+    # depth issues and stay compatible with numba nopython mode.
+    keep = np.zeros(n, dtype=np.bool_)
+    keep[0] = True
+    keep[n - 1] = True
+
+    # Stack of (start, end) index pairs stored as a pre-allocated array.
+    stack_arr = np.empty((n, 2), dtype=np.int64)
+    stack_arr[0, 0] = np.int64(0)
+    stack_arr[0, 1] = np.int64(n - 1)
+    stack_top = 1
+
+    while stack_top > 0:
+        stack_top -= 1
+        start = stack_arr[stack_top, 0]
+        end = stack_arr[stack_top, 1]
+
+        if end - start < 2:
+            continue
+
+        ax, ay = coords[start, 0], coords[start, 1]
+        bx, by = coords[end, 0], coords[end, 1]
+
+        max_dist = 0.0
+        max_idx = start
+        for i in range(start + 1, end):
+            d = _perpendicular_distance(
+                coords[i, 0], coords[i, 1], ax, ay, bx, by)
+            if d > max_dist:
+                max_dist = d
+                max_idx = i
+
+        if max_dist > tolerance:
+            keep[max_idx] = True
+            stack_arr[stack_top, 0] = start
+            stack_arr[stack_top, 1] = max_idx
+            stack_top += 1
+            stack_arr[stack_top, 0] = max_idx
+            stack_arr[stack_top, 1] = end
+            stack_top += 1
+
+    count = 0
+    for i in range(n):
+        if keep[i]:
+            count += 1
+
+    result = np.empty((count, 2), dtype=np.float64)
+    j = 0
+    for i in range(n):
+        if keep[i]:
+            result[j, 0] = coords[i, 0]
+            result[j, 1] = coords[i, 1]
+            j += 1
+
+    return result
+
+
 def _merge_polygon_rings(polys_list):
     """Merge polygon ring sets that share chunk-boundary edges.
 

--- a/xrspatial/tests/test_polygonize.py
+++ b/xrspatial/tests/test_polygonize.py
@@ -577,3 +577,82 @@ class TestSimplifyHelpers:
         coords = np.array([[0.0, 0.0], [4.0, 0.0]], dtype=np.float64)
         result = _douglas_peucker(coords, 1.0)
         assert_allclose(result, coords)
+
+    def test_simplify_polygons_reduces_vertices(self):
+        """Simplification should reduce vertex count on staircase edges."""
+        from ..polygonize import _simplify_polygons
+
+        # Staircase boundary between two values.
+        raster = np.array([
+            [1, 1, 1, 2, 2, 2],
+            [1, 1, 2, 2, 2, 2],
+            [1, 2, 2, 2, 2, 2],
+            [1, 1, 2, 2, 2, 2],
+            [1, 1, 1, 2, 2, 2],
+        ], dtype=np.int64)
+        data = xr.DataArray(raster)
+        column_orig, pp_orig = polygonize(data, return_type="numpy")
+
+        pp_simplified = _simplify_polygons(pp_orig, tolerance=1.5)
+
+        # Vertex count should be reduced for at least one polygon.
+        orig_total_verts = sum(
+            sum(len(r) for r in rings) for rings in pp_orig)
+        simp_total_verts = sum(
+            sum(len(r) for r in rings) for rings in pp_simplified)
+        assert simp_total_verts < orig_total_verts
+
+        # Total area across all polygons must be preserved (shared-edge
+        # simplification can shift area between adjacent polygons but
+        # the sum stays the same because the simplified edge is shared).
+        total_orig = sum(
+            sum(calc_boundary_area(r) for r in rings) for rings in pp_orig)
+        total_simp = sum(
+            sum(calc_boundary_area(r) for r in rings)
+            for rings in pp_simplified)
+        assert_allclose(total_simp, total_orig, atol=1e-10)
+
+    def test_simplify_polygons_topology_preserved(self):
+        """Adjacent simplified polygons should not create gaps."""
+        from ..polygonize import _simplify_polygons
+
+        # Two adjacent rectangles sharing an edge.
+        raster = np.array([[1, 1, 2, 2],
+                           [1, 1, 2, 2],
+                           [1, 1, 2, 2],
+                           [1, 1, 2, 2]], dtype=np.int64)
+        data = xr.DataArray(raster)
+        column, pp = polygonize(data, return_type="numpy")
+
+        pp_simplified = _simplify_polygons(pp, tolerance=0.0)
+
+        # With tolerance=0, no vertices should be removed; output
+        # should match input exactly.
+        for orig_rings, simp_rings in zip(pp, pp_simplified):
+            assert len(orig_rings) == len(simp_rings)
+            for orig_ring, simp_ring in zip(orig_rings, simp_rings):
+                assert_allclose(simp_ring, orig_ring)
+
+    def test_simplify_polygons_shared_edge_identical(self):
+        """Two polygons sharing an edge must have identical simplified edges."""
+        from ..polygonize import _simplify_polygons
+
+        # Create a raster where two regions share a staircase boundary.
+        raster = np.array([
+            [1, 1, 1, 2, 2, 2],
+            [1, 1, 2, 2, 2, 2],
+            [1, 2, 2, 2, 2, 2],
+            [1, 1, 2, 2, 2, 2],
+            [1, 1, 1, 2, 2, 2],
+        ], dtype=np.int64)
+        data = xr.DataArray(raster)
+        column, pp = polygonize(data, return_type="numpy")
+
+        pp_simplified = _simplify_polygons(pp, tolerance=1.5)
+
+        # Check total area is preserved (which requires no gaps/overlaps).
+        total_orig = sum(
+            sum(calc_boundary_area(r) for r in rings) for rings in pp)
+        total_simp = sum(
+            sum(calc_boundary_area(r) for r in rings) for rings in pp_simplified)
+        assert_allclose(total_simp, total_orig, atol=1e-10)

--- a/xrspatial/tests/test_polygonize.py
+++ b/xrspatial/tests/test_polygonize.py
@@ -593,7 +593,8 @@ class TestSimplifyHelpers:
         data = xr.DataArray(raster)
         column_orig, pp_orig = polygonize(data, return_type="numpy")
 
-        pp_simplified = _simplify_polygons(pp_orig, tolerance=1.5)
+        _, pp_simplified = _simplify_polygons(
+            column_orig, pp_orig, tolerance=1.5)
 
         # Vertex count should be reduced for at least one polygon.
         orig_total_verts = sum(
@@ -624,7 +625,7 @@ class TestSimplifyHelpers:
         data = xr.DataArray(raster)
         column, pp = polygonize(data, return_type="numpy")
 
-        pp_simplified = _simplify_polygons(pp, tolerance=0.0)
+        _, pp_simplified = _simplify_polygons(column, pp, tolerance=0.0)
 
         # With tolerance=0, no vertices should be removed; output
         # should match input exactly.
@@ -648,7 +649,7 @@ class TestSimplifyHelpers:
         data = xr.DataArray(raster)
         column, pp = polygonize(data, return_type="numpy")
 
-        pp_simplified = _simplify_polygons(pp, tolerance=1.5)
+        _, pp_simplified = _simplify_polygons(column, pp, tolerance=1.5)
 
         # Check total area is preserved (which requires no gaps/overlaps).
         total_orig = sum(
@@ -708,12 +709,28 @@ class TestSimplifyHelpers:
 
         # Find the small polygon (value 1, single pixel).
         small_idx = column.index(1)
-        small_poly = [pp[small_idx]]  # wrap in list for _simplify_polygons
+        small_col = [column[small_idx]]
+        small_poly = [pp[small_idx]]
 
         # Large tolerance should collapse the single-pixel polygon.
-        result = _simplify_polygons(small_poly, tolerance=10.0)
+        result_col, result_pp = _simplify_polygons(
+            small_col, small_poly, tolerance=10.0)
+        # Column and polygon_points must stay in sync.
+        assert len(result_col) == len(result_pp)
         # The polygon should be dropped since its exterior collapses.
-        assert len(result) == 0 or all(len(r[0]) >= 4 for r in result)
+        assert len(result_pp) == 0 or all(len(r[0]) >= 4 for r in result_pp)
+
+    def test_simplify_column_pp_sync_through_public_api(self):
+        """Public API must keep column and polygon_points in sync."""
+        # Raster with a single-pixel region that may collapse.
+        raster = np.array([
+            [1, 2, 2],
+            [2, 2, 2],
+            [2, 2, 2],
+        ], dtype=np.int64)
+        data = xr.DataArray(raster)
+        col, pp = polygonize(data, simplify_tolerance=10.0)
+        assert len(col) == len(pp)
 
 
 class TestPolygonizeSimplify:
@@ -878,6 +895,45 @@ class TestPolygonizeSimplify:
         result = polygonize(data, simplify_tolerance=0.5,
                             return_type="awkward")
         assert result is not None
+
+    def test_simplify_with_holes(self):
+        """Simplification should handle polygons with interior holes."""
+        raster = np.zeros((8, 8), dtype=np.int32)
+        raster[1:7, 1:7] = 1
+        raster[3:5, 3:5] = 0  # hole in the 1-region
+        data = xr.DataArray(raster)
+
+        col_orig, pp_orig = polygonize(data)
+        col_simp, pp_simp = polygonize(data, simplify_tolerance=0.5)
+
+        assert len(col_simp) == len(pp_simp)
+        # Area should be preserved.
+        total_orig = sum(
+            sum(calc_boundary_area(r) for r in rings) for rings in pp_orig)
+        total_simp = sum(
+            sum(calc_boundary_area(r) for r in rings) for rings in pp_simp)
+        assert_allclose(total_simp, total_orig, atol=1e-10)
+
+    def test_simplify_with_transform(self):
+        """Simplification should work with affine transform."""
+        raster = np.array([
+            [1, 1, 2, 2],
+            [1, 1, 2, 2],
+            [1, 1, 2, 2],
+        ], dtype=np.int64)
+        transform = np.array([10.0, 0.0, 100.0, 0.0, 10.0, 200.0])
+        data = xr.DataArray(raster)
+        col, pp = polygonize(data, transform=transform,
+                             simplify_tolerance=5.0)
+        assert len(col) == len(pp)
+        assert len(col) == 2
+
+    def test_simplify_single_pixel_raster(self):
+        """Simplification on a 1x1 raster should not crash."""
+        raster = np.array([[5]], dtype=np.int64)
+        data = xr.DataArray(raster)
+        col, pp = polygonize(data, simplify_tolerance=1.0)
+        assert len(col) == len(pp)
 
 
 @pytest.mark.skipif(da is None, reason="dask not installed")

--- a/xrspatial/tests/test_polygonize.py
+++ b/xrspatial/tests/test_polygonize.py
@@ -692,6 +692,29 @@ class TestSimplifyHelpers:
         result = _visvalingam_whyatt(coords, 1.0)
         assert_allclose(result, coords)
 
+    def test_simplify_polygons_drops_degenerate(self):
+        """Polygons that collapse below 4 vertices should be dropped."""
+        from ..polygonize import _simplify_polygons
+
+        # A single-pixel polygon (4 unique vertices forming a unit square).
+        # With a very large tolerance, it should collapse and be dropped.
+        raster = np.array([
+            [1, 2, 2],
+            [2, 2, 2],
+            [2, 2, 2],
+        ], dtype=np.int64)
+        data = xr.DataArray(raster)
+        column, pp = polygonize(data, return_type="numpy")
+
+        # Find the small polygon (value 1, single pixel).
+        small_idx = column.index(1)
+        small_poly = [pp[small_idx]]  # wrap in list for _simplify_polygons
+
+        # Large tolerance should collapse the single-pixel polygon.
+        result = _simplify_polygons(small_poly, tolerance=10.0)
+        # The polygon should be dropped since its exterior collapses.
+        assert len(result) == 0 or all(len(r[0]) >= 4 for r in result)
+
 
 class TestPolygonizeSimplify:
     """Tests for simplify_tolerance and simplify_method parameters."""
@@ -830,6 +853,32 @@ class TestPolygonizeSimplify:
         assert len(gdf) == 2
         assert gdf.geometry.is_valid.all()
 
+    def test_simplify_with_spatialpandas(self):
+        """Simplification should work with spatialpandas return type."""
+        pytest.importorskip("spatialpandas")
+        raster = np.array([
+            [1, 1, 2, 2],
+            [1, 1, 2, 2],
+            [1, 1, 2, 2],
+        ], dtype=np.int64)
+        data = xr.DataArray(raster)
+        result = polygonize(data, simplify_tolerance=0.5,
+                            return_type="spatialpandas")
+        assert len(result) == 2
+
+    def test_simplify_with_awkward(self):
+        """Simplification should work with awkward return type."""
+        pytest.importorskip("awkward")
+        raster = np.array([
+            [1, 1, 2, 2],
+            [1, 1, 2, 2],
+            [1, 1, 2, 2],
+        ], dtype=np.int64)
+        data = xr.DataArray(raster)
+        result = polygonize(data, simplify_tolerance=0.5,
+                            return_type="awkward")
+        assert result is not None
+
 
 @pytest.mark.skipif(da is None, reason="dask not installed")
 class TestPolygonizeSimplifyDask:
@@ -895,3 +944,38 @@ class TestPolygonizeSimplifyDask:
 
         for val in areas_np:
             assert_allclose(areas_dask[val], areas_np[val], atol=1e-10)
+
+
+@cuda_and_cupy_available
+class TestPolygonizeSimplifyCuPy:
+    """Simplification with CuPy backend."""
+
+    def test_simplify_cupy_matches_numpy(self):
+        """CuPy simplification should produce same areas as numpy."""
+        import cupy as cp
+        raster = np.array([
+            [1, 1, 1, 2, 2, 2],
+            [1, 1, 2, 2, 2, 2],
+            [1, 2, 2, 2, 2, 2],
+            [1, 1, 2, 2, 2, 2],
+            [1, 1, 1, 2, 2, 2],
+        ], dtype=np.int64)
+
+        data_np = xr.DataArray(raster)
+        data_cp = xr.DataArray(cp.asarray(raster))
+
+        col_np, pp_np = polygonize(data_np, simplify_tolerance=1.5)
+        col_cp, pp_cp = polygonize(data_cp, simplify_tolerance=1.5)
+
+        areas_np = {}
+        for val, rings in zip(col_np, pp_np):
+            a = sum(calc_boundary_area(r) for r in rings)
+            areas_np[val] = areas_np.get(val, 0.0) + a
+
+        areas_cp = {}
+        for val, rings in zip(col_cp, pp_cp):
+            a = sum(calc_boundary_area(r) for r in rings)
+            areas_cp[val] = areas_cp.get(val, 0.0) + a
+
+        for val in areas_np:
+            assert_allclose(areas_cp[val], areas_np[val], atol=1e-10)

--- a/xrspatial/tests/test_polygonize.py
+++ b/xrspatial/tests/test_polygonize.py
@@ -656,3 +656,242 @@ class TestSimplifyHelpers:
         total_simp = sum(
             sum(calc_boundary_area(r) for r in rings) for rings in pp_simplified)
         assert_allclose(total_simp, total_orig, atol=1e-10)
+
+    def test_visvalingam_whyatt_straight_line(self):
+        """VW on a straight line should reduce to just endpoints."""
+        from ..polygonize import _visvalingam_whyatt
+        coords = np.array([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0],
+                           [3.0, 0.0], [4.0, 0.0]], dtype=np.float64)
+        result = _visvalingam_whyatt(coords, 0.1)
+        expected = np.array([[0.0, 0.0], [4.0, 0.0]], dtype=np.float64)
+        assert_allclose(result, expected)
+
+    def test_visvalingam_whyatt_preserves_large_triangle(self):
+        """VW should keep a vertex forming a large triangle."""
+        from ..polygonize import _visvalingam_whyatt
+        coords = np.array([[0.0, 0.0], [2.0, 3.0], [4.0, 0.0]],
+                          dtype=np.float64)
+        # Triangle area = 0.5 * |0*(3-0) + 2*(0-0) + 4*(0-3)| = 6.0
+        result = _visvalingam_whyatt(coords, 5.0)
+        assert len(result) == 3  # area 6.0 > tolerance 5.0
+
+    def test_visvalingam_whyatt_removes_small_triangle(self):
+        """VW should remove a vertex forming a small triangle."""
+        from ..polygonize import _visvalingam_whyatt
+        coords = np.array([[0.0, 0.0], [2.0, 0.5], [4.0, 0.0]],
+                          dtype=np.float64)
+        # Triangle area = 0.5 * |0*(0.5-0) + 2*(0-0) + 4*(0-0.5)| = 1.0
+        result = _visvalingam_whyatt(coords, 2.0)
+        expected = np.array([[0.0, 0.0], [4.0, 0.0]], dtype=np.float64)
+        assert_allclose(result, expected)
+
+    def test_visvalingam_whyatt_two_points(self):
+        """VW on two points should return them unchanged."""
+        from ..polygonize import _visvalingam_whyatt
+        coords = np.array([[0.0, 0.0], [4.0, 0.0]], dtype=np.float64)
+        result = _visvalingam_whyatt(coords, 1.0)
+        assert_allclose(result, coords)
+
+
+class TestPolygonizeSimplify:
+    """Tests for simplify_tolerance and simplify_method parameters."""
+
+    def test_tolerance_none_no_change(self):
+        """tolerance=None should produce identical output to no-arg call."""
+        raster = np.array([[1, 1, 2, 2],
+                           [1, 1, 2, 2]], dtype=np.int64)
+        data = xr.DataArray(raster)
+        col1, pp1 = polygonize(data)
+        col2, pp2 = polygonize(data, simplify_tolerance=None)
+        assert col1 == col2
+        for r1, r2 in zip(pp1, pp2):
+            for a, b in zip(r1, r2):
+                assert_allclose(a, b)
+
+    def test_tolerance_zero_no_change(self):
+        """tolerance=0.0 should produce identical output."""
+        raster = np.array([[1, 1, 2, 2],
+                           [1, 1, 2, 2]], dtype=np.int64)
+        data = xr.DataArray(raster)
+        col1, pp1 = polygonize(data)
+        col2, pp2 = polygonize(data, simplify_tolerance=0.0)
+        assert col1 == col2
+        for r1, r2 in zip(pp1, pp2):
+            for a, b in zip(r1, r2):
+                assert_allclose(a, b)
+
+    def test_negative_tolerance_raises(self):
+        """Negative tolerance should raise ValueError."""
+        raster = np.array([[1, 1], [1, 1]], dtype=np.int64)
+        data = xr.DataArray(raster)
+        with pytest.raises(ValueError, match="simplify_tolerance"):
+            polygonize(data, simplify_tolerance=-1.0)
+
+    def test_invalid_method_raises(self):
+        """Unknown method should raise ValueError."""
+        raster = np.array([[1, 1], [1, 1]], dtype=np.int64)
+        data = xr.DataArray(raster)
+        with pytest.raises(ValueError, match="simplify_method"):
+            polygonize(data, simplify_tolerance=1.0,
+                       simplify_method="invalid")
+
+    def test_simplify_dp_reduces_vertices(self):
+        """Douglas-Peucker simplification should reduce total vertex count."""
+        raster = np.array([
+            [1, 1, 1, 2, 2, 2],
+            [1, 1, 2, 2, 2, 2],
+            [1, 2, 2, 2, 2, 2],
+            [1, 1, 2, 2, 2, 2],
+            [1, 1, 1, 2, 2, 2],
+        ], dtype=np.int64)
+        data = xr.DataArray(raster)
+        _, pp_orig = polygonize(data)
+        _, pp_simp = polygonize(data, simplify_tolerance=1.5)
+
+        orig_verts = sum(len(r) for rings in pp_orig for r in rings)
+        simp_verts = sum(len(r) for rings in pp_simp for r in rings)
+        assert simp_verts < orig_verts
+
+    def test_simplify_vw_reduces_vertices(self):
+        """Visvalingam-Whyatt simplification should reduce total vertex count."""
+        raster = np.array([
+            [1, 1, 1, 2, 2, 2],
+            [1, 1, 2, 2, 2, 2],
+            [1, 2, 2, 2, 2, 2],
+            [1, 1, 2, 2, 2, 2],
+            [1, 1, 1, 2, 2, 2],
+        ], dtype=np.int64)
+        data = xr.DataArray(raster)
+        _, pp_orig = polygonize(data)
+        _, pp_simp = polygonize(data, simplify_tolerance=1.5,
+                                simplify_method="visvalingam-whyatt")
+
+        orig_verts = sum(len(r) for rings in pp_orig for r in rings)
+        simp_verts = sum(len(r) for rings in pp_simp for r in rings)
+        assert simp_verts < orig_verts
+
+    def test_simplify_preserves_total_area(self):
+        """Total area must be preserved after simplification."""
+        raster = np.array([
+            [1, 1, 1, 2, 2, 2],
+            [1, 1, 2, 2, 2, 2],
+            [1, 2, 2, 2, 2, 2],
+            [1, 1, 2, 2, 2, 2],
+            [1, 1, 1, 2, 2, 2],
+        ], dtype=np.int64)
+        data = xr.DataArray(raster)
+        _, pp_orig = polygonize(data)
+        _, pp_simp = polygonize(data, simplify_tolerance=1.5)
+
+        total_orig = sum(
+            sum(calc_boundary_area(r) for r in rings) for rings in pp_orig)
+        total_simp = sum(
+            sum(calc_boundary_area(r) for r in rings) for rings in pp_simp)
+        assert_allclose(total_simp, total_orig, atol=1e-10)
+
+    def test_simplify_with_geopandas(self):
+        """Simplification should work with geopandas return type."""
+        pytest.importorskip("geopandas")
+        raster = np.array([
+            [1, 1, 2, 2],
+            [1, 1, 2, 2],
+            [1, 1, 2, 2],
+        ], dtype=np.int64)
+        data = xr.DataArray(raster)
+        gdf = polygonize(data, simplify_tolerance=0.5,
+                         return_type="geopandas")
+        assert len(gdf) == 2
+        assert gdf.geometry.is_valid.all()
+
+    def test_simplify_with_geojson(self):
+        """Simplification should work with geojson return type."""
+        raster = np.array([
+            [1, 1, 2, 2],
+            [1, 1, 2, 2],
+        ], dtype=np.int64)
+        data = xr.DataArray(raster)
+        fc = polygonize(data, simplify_tolerance=0.5,
+                        return_type="geojson")
+        assert fc["type"] == "FeatureCollection"
+        assert len(fc["features"]) == 2
+
+    def test_simplify_vw_with_geopandas(self):
+        """VW simplification should work with geopandas return type."""
+        pytest.importorskip("geopandas")
+        raster = np.array([
+            [1, 1, 2, 2],
+            [1, 1, 2, 2],
+            [1, 1, 2, 2],
+        ], dtype=np.int64)
+        data = xr.DataArray(raster)
+        gdf = polygonize(data, simplify_tolerance=0.5,
+                         simplify_method="visvalingam-whyatt",
+                         return_type="geopandas")
+        assert len(gdf) == 2
+        assert gdf.geometry.is_valid.all()
+
+
+@pytest.mark.skipif(da is None, reason="dask not installed")
+class TestPolygonizeSimplifyDask:
+    """Simplification with dask backend."""
+
+    def test_simplify_dask_matches_numpy(self):
+        """Dask simplification should produce same areas as numpy."""
+        raster = np.array([
+            [1, 1, 1, 2, 2, 2],
+            [1, 1, 2, 2, 2, 2],
+            [1, 2, 2, 2, 2, 2],
+            [1, 1, 2, 2, 2, 2],
+            [1, 1, 1, 2, 2, 2],
+        ], dtype=np.int64)
+
+        data_np = xr.DataArray(raster)
+        data_dask = xr.DataArray(da.from_array(raster, chunks=(3, 3)))
+
+        col_np, pp_np = polygonize(data_np, simplify_tolerance=1.5)
+        col_dask, pp_dask = polygonize(data_dask, simplify_tolerance=1.5)
+
+        # Compare per-value area sums.
+        areas_np = {}
+        for val, rings in zip(col_np, pp_np):
+            a = sum(calc_boundary_area(r) for r in rings)
+            areas_np[val] = areas_np.get(val, 0.0) + a
+
+        areas_dask = {}
+        for val, rings in zip(col_dask, pp_dask):
+            a = sum(calc_boundary_area(r) for r in rings)
+            areas_dask[val] = areas_dask.get(val, 0.0) + a
+
+        for val in areas_np:
+            assert_allclose(areas_dask[val], areas_np[val], atol=1e-10)
+
+    def test_simplify_vw_dask_matches_numpy(self):
+        """VW dask simplification should produce same areas as numpy."""
+        raster = np.array([
+            [1, 1, 1, 2, 2, 2],
+            [1, 1, 2, 2, 2, 2],
+            [1, 2, 2, 2, 2, 2],
+            [1, 1, 2, 2, 2, 2],
+            [1, 1, 1, 2, 2, 2],
+        ], dtype=np.int64)
+
+        data_np = xr.DataArray(raster)
+        data_dask = xr.DataArray(da.from_array(raster, chunks=(3, 3)))
+
+        col_np, pp_np = polygonize(data_np, simplify_tolerance=1.5,
+                                   simplify_method="visvalingam-whyatt")
+        col_dask, pp_dask = polygonize(data_dask, simplify_tolerance=1.5,
+                                       simplify_method="visvalingam-whyatt")
+
+        areas_np = {}
+        for val, rings in zip(col_np, pp_np):
+            a = sum(calc_boundary_area(r) for r in rings)
+            areas_np[val] = areas_np.get(val, 0.0) + a
+
+        areas_dask = {}
+        for val, rings in zip(col_dask, pp_dask):
+            a = sum(calc_boundary_area(r) for r in rings)
+            areas_dask[val] = areas_dask.get(val, 0.0) + a
+
+        for val in areas_np:
+            assert_allclose(areas_dask[val], areas_np[val], atol=1e-10)

--- a/xrspatial/tests/test_polygonize.py
+++ b/xrspatial/tests/test_polygonize.py
@@ -538,3 +538,42 @@ def test_polygonize_1008_geopandas_batch_with_holes():
 
     # Total area should equal raster size.
     assert_allclose(df.geometry.area.sum(), 36.0)
+
+
+class TestSimplifyHelpers:
+    """Tests for internal simplification helper functions."""
+
+    def test_douglas_peucker_straight_line(self):
+        """DP on a straight line should reduce to just endpoints."""
+        from ..polygonize import _douglas_peucker
+        coords = np.array([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0],
+                           [3.0, 0.0], [4.0, 0.0]], dtype=np.float64)
+        result = _douglas_peucker(coords, 0.1)
+        expected = np.array([[0.0, 0.0], [4.0, 0.0]], dtype=np.float64)
+        assert_allclose(result, expected)
+
+    def test_douglas_peucker_preserves_bend(self):
+        """DP should keep a vertex that exceeds tolerance."""
+        from ..polygonize import _douglas_peucker
+        coords = np.array([[0.0, 0.0], [2.0, 3.0], [4.0, 0.0]],
+                          dtype=np.float64)
+        # Distance of (2,3) from line (0,0)-(4,0) is 3.0
+        result = _douglas_peucker(coords, 2.0)
+        assert len(result) == 3  # all points kept
+
+    def test_douglas_peucker_removes_below_tolerance(self):
+        """DP should remove a vertex within tolerance."""
+        from ..polygonize import _douglas_peucker
+        coords = np.array([[0.0, 0.0], [2.0, 0.5], [4.0, 0.0]],
+                          dtype=np.float64)
+        # Distance of (2,0.5) from line (0,0)-(4,0) is 0.5
+        result = _douglas_peucker(coords, 1.0)
+        expected = np.array([[0.0, 0.0], [4.0, 0.0]], dtype=np.float64)
+        assert_allclose(result, expected)
+
+    def test_douglas_peucker_two_points(self):
+        """DP on two points should return them unchanged."""
+        from ..polygonize import _douglas_peucker
+        coords = np.array([[0.0, 0.0], [4.0, 0.0]], dtype=np.float64)
+        result = _douglas_peucker(coords, 1.0)
+        assert_allclose(result, coords)


### PR DESCRIPTION
## Summary

- Add `simplify_tolerance` and `simplify_method` parameters to `polygonize()`
- Two algorithms: Douglas-Peucker (distance-based) and Visvalingam-Whyatt (area-based)
- Shared-edge decomposition means adjacent polygons get the same simplified boundary, so no gaps or overlaps
- All backends (numpy, cupy, dask+numpy, dask+cupy) and all return types

Closes #1151

## Test plan

- [x] DP kernel: straight line, bend preservation, sub-tolerance removal, two-point input
- [x] VW kernel: straight line, large/small triangle area, two-point input
- [x] Shared-edge topology: vertex reduction, area preservation, shared edge identity
- [x] API validation: tolerance=None, tolerance=0, negative tolerance, bad method string
- [x] Both algorithms reduce vertices on staircase boundaries
- [x] Total area preserved after simplification
- [x] column and polygon_points stay in sync when degenerate polygons get dropped
- [x] All return types (geopandas, geojson, spatialpandas, awkward)
- [x] Dask produces same areas as numpy for both DP and VW
- [x] CuPy produces same areas as numpy
- [x] Edge cases: holes, affine transform, single-pixel raster
- [x] Backward compatible (all 77 existing tests still pass)