### PR TITLE
Validate cellsize in curvature() (#1270)

### DIFF
--- a/.claude/sweep-security-state.json
+++ b/.claude/sweep-security-state.json
@@ -140,6 +140,13 @@
       "categories_found": [1],
       "notes": "HIGH (fixed #1256): morph_erode/morph_dilate/morph_opening/morph_closing/morph_gradient/morph_white_tophat/morph_black_tophat accepted a user-supplied kernel with only shape/dtype/odd-size validation. Kernel dimensions drove np.pad/cp.pad on every backend and map_overlap depth on dask paths; a 99999x99999 kernel on a 1000x1000 raster would try to allocate ~80 GB of padded float64 memory with no warning. Fixed by adding local _available_memory_bytes() helper and _check_kernel_memory(rows, cols, ky, kx) that raises MemoryError before allocation when padded size exceeds 50% of available RAM; wired into _dispatch() so every public API entry point is guarded across all four backends. Mirrors bilateral #1236, convolution #1241, bump #1231. No other HIGH findings: Cat 2 (loop indices are Python ints, numba promotes to int64), Cat 3 (NaN propagation explicit via v!=v in both numpy and CUDA paths, tests verify), Cat 4 (GPU kernels _erode_gpu/_dilate_gpu have if i<rows and j<cols bounds guards, no shared memory), Cat 5 (no file I/O), Cat 6 (_validate_raster called in _dispatch, all backends cast to float64 before kernel)."
     },
+    "curvature": {
+      "last_inspected": "2026-04-25",
+      "issue": 1270,
+      "severity_max": "MEDIUM",
+      "categories_found": [3],
+      "notes": "MEDIUM (fixed #1270): curvature() divided by (cellsize * cellsize) in every backend kernel with no zero guard. cellsize came from get_dataarray_resolution(agg) which reads agg.attrs['res']; a raster with res=(0, 0) (or one zero component) produced inf for every interior pixel instead of a clean error. Fixed by validating cellsize_x/cellsize_y in the public curvature() API before backend dispatch and raising ValueError when either component is zero or non-finite (np.inf / np.nan). Inner numba/cupy kernels untouched. All four backends (numpy, cupy, dask+numpy, dask+cupy) inherit the check. No other findings: _validate_raster and _validate_boundary already in place; GPU kernel _run_gpu has bounds guard at curvature.py:84-86; _run_dask_numpy/_run_dask_cupy use map_overlap with depth=(1,1) bounded by chunk size; no file I/O; no int32 index math."
+    },
     "cost_distance": {
       "last_inspected": "2026-04-25",
       "issue": 1262,

--- a/xrspatial/curvature.py
+++ b/xrspatial/curvature.py
@@ -253,6 +253,14 @@ def curvature(agg: xr.DataArray,
     _validate_raster(agg, func_name='curvature', name='agg')
 
     cellsize_x, cellsize_y = get_dataarray_resolution(agg)
+    if (not np.isfinite(cellsize_x) or not np.isfinite(cellsize_y)
+            or cellsize_x == 0 or cellsize_y == 0):
+        raise ValueError(
+            "curvature() requires a non-zero, finite cell size on both axes; "
+            f"got cellsize_x={cellsize_x!r}, cellsize_y={cellsize_y!r}. "
+            "Set agg.attrs['res'] to a (x, y) tuple of non-zero floats, "
+            "or attach numeric x/y coordinates to the DataArray."
+        )
     cellsize = (cellsize_x + cellsize_y) / 2
 
     _validate_boundary(boundary)

--- a/xrspatial/tests/test_curvature.py
+++ b/xrspatial/tests/test_curvature.py
@@ -164,3 +164,15 @@ def test_boundary_invalid():
     agg = create_test_raster(data, attrs={'res': (1, 1)})
     with pytest.raises(ValueError, match="boundary must be one of"):
         curvature(agg, boundary='invalid')
+
+
+@pytest.mark.parametrize("res", [(0, 0), (0, 1), (1, 0),
+                                 (np.inf, 1), (1, np.nan)])
+def test_curvature_invalid_cellsize(res):
+    """curvature() must reject zero or non-finite cell sizes instead of
+    silently returning inf for every interior pixel.
+    """
+    data = np.zeros((5, 5), dtype=np.float32)
+    agg = create_test_raster(data, attrs={'res': res})
+    with pytest.raises(ValueError, match="non-zero, finite cell size"):
+        curvature(agg)


### PR DESCRIPTION
## Summary

Fixes #1270.

`curvature()` divided by `cellsize * cellsize` in every backend kernel with no zero guard. A raster whose `res` attribute was `(0, 0)` (or had one zero component) produced `inf` for every interior pixel instead of a clean error.

This validates `cellsize_x` and `cellsize_y` from `get_dataarray_resolution(agg)` in the public `curvature()` API before backend dispatch and raises `ValueError` when either component is zero or non-finite. Inner numba/cupy kernels are unchanged. All four backends (numpy, cupy, dask+numpy, dask+cupy) inherit the check.

Cat 3 (NaN/Inf as logic error) MEDIUM-severity finding from the recent security sweep.

## Changes

- `xrspatial/curvature.py`: validate cellsize in `curvature()` before dispatch, raise `ValueError` when either component is zero or non-finite.
- `xrspatial/tests/test_curvature.py`: parametrized test covering `res=(0, 0)`, `(0, 1)`, `(1, 0)`, `(inf, 1)`, `(1, nan)`.
- `.claude/sweep-security-state.json`: record the curvature inspection.

## Test plan

- [x] `pytest xrspatial/tests/test_curvature.py -x` (80 passed, 5 new)
- [x] Existing curvature tests still pass
- [x] New test confirms `ValueError` is raised instead of returning inf