### PR TITLE
Allow CI to trigger on main branch

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [labeled]
   push:
-    branches: [master]
+    branches: [master, main]
 
 env:
   ASV_FACTOR: "1.2"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - main
   pull_request:
     branches:
     - '*'

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -30,7 +30,7 @@
 
     // List of branches to benchmark. If not provided, defaults to "master"
     // (for git) or "default" (for mercurial).
-    "branches": ["master"],
+    "branches": ["master", "main"],
 
     // The DVCS being used.  If not set, it will be automatically
     // determined from "repo" by looking at the protocol in the URL


### PR DESCRIPTION
## Summary
- Adds `main` to the push-trigger branch lists in `.github/workflows/test.yml` and `.github/workflows/benchmarks.yml`.
- Adds `main` to `benchmarks/asv.conf.json`'s `branches` array.
- Bridge step before renaming the default branch from `master` to `main`: keeps CI running on both branches across the rename so there is no coverage gap on either side.

## Context
This is step 1 of a planned `master` → `main` default branch rename. After this PR merges, the rename will be performed via the GitHub UI (Settings → Branches → Rename), which retargets any open PRs, migrates branch protection rules, and installs URL redirects. A follow-up PR will drop `master` from the bridge and update documentation URLs.

The `actions/checkout@master` and `actions/setup-python@master` references on lines 21 and 23 of `test.yml` point at the external actions' own repos and are unrelated to this rename. They are a separate hygiene concern and are not changed here.

## Test plan
- [ ] CI runs green on this PR (pull_request trigger fires as today, since the `pull_request` block already uses `'*'`).
- [ ] After merge, a push to `master` still triggers both workflows.
- [ ] After the GitHub branch rename, a push to `main` triggers both workflows with no gap.