### PR TITLE
Guard true_color() eager backends against oversized rasters (#1291)

### DIFF
--- a/xrspatial/multispectral.py
+++ b/xrspatial/multispectral.py
@@ -26,6 +26,79 @@ except ImportError:
     da = None
 
 
+# Memory guard for the eager true_color() backends.
+# _true_color_numpy / _true_color_cupy materialize an (H, W, 4) uint8 cube
+# plus three (H, W) float32 normalize buffers and one (H, W) alpha buffer
+# from np.where -- roughly 17 bytes per input pixel at peak.  Round up to
+# a comfortable budget that also covers the temporaries inside
+# _normalize_data_cpu (val - min_val, exp(...), etc.).  Dask paths build
+# the cube lazily via da.stack and don't need the guard.
+_TRUE_COLOR_BYTES_PER_PIXEL = 24
+
+
+def _available_memory_bytes():
+    """Best-effort estimate of available host memory in bytes."""
+    try:
+        with open('/proc/meminfo', 'r') as f:
+            for line in f:
+                if line.startswith('MemAvailable:'):
+                    return int(line.split()[1]) * 1024  # kB -> bytes
+    except (OSError, ValueError, IndexError):
+        pass
+    try:
+        import psutil
+        return psutil.virtual_memory().available
+    except (ImportError, AttributeError):
+        pass
+    return 2 * 1024 ** 3  # 2 GB fallback
+
+
+def _available_gpu_memory_bytes():
+    """Best-effort estimate of free GPU memory in bytes.
+
+    Returns 0 when the query fails -- callers treat that as a sentinel
+    meaning "no GPU info, skip the guard".
+    """
+    try:
+        import cupy as _cp
+        free, _total = _cp.cuda.runtime.memGetInfo()
+        return int(free)
+    except Exception:
+        return 0
+
+
+def _check_true_color_memory(rows, cols):
+    """Raise MemoryError if the numpy true_color buffers exceed 50% of RAM."""
+    required = int(rows) * int(cols) * _TRUE_COLOR_BYTES_PER_PIXEL
+    available = _available_memory_bytes()
+    if required > 0.5 * available:
+        raise MemoryError(
+            f"true_color() on a {rows}x{cols} raster needs "
+            f"~{required / 1e9:.1f} GB of working memory, but only "
+            f"~{available / 1e9:.1f} GB is available. "
+            f"Use a smaller raster or a dask-backed DataArray."
+        )
+
+
+def _check_true_color_gpu_memory(rows, cols):
+    """Raise MemoryError if the cupy true_color buffers exceed 50% of free VRAM.
+
+    Skipped silently when the free-memory query fails -- the cupy
+    allocator will surface its own error in that case.
+    """
+    available = _available_gpu_memory_bytes()
+    if available <= 0:
+        return
+    required = int(rows) * int(cols) * _TRUE_COLOR_BYTES_PER_PIXEL
+    if required > 0.5 * available:
+        raise MemoryError(
+            f"true_color() on a {rows}x{cols} raster needs "
+            f"~{required / 1e9:.1f} GB of GPU working memory, but only "
+            f"~{available / 1e9:.1f} GB is free on the active device. "
+            f"Use a smaller raster or a dask+cupy DataArray."
+        )
+
+
 @ngjit
 def _arvi_cpu(nir_data, red_data, blue_data):
     out = np.full(nir_data.shape, np.nan, dtype=np.float32)
@@ -1600,9 +1673,11 @@ def _normalize_data(agg, pixel_max, c, th):
 
 
 def _true_color_numpy(r, g, b, nodata, c, th):
+    h, w = r.shape
+    _check_true_color_memory(h, w)
+
     a = np.where(np.logical_or(np.isnan(r), r <= nodata), 0, 255)
 
-    h, w = r.shape
     out = np.zeros((h, w, 4), dtype=np.uint8)
 
     pixel_max = 255
@@ -1629,6 +1704,9 @@ def _true_color_dask(r, g, b, nodata, c, th):
 
 
 def _true_color_cupy(r, g, b, nodata, c, th):
+    h, w = r.shape
+    _check_true_color_gpu_memory(h, w)
+
     pixel_max = 255
     r_data = r.data
     a = cupy.where(
@@ -1686,6 +1764,14 @@ def true_color(r, g, b, nodata=1, c=10.0, th=0.125, name='true_color'):
     true_color_agg : xarray.DataArray of the same type as inputs
         3D array true color image with dims of [y, x, band].
         All output attributes are copied from red band image.
+
+    Raises
+    ------
+    MemoryError
+        On the numpy and cupy backends, raised when the projected peak
+        working memory (about 24 bytes per input pixel) exceeds 50% of
+        available host RAM or free GPU VRAM.  Use a smaller raster or a
+        dask-backed DataArray for out-of-core processing.
 
     Examples
     --------

--- a/xrspatial/tests/test_multispectral.py
+++ b/xrspatial/tests/test_multispectral.py
@@ -762,6 +762,84 @@ def test_true_color_gpu(random_data, backend):
     )
 
 
+# true_color memory guards ----------
+def test_true_color_numpy_memory_guard(monkeypatch):
+    """Numpy true_color path raises MemoryError before allocation when the
+    projected footprint exceeds 50% of available RAM."""
+    from xrspatial import multispectral
+
+    # Pretend only 1 MB of RAM is available.  Even a 2x2 raster needs
+    # 24 * 2 * 2 = 96 bytes which is under 0.5 * 1 MB, so we also pretend
+    # the request is huge by faking a much larger raster shape via
+    # patching _check_true_color_memory's input.  Cleaner: use a 10000x10000
+    # raster shape but only allocate a 2x2 array, by patching _check first.
+    monkeypatch.setattr(
+        multispectral, '_available_memory_bytes', lambda: 1024 * 1024
+    )
+
+    red = xr.DataArray(np.ones((2, 2), dtype=np.float32), dims=['y', 'x'])
+    green = xr.DataArray(np.ones((2, 2), dtype=np.float32), dims=['y', 'x'])
+    blue = xr.DataArray(np.ones((2, 2), dtype=np.float32), dims=['y', 'x'])
+    red = red.assign_coords(y=[0, 1], x=[0, 1])
+    green = green.assign_coords(y=[0, 1], x=[0, 1])
+    blue = blue.assign_coords(y=[0, 1], x=[0, 1])
+
+    # 2x2 with 1 MB available is fine -- guard should pass.
+    out = multispectral.true_color(red, green, blue)
+    assert out.shape == (2, 2, 4)
+
+    # Now call _check_true_color_memory directly with a "huge" shape to
+    # confirm it raises before any allocation runs.
+    with pytest.raises(MemoryError, match='true_color'):
+        multispectral._check_true_color_memory(100_000, 100_000)
+
+
+def test_true_color_numpy_memory_guard_blocks_large_input(monkeypatch):
+    """End-to-end: the numpy true_color path raises MemoryError at the
+    public API entry, before np.zeros runs."""
+    from xrspatial import multispectral
+
+    # 100x100 raster, but pretend only 1000 bytes of RAM are free.  The
+    # 24 bytes/pixel * 100 * 100 = 240_000 byte budget exceeds 0.5 * 1000
+    # by orders of magnitude, so the guard fires.
+    monkeypatch.setattr(multispectral, '_available_memory_bytes', lambda: 1000)
+
+    red = xr.DataArray(np.ones((100, 100), dtype=np.float32), dims=['y', 'x'])
+    green = xr.DataArray(np.ones((100, 100), dtype=np.float32), dims=['y', 'x'])
+    blue = xr.DataArray(np.ones((100, 100), dtype=np.float32), dims=['y', 'x'])
+    red = red.assign_coords(y=np.arange(100), x=np.arange(100))
+    green = green.assign_coords(y=np.arange(100), x=np.arange(100))
+    blue = blue.assign_coords(y=np.arange(100), x=np.arange(100))
+
+    with pytest.raises(MemoryError, match='100x100'):
+        multispectral.true_color(red, green, blue)
+
+
+def test_true_color_gpu_memory_guard_silent_when_query_fails(monkeypatch):
+    """The GPU guard is a no-op when _available_gpu_memory_bytes returns 0
+    (cupy not installed or memGetInfo failed)."""
+    from xrspatial import multispectral
+
+    monkeypatch.setattr(
+        multispectral, '_available_gpu_memory_bytes', lambda: 0
+    )
+    # No raise: even a "100kx100k" input is allowed past the guard since
+    # the helper returned 0.
+    multispectral._check_true_color_gpu_memory(100_000, 100_000)
+
+
+def test_true_color_gpu_memory_guard_raises_when_oversized(monkeypatch):
+    """When free GPU memory is reported as small, _check_true_color_gpu_memory
+    raises MemoryError for an oversized request."""
+    from xrspatial import multispectral
+
+    monkeypatch.setattr(
+        multispectral, '_available_gpu_memory_bytes', lambda: 1024 * 1024
+    )
+    with pytest.raises(MemoryError, match='GPU working memory'):
+        multispectral._check_true_color_gpu_memory(100_000, 100_000)
+
+
 # NDSI ----------
 @pytest.fixture
 def expected_ndsi():


### PR DESCRIPTION
Closes #1291.

## Summary

- The numpy and cupy `true_color()` paths in `xrspatial/multispectral.py` materialized an `(H, W, 4)` uint8 output cube plus three `(H, W)` float32 buffers from the per-band sigmoid normalize step plus an alpha buffer, with no memory check. A 50000x50000 raster asked for around 42 GB and surfaced as an opaque allocator error.
- This PR adds `_available_memory_bytes` / `_available_gpu_memory_bytes` helpers and `_check_true_color_memory` / `_check_true_color_gpu_memory` budget checks that raise `MemoryError` before the first allocation when the 24 bytes/pixel footprint exceeds 50% of available RAM or free VRAM. Same shape as the guards already in `dasymetric.py`, `cost_distance.py`, and `diffusion.py`.
- Dask paths build the cube lazily through `da.stack` and `map_blocks`, so they are not affected and the guard is not wired into them.
- Adds four new tests covering the numpy guard (direct call and end-to-end via `true_color()`) and the GPU guard (silent fallback when `memGetInfo` is unavailable, raises when free VRAM is small).

## Test plan

- [x] `pytest xrspatial/tests/test_multispectral.py` passes (151/151).
- [x] `pytest xrspatial/tests/test_multispectral.py -k true_color` passes (40/40), including the four new memory-guard tests.
- [x] Manually confirmed the new error message includes the raster shape and the available-memory hint.

## Out of scope (follow-up)

The same audit also flagged a Cat 6 MEDIUM finding: `true_color()` doesn't call `validate_arrays(r, g, b)` to enforce equal shape across bands. That gets a separate issue and PR per the project's one-fix-per-security-PR policy.
