### PR TITLE
Guard diffuse() against unbounded allocations and steps loop (#1267)

### DIFF
--- a/.claude/sweep-security-state.json
+++ b/.claude/sweep-security-state.json
@@ -153,6 +153,13 @@
       "severity_max": null,
       "categories_found": [],
       "notes": "Clean. Small (271 LOC) module computing 3x3 second-derivative stencil. Cat 1: only single output buffer matching input shape (np.empty at line 37, cupy.empty at line 101) -- bounded by caller, per audit guidance not a finding. Cat 2: _cpu numba kernel uses range(1, rows-1)/range(1, cols-1) with simple (y, x) indices; no flat indexing or queue arrays; numba range loops produce int64. Cat 3: division by cellsize*cellsize on line 44 -- cellsize comes from get_dataarray_resolution() (raster property, not user-direct); cellsize=0 is unrealistic and would produce inf consistently across backends. NaN inputs propagate correctly through float arithmetic. Cat 4: _run_gpu (line 79-86) has full bounds guard via 'i + di <= out.shape[0] - 1 and j + dj <= out.shape[1] - 1' which guarantees i < shape[0] and j < shape[1] before the out[i, j] write; no shared memory; out is pre-filled with NaN at line 102 so threads outside the guard correctly leave NaN. Cat 5: no file I/O. Cat 6: curvature() calls _validate_raster at line 253; all four backend paths explicitly cast to float32 (lines 51, 62, 97, 112) so dtype is normalized before any computation; tests cover int32/int64/uint32/uint64/float32/float64 across numpy/cupy/dask+numpy/dask+cupy."
+    },
+    "diffusion": {
+      "last_inspected": "2026-04-25",
+      "issue": 1267,
+      "severity_max": "HIGH",
+      "categories_found": [1],
+      "notes": "HIGH (fixed #1267): diffuse() had no memory guard on its core allocations and steps was unbounded. (1) The public API allocated np.full(agg.shape) for scalar diffusivity even when the dispatched backend was dask, forcing a full numpy alpha raster up front -- a 100kx100k input would OOM on an 80 GB allocation before any backend dispatch. (2) _diffuse_step_numpy and _diffuse_cupy allocated per-step buffers with no memory check. (3) steps was validated only with min_val=1, so steps=10**12 was accepted and would loop forever. Fixed by adding _check_memory/_check_gpu_memory helpers (cost_distance pattern, ~32 B/pixel budget for u + out + alpha + padded copy at 50% of available RAM/VRAM), deferring the np.full alpha allocation until after the guard runs in eager paths, teaching _diffuse_dask_cupy to handle scalar alpha lazily via cp.full per chunk (mirroring _diffuse_dask_numpy), and capping steps at _MAX_STEPS = 100_000 in _validate_scalar. No other HIGH findings: GPU kernel _diffuse_step_gpu has bounds guard (if i < rows and j < cols), no shared memory, _validate_raster called on agg and on diffusivity DataArray, NaN check uses val != val correctly, no file I/O, no int32 indexing."
     }
   }
 }

--- a/xrspatial/diffusion.py
+++ b/xrspatial/diffusion.py
@@ -45,6 +45,91 @@ from xrspatial.utils import (
 )
 
 
+# ---------------------------------------------------------------------------
+# Memory guard
+# ---------------------------------------------------------------------------
+#
+# Per-step working set on the eager numpy / cupy paths:
+#   * u           : rows*cols  float64 (8 B)
+#   * out         : rows*cols  float64 (8 B)
+#   * alpha_arr   : rows*cols  float64 (8 B)   (only when materialised)
+#   * padded copy : rows*cols  float64 (8 B)   (rough upper bound for the
+#                                              padded buffer, ignoring the
+#                                              1-cell border)
+# Total ~32 bytes per pixel.  For dask paths the equivalent footprint is
+# per-chunk and is bounded by chunk size, so the public-API guard targets
+# the eager paths only.
+_BYTES_PER_PIXEL = 32
+
+# Hard cap on the number of explicit Euler iterations a single diffuse()
+# call will run.  100k steps on a modest 1024x1024 raster is already minutes
+# of CPU work; anything beyond this is almost certainly a misuse.
+_MAX_STEPS = 100_000
+
+
+def _available_memory_bytes():
+    """Best-effort estimate of available memory in bytes."""
+    try:
+        with open('/proc/meminfo', 'r') as f:
+            for line in f:
+                if line.startswith('MemAvailable:'):
+                    return int(line.split()[1]) * 1024  # kB -> bytes
+    except (OSError, ValueError, IndexError):
+        pass
+    try:
+        import psutil
+        return psutil.virtual_memory().available
+    except (ImportError, AttributeError):
+        pass
+    return 2 * 1024 ** 3  # 2 GB fallback
+
+
+def _available_gpu_memory_bytes():
+    """Best-effort estimate of free GPU memory in bytes.
+
+    Returns 0 when the query fails -- callers treat that as a sentinel
+    meaning "no GPU info, skip the guard".
+    """
+    try:
+        import cupy as _cp
+        free, _total = _cp.cuda.runtime.memGetInfo()
+        return int(free)
+    except Exception:
+        return 0
+
+
+def _check_memory(rows, cols):
+    """Raise MemoryError if the eager numpy diffuse buffers exceed 50% of RAM."""
+    required = int(rows) * int(cols) * _BYTES_PER_PIXEL
+    available = _available_memory_bytes()
+    if required > 0.5 * available:
+        raise MemoryError(
+            f"diffuse() on a {rows}x{cols} raster needs "
+            f"~{required / 1e9:.1f} GB of working memory, but only "
+            f"~{available / 1e9:.1f} GB is available. "
+            f"Use a dask-backed DataArray for out-of-core processing."
+        )
+
+
+def _check_gpu_memory(rows, cols):
+    """Raise MemoryError if the CuPy diffuse buffers exceed 50% of free GPU RAM.
+
+    Skipped (returns silently) when the free-memory query fails -- the
+    kernel will then fail at the cupy.asarray boundary anyway.
+    """
+    available = _available_gpu_memory_bytes()
+    if available <= 0:
+        return
+    required = int(rows) * int(cols) * _BYTES_PER_PIXEL
+    if required > 0.5 * available:
+        raise MemoryError(
+            f"diffuse() on a {rows}x{cols} raster needs "
+            f"~{required / 1e9:.1f} GB of GPU working memory, but only "
+            f"~{available / 1e9:.1f} GB is free on the active device. "
+            f"Use a dask+cupy DataArray for out-of-core processing."
+        )
+
+
 # ---- numpy backend ----
 
 @ngjit
@@ -74,6 +159,7 @@ def _diffuse_step_numpy(u, alpha_arr, dt_over_dx2, rows, cols):
 
 def _diffuse_numpy(data, alpha_arr, steps, dt_over_dx2, boundary):
     rows, cols = data.shape
+    _check_memory(rows, cols)
     u = data.astype(np.float64)
     for _ in range(steps):
         if boundary == 'nan':
@@ -110,9 +196,10 @@ def _diffuse_step_gpu(u, alpha_arr, dt_over_dx2, out):
 def _diffuse_cupy(data, alpha_arr, steps, dt_over_dx2, boundary):
     import cupy as cp
 
+    rows, cols = data.shape
+    _check_gpu_memory(rows, cols)
     u = cp.asarray(data, dtype=cp.float64)
     alpha_dev = cp.asarray(alpha_arr, dtype=cp.float64)
-    rows, cols = u.shape
     bpg, tpb = calc_cuda_dims((rows, cols))
 
     for _ in range(steps):
@@ -200,9 +287,12 @@ def _diffuse_dask_numpy(data, alpha, steps, dt_over_dx2, boundary):
 def _diffuse_chunk_cupy(chunk, alpha_chunk, dt_over_dx2, block_info=None):
     import cupy as cp
 
-    alpha_dev = cp.asarray(alpha_chunk[1:-1, 1:-1], dtype=cp.float64)
     rows = chunk.shape[0] - 2
     cols = chunk.shape[1] - 2
+    if np.ndim(alpha_chunk) == 0:
+        alpha_dev = cp.full((rows, cols), float(alpha_chunk), dtype=cp.float64)
+    else:
+        alpha_dev = cp.asarray(alpha_chunk[1:-1, 1:-1], dtype=cp.float64)
     bpg, tpb = calc_cuda_dims((rows, cols))
     out = cp.empty((rows, cols), dtype=cp.float64)
     _diffuse_step_gpu[bpg, tpb](chunk, alpha_dev, dt_over_dx2, out)
@@ -212,22 +302,32 @@ def _diffuse_chunk_cupy(chunk, alpha_chunk, dt_over_dx2, block_info=None):
     return result
 
 
-def _diffuse_dask_cupy(data, alpha_arr, steps, dt_over_dx2, boundary):
+def _diffuse_dask_cupy(data, alpha, steps, dt_over_dx2, boundary):
     import cupy as cp
 
-    _func = partial(
-        _diffuse_chunk_cupy,
-        alpha_chunk=alpha_arr,
-        dt_over_dx2=dt_over_dx2,
-    )
     u = data.astype(cp.float64)
     for _ in range(steps):
-        u = u.map_overlap(
-            _func,
-            depth=(1, 1),
-            boundary=_boundary_to_dask(boundary, is_cupy=True),
-            meta=cp.array(()),
-        )
+        if isinstance(alpha, (int, float, np.floating)):
+            _func = partial(
+                _diffuse_chunk_cupy,
+                alpha_chunk=float(alpha),
+                dt_over_dx2=dt_over_dx2,
+            )
+            u = u.map_overlap(
+                _func,
+                depth=(1, 1),
+                boundary=_boundary_to_dask(boundary, is_cupy=True),
+                meta=cp.array(()),
+            )
+        else:
+            u = da.map_overlap(
+                _diffuse_chunk_cupy,
+                u, alpha,
+                depth=(1, 1),
+                boundary=_boundary_to_dask(boundary, is_cupy=True),
+                meta=cp.array(()),
+                dt_over_dx2=dt_over_dx2,
+            )
     return u
 
 
@@ -256,7 +356,8 @@ def diffuse(
         DataArray of the same shape allows spatially varying
         diffusivity.
     steps : int, default 1
-        Number of time steps to run.
+        Number of time steps to run.  Capped at 100,000 to prevent a
+        single call from pinning a CPU indefinitely.
     dt : float or None
         Time step size.  When ``None`` the largest stable step is
         chosen automatically: ``dt = 0.25 * dx**2 / max(alpha)``.
@@ -272,11 +373,19 @@ def diffuse(
         Scalar field after *steps* diffusion steps.
     """
     _validate_raster(agg, func_name='diffuse', name='agg', ndim=2)
-    _validate_scalar(steps, func_name='diffuse', name='steps', dtype=int, min_val=1)
+    _validate_scalar(
+        steps,
+        func_name='diffuse',
+        name='steps',
+        dtype=int,
+        min_val=1,
+        max_val=_MAX_STEPS,
+    )
     _validate_boundary(boundary)
 
     # resolve diffusivity
-    #   - scalar: keep as float for dask paths (avoids full-raster allocation)
+    #   - scalar: keep as float; only materialised to a full raster if the
+    #     dispatched backend is eager (numpy/cupy) and actually needs it
     #   - DataArray: keep as .data (numpy/cupy/dask) for backend dispatch
     if isinstance(diffusivity, xr.DataArray):
         _validate_raster(diffusivity, func_name='diffuse', name='diffusivity', ndim=2)
@@ -302,7 +411,10 @@ def diffuse(
             )
         alpha_scalar = float(diffusivity)
         alpha_data = None
-        alpha_arr_eager = np.full(agg.shape, alpha_scalar, dtype=np.float64)
+        # Defer the np.full allocation: dask paths can use the scalar
+        # directly, and the eager paths build their own broadcast view
+        # below after passing the memory guard.
+        alpha_arr_eager = None
     else:
         raise TypeError(
             f"diffuse(): diffusivity must be a float or xr.DataArray, "
@@ -337,15 +449,33 @@ def diffuse(
 
     dt_over_dx2 = float(dt) / (dx * dx)
 
-    # Build the alpha argument for each backend:
-    #   - numpy/cupy eager: always use alpha_arr_eager (full numpy array)
-    #   - dask: use alpha_scalar (float) or alpha_data (dask array)
-    if alpha_arr_eager is None and alpha_data is not None:
-        # Dask DataArray diffusivity, numpy path not yet built
-        alpha_arr_eager = alpha_data.compute()
-        if hasattr(alpha_arr_eager, 'get'):
-            alpha_arr_eager = alpha_arr_eager.get()
-        alpha_arr_eager = np.asarray(alpha_arr_eager, dtype=np.float64)
+    # Decide which backend will run before materialising any full-raster
+    # alpha buffer.  This matters for the dask + scalar case: we want to
+    # leave alpha as a scalar all the way through to the per-chunk worker
+    # rather than allocating an N*M float64 raster up front.
+    is_eager_numpy = isinstance(agg.data, np.ndarray)
+    is_eager_cupy = (
+        has_cuda_and_cupy() and is_cupy_array(agg.data)
+    )
+    needs_eager_alpha = is_eager_numpy or is_eager_cupy
+
+    if needs_eager_alpha and alpha_arr_eager is None:
+        if alpha_scalar is not None:
+            # Run the memory guard *before* allocating the full raster.
+            # The guard already accounts for alpha_arr in its budget.
+            rows_, cols_ = agg.shape
+            if is_eager_cupy:
+                _check_gpu_memory(rows_, cols_)
+            else:
+                _check_memory(rows_, cols_)
+            alpha_arr_eager = np.full(agg.shape, alpha_scalar, dtype=np.float64)
+        elif alpha_data is not None:
+            # Dask DataArray diffusivity but the input array itself is eager.
+            # This is unusual but supported: materialise alpha now.
+            alpha_arr_eager = alpha_data.compute()
+            if hasattr(alpha_arr_eager, 'get'):
+                alpha_arr_eager = alpha_arr_eager.get()
+            alpha_arr_eager = np.asarray(alpha_arr_eager, dtype=np.float64)
 
     dask_alpha = alpha_scalar if alpha_scalar is not None else alpha_data
 
@@ -360,7 +490,7 @@ def diffuse(
         dask_func=partial(_diffuse_dask_numpy, alpha=dask_alpha,
                           steps=steps, dt_over_dx2=dt_over_dx2,
                           boundary=boundary),
-        dask_cupy_func=partial(_diffuse_dask_cupy, alpha_arr=alpha_arr_eager,
+        dask_cupy_func=partial(_diffuse_dask_cupy, alpha=dask_alpha,
                                steps=steps, dt_over_dx2=dt_over_dx2,
                                boundary=boundary),
     )

--- a/xrspatial/tests/test_diffusion.py
+++ b/xrspatial/tests/test_diffusion.py
@@ -217,3 +217,130 @@ def test_diffusivity_shape_mismatch():
 def test_non_dataarray_input():
     with pytest.raises(TypeError):
         diffuse(np.ones((5, 5)))
+
+
+# ---- security guards (issue #1267) ----
+
+def test_steps_upper_bound_rejected():
+    """`steps` above the safety cap should raise ValueError."""
+    data = np.ones((4, 4))
+    agg = create_test_raster(data)
+    with pytest.raises(ValueError, match='steps'):
+        diffuse(agg, steps=10**12)
+
+
+def test_max_steps_constant_documented():
+    """The documented step cap should match _MAX_STEPS."""
+    from xrspatial.diffusion import _MAX_STEPS
+    assert _MAX_STEPS == 100_000
+
+
+def test_oversize_raster_raises_memory_error(monkeypatch):
+    """A raster whose buffers exceed the memory budget should raise."""
+    import xrspatial.diffusion as _diff
+
+    # Pretend the host has only 16 MB of available RAM.
+    monkeypatch.setattr(_diff, '_available_memory_bytes',
+                        lambda: 16 * 1024 * 1024)
+
+    # 4096x4096 float64 buffers = ~512 MB peak working set, well over
+    # 50% of 16 MB.
+    data = np.ones((4096, 4096), dtype=np.float64)
+    agg = create_test_raster(data, attrs={'res': (1.0, 1.0)})
+
+    with pytest.raises(MemoryError, match='diffuse'):
+        diffuse(agg, diffusivity=1.0, steps=1, boundary='nearest')
+
+
+def test_dask_scalar_diffusivity_does_not_materialize_alpha(monkeypatch):
+    """Dask + scalar diffusivity must not call np.full at agg.shape.
+
+    Regression for issue #1267: the public API used to call
+    np.full(agg.shape, alpha) up front, even when the dispatched
+    backend was dask + scalar (which can pass the scalar through).
+    A 100kx100k input would force an 80 GB numpy alloc.
+    """
+    if not _has_dask:
+        pytest.skip('dask not available')
+
+    import xrspatial.diffusion as _diff
+
+    calls = []
+    real_full = np.full
+
+    def tracking_full(shape, *args, **kwargs):
+        calls.append(tuple(shape) if hasattr(shape, '__iter__') else (shape,))
+        return real_full(shape, *args, **kwargs)
+
+    monkeypatch.setattr(_diff.np, 'full', tracking_full)
+
+    data = np.ones((64, 64), dtype=np.float64)
+    dask_agg = create_test_raster(data, backend='dask',
+                                  attrs={'res': (1.0, 1.0)},
+                                  chunks=(16, 16))
+
+    diffuse(dask_agg, diffusivity=0.5, steps=2,
+            boundary='nearest').data.compute()
+
+    full_shape_calls = [c for c in calls if c == data.shape]
+    assert full_shape_calls == [], (
+        f"np.full was called with the full raster shape {data.shape}: "
+        f"{full_shape_calls}. Scalar diffusivity on a dask path should "
+        f"not materialise a full numpy alpha array."
+    )
+
+
+def test_dask_scalar_matches_dask_array_diffusivity():
+    """Scalar-alpha and uniform-array-alpha dask paths should agree."""
+    if not _has_dask:
+        pytest.skip('dask not available')
+
+    data = _make_hotspot((11, 11))
+    dask_agg = create_test_raster(data, backend='dask',
+                                  attrs={'res': (1.0, 1.0)},
+                                  chunks=(6, 6))
+    alpha_xr = create_test_raster(np.full((11, 11), 0.5),
+                                  backend='dask',
+                                  attrs={'res': (1.0, 1.0)},
+                                  chunks=(6, 6))
+
+    r_scalar = diffuse(dask_agg, diffusivity=0.5, steps=3,
+                       boundary='nearest')
+    r_array = diffuse(dask_agg, diffusivity=alpha_xr, steps=3,
+                      boundary='nearest')
+
+    np.testing.assert_allclose(
+        r_scalar.data.compute(), r_array.data.compute(), rtol=1e-12
+    )
+
+
+def test_oversize_raster_raises_before_alpha_alloc(monkeypatch):
+    """The memory guard fires before np.full(agg.shape) runs."""
+    import xrspatial.diffusion as _diff
+
+    monkeypatch.setattr(_diff, '_available_memory_bytes',
+                        lambda: 16 * 1024 * 1024)
+
+    full_calls = []
+    real_full = np.full
+
+    def tracking_full(shape, *args, **kwargs):
+        full_calls.append(shape)
+        return real_full(shape, *args, **kwargs)
+
+    monkeypatch.setattr(_diff.np, 'full', tracking_full)
+
+    data = np.ones((4096, 4096), dtype=np.float64)
+    agg = create_test_raster(data, attrs={'res': (1.0, 1.0)})
+
+    with pytest.raises(MemoryError):
+        diffuse(agg, diffusivity=1.0, steps=1, boundary='nearest')
+
+    oversize_full_calls = [
+        c for c in full_calls
+        if hasattr(c, '__iter__') and tuple(c) == data.shape
+    ]
+    assert oversize_full_calls == [], (
+        f"np.full was called with the oversize shape {data.shape} "
+        f"before the memory guard: {oversize_full_calls}"
+    )


### PR DESCRIPTION
Closes #1267.

## Summary

- Adds peak-memory guards (`_check_memory` / `_check_gpu_memory`, cost_distance pattern, ~32 B/pixel) that fire before the eager numpy / cupy paths allocate per-step buffers.
- Stops materialising `np.full(agg.shape, alpha)` up front for scalar diffusivity. Dask paths now keep the scalar through to the per-chunk worker; eager paths only build the full alpha raster after the memory guard runs.
- Teaches `_diffuse_dask_cupy` to handle scalar alpha lazily via `cp.full` per chunk, matching `_diffuse_dask_numpy`.
- Caps `steps` at `_MAX_STEPS = 100_000` via `_validate_scalar(max_val=...)` so a single call can't pin a CPU forever.

## Test plan

- [x] All existing diffusion tests still pass (15/15)
- [x] New test: oversize raster raises `MemoryError` (with `_available_memory_bytes` monkeypatched)
- [x] New test: dask + scalar diffusivity does not call `np.full(agg.shape)`
- [x] New test: dask scalar-alpha matches dask DataArray-alpha (uniform value)
- [x] New test: `steps=10**12` raises `ValueError`
- [x] New test: memory guard fires before `np.full` runs on the oversize input