### PR TITLE
Guard contour segment buffers against oversize allocation (#1240)

### DIFF
--- a/.claude/sweep-security-state.json
+++ b/.claude/sweep-security-state.json
@@ -83,6 +83,13 @@
       "categories_found": [],
       "notes": "Clean. aspect() calls _validate_raster at line 400 and _validate_boundary at line 406. northness()/eastness() delegate to aspect() so inherit validation. Cat 1: allocations match input shape. Cat 3: CPU and GPU kernels propagate NaN correctly through arctan2. Cat 4: _run_gpu (planar, aspect.py:144-147) uses combined bounds+stencil guard. _run_gpu_geodesic_aspect (geodesic.py:395) has explicit bounds check. No shared memory. Cat 5: no file I/O. Cat 6: all backends cast dtype explicitly; tests cover int32/int64/uint32/uint64/float32/float64."
     },
+    "contour": {
+      "last_inspected": "2026-04-23",
+      "issue": 1240,
+      "severity_max": "HIGH",
+      "categories_found": [1],
+      "notes": "HIGH (fixed #1240): _contours_numpy allocated two (max_segs_per_level, 2) float64 buffers per level with no memory check, where max_segs_per_level = 2*(ny-1)*(nx-1). A 20000x20000 raster peaked at ~12.8 GB per level before touching _stitch_segments' endpoint dict. Fixed by adding _available_memory_bytes() guard (32 bytes/segment) that raises MemoryError before np.empty when estimate > 0.5 * available. CuPy path transfers to CPU and inherits the guard; dask paths process each chunk independently and are not affected. MEDIUM (unfixed, Cat 6): contours() does not call _validate_raster -- only ndim and shape are checked, dtype is not validated (object/string dtypes would fail later with a confusing error). No CUDA kernels. No file I/O. NaN handling via self-comparison (line 50) and division-by-zero guarded in _emit_seg interpolation."
+    },
     "balanced_allocation": {
       "last_inspected": "2026-04-23",
       "issue": null,

--- a/xrspatial/contour.py
+++ b/xrspatial/contour.py
@@ -30,6 +30,23 @@ except ImportError:
     cuda = None
 
 
+def _available_memory_bytes():
+    """Best-effort estimate of available memory in bytes."""
+    try:
+        with open('/proc/meminfo', 'r') as f:
+            for line in f:
+                if line.startswith('MemAvailable:'):
+                    return int(line.split()[1]) * 1024
+    except (OSError, ValueError, IndexError):
+        pass
+    try:
+        import psutil
+        return psutil.virtual_memory().available
+    except (ImportError, AttributeError):
+        pass
+    return 2 * 1024 ** 3
+
+
 @ngjit
 def _marching_squares_kernel(data, level, seg_rows, seg_cols, seg_count):
     """Process all 2x2 quads for a single contour level.
@@ -301,6 +318,20 @@ def _contours_numpy(data, levels):
     data = np.asarray(data, dtype=np.float64)
     ny, nx = data.shape
     max_segs_per_level = (ny - 1) * (nx - 1) * 2  # worst case: every quad saddle
+
+    # Peak per level: two float64 (row, col) arrays of shape (max_segs, 2).
+    # 16 bytes per segment per array, two arrays -> 32 bytes per segment.
+    # Only one level's buffers are live at a time, so check a single level.
+    required_bytes = max_segs_per_level * 32
+    available = _available_memory_bytes()
+    if required_bytes > 0.5 * available:
+        raise MemoryError(
+            f"contours() on a {ny}x{nx} raster needs "
+            f"~{required_bytes / 1e9:.1f} GB for segment buffers per level, "
+            f"but only {available / 1e9:.1f} GB is available.  "
+            f"Pass a dask-backed agg so chunks are processed independently, "
+            f"or use a smaller raster."
+        )
 
     results = []
     for level in levels:

--- a/xrspatial/tests/test_contour.py
+++ b/xrspatial/tests/test_contour.py
@@ -348,6 +348,44 @@ class TestAccessor:
 
 
 # ---------------------------------------------------------------------------
+# Memory guard (#1240)
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryGuard:
+
+    def test_rejects_oversize_numpy(self, monkeypatch):
+        """contours() raises MemoryError when segment buffers exceed budget."""
+        import xrspatial.contour as contour_mod
+
+        # Force available memory to 1 MB so even a small raster trips the
+        # guard.  A 1000x1000 raster needs ~32 MB per level's buffers.
+        monkeypatch.setattr(
+            contour_mod, '_available_memory_bytes', lambda: 1 * 1024 * 1024
+        )
+
+        data = np.zeros((1000, 1000), dtype=np.float64)
+        agg = xr.DataArray(data, dims=['y', 'x'])
+
+        with pytest.raises(MemoryError, match="segment buffers per level"):
+            contours(agg, levels=[0.5])
+
+    def test_allows_within_budget(self, monkeypatch):
+        """A small raster stays under the guard and returns normally."""
+        import xrspatial.contour as contour_mod
+
+        monkeypatch.setattr(
+            contour_mod, '_available_memory_bytes', lambda: 8 * 1024 ** 3
+        )
+
+        data = _make_peak()
+        agg = create_test_raster(data, backend='numpy')
+        result = contours(agg, levels=[1.5])
+        assert isinstance(result, list)
+        assert len(result) > 0
+
+
+# ---------------------------------------------------------------------------
 # Reference validation against skimage.measure.find_contours
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #1240.

## Summary

`_contours_numpy` allocated two float64 `(max_segs, 2)` buffers per level with no memory check, where `max_segs = 2 * (ny-1) * (nx-1)`. A 20000x20000 raster peaks at ~12.8 GB per level before `_stitch_segments` builds its endpoint dict. `_contours_cupy` transfers to CPU and hits the same path, so both backends were reachable from a DataArray parameter.

This change adds a `_available_memory_bytes()` helper (matches the one in `bump.py`, `viewshed.py`, `pathfinding.py`) and checks the per-level buffer budget (32 bytes per segment) against half of available memory before the first `np.empty`. Dask paths process each chunk independently, so they are not affected.

Also records the contour entry in the security sweep state.

## Test plan

- [x] `pytest xrspatial/tests/test_contour.py` (24 passed)
- [x] New `TestMemoryGuard::test_rejects_oversize_numpy` - monkeypatches `_available_memory_bytes` to 1 MB and confirms `MemoryError` on a 1000x1000 raster
- [x] New `TestMemoryGuard::test_allows_within_budget` - confirms normal operation when memory is plentiful
- [x] Manual repro: 1000x1000 raster with forced 1 MB budget raises with the expected message pointing to the dask backend