### PR TITLE
Validate input rasters in edge_detection public API (#1271)

### DIFF
--- a/.claude/sweep-security-state.json
+++ b/.claude/sweep-security-state.json
@@ -153,6 +153,13 @@
       "severity_max": null,
       "categories_found": [],
       "notes": "Clean. Small (271 LOC) module computing 3x3 second-derivative stencil. Cat 1: only single output buffer matching input shape (np.empty at line 37, cupy.empty at line 101) -- bounded by caller, per audit guidance not a finding. Cat 2: _cpu numba kernel uses range(1, rows-1)/range(1, cols-1) with simple (y, x) indices; no flat indexing or queue arrays; numba range loops produce int64. Cat 3: division by cellsize*cellsize on line 44 -- cellsize comes from get_dataarray_resolution() (raster property, not user-direct); cellsize=0 is unrealistic and would produce inf consistently across backends. NaN inputs propagate correctly through float arithmetic. Cat 4: _run_gpu (line 79-86) has full bounds guard via 'i + di <= out.shape[0] - 1 and j + dj <= out.shape[1] - 1' which guarantees i < shape[0] and j < shape[1] before the out[i, j] write; no shared memory; out is pre-filled with NaN at line 102 so threads outside the guard correctly leave NaN. Cat 5: no file I/O. Cat 6: curvature() calls _validate_raster at line 253; all four backend paths explicitly cast to float32 (lines 51, 62, 97, 112) so dtype is normalized before any computation; tests cover int32/int64/uint32/uint64/float32/float64 across numpy/cupy/dask+numpy/dask+cupy."
+    },
+    "edge_detection": {
+      "last_inspected": "2026-04-25",
+      "issue": 1271,
+      "severity_max": "MEDIUM",
+      "categories_found": [6],
+      "notes": "MEDIUM (fixed #1271): the five public functions sobel_x, sobel_y, laplacian, prewitt_x, prewitt_y did not call _validate_raster on agg. Non-DataArray inputs raised AttributeError from agg.data and wrong-ndim DataArrays failed inside numba/cupy with confusing errors instead of clean TypeError/ValueError. Numerical correctness was unaffected because convolve_2d._promote_float casts integer dtypes to float32 before the kernel runs. Fixed by adding _validate_raster(agg, func_name=..., name='agg') at the top of each function. No CRITICAL/HIGH findings: convolve_2d enforces 3x3 odd kernels and 2D agg.data, allocations match input shape, no CUDA kernels owned by this module, no file I/O."
     }
   }
 }

--- a/xrspatial/edge_detection.py
+++ b/xrspatial/edge_detection.py
@@ -2,6 +2,7 @@ import numpy as np
 import xarray as xr
 
 from xrspatial.convolution import convolve_2d
+from xrspatial.utils import _validate_raster
 
 # -- Sobel kernels ----------------------------------------------------------
 SOBEL_X = np.array([[-1, 0, 1],
@@ -50,6 +51,7 @@ def sobel_x(agg, name='sobel_x', boundary='nan'):
     xarray.DataArray
         Horizontal gradient with the same shape and backend as the input.
     """
+    _validate_raster(agg, func_name='sobel_x', name='agg')
     out = convolve_2d(agg.data, SOBEL_X, boundary)
     return xr.DataArray(out, name=name, coords=agg.coords,
                         dims=agg.dims, attrs=agg.attrs)
@@ -78,6 +80,7 @@ def sobel_y(agg, name='sobel_y', boundary='nan'):
     xarray.DataArray
         Vertical gradient with the same shape and backend as the input.
     """
+    _validate_raster(agg, func_name='sobel_y', name='agg')
     out = convolve_2d(agg.data, SOBEL_Y, boundary)
     return xr.DataArray(out, name=name, coords=agg.coords,
                         dims=agg.dims, attrs=agg.attrs)
@@ -106,6 +109,7 @@ def laplacian(agg, name='laplacian', boundary='nan'):
     xarray.DataArray
         Laplacian response with the same shape and backend as the input.
     """
+    _validate_raster(agg, func_name='laplacian', name='agg')
     out = convolve_2d(agg.data, LAPLACIAN_KERNEL, boundary)
     return xr.DataArray(out, name=name, coords=agg.coords,
                         dims=agg.dims, attrs=agg.attrs)
@@ -134,6 +138,7 @@ def prewitt_x(agg, name='prewitt_x', boundary='nan'):
     xarray.DataArray
         Horizontal gradient with the same shape and backend as the input.
     """
+    _validate_raster(agg, func_name='prewitt_x', name='agg')
     out = convolve_2d(agg.data, PREWITT_X, boundary)
     return xr.DataArray(out, name=name, coords=agg.coords,
                         dims=agg.dims, attrs=agg.attrs)
@@ -162,6 +167,7 @@ def prewitt_y(agg, name='prewitt_y', boundary='nan'):
     xarray.DataArray
         Vertical gradient with the same shape and backend as the input.
     """
+    _validate_raster(agg, func_name='prewitt_y', name='agg')
     out = convolve_2d(agg.data, PREWITT_Y, boundary)
     return xr.DataArray(out, name=name, coords=agg.coords,
                         dims=agg.dims, attrs=agg.attrs)

--- a/xrspatial/tests/test_edge_detection.py
+++ b/xrspatial/tests/test_edge_detection.py
@@ -202,6 +202,33 @@ class TestEdgeCases:
 
 
 # ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+class TestInputValidation:
+    @pytest.mark.parametrize('func', [sobel_x, sobel_y, laplacian, prewitt_x, prewitt_y])
+    def test_non_dataarray_raises_type_error(self, func):
+        # plain numpy array should be rejected with a clean TypeError,
+        # not an AttributeError from agg.data
+        with pytest.raises(TypeError, match='must be an xarray.DataArray'):
+            func(np.zeros((5, 5), dtype=np.float64))
+
+    @pytest.mark.parametrize('func', [sobel_x, sobel_y, laplacian, prewitt_x, prewitt_y])
+    def test_1d_dataarray_raises_value_error(self, func):
+        # 1-D input should raise ValueError, not fail later inside the kernel
+        agg = xr.DataArray(np.zeros(10, dtype=np.float64), dims=['x'])
+        with pytest.raises(ValueError, match='2D'):
+            func(agg)
+
+    @pytest.mark.parametrize('func', [sobel_x, sobel_y, laplacian, prewitt_x, prewitt_y])
+    def test_3d_dataarray_raises_value_error(self, func):
+        agg = xr.DataArray(np.zeros((3, 5, 6), dtype=np.float64),
+                           dims=['z', 'y', 'x'])
+        with pytest.raises(ValueError, match='2D'):
+            func(agg)
+
+
+# ---------------------------------------------------------------------------
 # Boundary modes
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Add `_validate_raster(agg)` at the top of `sobel_x`, `sobel_y`, `laplacian`, `prewitt_x`, and `prewitt_y`. The sibling modules (aspect, slope, curvature, bilateral) already do this; edge_detection was the outlier.
- Add tests for `np.ndarray`, 1-D DataArray, and 3-D DataArray inputs across all five functions. Non-DataArray now raises `TypeError`, wrong-ndim raises `ValueError`.
- Record the inspection in `.claude/sweep-security-state.json` (severity MEDIUM, Cat 6).

Cat 6 finding from the latest security sweep. Numerical correctness was not affected because `convolve_2d._promote_float` already casts integer dtypes to float32. This is purely an error-message UX fix.

Closes #1271.

## Test plan

- [x] `pytest xrspatial/tests/test_edge_detection.py -x` (87 passed)
- [x] New `TestInputValidation` class covers all five public functions across three failure modes