### PR TITLE
Guard natural_breaks against oversize Jenks matrices (#1246)

### DIFF
--- a/xrspatial/classify.py
+++ b/xrspatial/classify.py
@@ -35,6 +35,23 @@ from xrspatial.utils import (
 from xrspatial.dataset_support import supports_dataset
 
 
+def _available_memory_bytes():
+    """Best-effort estimate of available memory in bytes."""
+    try:
+        with open('/proc/meminfo', 'r') as f:
+            for line in f:
+                if line.startswith('MemAvailable:'):
+                    return int(line.split()[1]) * 1024
+    except (OSError, ValueError, IndexError):
+        pass
+    try:
+        import psutil
+        return psutil.virtual_memory().available
+    except (ImportError, AttributeError):
+        pass
+    return 2 * 1024 ** 3
+
+
 @ngjit
 def _cpu_binary(data, values):
     out = np.empty(data.shape, dtype=data.dtype)
@@ -661,6 +678,24 @@ def _compute_natural_break_bins(data_flat_np, num_sample, k, max_data):
 
     # only include finite values
     sample_data = sample_data[np.isfinite(sample_data)]
+
+    # _run_jenks allocates two float64 matrices of shape
+    # (n_data + 1, n_classes + 1). Reject inputs that would exceed half of
+    # available memory so a num_sample=None call on a large raster fails
+    # fast instead of OOMing the process.
+    jenks_bytes = 2 * (sample_data.size + 1) * (k + 1) * 8
+    avail = _available_memory_bytes()
+    if jenks_bytes > 0.5 * avail:
+        raise MemoryError(
+            'natural_breaks would allocate ~{:.1f} GB for the Jenks '
+            'matrices ({} data points, k={}), exceeding the memory budget '
+            'of {:.1f} GB. Pass a smaller num_sample to subsample the '
+            'input.'.format(
+                jenks_bytes / 1024 ** 3, sample_data.size, k,
+                0.5 * avail / 1024 ** 3,
+            )
+        )
+
     uv = np.unique(sample_data)
     uvk = len(uv)
 

--- a/xrspatial/tests/test_classify.py
+++ b/xrspatial/tests/test_classify.py
@@ -417,6 +417,31 @@ def test_natural_breaks_numpy_num_sample_none(result_natural_breaks):
     general_output_checks(numpy_agg, result, expected_result, verify_dtype=True)
 
 
+# --- Memory guard for natural_breaks ---
+
+def test_natural_breaks_rejects_oversize_jenks(monkeypatch):
+    # A 400x400 raster produces 160_000 finite points -> Jenks matrices
+    # ~15 MB at k=5. Shrink the memory budget so the guard trips.
+    import xrspatial.classify as classify_mod
+    monkeypatch.setattr(
+        classify_mod, '_available_memory_bytes', lambda: 1_000_000
+    )
+    agg = xr.DataArray(np.random.RandomState(0).rand(400, 400))
+    with pytest.raises(MemoryError, match='natural_breaks would allocate'):
+        natural_breaks(agg, num_sample=None, k=5)
+
+
+def test_natural_breaks_allows_within_budget(monkeypatch):
+    # Same raster, generous budget -> no error.
+    import xrspatial.classify as classify_mod
+    monkeypatch.setattr(
+        classify_mod, '_available_memory_bytes', lambda: 8 * 1024 ** 3
+    )
+    agg = xr.DataArray(np.random.RandomState(0).rand(50, 50))
+    result = natural_breaks(agg, num_sample=None, k=3)
+    assert result.shape == (50, 50)
+
+
 # --- Edge cases for equal_interval ---
 
 def test_equal_interval_k_equals_1():


### PR DESCRIPTION
## Summary

Fixes #1246. `natural_breaks(agg, num_sample=None)` on the numpy and cupy backends skipped sampling and passed the full raster to `_run_jenks`, which allocates two `(n_data + 1, n_classes + 1)` float64 matrices. A 10000 × 10000 raster at `k=5` needed ~9.6 GB per matrix pair.

## Change

Add `_available_memory_bytes()` to `classify.py` (same pattern as `bump.py`) and check the Jenks matrix size in `_compute_natural_break_bins` after sampling and NaN-filtering. If the matrices would exceed 50% of available memory, raise `MemoryError` with a message pointing the user at `num_sample`.

The guard covers all four backends since every path funnels through `_compute_natural_break_bins`.

## Test plan

- [x] `test_natural_breaks_rejects_oversize_jenks` — shrinks the memory budget via monkeypatch and confirms a 400x400 raster trips the guard
- [x] `test_natural_breaks_allows_within_budget` — generous budget, small raster, expected success
- [x] Full `test_classify.py` suite passes (87 tests)
- [x] Existing `test_natural_breaks_all_nan` and `test_natural_breaks_numpy_num_sample_none` still behave the same

## Background

Found during a security sweep of `classify.py` (Cat 1 MEDIUM).