### PR TITLE
Reject oversize convolution kernels before allocation (#1241)

### DIFF
--- a/.claude/sweep-security-state.json
+++ b/.claude/sweep-security-state.json
@@ -89,6 +89,13 @@
       "severity_max": null,
       "categories_found": [],
       "notes": "Clean. Cat 1: memory guard at lines 311-326 uses _available_memory_bytes() and raises MemoryError when total_estimate (array_bytes * (n_sources + 3)) exceeds 0.8 * avail BEFORE computing any cost surface. Trivial n_sources==0/1 paths only allocate arrays matching input size. Cat 2: np.prod(raster.shape) returns int64, no overflow. Cat 3: divisions by target_weight (lines 373, 380) are guarded by total==0 break (364) and target_weight>0 check (379); fric_weight strips NaN via np.where(np.isfinite & >0). Cat 4: no CUDA kernels. Cat 5: no file I/O. Cat 6: _validate_raster called on both raster and friction (lines 275-277)."
+    },
+    "convolution": {
+      "last_inspected": "2026-04-23",
+      "issue": 1241,
+      "severity_max": "HIGH",
+      "categories_found": [1],
+      "notes": "HIGH (fixed #1241): circle_kernel() and annulus_kernel() in xrspatial/convolution.py accepted a user-supplied radius with no upper bound. The kernel is built via _ellipse_kernel(half_w, half_h) where half_w = int(radius_meters/cellsize_x), so memory grew quadratically with the radius. cellsize=1, radius=100000 -> 200001x200001 float64 ~ 320 GB. annulus_kernel calls circle_kernel twice so the same hole applied. Fixed by adding _check_kernel_memory() (local _available_memory_bytes() helper like bump.py/viewshed.py) and calling it in circle_kernel before _ellipse_kernel. Budget = 32 bytes/cell to cover the output plus linspace/ellipse-mask temporaries; raises MemoryError when required > 0.5*available. No other HIGH findings: _convolve_2d_cuda has bounds guard (lines 371-373) and inner-index check (lines 384-385), no shared memory/syncthreads needed. All four backends call _promote_float on input dtype so integer inputs cast to float32 cleanly; _convolve_2d_numpy propagates NaN through multiply+accumulate. No file I/O. MEDIUM (unfixed, Cat 6): convolve_2d() does not call _validate_raster on input; non-numeric DataArray would fail inside numba/cupy with a confusing error. MEDIUM (unfixed, Cat 1): custom_kernel() does not cap kernel shape, so a caller can still pass a huge np.ones((N,N)) directly -- but that is a self-inflicted allocation outside the library, and _convolve_2d_numpy would still try to padded-allocate around it via _pad_array."
     }
   }
 }

--- a/xrspatial/convolution.py
+++ b/xrspatial/convolution.py
@@ -142,6 +142,47 @@ def calc_cellsize(raster):
     return cellsize_x, np.abs(cellsize_y)
 
 
+def _available_memory_bytes():
+    """Best-effort estimate of available memory in bytes."""
+    # Try /proc/meminfo (Linux)
+    try:
+        with open('/proc/meminfo', 'r') as f:
+            for line in f:
+                if line.startswith('MemAvailable:'):
+                    return int(line.split()[1]) * 1024
+    except (OSError, ValueError, IndexError):
+        pass
+    # Try psutil
+    try:
+        import psutil
+        return psutil.virtual_memory().available
+    except (ImportError, AttributeError):
+        pass
+    # Fallback: 2 GB
+    return 2 * 1024 ** 3
+
+
+def _check_kernel_memory(half_w, half_h, radius):
+    """Raise MemoryError if the kernel would exceed half of available RAM.
+
+    ``_ellipse_kernel`` allocates a float64 array of shape
+    ``(2*half_h + 1, 2*half_w + 1)``, plus temporaries of the same size
+    for the ellipse mask and the linspace grids.  Budget ~32 bytes per
+    cell to cover the output plus the intermediate arrays.
+    """
+    cells = (2 * half_w + 1) * (2 * half_h + 1)
+    required = cells * 32
+    available = _available_memory_bytes()
+    if required > 0.5 * available:
+        raise MemoryError(
+            f"kernel radius={radius} with cellsize implies a "
+            f"{2 * half_h + 1}x{2 * half_w + 1} kernel that needs "
+            f"~{required / 1e9:.1f} GB, but only "
+            f"{available / 1e9:.1f} GB is available. "
+            f"Use a smaller radius or a larger cellsize."
+        )
+
+
 def _ellipse_kernel(half_w, half_h):
     # x values of interest
     x = np.linspace(-half_w, half_w, 2 * half_w + 1)
@@ -199,6 +240,12 @@ def circle_kernel(cellsize_x, cellsize_y, radius):
 
     kernel_half_w = int(r / cellsize_x)
     kernel_half_h = int(r / cellsize_y)
+
+    # Guard against runaway allocation: the ellipse kernel grows
+    # quadratically with the radius, so a user-supplied radius with no
+    # cap can OOM the host (e.g. cellsize=1, radius=100000 gives a
+    # 200001x200001 float64 kernel ~ 320 GB).
+    _check_kernel_memory(kernel_half_w, kernel_half_h, radius)
 
     kernel = _ellipse_kernel(kernel_half_w, kernel_half_h)
     return kernel

--- a/xrspatial/tests/test_focal.py
+++ b/xrspatial/tests/test_focal.py
@@ -200,6 +200,30 @@ def test_kernel(kernel_circle_1_1_1, kernel_annulus_2_2_2_1):
     np.testing.assert_allclose(kernel_annulus, kernel_annulus_2_2_2_1, equal_nan=True)
 
 
+def test_circle_kernel_rejects_oversize_radius_1241():
+    # Regression test for #1241: circle_kernel() with no radius cap.
+    # cellsize=1, radius=1_000_000 implies a ~2M x 2M float64 kernel
+    # (~32 TB), which should be rejected before allocation.
+    with pytest.raises(MemoryError, match="radius=1000000"):
+        circle_kernel(1, 1, 1_000_000)
+
+
+def test_annulus_kernel_rejects_oversize_radius_1241():
+    # Regression test for #1241: annulus_kernel() calls circle_kernel
+    # twice, so the same oversize-radius guard must fire for either
+    # outer or inner radius.
+    with pytest.raises(MemoryError, match="radius=1000000"):
+        annulus_kernel(1, 1, 1_000_000, 1)
+
+
+def test_circle_kernel_small_radius_not_rejected_1241():
+    # Regression test for #1241: the guard must not fire for realistic
+    # kernel sizes.  A radius=100 on cellsize=1 gives a 201x201 kernel
+    # (~320 KB float64) which should allocate fine.
+    kernel = circle_kernel(1, 1, 100)
+    assert kernel.shape == (201, 201)
+
+
 def test_convolution_numpy(
     convolve_2d_data,
     convolution_custom_kernel,


### PR DESCRIPTION
## Summary

Fixes #1241. `circle_kernel()` and `annulus_kernel()` in `xrspatial/convolution.py` took a `radius` argument with no upper bound, so one number from the caller could drive a ~320 GB allocation on `cellsize=1, radius=100000` (or ~32 TB at `radius=1_000_000`).

Adds a local `_available_memory_bytes()` helper (same shape as the one in `bump.py` and `viewshed.py`) and a `_check_kernel_memory()` guard called inside `circle_kernel()` before `_ellipse_kernel()` runs. `annulus_kernel` inherits the guard because it calls `circle_kernel` twice. The budget is 32 bytes/cell to cover the float64 output plus the linspace and ellipse-mask temporaries, and it raises `MemoryError` when required > 0.5 * available.

Normal kernels (e.g. `circle_kernel(1, 1, 100)` -> 201x201) are unaffected.

## Test plan

- [x] `pytest xrspatial/tests/test_focal.py`: 127 existing + 3 new tests pass
- [x] `pytest xrspatial/tests/test_morphology.py`: 32 tests pass (morphology uses the kernel helpers downstream)
- [x] New regression tests:
  - `test_circle_kernel_rejects_oversize_radius_1241`: radius=1e6 raises MemoryError
  - `test_annulus_kernel_rejects_oversize_radius_1241`: radius=1e6 raises MemoryError
  - `test_circle_kernel_small_radius_not_rejected_1241`: radius=100 still builds
- [x] Updates `.claude/sweep-security-state.json` with the finding