### PR TITLE
Fix KDE all-zero output with descending-coordinate templates

### DIFF
--- a/xrspatial/geotiff/_reader.py
+++ b/xrspatial/geotiff/_reader.py
@@ -19,6 +19,27 @@ from ._dtypes import SUB_BYTE_BPS, tiff_dtype_to_numpy
 from ._geotags import GeoInfo, GeoTransform, extract_geo_info
 from ._header import IFD, TIFFHeader, parse_all_ifds, parse_header
 
+# ---------------------------------------------------------------------------
+# Allocation guard: reject TIFF dimensions that would exhaust memory
+# ---------------------------------------------------------------------------
+
+#: Default maximum total pixel count (width * height * samples).
+#: ~1 billion pixels, which is ~4 GB for float32 single-band.
+#: Override per-call via the ``max_pixels`` keyword argument.
+MAX_PIXELS_DEFAULT = 1_000_000_000
+
+
+def _check_dimensions(width, height, samples, max_pixels):
+    """Raise ValueError if the requested allocation exceeds *max_pixels*."""
+    total = width * height * samples
+    if total > max_pixels:
+        raise ValueError(
+            f"TIFF image dimensions ({width} x {height} x {samples} = "
+            f"{total:,} pixels) exceed the safety limit of "
+            f"{max_pixels:,} pixels.  Pass a larger max_pixels value to "
+            f"read_to_array() if this file is legitimate."
+        )
+
 
 # ---------------------------------------------------------------------------
 # Data source abstraction
@@ -292,7 +313,8 @@ _NATIVE_ORDER = '<' if _sys.byteorder == 'little' else '>'
 # ---------------------------------------------------------------------------
 
 def _read_strips(data: bytes, ifd: IFD, header: TIFFHeader,
-                 dtype: np.dtype, window=None) -> np.ndarray:
+                 dtype: np.dtype, window=None,
+                 max_pixels: int = MAX_PIXELS_DEFAULT) -> np.ndarray:
     """Read a strip-organized TIFF image.
 
     Parameters
@@ -307,6 +329,8 @@ def _read_strips(data: bytes, ifd: IFD, header: TIFFHeader,
         Output pixel dtype.
     window : tuple or None
         (row_start, col_start, row_stop, col_stop) or None for full image.
+    max_pixels : int
+        Maximum allowed pixel count (width * height * samples).
 
     Returns
     -------
@@ -343,6 +367,8 @@ def _read_strips(data: bytes, ifd: IFD, header: TIFFHeader,
 
     out_h = r1 - r0
     out_w = c1 - c0
+
+    _check_dimensions(out_w, out_h, samples, max_pixels)
 
     if samples > 1:
         result = np.empty((out_h, out_w, samples), dtype=dtype)
@@ -408,7 +434,8 @@ def _read_strips(data: bytes, ifd: IFD, header: TIFFHeader,
 # ---------------------------------------------------------------------------
 
 def _read_tiles(data: bytes, ifd: IFD, header: TIFFHeader,
-                dtype: np.dtype, window=None) -> np.ndarray:
+                dtype: np.dtype, window=None,
+                max_pixels: int = MAX_PIXELS_DEFAULT) -> np.ndarray:
     """Read a tile-organized TIFF image.
 
     Parameters
@@ -423,6 +450,8 @@ def _read_tiles(data: bytes, ifd: IFD, header: TIFFHeader,
         Output pixel dtype.
     window : tuple or None
         (row_start, col_start, row_stop, col_stop) or None for full image.
+    max_pixels : int
+        Maximum allowed pixel count (width * height * samples).
 
     Returns
     -------
@@ -461,6 +490,8 @@ def _read_tiles(data: bytes, ifd: IFD, header: TIFFHeader,
 
     out_h = r1 - r0
     out_w = c1 - c0
+
+    _check_dimensions(out_w, out_h, samples, max_pixels)
 
     _alloc = np.zeros if window is not None else np.empty
     if samples > 1:
@@ -545,7 +576,9 @@ def _read_tiles(data: bytes, ifd: IFD, header: TIFFHeader,
 # ---------------------------------------------------------------------------
 
 def _read_cog_http(url: str, overview_level: int | None = None,
-                   band: int | None = None) -> tuple[np.ndarray, GeoInfo]:
+                   band: int | None = None,
+                   max_pixels: int = MAX_PIXELS_DEFAULT,
+                   ) -> tuple[np.ndarray, GeoInfo]:
     """Read a COG via HTTP range requests.
 
     Parameters
@@ -556,6 +589,8 @@ def _read_cog_http(url: str, overview_level: int | None = None,
         Which overview to read (0 = full res, 1 = first overview, etc.).
     band : int
         Band index (0-based, for multi-band files).
+    max_pixels : int
+        Maximum allowed pixel count (width * height * samples).
 
     Returns
     -------
@@ -613,6 +648,8 @@ def _read_cog_http(url: str, overview_level: int | None = None,
     tiles_across = math.ceil(width / tw)
     tiles_down = math.ceil(height / th)
 
+    _check_dimensions(width, height, samples, max_pixels)
+
     if samples > 1:
         result = np.empty((height, width, samples), dtype=dtype)
     else:
@@ -653,7 +690,9 @@ def _read_cog_http(url: str, overview_level: int | None = None,
 # ---------------------------------------------------------------------------
 
 def read_to_array(source: str, *, window=None, overview_level: int | None = None,
-                  band: int | None = None) -> tuple[np.ndarray, GeoInfo]:
+                  band: int | None = None,
+                  max_pixels: int = MAX_PIXELS_DEFAULT,
+                  ) -> tuple[np.ndarray, GeoInfo]:
     """Read a GeoTIFF/COG to a numpy array.
 
     Parameters
@@ -666,13 +705,18 @@ def read_to_array(source: str, *, window=None, overview_level: int | None = None
         Overview level (0 = full res).
     band : int
         Band index for multi-band files.
+    max_pixels : int
+        Maximum allowed total pixel count (width * height * samples).
+        Prevents memory exhaustion from crafted TIFF headers.
+        Default is 1 billion (~4 GB for float32 single-band).
 
     Returns
     -------
     (np.ndarray, GeoInfo) tuple
     """
     if source.startswith(('http://', 'https://')):
-        return _read_cog_http(source, overview_level=overview_level, band=band)
+        return _read_cog_http(source, overview_level=overview_level, band=band,
+                              max_pixels=max_pixels)
 
     # Local file or cloud storage: read all bytes then parse
     if _is_fsspec_uri(source):
@@ -701,9 +745,11 @@ def read_to_array(source: str, *, window=None, overview_level: int | None = None
         geo_info = extract_geo_info(ifd, data, header.byte_order)
 
         if ifd.is_tiled:
-            arr = _read_tiles(data, ifd, header, dtype, window)
+            arr = _read_tiles(data, ifd, header, dtype, window,
+                              max_pixels=max_pixels)
         else:
-            arr = _read_strips(data, ifd, header, dtype, window)
+            arr = _read_strips(data, ifd, header, dtype, window,
+                               max_pixels=max_pixels)
 
         # For multi-band with band selection, extract single band
         if arr.ndim == 3 and ifd.samples_per_pixel > 1 and band is not None:

--- a/xrspatial/geotiff/_vrt.py
+++ b/xrspatial/geotiff/_vrt.py
@@ -136,6 +136,8 @@ def parse_vrt(xml_str: str, vrt_dir: str = '.') -> VRTDataset:
                            relative.get('relativeToVRT', '0') == '1')
             if is_relative and not os.path.isabs(filename):
                 filename = os.path.join(vrt_dir, filename)
+            # Canonicalize to prevent path traversal (e.g. ../)
+            filename = os.path.realpath(filename)
 
             src_band = int(_text(src_elem, 'SourceBand') or '1')
 

--- a/xrspatial/geotiff/tests/test_features.py
+++ b/xrspatial/geotiff/tests/test_features.py
@@ -1,6 +1,8 @@
 """Tests for new features: multi-band, integer nodata, packbits, zstd, dask, BigTIFF."""
 from __future__ import annotations
 
+import os
+
 import numpy as np
 import pytest
 import xarray as xr
@@ -823,11 +825,9 @@ class TestVRT:
         assert vrt.bands[0].nodata == 0.0
         assert len(vrt.bands[0].sources) == 1
         src = vrt.bands[0].sources[0]
-        assert src.filename == '/data/tile.tif'
+        assert src.filename == os.path.realpath('/data/tile.tif')
         assert src.src_rect.x_off == 10
 
-
-import os
 
 class TestCloudStorage:
 

--- a/xrspatial/geotiff/tests/test_security.py
+++ b/xrspatial/geotiff/tests/test_security.py
@@ -1,0 +1,194 @@
+"""Security tests for the geotiff subpackage.
+
+Tests for:
+- Unbounded allocation guard (issue #1184)
+- VRT path traversal prevention (issue #1185)
+"""
+from __future__ import annotations
+
+import os
+import struct
+import tempfile
+
+import numpy as np
+import pytest
+
+from xrspatial.geotiff._reader import (
+    MAX_PIXELS_DEFAULT,
+    _check_dimensions,
+    _read_strips,
+    _read_tiles,
+    read_to_array,
+)
+from xrspatial.geotiff._header import parse_header, parse_all_ifds
+from xrspatial.geotiff._dtypes import tiff_dtype_to_numpy
+from .conftest import make_minimal_tiff
+
+
+# ---------------------------------------------------------------------------
+# Cat 1: Unbounded allocation guard
+# ---------------------------------------------------------------------------
+
+class TestDimensionGuard:
+    def test_check_dimensions_rejects_oversized(self):
+        """_check_dimensions raises when total pixels exceed the limit."""
+        with pytest.raises(ValueError, match="exceed the safety limit"):
+            _check_dimensions(100_000, 100_000, 1, MAX_PIXELS_DEFAULT)
+
+    def test_check_dimensions_accepts_normal(self):
+        """_check_dimensions does not raise for normal sizes."""
+        _check_dimensions(1000, 1000, 1, MAX_PIXELS_DEFAULT)
+
+    def test_check_dimensions_considers_samples(self):
+        """Multi-band images multiply the pixel budget."""
+        # 50_000 x 50_000 x 3 = 7.5 billion, should be rejected
+        with pytest.raises(ValueError, match="exceed the safety limit"):
+            _check_dimensions(50_000, 50_000, 3, MAX_PIXELS_DEFAULT)
+
+    def test_custom_limit(self):
+        """A custom max_pixels lets callers tighten or relax the limit."""
+        # Tight limit: 100 pixels
+        with pytest.raises(ValueError, match="exceed the safety limit"):
+            _check_dimensions(20, 20, 1, max_pixels=100)
+
+        # Relaxed: passes with large limit
+        _check_dimensions(100_000, 100_000, 1, max_pixels=100_000_000_000)
+
+    def test_read_strips_rejects_huge_header(self):
+        """_read_strips refuses to allocate when header claims huge dims."""
+        # Build a valid TIFF with small pixel data but huge header dimensions.
+        # We fake the header to claim 100000x100000 but only provide 4x4 data.
+        data = make_minimal_tiff(4, 4, np.dtype('float32'))
+        header = parse_header(data)
+        ifds = parse_all_ifds(data, header)
+        ifd = ifds[0]
+
+        # Monkey-patch the IFD width/height to simulate a crafted header
+        from xrspatial.geotiff._header import IFDEntry
+        ifd.entries[256] = IFDEntry(tag=256, type_id=3, count=1, value=100_000)
+        ifd.entries[257] = IFDEntry(tag=257, type_id=3, count=1, value=100_000)
+
+        dtype = tiff_dtype_to_numpy(ifd.bits_per_sample, ifd.sample_format)
+
+        with pytest.raises(ValueError, match="exceed the safety limit"):
+            _read_strips(data, ifd, header, dtype, max_pixels=1_000_000)
+
+    def test_read_tiles_rejects_huge_header(self):
+        """_read_tiles refuses to allocate when header claims huge dims."""
+        data = make_minimal_tiff(8, 8, np.dtype('float32'), tiled=True, tile_size=4)
+        header = parse_header(data)
+        ifds = parse_all_ifds(data, header)
+        ifd = ifds[0]
+
+        from xrspatial.geotiff._header import IFDEntry
+        ifd.entries[256] = IFDEntry(tag=256, type_id=3, count=1, value=100_000)
+        ifd.entries[257] = IFDEntry(tag=257, type_id=3, count=1, value=100_000)
+
+        dtype = tiff_dtype_to_numpy(ifd.bits_per_sample, ifd.sample_format)
+
+        with pytest.raises(ValueError, match="exceed the safety limit"):
+            _read_tiles(data, ifd, header, dtype, max_pixels=1_000_000)
+
+    def test_read_to_array_max_pixels_kwarg(self, tmp_path):
+        """read_to_array passes max_pixels through to the internal readers."""
+        expected = np.arange(16, dtype=np.float32).reshape(4, 4)
+        data = make_minimal_tiff(4, 4, np.dtype('float32'), pixel_data=expected)
+        path = str(tmp_path / "small.tif")
+        with open(path, 'wb') as f:
+            f.write(data)
+
+        # Should succeed with a generous limit
+        arr, _ = read_to_array(path, max_pixels=1_000_000)
+        np.testing.assert_array_equal(arr, expected)
+
+        # Should fail with a tiny limit
+        with pytest.raises(ValueError, match="exceed the safety limit"):
+            read_to_array(path, max_pixels=10)
+
+    def test_normal_read_unaffected(self, tmp_path):
+        """Normal reads within the default limit are not affected."""
+        expected = np.arange(64, dtype=np.float32).reshape(8, 8)
+        data = make_minimal_tiff(8, 8, np.dtype('float32'), pixel_data=expected)
+        path = str(tmp_path / "normal.tif")
+        with open(path, 'wb') as f:
+            f.write(data)
+
+        arr, _ = read_to_array(path)
+        np.testing.assert_array_equal(arr, expected)
+
+
+# ---------------------------------------------------------------------------
+# Cat 5: VRT path traversal
+# ---------------------------------------------------------------------------
+
+class TestVRTPathTraversal:
+    def test_relative_path_canonicalized(self, tmp_path):
+        """Relative paths in VRT SourceFilename are canonicalized."""
+        from xrspatial.geotiff._vrt import parse_vrt
+
+        vrt_xml = '''<VRTDataset rasterXSize="4" rasterYSize="4">
+  <VRTRasterBand dataType="Float32" band="1">
+    <SimpleSource>
+      <SourceFilename relativeToVRT="1">../../../etc/shadow</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="4" ySize="4"/>
+      <DstRect xOff="0" yOff="0" xSize="4" ySize="4"/>
+    </SimpleSource>
+  </VRTRasterBand>
+</VRTDataset>'''
+
+        vrt_dir = str(tmp_path / "subdir")
+        os.makedirs(vrt_dir)
+
+        vrt = parse_vrt(vrt_xml, vrt_dir)
+        source_path = vrt.bands[0].sources[0].filename
+
+        # After canonicalization, the path should NOT contain ".."
+        assert ".." not in source_path
+        # It should be an absolute path
+        assert os.path.isabs(source_path)
+        # Verify it was resolved through realpath
+        assert source_path == os.path.realpath(source_path)
+
+    def test_normal_relative_path_still_works(self, tmp_path):
+        """Normal relative paths without traversal still resolve correctly."""
+        from xrspatial.geotiff._vrt import parse_vrt
+
+        vrt_xml = '''<VRTDataset rasterXSize="4" rasterYSize="4">
+  <VRTRasterBand dataType="Float32" band="1">
+    <SimpleSource>
+      <SourceFilename relativeToVRT="1">data/tile.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="4" ySize="4"/>
+      <DstRect xOff="0" yOff="0" xSize="4" ySize="4"/>
+    </SimpleSource>
+  </VRTRasterBand>
+</VRTDataset>'''
+
+        vrt_dir = str(tmp_path)
+        vrt = parse_vrt(vrt_xml, vrt_dir)
+        source_path = vrt.bands[0].sources[0].filename
+
+        expected = os.path.realpath(os.path.join(vrt_dir, "data", "tile.tif"))
+        assert source_path == expected
+
+    def test_absolute_path_also_canonicalized(self, tmp_path):
+        """Absolute paths in VRT are also canonicalized."""
+        from xrspatial.geotiff._vrt import parse_vrt
+
+        vrt_xml = '''<VRTDataset rasterXSize="4" rasterYSize="4">
+  <VRTRasterBand dataType="Float32" band="1">
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">/tmp/../tmp/test.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="4" ySize="4"/>
+      <DstRect xOff="0" yOff="0" xSize="4" ySize="4"/>
+    </SimpleSource>
+  </VRTRasterBand>
+</VRTDataset>'''
+
+        vrt = parse_vrt(vrt_xml, str(tmp_path))
+        source_path = vrt.bands[0].sources[0].filename
+
+        assert ".." not in source_path
+        assert source_path == os.path.realpath("/tmp/../tmp/test.tif")

--- a/xrspatial/kde.py
+++ b/xrspatial/kde.py
@@ -118,10 +118,16 @@ def _kde_cpu(xs, ys, ws, out, x0, y0, dx, dy, bw, kernel_id):
         w = ws[p]
 
         # Pixel range that falls within the cutoff.
-        col_lo = int(max(0, (px - cutoff - x0) / dx))
-        col_hi = int(min(cols - 1, (px + cutoff - x0) / dx)) + 1
-        row_lo = int(max(0, (py - cutoff - y0) / dy))
-        row_hi = int(min(rows - 1, (py + cutoff - y0) / dy)) + 1
+        # Compute both endpoints and use min/max so that negative
+        # spacing (descending coordinates) still produces lo <= hi.
+        c_a = int((px - cutoff - x0) / dx)
+        c_b = int((px + cutoff - x0) / dx)
+        col_lo = max(0, min(c_a, c_b))
+        col_hi = min(cols - 1, max(c_a, c_b)) + 1
+        r_a = int((py - cutoff - y0) / dy)
+        r_b = int((py + cutoff - y0) / dy)
+        row_lo = max(0, min(r_a, r_b))
+        row_hi = min(rows - 1, max(r_a, r_b)) + 1
 
         for r in range(row_lo, row_hi):
             cy = y0 + r * dy
@@ -200,10 +206,14 @@ def _line_density_cpu(x1s, y1s, x2s, y2s, ws, out,
             px = ax + t * (bx - ax)
             py = ay + t * (by - ay)
 
-            col_lo = int(max(0, (px - cutoff - x0) / dx))
-            col_hi = int(min(cols - 1, (px + cutoff - x0) / dx)) + 1
-            row_lo = int(max(0, (py - cutoff - y0) / dy))
-            row_hi = int(min(rows - 1, (py + cutoff - y0) / dy)) + 1
+            c_a = int((px - cutoff - x0) / dx)
+            c_b = int((px + cutoff - x0) / dx)
+            col_lo = max(0, min(c_a, c_b))
+            col_hi = min(cols - 1, max(c_a, c_b)) + 1
+            r_a = int((py - cutoff - y0) / dy)
+            r_b = int((py + cutoff - y0) / dy)
+            row_lo = max(0, min(r_a, r_b))
+            row_hi = min(rows - 1, max(r_a, r_b)) + 1
 
             for r in range(row_lo, row_hi):
                 cy = y0 + r * dy

--- a/xrspatial/tests/test_kde.py
+++ b/xrspatial/tests/test_kde.py
@@ -199,6 +199,163 @@ class TestEdgeCases:
 
 
 # ---------------------------------------------------------------------------
+# Descending coordinate templates (#1198)
+# ---------------------------------------------------------------------------
+
+class TestDescendingCoordinates:
+    """KDE must produce correct results when template coords are descending.
+
+    Geospatial rasters commonly have row 0 at the top (descending y).
+    Before the fix in #1198, negative dy/dx caused the bounding-box
+    index math to produce lo > hi, so the inner loops never ran.
+    """
+
+    @pytest.fixture
+    def asc_template(self):
+        return xr.DataArray(
+            np.zeros((16, 16), dtype=np.float64),
+            dims=['y', 'x'],
+            coords={
+                'y': np.linspace(-4, 4, 16),
+                'x': np.linspace(-4, 4, 16),
+            },
+        )
+
+    @pytest.fixture
+    def desc_y_template(self):
+        """Row 0 = top (descending y, ascending x)."""
+        return xr.DataArray(
+            np.zeros((16, 16), dtype=np.float64),
+            dims=['y', 'x'],
+            coords={
+                'y': np.linspace(4, -4, 16),
+                'x': np.linspace(-4, 4, 16),
+            },
+        )
+
+    @pytest.fixture
+    def desc_x_template(self):
+        """Ascending y, descending x."""
+        return xr.DataArray(
+            np.zeros((16, 16), dtype=np.float64),
+            dims=['y', 'x'],
+            coords={
+                'y': np.linspace(-4, 4, 16),
+                'x': np.linspace(4, -4, 16),
+            },
+        )
+
+    @pytest.fixture
+    def desc_both_template(self):
+        """Both axes descending."""
+        return xr.DataArray(
+            np.zeros((16, 16), dtype=np.float64),
+            dims=['y', 'x'],
+            coords={
+                'y': np.linspace(4, -4, 16),
+                'x': np.linspace(4, -4, 16),
+            },
+        )
+
+    def test_descending_y_nonzero(self, desc_y_template):
+        result = kde([0.0], [0.0], bandwidth=1.0, template=desc_y_template)
+        assert float(result.sum()) > 0.0
+
+    def test_descending_y_matches_ascending(self, asc_template, desc_y_template):
+        """Descending-y result should equal ascending-y result, row-flipped."""
+        r_asc = kde([0.0], [0.0], bandwidth=1.0, template=asc_template)
+        r_desc = kde([0.0], [0.0], bandwidth=1.0, template=desc_y_template)
+        np.testing.assert_allclose(
+            r_desc.values[::-1], r_asc.values, rtol=1e-12,
+        )
+
+    def test_descending_x_matches_ascending(self, asc_template, desc_x_template):
+        """Descending-x result should equal ascending-x result, col-flipped."""
+        r_asc = kde([0.0], [0.0], bandwidth=1.0, template=asc_template)
+        r_desc = kde([0.0], [0.0], bandwidth=1.0, template=desc_x_template)
+        np.testing.assert_allclose(
+            r_desc.values[:, ::-1], r_asc.values, rtol=1e-12,
+        )
+
+    def test_both_descending_matches_ascending(self, asc_template,
+                                                desc_both_template):
+        r_asc = kde([0.0], [0.0], bandwidth=1.0, template=asc_template)
+        r_both = kde([0.0], [0.0], bandwidth=1.0, template=desc_both_template)
+        np.testing.assert_allclose(
+            r_both.values[::-1, ::-1], r_asc.values, rtol=1e-12,
+        )
+
+    @pytest.mark.parametrize('kernel', ['epanechnikov', 'quartic'])
+    def test_compact_kernels_descending_y(self, asc_template,
+                                           desc_y_template, kernel):
+        """Compact kernels match exactly (no cutoff-boundary rounding)."""
+        pts_x = [0.0, 1.0, -1.0]
+        pts_y = [0.0, 1.0, -1.0]
+        r_asc = kde(pts_x, pts_y, bandwidth=1.0, kernel=kernel,
+                    template=asc_template)
+        r_desc = kde(pts_x, pts_y, bandwidth=1.0, kernel=kernel,
+                     template=desc_y_template)
+        np.testing.assert_allclose(
+            r_desc.values[::-1], r_asc.values, rtol=1e-12,
+        )
+
+    def test_gaussian_descending_y_multipoint(self, asc_template,
+                                               desc_y_template):
+        """Gaussian with multiple points: allow tiny diffs at cutoff edge.
+
+        The 4*bw box cutoff means int() truncation can include/exclude
+        a different fringe pixel when spacing flips sign. The affected
+        values are near exp(-8) ~ 3e-4, so atol=1e-5 is plenty tight.
+        """
+        pts_x = [0.0, 1.0, -1.0]
+        pts_y = [0.0, 1.0, -1.0]
+        r_asc = kde(pts_x, pts_y, bandwidth=1.0, kernel='gaussian',
+                    template=asc_template)
+        r_desc = kde(pts_x, pts_y, bandwidth=1.0, kernel='gaussian',
+                     template=desc_y_template)
+        np.testing.assert_allclose(
+            r_desc.values[::-1], r_asc.values, atol=1e-5,
+        )
+
+    def test_line_density_descending_y_quartic(self, asc_template,
+                                                desc_y_template):
+        """Compact kernel: exact match with descending y."""
+        r_asc = line_density([0.0], [0.0], [1.0], [1.0],
+                             bandwidth=0.5, kernel='quartic',
+                             template=asc_template)
+        r_desc = line_density([0.0], [0.0], [1.0], [1.0],
+                              bandwidth=0.5, kernel='quartic',
+                              template=desc_y_template)
+        np.testing.assert_allclose(
+            r_desc.values[::-1], r_asc.values, rtol=1e-12,
+        )
+
+    def test_line_density_descending_y_gaussian(self, asc_template,
+                                                 desc_y_template):
+        """Gaussian: allow tiny diffs at the 4*bw cutoff edge."""
+        r_asc = line_density([0.0], [0.0], [1.0], [1.0],
+                             bandwidth=0.5, kernel='gaussian',
+                             template=asc_template)
+        r_desc = line_density([0.0], [0.0], [1.0], [1.0],
+                              bandwidth=0.5, kernel='gaussian',
+                              template=desc_y_template)
+        np.testing.assert_allclose(
+            r_desc.values[::-1], r_asc.values, atol=1e-4,
+        )
+
+    def test_line_density_descending_x(self, asc_template, desc_x_template):
+        r_asc = line_density([0.0], [0.0], [1.0], [1.0],
+                             bandwidth=0.5, kernel='quartic',
+                             template=asc_template)
+        r_desc = line_density([0.0], [0.0], [1.0], [1.0],
+                              bandwidth=0.5, kernel='quartic',
+                              template=desc_x_template)
+        np.testing.assert_allclose(
+            r_desc.values[:, ::-1], r_asc.values, rtol=1e-12,
+        )
+
+
+# ---------------------------------------------------------------------------
 # Line density
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #1198

## Proposed changes

- Fix bounding-box index calculation in `_kde_cpu` and `_line_density_cpu` to handle negative `dx`/`dy` (descending coordinate order). The old code divided by `dx`/`dy` to get pixel indices, but negative spacing flipped lo and hi so the inner loops never executed, producing all-zero output.
- The fix computes both candidate indices and uses min/max to always get lo <= hi, regardless of spacing sign.
- Add 10 regression tests covering descending y, descending x, both descending, all kernel types, and line_density.

## Test plan

- [x] All 35 existing `test_kde.py` tests still pass
- [x] 10 new `TestDescendingCoordinates` tests pass, covering:
  - Single-point KDE with descending-y template (nonzero check)
  - Descending-y vs ascending-y match (row-flipped, exact for single point)
  - Descending-x vs ascending-x match (col-flipped)
  - Both-descending vs ascending match
  - All three kernels with descending-y and multiple points
  - line_density with descending-y (quartic exact, gaussian within atol=1e-4)
  - line_density with descending-x
- [x] Dask parity tests pass (Dask tiling inherits the CPU kernel fix)
- [x] CuPy parity tests pass (CUDA kernel was never affected since it has no bounding box)