### PR TITLE
Cap dask graph size in read_geotiff_dask and batch adler32 transfers

### DIFF
--- a/xrspatial/geotiff/__init__.py
+++ b/xrspatial/geotiff/__init__.py
@@ -937,6 +937,27 @@ def read_geotiff_dask(source: str, *, dtype=None, chunks: int | tuple = 512,
     else:
         ch_h, ch_w = chunks
 
+    # Graph-size guard. Each chunk becomes a delayed task whose Python graph
+    # entry retains ~1KB. At very large chunk counts the graph itself OOMs
+    # the driver before any read executes (30TB at chunks=256 => ~500M tasks
+    # => ~500GB graph on host). Auto-scale chunks up to cap total task count.
+    _MAX_DASK_CHUNKS = 1_000_000
+    n_chunks = ((full_h + ch_h - 1) // ch_h) * ((full_w + ch_w - 1) // ch_w)
+    if n_chunks > _MAX_DASK_CHUNKS:
+        import math
+        scale = math.sqrt(n_chunks / _MAX_DASK_CHUNKS)
+        new_ch_h = int(math.ceil(ch_h * scale))
+        new_ch_w = int(math.ceil(ch_w * scale))
+        import warnings
+        warnings.warn(
+            f"read_geotiff_dask: requested chunks=({ch_h}, {ch_w}) on a "
+            f"{full_h}x{full_w} image would produce {n_chunks} dask tasks, "
+            f"exceeding the {_MAX_DASK_CHUNKS}-task cap. Auto-scaling to "
+            f"chunks=({new_ch_h}, {new_ch_w}).",
+            stacklevel=2,
+        )
+        ch_h, ch_w = new_ch_h, new_ch_w
+
     # Build dask array from delayed windowed reads
     rows = list(range(0, full_h, ch_h))
     cols = list(range(0, full_w, ch_w))

--- a/xrspatial/geotiff/_gpu_decode.py
+++ b/xrspatial/geotiff/_gpu_decode.py
@@ -1813,15 +1813,24 @@ def _nvcomp_batch_compress(d_tile_bufs, tile_byte_counts, tile_bytes,
             return None
 
         # For deflate, compute adler32 checksums from uncompressed tiles
-        # before reading compressed data (need the originals)
+        # before reading compressed data (need the originals).
+        # Batch the GPU->CPU transfer so all tiles move in a single DMA
+        # instead of one .get() per tile (which serializes on the default
+        # stream and is the dominant cost on the deflate path).
         adler_checksums = None
         if compression in (8, 32946):
             import zlib
             import struct
-            adler_checksums = []
-            for i in range(n_tiles):
-                uncomp = d_tile_bufs[i].get().tobytes()
-                adler_checksums.append(zlib.adler32(uncomp))
+            adler_checksums = [None] * n_tiles
+            if n_tiles > 0:
+                d_contig = cupy.empty(n_tiles * tile_bytes, dtype=cupy.uint8)
+                for i in range(n_tiles):
+                    d_contig[i * tile_bytes:(i + 1) * tile_bytes] = \
+                        d_tile_bufs[i][:tile_bytes]
+                host_view = memoryview(d_contig.get())
+                for i in range(n_tiles):
+                    adler_checksums[i] = zlib.adler32(
+                        host_view[i * tile_bytes:(i + 1) * tile_bytes])
 
         # Read compressed sizes and data back to CPU
         comp_sizes = d_comp_sizes.get().astype(int)


### PR DESCRIPTION
## Summary

- `read_geotiff_dask`: cap total dask chunks at 1,000,000. When the requested `chunks=` would exceed the cap, auto-scale chunk size upward and emit a `UserWarning`. Prevents driver OOM during graph construction for very large files at small chunk sizes.
- `_nvcomp_batch_compress` (deflate path): batch all tile uncompressed buffers into a single contiguous device buffer, transfer host-side once, and compute `zlib.adler32` from memoryview slices. Removes `n_tiles` per-tile `.get()` sync points and `tobytes()` copies.

## Motivation

Static analysis on 30TB-scale dask workloads flagged `read_geotiff_dask` as WILL-OOM for an unrealistic-but-legal combination: at `chunks=256` a 2.87M × 2.87M image would build ~125M spatial chunks and ~500M dask tasks. Each delayed task retains ~1KB of Python graph metadata, so the driver allocates tens to hundreds of GB for the graph alone — before any file read executes. The cap keeps the graph bounded without changing behavior for normal chunk sizes.

The adler32 finding is on the GPU write path: when nvCOMP returns raw deflate we have to wrap it in a zlib container, which needs an adler32 trailer computed from the *uncompressed* bytes. The previous code pulled each tile off the device individually, each `.get()` being a stream sync, each `.tobytes()` an extra copy. Batching gives us one DMA instead of N.

## Benchmark

Graph-construction measurement for a synthetic GeoTIFF (4096 × 4096 float32):

| chunks | tasks | wall_ms | retained MB |
|-------:|------:|--------:|------------:|
| 2048   |    16 |      65 |        0.20 |
|  512   |   256 |      81 |        0.48 |
|  256   |  1024 |     127 |        1.11 |
|  128   |  4096 |     335 |        3.76 |
|   64   | 16384 |    1138 |       14.31 |

Linear in task count confirms the O(N) graph scaling. The cap triggers only when the computed chunk count exceeds 1,000,000; at normal usage the behavior and task count are unchanged.

## Test plan

- [x] `pytest xrspatial/geotiff/tests/ -k "dask or read_geotiff"` — 12 existing tests pass
- [x] Manual smoke: verify `read_geotiff_dask` with default chunks produces no warning; verify small-chunks case emits the expected `UserWarning` with the auto-scaled tuple

## Out of scope

- CPU-side adler32 performance is unchanged (same `zlib.adler32` call per tile on host data).
- The graph-size cap is a defensive upper bound; tuning the default `chunks` size for very large files is left for a follow-up.