### PR TITLE
Guard cost_distance numpy path against oversize rasters (#1252)

### DIFF
--- a/xrspatial/cost_distance.py
+++ b/xrspatial/cost_distance.py
@@ -233,12 +233,62 @@ def _cost_distance_kernel(
 
 
 # ---------------------------------------------------------------------------
+# Memory safety helpers
+# ---------------------------------------------------------------------------
+
+# Peak working-memory footprint of _cost_distance_kernel per pixel:
+#   dist   (float64)  : 8
+#   h_keys (float64)  : 8
+#   h_rows (int64)    : 8
+#   h_cols (int64)    : 8
+#   visited (int8)    : 1
+#   out    (float32)  : 4
+# Total ~37 bytes/pixel.  Round up to 40 for intermediate temporaries.
+_BYTES_PER_PIXEL = 40
+
+
+def _available_memory_bytes():
+    """Best-effort estimate of available memory in bytes."""
+    # Try /proc/meminfo (Linux)
+    try:
+        with open('/proc/meminfo', 'r') as f:
+            for line in f:
+                if line.startswith('MemAvailable:'):
+                    return int(line.split()[1]) * 1024  # kB -> bytes
+    except (OSError, ValueError, IndexError):
+        pass
+    # Try psutil
+    try:
+        import psutil
+        return psutil.virtual_memory().available
+    except (ImportError, AttributeError):
+        pass
+    # Fallback: 2 GB
+    return 2 * 1024 ** 3
+
+
+def _check_memory(height, width):
+    """Raise MemoryError if the Dijkstra kernel would exceed 50% of RAM."""
+    required = int(height) * int(width) * _BYTES_PER_PIXEL
+    available = _available_memory_bytes()
+    if required > 0.5 * available:
+        raise MemoryError(
+            f"cost_distance on a {height}x{width} grid requires "
+            f"~{required / 1e9:.1f} GB of working memory but only "
+            f"~{available / 1e9:.1f} GB is available.  "
+            f"Set a finite `max_cost=` to bound the search, or use a "
+            f"dask-backed DataArray for out-of-core processing."
+        )
+
+
+# ---------------------------------------------------------------------------
 # NumPy wrapper
 # ---------------------------------------------------------------------------
 
 def _cost_distance_numpy(source_data, friction_data, cellsize_x, cellsize_y,
                          max_cost, target_values, dy, dx, dd):
     height, width = source_data.shape
+    _check_memory(height, width)
     return _cost_distance_kernel(
         source_data, friction_data, height, width,
         cellsize_x, cellsize_y, max_cost,
@@ -922,11 +972,7 @@ def _cost_distance_dask_iterative(source_da, friction_da,
                    np.prod(friction_da.shape) * friction_da.dtype.itemsize)
     # Working memory: tile cache (~2x dataset) + result (~1x) + boundaries
     estimated = total_bytes * 3
-    try:
-        from xrspatial.zonal import _available_memory_bytes
-        avail = _available_memory_bytes()
-    except ImportError:
-        avail = 2 * 1024**3
+    avail = _available_memory_bytes()
     if estimated > 0.8 * avail:
         raise MemoryError(
             f"cost_distance iterative Dijkstra needs ~{estimated / 1e9:.1f} GB "

--- a/xrspatial/tests/test_cost_distance.py
+++ b/xrspatial/tests/test_cost_distance.py
@@ -708,3 +708,52 @@ def test_iterative_no_rechunk_to_single():
 
     assert not single_chunk_detected[0], \
         "cost_distance rechunked to a single chunk (OOM risk)"
+
+
+# -----------------------------------------------------------------------
+# Memory guard on numpy path (Issue #1252)
+# -----------------------------------------------------------------------
+
+def test_numpy_memory_guard_raises_for_oversize_raster():
+    """Large numpy inputs should raise MemoryError before allocating."""
+    from unittest.mock import patch
+
+    source = np.zeros((4, 4))
+    source[0, 0] = 1.0
+    friction = np.ones((4, 4))
+
+    raster = _make_raster(source, backend='numpy')
+    fric = _make_raster(friction, backend='numpy')
+
+    # Pretend only 1 KB is available.  A 4x4 raster needs ~640 bytes of
+    # working memory, which sits under the 50% cutoff; bump the reported
+    # availability below 2x the required footprint to trigger the guard.
+    with patch(
+        'xrspatial.cost_distance._available_memory_bytes', return_value=1000
+    ):
+        with pytest.raises(MemoryError, match="max_cost"):
+            cost_distance(raster, fric)
+
+
+def test_numpy_memory_guard_passes_for_small_raster():
+    """A tiny raster should sail through the guard even on low-memory hosts."""
+    from unittest.mock import patch
+
+    source = np.zeros((4, 4))
+    source[0, 0] = 1.0
+    friction = np.ones((4, 4))
+
+    raster = _make_raster(source, backend='numpy')
+    fric = _make_raster(friction, backend='numpy')
+
+    # 1 MB reported available: 4x4 kernel working set is ~640 B, well under
+    # the 50% cutoff.
+    with patch(
+        'xrspatial.cost_distance._available_memory_bytes',
+        return_value=1024 * 1024,
+    ):
+        result = cost_distance(raster, fric)
+
+    out = _compute(result)
+    assert out[0, 0] == 0.0
+    np.testing.assert_allclose(out[0, 1], 1.0, atol=1e-5)


### PR DESCRIPTION
Fixes #1252.

## Summary

- `_cost_distance_kernel` allocated ~37 bytes/pixel of working memory with no size check. A 20000x20000 raster tried to grab ~15 GB before any validation and OOM-killed the process.
- Add a peak-memory guard to `_cost_distance_numpy` modelled on the viewshed #1229 fix and pathfinding's `_check_memory`: compute `40 * H * W` bytes (37 + slack for temporaries), compare against `_available_memory_bytes()`, and raise `MemoryError` pointing users at `max_cost=` or a dask-backed DataArray when the request would eat more than 50% of RAM.
- `max_cost` routes through the dask `map_overlap` path when the raster is chunked, and the guard only fires on the single-numpy-array path, so users have an immediate workaround.
- Also drops the `zonal._available_memory_bytes` import in `_cost_distance_dask_iterative` and uses the local helper instead.

## Allocations the 40 bytes/pixel covers

- `dist` (float64): 8 bytes/pixel
- `h_keys` (float64): 8 bytes/pixel
- `h_rows` (int64): 8 bytes/pixel
- `h_cols` (int64): 8 bytes/pixel
- `visited` (int8): 1 byte/pixel
- `out` (float32): 4 bytes/pixel
- Slack for temporaries: ~3 bytes/pixel

## Test plan

- [x] `test_numpy_memory_guard_raises_for_oversize_raster` patches `_available_memory_bytes` low and asserts `MemoryError` mentioning `max_cost`
- [x] `test_numpy_memory_guard_passes_for_small_raster` confirms small inputs sail through on low-memory hosts
- [x] Full `pytest xrspatial/tests/test_cost_distance.py` passes (50/50)