### PR TITLE
Fix cupy zonal_stats silently ignoring nodata_values=0 (#1227)

### DIFF
--- a/.claude/sweep-security-state.json
+++ b/.claude/sweep-security-state.json
@@ -26,6 +26,13 @@
       "severity_max": "HIGH",
       "categories_found": [1, 2],
       "notes": "HIGH: unbounded out/written allocation in _run_numpy/_run_cupy driven by user-supplied width/height/resolution (no cap). MEDIUM (unfixed): _build_row_csr_numba total=row_ptr[height] is int32 and can wrap for very tall rasters with many long edges."
+    },
+    "zonal": {
+      "last_inspected": "2026-04-22",
+      "issue": 1227,
+      "severity_max": "HIGH",
+      "categories_found": [1, 2, 6],
+      "notes": "HIGH (fixed #1227): _stats_cupy used `if nodata_values:` (truthy) so nodata_values=0 silently skipped the filter on the cupy backend, producing wrong stats vs every other backend. MEDIUM (unfixed): _strides uses np.int32 for stride indices — can wrap for arrays > ~2B elements in the numpy path. MEDIUM (unfixed): hypsometric_integral() skips _validate_raster on zones/values; _regions_numpy has no memory guard (numpy-only path, bounded by caller-allocated input). MEDIUM (unfixed): _stats_numpy return_type='xarray.DataArray' allocates np.full((n_stats, values.size)) with no guard."
     }
   }
 }

--- a/xrspatial/tests/test_zonal.py
+++ b/xrspatial/tests/test_zonal.py
@@ -801,6 +801,45 @@ def test_stats_nodata_wipes_zone(backend):
     check_results(backend, df_result, expected)
 
 
+@pytest.mark.parametrize("backend", ['numpy', 'dask+numpy', 'cupy', 'dask+cupy'])
+def test_stats_nodata_values_zero_across_backends_1227(backend):
+    """Regression: nodata_values=0 must be filtered on every backend.
+
+    The cupy path previously used `if nodata_values:` (truthiness), so passing
+    nodata_values=0 silently skipped the filter and zeros were included in
+    the per-zone statistics.  Every other backend used `is not None` and
+    dropped the zeros correctly — that divergence is what this test pins.
+    """
+    if 'cupy' in backend and not has_cuda_and_cupy():
+        pytest.skip("Requires CUDA and CuPy")
+    if 'dask' in backend and not dask_array_available():
+        pytest.skip("Requires Dask")
+
+    # Zone 1: one zero (should be dropped) and three 10s -> mean=10, count=3.
+    # Zone 2: one zero (should be dropped) and three 20s -> mean=20, count=3.
+    zones_data = np.array([[1, 1, 2, 2],
+                           [1, 1, 2, 2]], dtype=float)
+    values_data = np.array([[0.0, 10.0, 0.0, 20.0],
+                            [10.0, 10.0, 20.0, 20.0]])
+
+    zones = create_test_raster(zones_data, backend, chunks=(2, 2))
+    values = create_test_raster(values_data, backend, chunks=(2, 2))
+
+    funcs = ['mean', 'sum', 'count']
+    df_result = stats(
+        zones=zones, values=values,
+        stats_funcs=funcs, nodata_values=0,
+    )
+
+    expected = {
+        'zone':  [1, 2],
+        'mean':  [10.0, 20.0],
+        'sum':   [30.0, 60.0],
+        'count': [3, 3],
+    }
+    check_results(backend, df_result, expected)
+
+
 @pytest.mark.skipif(not dask_array_available(), reason="Requires Dask")
 @pytest.mark.parametrize("backend", ['dask+numpy', 'dask+cupy'])
 def test_stats_zone_in_subset_of_blocks(backend):

--- a/xrspatial/zonal.py
+++ b/xrspatial/zonal.py
@@ -544,7 +544,9 @@ def _stats_cupy(
     values_by_zone = values[sorted_indices]
 
     # filter out values that are non-finite or values equal to nodata_values
-    if nodata_values:
+    # Note: use `is not None` instead of truthiness so that nodata_values=0
+    # (a common sentinel) still triggers the filter, matching the numpy path.
+    if nodata_values is not None:
         filter_values = cupy.isfinite(values_by_zone) & (
             values_by_zone != nodata_values)
     else:


### PR DESCRIPTION
## Summary

Fixes #1227. `_stats_cupy` used `if nodata_values:` to decide whether to apply the nodata filter. That's a truthiness check, so `nodata_values=0` (a common sentinel for integer rasters) fell through the else branch and zeros were never dropped. Every other backend uses `if nodata_values is not None:`.

So `zonal_stats(..., nodata_values=0)` on a cupy DataArray returned different numbers than on numpy, dask+numpy, or dask+cupy, silently.

### The fix

One-line change at `xrspatial/zonal.py:547`: `is not None`, to match the rest of the module.

### Test coverage

Added `test_stats_nodata_values_zero_across_backends_1227`. It builds zones with one zero cell per zone that should be filtered out, runs `stats(..., nodata_values=0, stats_funcs=['mean', 'sum', 'count'])` on all four backends, and asserts the results match.

Before the fix the cupy case returns `mean=[7.5, 15.0]`; after, `[10.0, 20.0]` like the other backends.

### Security sweep state

Added a `zonal` entry to `.claude/sweep-security-state.json` covering this HIGH finding and the MEDIUMs I didn't fix (int32 stride overflow in `_strides`, no `_validate_raster` call in `hypsometric_integral`, no memory guard on the numpy path of `_regions_numpy`).

## Test plan

- [x] New regression test passes on all four backends locally
- [x] `pytest xrspatial/tests/test_zonal.py` fully passes (125 tests)
- [x] Confirmed the test fails without the fix (catches the exact bug)