### PR TITLE
Replace master references with main after default branch rename

### DIFF
--- a/.claude/commands/bench.md
+++ b/.claude/commands/bench.md
@@ -1,6 +1,6 @@
 # Bench: Local Performance Comparison
 
-Run ASV benchmarks for the current branch against master and report regressions
+Run ASV benchmarks for the current branch against main and report regressions
 and improvements. The prompt is: $ARGUMENTS
 
 ---
@@ -9,7 +9,7 @@ and improvements. The prompt is: $ARGUMENTS
 
 1. If $ARGUMENTS names specific benchmark classes or functions (e.g. `Slope`,
    `flow_accumulation`), use those directly.
-2. If $ARGUMENTS is empty or says "auto", run `git diff origin/master --name-only`
+2. If $ARGUMENTS is empty or says "auto", run `git diff origin/main --name-only`
    to find changed source files under `xrspatial/`. Map each changed file to the
    corresponding benchmark module in `benchmarks/benchmarks/`. Use the filename
    and imports to match (e.g. changes to `slope.py` map to `benchmarks/benchmarks/slope.py`).
@@ -30,7 +30,7 @@ and improvements. The prompt is: $ARGUMENTS
 Run ASV in continuous-comparison mode from the `benchmarks/` directory:
 
 ```bash
-cd benchmarks && asv continuous origin/master HEAD -b "<regex>" -e
+cd benchmarks && asv continuous origin/main HEAD -b "<regex>" -e
 ```
 
 Where `<regex>` is a pattern matching the benchmark classes identified in Step 1
@@ -64,7 +64,7 @@ Parse the output and classify each result:
 ## Step 5 -- Generate the report
 
 ```
-## Benchmark Report: <branch> vs master
+## Benchmark Report: <branch> vs main
 
 ### Changed files
 - <list of changed source files>
@@ -74,7 +74,7 @@ Parse the output and classify each result:
 
 ### Results
 
-| Benchmark                          | master    | HEAD      | Ratio | Status     |
+| Benchmark                          | main    | HEAD      | Ratio | Status     |
 |------------------------------------|-----------|-----------|-------|------------|
 | slope.Slope.time_numpy             | 3.45 ms   | 3.51 ms   | 1.02x | UNCHANGED  |
 | slope.Slope.time_dask_numpy        | 8.12 ms   | 4.23 ms   | 0.52x | IMPROVED   |
@@ -124,4 +124,4 @@ Do NOT write benchmark files automatically. Report the gap and propose, then wai
   analysis (unless the user explicitly asks for a benchmark to be written in
   response to Step 6).
 - If $ARGUMENTS says "compare <branch1> <branch2>", run
-  `asv continuous <branch1> <branch2>` instead of the default origin/master vs HEAD.
+  `asv continuous <branch1> <branch2>` instead of the default origin/main vs HEAD.

--- a/.claude/commands/efficiency-audit.md
+++ b/.claude/commands/efficiency-audit.md
@@ -267,7 +267,7 @@ Thresholds: IMPROVED < 0.8x, REGRESSION > 1.2x, else UNCHANGED.
 - If $ARGUMENTS includes a severity filter (e.g. "high only"), only report
   findings at that severity level.
 - If $ARGUMENTS includes "diff" or "changed", restrict the audit to files
-  changed on the current branch vs origin/master.
+  changed on the current branch vs origin/main.
 - Baseline benchmark scripts are disposable. Clean up `/tmp/` scripts after
   capturing results.
 - The 512x512 array size is a default. If $ARGUMENTS includes a size like

--- a/.claude/commands/release-major.md
+++ b/.claude/commands/release-major.md
@@ -16,7 +16,7 @@ $ARGUMENTS
 ## Step 2 -- Create a release branch
 
 ```bash
-git checkout master && git pull
+git checkout main && git pull
 git checkout -b release/vX.Y.Z
 ```
 
@@ -49,7 +49,7 @@ git push -u origin release/vX.Y.Z
 
 ## Step 5 -- Verify CI
 
-1. Run `gh pr create --title "Release vX.Y.Z" --body "Changelog update for vX.Y.Z major release."` to open a PR against master.
+1. Run `gh pr create --title "Release vX.Y.Z" --body "Changelog update for vX.Y.Z major release."` to open a PR against main.
 2. Wait for CI:
    ```bash
    gh pr checks <PR_NUMBER> --watch
@@ -65,7 +65,7 @@ gh pr merge <PR_NUMBER> --merge --delete-branch
 ## Step 7 -- Tag the release
 
 ```bash
-git checkout master && git pull
+git checkout main && git pull
 git tag -a vX.Y.Z -m "Version X.Y.Z"
 git push origin vX.Y.Z
 ```

--- a/.claude/commands/release-minor.md
+++ b/.claude/commands/release-minor.md
@@ -16,7 +16,7 @@ $ARGUMENTS
 ## Step 2 -- Create a release branch
 
 ```bash
-git checkout master && git pull
+git checkout main && git pull
 git checkout -b release/vX.Y.Z
 ```
 
@@ -49,7 +49,7 @@ git push -u origin release/vX.Y.Z
 
 ## Step 5 -- Verify CI
 
-1. Run `gh pr create --title "Release vX.Y.Z" --body "Changelog update for vX.Y.Z minor release."` to open a PR against master.
+1. Run `gh pr create --title "Release vX.Y.Z" --body "Changelog update for vX.Y.Z minor release."` to open a PR against main.
 2. Wait for CI:
    ```bash
    gh pr checks <PR_NUMBER> --watch
@@ -65,7 +65,7 @@ gh pr merge <PR_NUMBER> --merge --delete-branch
 ## Step 7 -- Tag the release
 
 ```bash
-git checkout master && git pull
+git checkout main && git pull
 git tag -a vX.Y.Z -m "Version X.Y.Z"
 git push origin vX.Y.Z
 ```

--- a/.claude/commands/release-patch.md
+++ b/.claude/commands/release-patch.md
@@ -16,7 +16,7 @@ $ARGUMENTS
 ## Step 2 -- Create a release branch
 
 ```bash
-git checkout master && git pull
+git checkout main && git pull
 git checkout -b release/vX.Y.Z
 ```
 
@@ -46,7 +46,7 @@ git push -u origin release/vX.Y.Z
 
 ## Step 5 -- Verify CI
 
-1. Run `gh pr create --title "Release vX.Y.Z" --body "Changelog update for vX.Y.Z patch release."` to open a PR against master.
+1. Run `gh pr create --title "Release vX.Y.Z" --body "Changelog update for vX.Y.Z patch release."` to open a PR against main.
 2. Wait for CI:
    ```bash
    gh pr checks <PR_NUMBER> --watch
@@ -62,7 +62,7 @@ gh pr merge <PR_NUMBER> --merge --delete-branch
 ## Step 7 -- Tag the release
 
 ```bash
-git checkout master && git pull
+git checkout main && git pull
 git tag -a vX.Y.Z -m "Version X.Y.Z"
 git push origin vX.Y.Z
 ```

--- a/.claude/commands/validate.md
+++ b/.claude/commands/validate.md
@@ -10,7 +10,7 @@ four backends. The prompt is: $ARGUMENTS
 
 1. If $ARGUMENTS names a specific function (e.g. `slope`, `flow_accumulation`),
    use that.
-2. If $ARGUMENTS is empty or says "auto", run `git diff origin/master --name-only`
+2. If $ARGUMENTS is empty or says "auto", run `git diff origin/main --name-only`
    to find changed source files under `xrspatial/`. Identify which public functions
    were added or modified. If multiple functions changed, validate each one.
 3. Read the function's source to understand:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [labeled]
   push:
-    branches: [master, main]
+    branches: [main]
 
 env:
   ASV_FACTOR: "1.2"
@@ -35,12 +35,12 @@ jobs:
         if: github.event_name == 'pull_request'
         working-directory: benchmarks
         run: |
-          asv continuous origin/master HEAD \
+          asv continuous origin/main HEAD \
             --factor $ASV_FACTOR \
             --bench "^(Slope|Proximity|Zonal|CostDistance|Focal|Rescale|Standardize|Diffusion|Dasymetric)" \
             | tee bench_output.txt
 
-      - name: Run benchmarks (push to master)
+      - name: Run benchmarks (push to main)
         if: github.event_name == 'push'
         working-directory: benchmarks
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,6 @@ name: pytest
 on:
   push:
     branches:
-      - master
       - main
   pull_request:
     branches:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Xarray-Spatial
 
-As stated in [Xarray Spatial code of conduct](https://github.com/xarray-contrib/xarray-spatial/blob/master/CODE_OF_CONDUCT.md), a primary goal of Xarray Spatial is to be inclusive to the largest number of contributors. However, we do have some requests for how contributions should be made. Please read these guidelines before contributing to have a most positive experience with Xarray Spatial.
+As stated in [Xarray Spatial code of conduct](https://github.com/xarray-contrib/xarray-spatial/blob/main/CODE_OF_CONDUCT.md), a primary goal of Xarray Spatial is to be inclusive to the largest number of contributors. However, we do have some requests for how contributions should be made. Please read these guidelines before contributing to have a most positive experience with Xarray Spatial.
 
 ### Getting Started
 
@@ -30,7 +30,7 @@ In order to avoid duplication of effort, it's always a good idea to comment on a
 
 2. Create a fork of the Xarray Spatial repository on GitHub (this is only done before *first*) contribution.
 
-3. Create a branch off the `master` branch with a meaningful name. Preferably include issue number and a few keywords, so that we will have a rough idea what the branch refers to, without looking up the issue. 
+3. Create a branch off the `main` branch with a meaningful name. Preferably include issue number and a few keywords, so that we will have a rough idea what the branch refers to, without looking up the issue. 
 
 4. Commit your changes and push them to GitHub.
 
@@ -40,7 +40,7 @@ In order to avoid duplication of effort, it's always a good idea to comment on a
 
 7. We don't accept code contributions without tests. If there are valid reasons for not including a test, please discuss this in the issue.
 
-8. We will review your PR as time permits. Reviewers may comment on your contributions, ask you questions regarding the implementation or request changes. If changes are requested, push new commits to the existing branch. Do *NOT* rebase, amend, or cherry-pick published commits. Any of those actions will make us start the review from scratch. If you need updates from `master`, just merge it into your branch.
+8. We will review your PR as time permits. Reviewers may comment on your contributions, ask you questions regarding the implementation or request changes. If changes are requested, push new commits to the existing branch. Do *NOT* rebase, amend, or cherry-pick published commits. Any of those actions will make us start the review from scratch. If you need updates from `main`, just merge it into your branch.
 
 
 ### Attribution

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 <tr>
   <td>License</td>
   <td>
-    <a href="https://github.com/xarray-contrib/xarray-spatial/blob/master/LICENSE.txt">
+    <a href="https://github.com/xarray-contrib/xarray-spatial/blob/main/LICENSE.txt">
     <img src="https://img.shields.io/pypi/l/xarray-spatial.svg"
          alt="MIT" />
     </a>
@@ -62,7 +62,7 @@
   <td>
     <div>
       <a href="https:https://codecov.io/gh/xarray-contrib/xarray-spatial">
-      <img alt="Language grade: Python" src="https://codecov.io/gh/xarray-contrib/xarray-spatial/branch/master/graph/badge.svg"/>
+      <img alt="Language grade: Python" src="https://codecov.io/gh/xarray-contrib/xarray-spatial/branch/main/graph/badge.svg"/>
       </a>
     </div>
   </td>

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -22,7 +22,7 @@ If you want to benchmark `cupy`-backed `DataArray`s and have the hardware and dr
 
 If you want to benchmark algorithms that use the ray-tracing code in `rtxpy`, then uncomment the `rtxpy` line in `asv.conf.json` as well as the `cupy` line.
 
-To run all benchmarks against the default `master` branch:
+To run all benchmarks against the default `main` branch:
 ```
 cd benchmarks
 asv run
@@ -30,9 +30,9 @@ asv run
 
 The first time this is run it will create a machine file to store information about your machine. Then a virtual environment will be created and each benchmark will be run multiple times to obtain a statistically valid benchmark time.
 
-To list the benchmark timings stored for the `master` branch use:
+To list the benchmark timings stored for the `main` branch use:
 ```
-asv show master
+asv show main
 ```
 
 ASV ships with its own simple webserver to interactively display the results in a webbrowser. To use this:
@@ -70,15 +70,15 @@ where the text after the `-b` flag is used as a regex to match benchmark file, c
 Benchmarking code changes
 -------------------------
 
-You can compare the performance of code on different branches and in different commits. Usually if you want to determine how much faster a new algorithm is, the old code will be in the `master` branch and the new code will be in a new feature branch. Because ASV uses virtual environments and checks out the `xarray-spatial` source code into these virtual environments, your new code must be committed into the new feature branch.
+You can compare the performance of code on different branches and in different commits. Usually if you want to determine how much faster a new algorithm is, the old code will be in the `main` branch and the new code will be in a new feature branch. Because ASV uses virtual environments and checks out the `xarray-spatial` source code into these virtual environments, your new code must be committed into the new feature branch.
 
-To benchmark the latest commits on `master` and your new feature branch, edit `asv.conf.json` to change the line
+To benchmark the latest commits on `main` and your new feature branch, edit `asv.conf.json` to change the line
 ```
-"branches": ["master"],
+"branches": ["main"],
 ```
 into
 ```
-"branches": ["master", "new_feature_branch"],
+"branches": ["main", "new_feature_branch"],
 ```
 or similar.
 

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -30,7 +30,7 @@
 
     // List of branches to benchmark. If not provided, defaults to "master"
     // (for git) or "default" (for mercurial).
-    "branches": ["master", "main"],
+    "branches": ["main"],
 
     // The DVCS being used.  If not set, it will be automatically
     // determined from "repo" by looking at the protocol in the URL

--- a/docs/source/getting_started/usage.rst
+++ b/docs/source/getting_started/usage.rst
@@ -36,7 +36,7 @@ arguments.
    ndvi_result = ndvi(my_dataset, nir='band_5', red='band_4')
 
 
-Check out the user guide `here <https://github.com/xarray-contrib/xarray-spatial/blob/master/examples/user_guide>`_.
+Check out the user guide `here <https://github.com/xarray-contrib/xarray-spatial/blob/main/examples/user_guide>`_.
 
 
 Dependencies

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,7 +24,7 @@ xarray-spatial does not depend on GDAL / GEOS, which makes it fully extensible i
 
    ---
    .. image:: _static/img/0-0.png
-      :target: https://github.com/xarray-contrib/xarray-spatial/blob/master/examples
+      :target: https://github.com/xarray-contrib/xarray-spatial/blob/main/examples
    ---
    .. image:: _static/img/0-1.png
       :target: user_guide/proximity.html
@@ -36,7 +36,7 @@ xarray-spatial does not depend on GDAL / GEOS, which makes it fully extensible i
       :target: user_guide/proximity.html
    ---
    .. image:: _static/img/0-4.png
-      :target: https://github.com/xarray-contrib/xarray-spatial/blob/master/examples/pharmacy-deserts.ipynb
+      :target: https://github.com/xarray-contrib/xarray-spatial/blob/main/examples/pharmacy-deserts.ipynb
    ---
    .. image:: _static/img/1-0.png
       :target: user_guide/surface.html
@@ -51,7 +51,7 @@ xarray-spatial does not depend on GDAL / GEOS, which makes it fully extensible i
       :target: user_guide/surface.html
    ---
    .. image:: _static/img/1-4.png
-      :target: https://github.com/xarray-contrib/xarray-spatial/blob/master/examples/pharmacy-deserts.ipynb
+      :target: https://github.com/xarray-contrib/xarray-spatial/blob/main/examples/pharmacy-deserts.ipynb
    ---
    .. image:: _static/img/2-0.png
       :target: user_guide/surface.html
@@ -66,25 +66,25 @@ xarray-spatial does not depend on GDAL / GEOS, which makes it fully extensible i
       :target: user_guide/classification.html
    ---
    .. image:: _static/img/2-4.png
-      :target: https://github.com/xarray-contrib/xarray-spatial/blob/master/examples/pharmacy-deserts.ipynb
+      :target: https://github.com/xarray-contrib/xarray-spatial/blob/main/examples/pharmacy-deserts.ipynb
    ---
    .. image:: _static/img/3-0.png
-      :target: https://github.com/xarray-contrib/xarray-spatial/blob/master/examples
+      :target: https://github.com/xarray-contrib/xarray-spatial/blob/main/examples
    ---
    .. image:: _static/img/3-1.png
-      :target: https://github.com/xarray-contrib/xarray-spatial/blob/master/examples
+      :target: https://github.com/xarray-contrib/xarray-spatial/blob/main/examples
    ---
    .. image:: _static/img/3-2.png
       :target: user_guide/classification.html
    ---
    .. image:: _static/img/3-3.png
-      :target: https://github.com/xarray-contrib/xarray-spatial/blob/master/examples/pharmacy-deserts.ipynb
+      :target: https://github.com/xarray-contrib/xarray-spatial/blob/main/examples/pharmacy-deserts.ipynb
    ---
    .. image:: _static/img/3-4.png
-      :target: https://github.com/xarray-contrib/xarray-spatial/blob/master/examples
+      :target: https://github.com/xarray-contrib/xarray-spatial/blob/main/examples
    ---
    .. image:: _static/img/4-0.png
-      :target: https://github.com/xarray-contrib/xarray-spatial/blob/master/examples/Pathfinding_Austin_Road_Network.ipynb
+      :target: https://github.com/xarray-contrib/xarray-spatial/blob/main/examples/Pathfinding_Austin_Road_Network.ipynb
    ---
    .. image:: _static/img/4-1.png
       :target: user_guide/surface.html#Hillshade
@@ -96,7 +96,7 @@ xarray-spatial does not depend on GDAL / GEOS, which makes it fully extensible i
       :target: user_guide/surface.html#Slope
    ---
    .. image:: _static/img/4-4.png
-      :target: https://github.com/xarray-contrib/xarray-spatial/blob/master/examples/pharmacy-deserts.ipynb#Create-a-%22Distance-to-Nearest-Pharmacy%22-Layer-&-Classify-into-5-Groups
+      :target: https://github.com/xarray-contrib/xarray-spatial/blob/main/examples/pharmacy-deserts.ipynb#Create-a-%22Distance-to-Nearest-Pharmacy%22-Layer-&-Classify-into-5-Groups
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
## Summary
- Removes `master` from the CI push-trigger bridge added in #1255 — `test.yml` and `benchmarks.yml` now trigger only on `main`.
- Updates the ASV benchmark comparison baseline from `origin/master` to `origin/main` and adjusts the step label.
- Sets `benchmarks/asv.conf.json` branches list to `["main"]`.
- Updates `README.md` (license link, Codecov badge) and `CONTRIBUTING.md` prose.
- Updates `docs/source/index.rst` (10 example URLs), `docs/source/getting_started/usage.rst`, and `benchmarks/README.md`.
- Updates `.claude/commands/` release, bench, validate, and efficiency-audit scripts.

## Context
Second step of the `master` → `main` default branch rename. The first PR (#1255) widened CI triggers to accept both names so there was no coverage gap across the GitHub-side rename. This PR drops the bridge now that `main` is the default.

A few "master" occurrences are intentionally left alone:
- `actions/checkout@master` and `actions/setup-python@master` in `.github/workflows/test.yml` — these refer to the `master` branches of the *actions' own repos*, not this one. Unpinned `@master` is a separate hygiene concern worth a follow-up PR to pin to `@v4`/`@v5`.
- `master_doc` references in `docs/source/conf.py` and Sphinx templates — this is Sphinx's own config variable name.
- The ASV default-branch comment in `asv.conf.json` — documents ASV's upstream behavior, not this project's branch.

## Contributor migration
If you have a local clone of this repository, run:

\`\`\`bash
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
git remote prune origin
\`\`\`

## Test plan
- [ ] CI passes on this PR (pull_request trigger fires as before).
- [ ] After merge, a push to \`main\` triggers both \`pytest\` and \`Benchmarks\` workflows.
- [ ] The Codecov badge on \`README.md\` renders correctly on the \`main\` branch.
- [ ] Docs rebuild successfully on Read the Docs with the new \`/blob/main/\` URLs.