### PR TITLE
Add security sweep state for proximity, aspect, balanced_allocation

### DIFF
--- a/.claude/sweep-security-state.json
+++ b/.claude/sweep-security-state.json
@@ -62,19 +62,26 @@
       "categories_found": [6],
       "notes": "HIGH (fixed #1232): perlin() accepted integer-dtyped DataArrays via _validate_raster, but all four backends write float noise into the input buffer in place, then normalize by ptp. With integer storage the float values cast to 0, ptp=0, and the div-by-zero produced NaN/Inf that cast back to INT_MIN on every pixel. Fixed by adding an np.issubdtype(agg.dtype, np.floating) check in perlin() that raises ValueError. MEDIUM (unfixed follow-up): _perlin_numpy/_perlin_cupy/_perlin_dask_numpy/_perlin_dask_cupy all divide by ptp/(max-min) with no zero guard, so degenerate inputs like freq=(0,0) still emit NaN through the normalization step. GPU kernels have bounds guards, shared memory is fixed-size 512 int32 (not user-influenced), cuda.syncthreads() is present after the cooperative load. No file I/O."
     },
-    "pathfinding": {
+    "proximity": {
       "last_inspected": "2026-04-22",
       "issue": null,
-      "severity_max": "MEDIUM",
-      "categories_found": [1, 6],
-      "notes": "No CRITICAL/HIGH findings. Cat 1 already well-guarded: _check_memory(h, w) runs before every numpy/cupy _a_star_search allocation and covers the ~65 bytes/pixel footprint (parent_ys/xs int64, g_cost f64, visited i8, three heap arrays h_keys/h_rows/h_cols sized h*w). Auto-radius falls back when full grid exceeds 50% RAM, HPA* kicks in for long paths. Dask path uses sparse dict/set and on-demand chunk cache so no full-grid numpy materialisation. No CUDA kernels (cupy backend transfers to CPU). No file-path I/O from user input (only /proc/meminfo read). MEDIUM (unfixed, Cat 1): multi_stop_search does not cap len(waypoints); _optimize_waypoint_order builds an O(N^2) dist matrix and runs N^2 A* calls, and _nearest_neighbor_2opt is O(N^3), so pathological waypoint lists can cause extreme CPU consumption (DoS). MEDIUM (unfixed, Cat 6): a_star_search and multi_stop_search do not call _validate_raster(surface) -- only ndim==2 is checked, dtype is not; non-numeric dtypes would fail inside numba with confusing errors rather than a clean TypeError. int64 overflow in height*width (line 214 max_heap) is not reachable given the memory guard (~46340x46340 would already raise MemoryError long before 2**63)."
+      "severity_max": null,
+      "categories_found": [],
+      "notes": "Clean. Public APIs (proximity/allocation/direction) all call _validate_raster. GPU kernel _proximity_cuda_kernel has bounds guard at lines 359-360. Dask KDTree path has explicit memory guards (lines 897-903 result array, 1297-1312 unbounded distance fallback, 681-682 cache budget). Index math uses np.int64 for pan_near_x/pan_near_y, target_counts, y_offsets/x_offsets -- no int32 overflow risk. Target detection filters NaN via np.isfinite (lines 533, 657). _calc_direction guards x1==x2 & y1==y2 before arctan2. No file I/O. LOW (not flagged): line 1235 pad_y/pad_x omit abs() while line 437 uses it -- minor inconsistency, not exploitable."
     },
-    "bump": {
-      "last_inspected": "2026-04-22",
-      "issue": 1231,
-      "severity_max": "HIGH",
-      "categories_found": [1],
-      "notes": "HIGH (fixed #1231): _finish_bump allocated np.zeros((height, width)) with no memory guard. The existing count guard (added in #1206) only protected the locs/heights arrays, so bump(width=1_000_000, height=1_000_000) passed the guard (count capped at 10M ~ 160 MB) and then tried to allocate an 8 TB float64 raster. Fixed by extending the memory budget check to include raster_bytes = w * h * 8 when the backend will materialize the full array; dask paths build per-chunk and are excluded. No other HIGH findings: _bump_dask_numpy/_bump_dask_cupy build output lazily via da.from_delayed, no CUDA kernels (cupy path wraps the numba CPU kernel), no file I/O, no int32 overflow in realistic scenarios. MEDIUM (unfixed, Cat 6): bump() does not call _validate_raster on agg (dtype is not checked; shape unpacking catches wrong-ndim, but a non-numeric DataArray would fail confusingly downstream)."
+    "aspect": {
+      "last_inspected": "2026-04-23",
+      "issue": null,
+      "severity_max": null,
+      "categories_found": [],
+      "notes": "Clean. aspect() calls _validate_raster at line 400 and _validate_boundary at line 406. northness()/eastness() delegate to aspect() so inherit validation. Cat 1: allocations match input shape. Cat 3: CPU and GPU kernels propagate NaN correctly through arctan2. Cat 4: _run_gpu (planar, aspect.py:144-147) uses combined bounds+stencil guard. _run_gpu_geodesic_aspect (geodesic.py:395) has explicit bounds check. No shared memory. Cat 5: no file I/O. Cat 6: all backends cast dtype explicitly; tests cover int32/int64/uint32/uint64/float32/float64."
+    },
+    "balanced_allocation": {
+      "last_inspected": "2026-04-23",
+      "issue": null,
+      "severity_max": null,
+      "categories_found": [],
+      "notes": "Clean. Cat 1: memory guard at lines 311-326 uses _available_memory_bytes() and raises MemoryError when total_estimate (array_bytes * (n_sources + 3)) exceeds 0.8 * avail BEFORE computing any cost surface. Trivial n_sources==0/1 paths only allocate arrays matching input size. Cat 2: np.prod(raster.shape) returns int64, no overflow. Cat 3: divisions by target_weight (lines 373, 380) are guarded by total==0 break (364) and target_weight>0 check (379); fric_weight strips NaN via np.where(np.isfinite & >0). Cat 4: no CUDA kernels. Cat 5: no file I/O. Cat 6: _validate_raster called on both raster and friction (lines 275-277)."
     }
   }
 }


### PR DESCRIPTION
## Summary

- Adds clean-inspection state entries for `proximity`, `aspect`, and `balanced_allocation` from the 2026-04-22 and 2026-04-23 security sweeps. No CRITICAL/HIGH/MEDIUM findings in any of them.
- Removes two pre-existing duplicate entries for `pathfinding` and `bump` that had crept into the file. JSON parsers only keep the last occurrence of a duplicate key, so effective state does not change.

HIGH findings from the same sweep (`viewshed`, `bilateral`) already landed via their fix PRs (#1230, #1238) so those entries were added separately.

## Test plan

- [ ] `python -c "import json; d=json.load(open('.claude/sweep-security-state.json')); assert len(d['inspections'])==12"` passes
- [ ] Entries for `proximity`, `aspect`, `balanced_allocation` are present with `issue: null`
- [ ] No duplicate keys in the file