### PR TITLE
Handle degenerate input in equal_interval (#1244)

### DIFF
--- a/xrspatial/classify.py
+++ b/xrspatial/classify.py
@@ -887,6 +887,15 @@ def _run_equal_interval(agg, k, module):
         min_data = float(min_lazy)
         max_data = float(max_lazy)
 
+    # Degenerate data: all-NaN/inf, or every finite pixel has the same value.
+    # Collapse to a single bin so finite pixels map to class 0 and any
+    # non-finite pixels remain NaN (handled by _cpu_bin's isfinite check).
+    if not np.isfinite(max_data - min_data) or max_data == min_data:
+        cut_value = max_data if np.isfinite(max_data) else 0.0
+        cuts = np.array([cut_value], dtype=np.float64)
+        out = _bin(agg, cuts, np.arange(1))
+        return out
+
     width = (max_data - min_data) / k
     # Build cuts as numpy — only k elements, no need for dask/cupy overhead
     cuts = np.arange(min_data + width, max_data + width, width)

--- a/xrspatial/tests/test_classify.py
+++ b/xrspatial/tests/test_classify.py
@@ -431,14 +431,29 @@ def test_equal_interval_k_equals_1():
     assert np.all(np.isnan(result_data[~input_finite]))
 
 
-# --- All-NaN edge cases ---
-# These document current failure behavior for degenerate inputs.
+# --- Degenerate input edge cases ---
 
 def test_equal_interval_all_nan():
     data = np.full((4, 5), np.nan)
     agg = xr.DataArray(data)
-    with pytest.raises(ValueError):
-        equal_interval(agg, k=3)
+    result = equal_interval(agg, k=3)
+    assert np.all(np.isnan(result.data))
+
+
+def test_equal_interval_all_same_values():
+    data = np.full((4, 5), 7.0)
+    agg = xr.DataArray(data)
+    result = equal_interval(agg, k=3)
+    finite_mask = np.isfinite(result.data)
+    assert np.all(result.data[finite_mask] == 0)
+
+
+def test_equal_interval_all_inf():
+    data = np.full((4, 5), np.inf)
+    agg = xr.DataArray(data)
+    result = equal_interval(agg, k=3)
+    # inf values are non-finite and should map to NaN
+    assert np.all(np.isnan(result.data))
 
 
 def test_natural_breaks_all_nan():


### PR DESCRIPTION
## Summary

Fixes #1244. `equal_interval()` crashes with `ZeroDivisionError` when `max == min` and with `ValueError` on all-NaN/inf input. Collapse the degenerate case to a single bin so finite pixels map to class 0 and non-finite pixels stay NaN, matching `std_mean`'s behavior for constant input.

## Change

In `_run_equal_interval`, check `not np.isfinite(max_data - min_data) or max_data == min_data` before computing `width`. When true, build a one-element `cuts` array and skip the `np.arange` step.

## Test plan

- [x] `test_equal_interval_all_same_values` — constant input, all finite pixels map to class 0
- [x] `test_equal_interval_all_nan` — updated from expecting ValueError to expecting all-NaN output
- [x] `test_equal_interval_all_inf` — new, all-inf input maps to all NaN
- [x] Full `test_classify.py` suite passes (87 tests)
- [x] Manual dask verification for constant and all-NaN inputs

## Background

Found during a security sweep of `classify.py` (Cat 3 MEDIUM). No HIGH/CRITICAL issues in the module.