### PR TITLE
Make /sweep-performance dispatch fix subagents in parallel

### DIFF
--- a/.claude/commands/sweep-performance.md
+++ b/.claude/commands/sweep-performance.md
@@ -1,36 +1,29 @@
-# Performance Sweep: Parallel Triage and Fix Workflow
+# Performance Sweep: Dispatch subagents to audit and fix performance issues
 
 Audit xrspatial modules for performance bottlenecks, OOM risk under 30TB dask
-workloads, and backend-specific anti-patterns. Dispatches parallel subagents
-for fast triage, then generates a ralph-loop to benchmark and fix HIGH-severity
-issues.
+workloads, and backend-specific anti-patterns. Subagents fix HIGH-severity
+findings via /rockout in the same agent that did the audit, in parallel.
 
 Optional arguments: $ARGUMENTS
 (e.g. `--top 5`, `--exclude slope,aspect`, `--only-io`, `--reset-state`)
 
 ---
 
-## Step 0 -- Determine mode and parse arguments
+## Step 0 -- Parse arguments
 
 Parse $ARGUMENTS for these flags (multiple may combine):
 
 | Flag | Effect |
 |------|--------|
-| `--top N` | Limit Phase 1 to the top N scored modules (default: all) |
+| `--top N` | Audit only the top N scored modules (default: 3) |
 | `--exclude mod1,mod2` | Remove named modules from scope |
 | `--only-terrain` | Restrict to: slope, aspect, curvature, terrain, terrain_metrics, hillshade, sky_view_factor |
 | `--only-focal` | Restrict to: focal, convolution, morphology, bilateral, edge_detection, glcm |
 | `--only-hydro` | Restrict to: flood, cost_distance, geodesic, surface_distance, viewshed, erosion, diffusion |
 | `--only-io` | Restrict to: geotiff, reproject, rasterize, polygonize |
 | `--reset-state` | Delete `.claude/sweep-performance-state.csv` and treat all modules as never-inspected |
-| `--skip-phase1` | Skip triage; reuse last state file; go straight to ralph-loop generation for unresolved HIGH items |
-| `--report-only` | Run Phase 1 triage but do not generate a ralph-loop command |
-| `--size small` | Phase 2 benchmarks use 128x128 arrays |
-| `--size large` | Phase 2 benchmarks use 2048x2048 arrays |
-| `--high-only` | Only report HIGH severity findings in the triage output |
-
-If `--skip-phase1` is set, jump to Step 6 (ralph-loop generation).
-Otherwise proceed to Step 1.
+| `--no-fix` | Audit only; subagents do not run /rockout. Useful for re-triage without producing PRs. |
+| `--high-only` | Drop modules whose state row shows zero HIGH findings from the last triage within the past 30 days. |
 
 ## Step 1 -- Discover modules in scope
 
@@ -40,9 +33,9 @@ Enumerate all candidate modules. For each, record its file path(s):
 `__init__.py`, `_version.py`, `__main__.py`, `utils.py`, `accessor.py`,
 `preview.py`, `dataset_support.py`, `diagnostics.py`, `analytics.py`.
 
-**Subpackage modules:** The `geotiff/` and `reproject/` directories under
-`xrspatial/`. Treat each subpackage as a single audit unit. List all `.py`
-files within each (excluding `__init__.py`).
+**Subpackage modules:** The `geotiff/`, `reproject/`, and `hydro/` directories
+under `xrspatial/`. Treat each subpackage as a single audit unit. List all
+`.py` files within each (excluding `__init__.py`).
 
 Apply `--only-*` and `--exclude` filters from Step 0 to narrow the list.
 
@@ -81,19 +74,16 @@ slope,2026-04-15,SAFE,compute-bound,0,,"optional single-line notes"
 - `notes` is CSV-quoted; newlines must be flattened to spaces on write so
   every module stays exactly one line.
 
-There is no top-level `last_triage` field; the most recent triage date is
-derivable as `max(last_inspected)` across rows.
-
 The file is registered with `merge=union` in `.gitattributes`, so two
 parallel sweeps touching different modules auto-merge without conflict.
 A transient duplicate-row state can occur after a merge if both branches
-modified the same module; the read-update-write cycle in step 5 keys rows
-by `module` and last-write-wins, so the next write cleans up.
+modified the same module; the read-update-write cycle in the agent prompt
+keys rows by `module` and last-write-wins, so the next write cleans up.
 
 ### Compute scores
 
 ```
-days_since_inspected = (today - last_perf_inspected).days   # 9999 if never
+days_since_inspected = (today - last_inspected).days   # 9999 if never
 days_since_modified  = (today - last_modified).days
 
 score = (days_since_inspected * 3)
@@ -106,432 +96,230 @@ score = (days_since_inspected * 3)
       - (has_existing_bench * 100)
 ```
 
-Sort modules by score descending. If `--top N` is set, keep only the top N.
+Sort modules by score descending. Apply `--top N` (default 3).
 
-## Step 3 -- Dispatch parallel subagents for static triage
+If `--high-only` is set, drop any module whose state row shows
+`high_count == 0` AND `last_inspected` is within the last 30 days. The
+filter only looks at past triage results — it cannot predict findings on a
+never-inspected module.
 
-For each module in the scored list, dispatch a subagent using the Agent tool.
-Launch ALL subagents in a single message (parallel dispatch). Each subagent
-receives the prompt below, with `MODULE_NAME` and `MODULE_FILES` substituted.
+## Step 3 -- Print the ranked table and launch subagents
 
-**Subagent prompt template:**
+### 3a. Print the ranked table
+
+Print a markdown table showing ALL scored modules (not just selected ones),
+sorted by score descending:
+
+```
+| Rank | Module          | Score  | Last Inspected | Dask | CUDA | IO  | LOC  |
+|------|-----------------|--------|----------------|------|------|-----|------|
+| 1    | geotiff         | 30600  | never          | yes  | no   | yes | 1400 |
+| 2    | viewshed        | 30050  | never          | yes  | yes  | no  | 800  |
+| ...  | ...             | ...    | ...            | ...  | ...  | ... | ...  |
+```
+
+### 3b. Launch subagents for the top N modules
+
+For each of the top N modules (default 3), launch an Agent in parallel using
+`isolation: "worktree"` and `mode: "auto"`. All N agents must be dispatched
+in a single message so they run concurrently.
+
+Each agent's prompt must be self-contained and follow this template (adapt
+the module name, paths, and metadata):
 
 ~~~
-You are auditing the xrspatial module "MODULE_NAME" for performance issues.
+You are auditing the xrspatial module "{module}" for performance issues.
 
-Read these files: MODULE_FILES
+This module has {commits} commits and {loc} lines of code.
 
-Perform ALL of the following analyses and return your findings as a single
-JSON object. Do NOT modify any files. This is read-only analysis.
+Read these files: {module_files}
 
-### 1. Dask Path Analysis
+Also read xrspatial/utils.py for _validate_raster() behavior, and
+xrspatial/tests/general_checks.py for cross-backend test helpers.
 
-Trace every dask code path (_run_dask, _run_dask_cupy, or any function that
-receives dask-backed DataArrays). Flag these patterns with severity:
+**Your task:**
 
-- HIGH: `.values` on a dask-backed DataArray or CuPy array (premature materialization)
-- HIGH: `.compute()` inside a loop (materializes full graph each iteration)
-- HIGH: `np.array()` or `np.asarray()` wrapping a dask or CuPy array
-- MEDIUM: `da.stack()` without a following `.rechunk()`
-- MEDIUM: `map_overlap` with depth >= chunk_size / 4
-- MEDIUM: Missing `boundary` argument in `map_overlap`
-- MEDIUM: Same function called twice on same input without caching
-- MEDIUM: Python `for` loop iterating over dask chunks (serializes the graph)
+1. Read all listed files thoroughly, including the matching test file(s)
+   under xrspatial/tests/.
 
-If the module has NO dask code path, note "no dask backend" and skip.
+2. Audit for these 6 categories. For each, look for the specific patterns
+   described. Only flag issues ACTUALLY present in the code.
 
-### 2. 30TB / 16GB OOM Verdict
+   **Cat 1 — Dask materialization**
+   - HIGH: `.values` on a dask-backed DataArray or CuPy array
+   - HIGH: `.compute()` inside a loop
+   - HIGH: `np.array()` or `np.asarray()` wrapping a dask or CuPy array
+   - MEDIUM: `da.stack()` without a following `.rechunk()`
 
-For each dask code path found in section 1:
+   **Cat 2 — Dask chunking and overlap**
+   - MEDIUM: `map_overlap` with depth >= chunk_size / 4
+   - MEDIUM: Missing `boundary` argument in `map_overlap`
+   - MEDIUM: Same function called twice on same input without caching
+   - MEDIUM: Python `for` loop iterating over dask chunks
 
-**Part A — Static trace:** Follow the code end-to-end. Answer: does peak
-memory scale with total array size, or with chunk size? If any operation
-forces full materialization, the verdict is WILL OOM.
+   **Cat 3 — GPU transfer**
+   - HIGH: `.data.get()` followed by CuPy operations (GPU→CPU→GPU round-trip)
+   - HIGH: `cupy.asarray()` inside a loop
+   - MEDIUM: Mixing NumPy and CuPy ops in same function without clear reason
+   - MEDIUM: Register pressure — count float64 local variables in `@cuda.jit`
+     kernels; flag if >20
+   - MEDIUM: Thread blocks >16x16 on kernels with >20 float64 locals
 
-**Part B — Task graph simulation:** Write and run a Python script (in /tmp/
-with a unique name including "MODULE_NAME") that:
+   **Cat 4 — Memory allocation**
+   - MEDIUM: Unnecessary `.copy()` on arrays never mutated downstream
+   - MEDIUM: Large temporary arrays that could be fused into the kernel
+   - LOW: `np.zeros_like()` + fill loop where `np.empty()` would suffice
 
-```python
-import dask.array as da
-import xarray as xr
-import json, sys
+   **Cat 5 — Numba anti-patterns**
+   - MEDIUM: Missing `@ngjit` on nested for-loops over `.data` arrays
+   - MEDIUM: `@jit` without `nopython=True`
+   - LOW: Type instability — initializing with int then assigning float
+   - LOW: Column-major iteration on row-major arrays (inner loop should be
+     last axis)
 
-arr = da.zeros((2560, 2560), chunks=(256, 256), dtype='float64')
-raster = xr.DataArray(arr, dims=['y', 'x'])
+   **Cat 6 — 30TB / 16GB OOM verdict**
+   For each dask code path, follow it end-to-end. Decide whether peak memory
+   scales with chunk size or with the full array. Optionally write a small
+   script under `/tmp/` (with a unique name including the module name) that
+   constructs the dask task graph and reports task count and fan-in:
 
-# Add coords if the function needs them (geodesic, slope with CRS, etc.)
-# raster = raster.assign_coords(x=np.linspace(-180, 180, 2560),
-#                                y=np.linspace(-90, 90, 2560))
+   ```python
+   import dask.array as da
+   import xarray as xr
+   import json
 
-try:
-    result = MODULE_FUNCTION(raster, **DEFAULT_ARGS)
-    graph = result.__dask_graph__()
-    task_count = len(graph)
-    tasks_per_chunk = task_count / 100.0
+   arr = da.zeros((2560, 2560), chunks=(256, 256), dtype='float64')
+   raster = xr.DataArray(arr, dims=['y', 'x'])
+   # add coords if needed
+   try:
+       result = MODULE_FUNCTION(raster, **DEFAULT_ARGS)
+       graph = result.__dask_graph__()
+       task_count = len(graph)
+       print(json.dumps({
+           "success": True,
+           "task_count": task_count,
+           "tasks_per_chunk": round(task_count / 100.0, 2),
+       }))
+   except Exception as e:
+       print(json.dumps({"success": False, "error": str(e)}))
+   ```
 
-    # Check for fan-out: any task key that depends on more than 4 other tasks
-    deps = dict(graph)
-    max_fan_in = 0
-    for key, val in deps.items():
-        if hasattr(val, '__dask_graph__'):
-            sub = val.__dask_graph__()
-            max_fan_in = max(max_fan_in, len(sub))
+   The script must NEVER call `.compute()` — graph construction only.
 
-    print(json.dumps({
-        "success": True,
-        "task_count": task_count,
-        "tasks_per_chunk": round(tasks_per_chunk, 2),
-        "max_fan_in": max_fan_in,
-        "extrapolation_30tb": "~{} tasks at 57M chunks".format(
-            int(tasks_per_chunk * 57_000_000))
-    }))
-except Exception as e:
-    print(json.dumps({"success": False, "error": str(e)}))
-```
+   Verdict: one of `SAFE`, `RISKY`, `WILL OOM`, or `N/A` (no dask backend).
 
-Adapt the function call and imports for the specific module. Run the script
-and capture its JSON output. If it errors, record the error and rely on
-Part A alone.
+3. Classify the module's bottleneck as ONE of:
+   `IO-bound`, `memory-bound`, `compute-bound`, `graph-bound`.
 
-**Verdict:** One of:
-- `SAFE` — memory bounded by chunk size, graph scales linearly
-- `RISKY` — bounded but tight (e.g. large overlap depth, 3D intermediates)
-- `WILL OOM` — forces full materialization or unbounded memory growth
+4. For each real issue found, assign a severity (CRITICAL/HIGH/MEDIUM/LOW)
+   and note the exact file and line number.
 
-### 3. GPU Transfer Analysis
+5. If any CRITICAL or HIGH issue is found, run /rockout to fix it end-to-end
+   (GitHub issue, worktree branch, fix, tests, and PR). Include the OOM
+   verdict, bottleneck classification, and affected backends in the rockout
+   prompt so it has full performance context.
 
-Scan for CuPy/CUDA code paths. Flag:
+   Skip step 5 entirely if `--no-fix` was passed to the parent sweep.
 
-- HIGH: `.data.get()` followed by CuPy operations (GPU-CPU-GPU round-trip)
-- HIGH: `cupy.asarray()` inside a loop (repeated CPU-GPU transfers)
-- MEDIUM: Mixing NumPy and CuPy ops in same function without clear reason
-- MEDIUM: Register pressure — count float64 local variables in `@cuda.jit`
-  kernels; flag if >20
-- MEDIUM: Thread blocks >16x16 on kernels with >20 float64 locals
+6. After finishing (whether you found issues or not), update the inspection
+   state file `.claude/sweep-performance-state.csv`. Header:
 
-If the module has NO GPU code path, note "no GPU backend" and skip.
+   `module,last_inspected,oom_verdict,bottleneck,high_count,issue,notes`
 
-### 4. Memory Allocation Patterns
+   Use this Python pattern to read, update, and write it (do NOT hand-edit
+   the file -- always go through csv.DictReader / csv.DictWriter so quoting
+   stays consistent):
 
-- MEDIUM: Unnecessary `.copy()` on arrays never mutated downstream
-- MEDIUM: Large temporary arrays that could be fused into the kernel
-- LOW: `np.zeros_like()` + fill loop where `np.empty()` would suffice
+   ```python
+   import csv
+   from pathlib import Path
 
-### 5. Numba Anti-Patterns
+   path = Path(".claude/sweep-performance-state.csv")
+   header = ["module", "last_inspected", "oom_verdict", "bottleneck",
+             "high_count", "issue", "notes"]
 
-- MEDIUM: Missing `@ngjit` on nested for-loops over `.data` arrays
-- MEDIUM: `@jit` without `nopython=True` (object-mode fallback risk)
-- LOW: Type instability — initializing with int then assigning float
-- LOW: Column-major iteration on row-major arrays (inner loop should be last axis)
+   rows = {}
+   if path.exists():
+       with path.open() as f:
+           for r in csv.DictReader(f):
+               rows[r["module"]] = r  # last write wins on dupes
 
-### 6. Bottleneck Classification
+   rows["{module}"] = {
+       "module": "{module}",
+       "last_inspected": "<today's ISO date, e.g. 2026-04-29>",
+       "oom_verdict": "<SAFE|RISKY|WILL OOM|N/A>",
+       "bottleneck": "<IO-bound|memory-bound|compute-bound|graph-bound>",
+       "high_count": "<integer, count of HIGH findings>",
+       "issue": "<issue number from rockout, or empty string>",
+       "notes": "<single-line notes (replace any newlines with spaces), or empty>",
+   }
 
-Based on your analysis, classify the module as ONE of:
-- `IO-bound` — dominated by disk reads/writes or serialization
-- `memory-bound` — peak allocation is the limiting factor
-- `compute-bound` — CPU/GPU time dominates, memory is fine
-- `graph-bound` — dask task graph overhead dominates
+   with path.open("w", newline="") as f:
+       w = csv.DictWriter(f, fieldnames=header, quoting=csv.QUOTE_MINIMAL)
+       w.writeheader()
+       for m in sorted(rows):
+           w.writerow(rows[m])
+   ```
 
-### Output Format
+   Use empty strings (not `null`) for missing values. Set `issue` to the
+   issue number when one was filed, otherwise leave it empty.
 
-Return EXACTLY this JSON structure (no extra text before or after):
+   Then `git add .claude/sweep-performance-state.csv` and commit it to the
+   worktree branch so the state update is included in the PR.
 
-```json
-{
-  "module": "MODULE_NAME",
-  "files_read": ["list of files you read"],
-  "findings": [
-    {
-      "severity": "HIGH|MEDIUM|LOW",
-      "category": "dask_materialization|dask_chunking|gpu_transfer|register_pressure|memory_allocation|numba_antipattern",
-      "file": "filename.py",
-      "line": 123,
-      "description": "what the issue is",
-      "fix": "how to fix it",
-      "backends_affected": ["dask+numpy", "dask+cupy", "cupy", "numpy"]
-    }
-  ],
-  "oom_verdict": {
-    "dask_numpy": "SAFE|RISKY|WILL OOM",
-    "dask_cupy": "SAFE|RISKY|WILL OOM",
-    "reasoning": "one-sentence explanation",
-    "estimated_peak_per_chunk_mb": 0.5,
-    "task_count": 3721,
-    "tasks_per_chunk": 37.21,
-    "graph_simulation_ran": true
-  },
-  "bottleneck": "compute-bound|memory-bound|IO-bound|graph-bound",
-  "bottleneck_reasoning": "one-sentence explanation"
-}
-```
-
-IMPORTANT: Only flag patterns that are ACTUALLY present in the code. Do not
-report hypothetical issues. False positives are worse than missed issues.
-If a pattern like `.values` is used on a known-numpy-only code path, do not
-flag it.
+Important:
+- Only flag patterns ACTUALLY present in the code. False positives are worse
+  than missed issues.
+- Read the tests for this module before flagging a pattern as harmful — the
+  test may codify the current behavior intentionally.
+- For CUDA code, verify register pressure and bounds before flagging.
+- Do NOT flag the use of numba @jit itself as a performance issue. Focus on
+  what the JIT code does, not that it uses JIT.
+- For the hydro subpackage: focus on one representative variant (d8) in
+  detail, then note which dinf/mfd files share the same pattern. Do not read
+  all 29 files line by line.
+- This repo uses ArrayTypeFunctionMapping to dispatch across numpy/cupy/dask
+  backends. Check all backend paths, not just numpy.
+- Do NOT call `.compute()` in any analysis script. Graph construction only.
 ~~~
 
-Wait for all subagents to return before proceeding to Step 4.
+### 3c. Print a status line
 
-## Step 4 -- Merge results and print the triage report
-
-Parse the JSON returned by each subagent. If a subagent returned malformed
-output, record the module as "audit failed" with a note.
-
-### 4a. Print the Module Risk Ranking Table
-
-Sort modules by score descending. Print:
+After dispatching, print:
 
 ```
-## Performance Sweep — Static Triage Report
-
-### Module Risk Ranking
-| Rank | Module          | Score  | OOM Verdict     | Bottleneck    | HIGH | MED | LOW |
-|------|-----------------|--------|-----------------|---------------|------|-----|-----|
-| 1    | geotiff         | 31200  | WILL OOM (d+np) | IO-bound      | 3    | 1   | 0   |
-| 2    | viewshed        | 30050  | RISKY (d+np)    | memory-bound  | 2    | 2   | 1   |
-| ...  | ...             | ...    | ...             | ...           | ...  | ... | ... |
+Launched {N} performance audit agents: {module1}, {module2}, {module3}
 ```
 
-If `--high-only` is set, only count HIGH findings and omit modules with zero HIGH.
+## Step 4 -- State updates
 
-### 4b. Print the 30TB / 16GB Verdict Summary
-
-Group modules by OOM verdict:
-
-```
-### 30TB on Disk / 16GB RAM — Out-of-Memory Analysis
-
-#### WILL OOM (fix required)
-- **module_name**: reasoning from subagent
-
-#### RISKY (bounded but tight)
-- **module_name**: reasoning from subagent
-
-#### SAFE (memory bounded by chunk size)
-- module_name, module_name, module_name, ...
-```
-
-### 4c. Print Detailed Findings
-
-For each module that has findings, print a severity-grouped table:
+State is updated by the subagents themselves (see agent prompt step 6).
+After completion, verify state with:
 
 ```
-### module_name (bottleneck: compute-bound, OOM: SAFE)
-
-| # | Severity | File:Line      | Category                | Description                  | Fix                           |
-|---|----------|----------------|-------------------------|------------------------------|-------------------------------|
-| 1 | HIGH     | slope.py:142   | dask_materialization    | .values on dask input        | Use .data or stay lazy        |
-| 2 | MEDIUM   | slope.py:88    | dask_chunking           | map_overlap depth too large  | Reduce depth or warn users    |
+column -t -s, .claude/sweep-performance-state.csv | less
 ```
 
-### 4d. Print Actionable Rockout Commands
-
-For each HIGH-severity finding, print a ready-to-paste `/rockout` command:
-
-```
-### Ready-to-Run Fixes (HIGH severity only)
-
-1. **geotiff** — eager .values materialization (WILL OOM)
-   /rockout "Fix eager .values materialization in geotiff reader.
-   The dask read path at reader.py:87 calls .values which forces
-   the full array into memory. For 30TB inputs this will OOM on
-   a 16GB machine. Must stay lazy through the entire read path."
-
-2. **cost_distance** — iterative solver unbounded memory (WILL OOM)
-   /rockout "Fix cost_distance iterative solver to work within
-   bounded memory. Currently materializes the full distance matrix
-   each iteration. Must use chunked iteration for 30TB dask inputs."
-```
-
-Construct each `/rockout` command from the finding's description and fix fields.
-Include the OOM verdict and bottleneck classification in the prompt text so
-rockout has full context.
-
-## Step 5 -- Update state file
-
-Update `.claude/sweep-performance-state.csv` with the triage results.
-Header:
-
-`module,last_inspected,oom_verdict,bottleneck,high_count,issue,notes`
-
-Use this Python pattern to read existing rows, update entries for modules
-that were just audited, and keep entries for modules not in this run's
-scope. Do NOT hand-edit the file -- always go through csv.DictReader /
-csv.DictWriter so quoting stays consistent:
-
-```python
-import csv
-from pathlib import Path
-
-path = Path(".claude/sweep-performance-state.csv")
-header = ["module", "last_inspected", "oom_verdict", "bottleneck",
-          "high_count", "issue", "notes"]
-
-rows = {}
-if path.exists():
-    with path.open() as f:
-        for r in csv.DictReader(f):
-            rows[r["module"]] = r  # last write wins on dupes
-
-for module, result in triage_results.items():
-    rows[module] = {
-        "module": module,
-        "last_inspected": "<current ISO datetime>",
-        "oom_verdict": result["oom_verdict"],   # SAFE / RISKY / WILL OOM
-        "bottleneck": result["bottleneck"],     # IO-bound / memory-bound / compute-bound / graph-bound
-        "high_count": str(result["high_count"]),
-        "issue": "",                             # filled later by Phase 2 if a fix lands
-        "notes": rows.get(module, {}).get("notes", ""),  # preserve any existing notes
-    }
-
-with path.open("w", newline="") as f:
-    w = csv.DictWriter(f, fieldnames=header, quoting=csv.QUOTE_MINIMAL)
-    w.writeheader()
-    for m in sorted(rows):
-        w.writerow(rows[m])
-```
-
-Use empty strings (not `null`) for missing values.
-
-If `--report-only` is set, stop here. Do not proceed to Step 6.
-
-## Step 6 -- Generate the ralph-loop command
-
-Collect all modules from Step 4 (or from the state file if `--skip-phase1`)
-that have at least one HIGH-severity finding and no `issue` recorded in the
-state file (i.e. not yet fixed).
-
-Sort them by: WILL OOM first, then RISKY, then by HIGH count descending.
-
-Determine the benchmark array size from arguments:
-- `--size small` → 128x128
-- `--size large` → 2048x2048
-- default → 512x512
-
-### 6a. Print the ranked target list
-
-```
-### Phase 2 Targets (HIGH severity, unfixed)
-| # | Module        | HIGH Count | OOM Verdict | Bottleneck   |
-|---|---------------|------------|-------------|--------------|
-| 1 | geotiff       | 3          | WILL OOM    | IO-bound     |
-| 2 | cost_distance | 1          | WILL OOM    | memory-bound |
-| 3 | viewshed      | 2          | RISKY       | memory-bound |
-```
-
-If no modules qualify, print:
-"No HIGH-severity findings to fix. Run `/sweep-performance` without
-`--skip-phase1` to refresh the triage."
-Then stop.
-
-### 6b. Invoke the ralph-loop automatically
-
-Using the target list, invoke the ralph-loop skill directly via the Skill tool.
-Do NOT print the command for manual copy-paste — execute it immediately.
-
-Set `--max-iterations` to the number of target modules plus 2 (buffer for
-retries).
-
-Call the Skill tool with `skill: "ralph-loop"` and pass the following as `args`
-(with `<module>`, `<N>`, `<OOM verdict>`, `<SIZE>`, and `<N+2>` substituted
-from the actual triage results):
-
-```
-"Performance sweep Phase 2: benchmark and fix HIGH-severity findings.
-
-**Target modules in priority order:**
-1. <module> (<N> HIGH findings, <OOM verdict>) -- <one-line summary of worst finding>
-2. <module> ...
-...
-
-**For each module, in order:**
-
-1. Write a benchmark script at /tmp/perf_sweep_bench_<module>.py that:
-   - Imports the module's public functions
-   - Creates a test array (<SIZE>x<SIZE>, float64)
-   - For EACH available backend (numpy, dask+numpy; cupy and dask+cupy only if available):
-     a. Wrap the array in the appropriate DataArray type
-     b. Measure wall time: timeit.repeat(number=1, repeat=3), take median
-     c. Measure Python memory: tracemalloc.start() / tracemalloc.get_traced_memory()[1] for peak
-     d. Measure process memory: resource.getrusage(RUSAGE_SELF).ru_maxrss before and after
-     e. For CuPy backends: cupy.get_default_memory_pool().used_bytes() before and after
-   - Print results as JSON to stdout
-
-2. Run the benchmark script and capture results.
-
-3. Confirm the HIGH finding from Phase 1:
-   - If the dask backend uses significantly more memory than expected for
-     the chunk size, or wall time shows a materialization stall: CONFIRMED.
-   - If the benchmark shows no anomaly: downgrade to MEDIUM in state file,
-     print 'False positive — skipping' and move to the next module.
-
-4. If confirmed: run /rockout to fix the issue end-to-end (issue, worktree,
-   implementation, tests, docs). Include the benchmark numbers in the
-   issue body for context.
-
-5. After rockout completes: rerun the same benchmark script. Print a
-   before/after comparison:
-   | Backend    | Metric       | Before | After  | Ratio | Verdict    |
-   |------------|-------------|--------|--------|-------|------------|
-   | numpy      | wall_ms     | 45.2   | 12.1   | 0.27x | IMPROVED   |
-   | dask+numpy | peak_rss_mb | 892    | 34     | 0.04x | IMPROVED   |
-   Thresholds: IMPROVED < 0.8x, REGRESSION > 1.2x, else UNCHANGED.
-
-6. Update .claude/sweep-performance-state.csv with the issue number using
-   the read-update-write pattern documented in Step 5 (csv.DictReader /
-   DictWriter, keyed by module, last-write-wins on duplicates). Set the
-   `issue` field for this module to the rockout-filed issue number. Then
-   `git add` and commit it to the worktree branch so the state update is
-   included in the PR.
-
-7. Output <promise>ITERATION DONE</promise>
-
-If all targets have been addressed or confirmed as false positives:
-<promise>ALL PERFORMANCE ISSUES FIXED</promise>." --max-iterations <N+2> --completion-promise "ALL PERFORMANCE ISSUES FIXED"
-```
-
-### 6c. Print status
-
-After invoking the ralph-loop, print:
-
-```
-Phase 2 ralph-loop launched with <N> target modules.
-
-Other options:
-  Fix one manually:    copy any /rockout command from the triage report above
-  Rerun triage only:   /sweep-performance --report-only
-  Skip Phase 1:        /sweep-performance --skip-phase1 (reuses last triage)
-  Reset all tracking:  /sweep-performance --reset-state
-```
+To reset all tracking: `/sweep-performance --reset-state`
 
 ---
 
 ## General Rules
 
-- Phase 1 subagents do NOT modify any source, test, or benchmark files.
-  Read-only analysis only.
-- Phase 2 ralph-loop modifies code only through `/rockout`.
-- Temporary benchmark scripts and graph simulation scripts go in `/tmp/`
-  with unique names including the module name (e.g. `/tmp/perf_sweep_bench_slope.py`,
-  `/tmp/perf_sweep_graph_slope.py`). Clean them up after capturing results.
-- Only flag patterns that are ACTUALLY present in the code. Do not report
-  hypothetical issues or patterns that "could" occur.
-- Include the exact file path and line number for every finding so the user
-  can navigate directly to the issue.
-- False positives are worse than missed issues. If you are not confident a
-  pattern is actually harmful in context (e.g. `.values` used intentionally
-  on a known-numpy array), do not flag it.
-- The 30TB simulation constructs the dask task graph only; it NEVER calls
-  `.compute()`.
+- Do NOT modify any source files from the parent. Subagents handle fixes via
+  /rockout.
+- Keep the parent output concise — the ranked table and dispatch line are
+  the deliverables.
+- If $ARGUMENTS is empty, use defaults: top 3, no category filter, no
+  exclusions.
 - State file (`.claude/sweep-performance-state.csv`) is tracked in git, with
   `merge=union` set in `.gitattributes` so parallel sweeps touching
   different modules auto-merge. Subagents must `git add` and commit it so
   the state update lands in the PR.
-- If $ARGUMENTS is empty, use defaults: audit all modules, benchmark at
-  512x512, generate ralph-loop for HIGH items.
-- For subpackage modules (geotiff, reproject), the subagent should read ALL
+- For subpackage modules (geotiff, reproject, hydro), the subagent reads ALL
   `.py` files in the subpackage directory, not just `__init__.py`.
-- When generating `/rockout` commands, include the OOM verdict, bottleneck
-  classification, and affected backends in the prompt text so rockout has
-  full performance context.
+- Only flag patterns that are ACTUALLY present in the code. Do not report
+  hypothetical issues or patterns that "could" occur with imaginary inputs.
+- False positives are worse than missed issues. When in doubt, skip.
+- The 30TB graph simulation NEVER calls `.compute()` — it constructs the
+  dask graph and inspects it.


### PR DESCRIPTION
## Summary
- `/sweep-performance` used to do parallel triage and then a single ralph-loop that worked through HIGH findings one at a time. This switches it to one parallel dispatch where each subagent audits its module and runs `/rockout` itself, matching `/sweep-security` and `/sweep-accuracy`.
- Drops `--skip-phase1`, `--report-only`, `--size`. Adds `--no-fix` for audit-only runs. Keeps `--top`, `--exclude`, `--only-*`, `--reset-state`, `--high-only`.
- No `xrspatial/` source changes. The state CSV format is unchanged.

Closes #1315

## Test plan
- [ ] `/sweep-performance --top 1 --no-fix` dispatches one subagent and the state row gets written.
- [ ] `/sweep-performance --top 2` against modules with known HIGH findings produces two `/rockout` PRs in parallel.
- [ ] `.claude/sweep-performance-state.csv` schema is unchanged after a sweep.