### PR TITLE
Guard min_observable_height() against unbounded boolean stack (#1317)

### DIFF
--- a/xrspatial/experimental/min_observable_height.py
+++ b/xrspatial/experimental/min_observable_height.py
@@ -22,6 +22,41 @@ import xarray
 from ..viewshed import viewshed, INVISIBLE
 
 
+# Bool stack uses 1 byte per cell.
+_BYTES_PER_CELL = 1
+
+
+def _available_memory_bytes():
+    """Best-effort estimate of available memory in bytes."""
+    try:
+        with open('/proc/meminfo', 'r') as f:
+            for line in f:
+                if line.startswith('MemAvailable:'):
+                    return int(line.split()[1]) * 1024  # kB -> bytes
+    except (OSError, ValueError, IndexError):
+        pass
+    try:
+        import psutil
+        return psutil.virtual_memory().available
+    except (ImportError, AttributeError):
+        pass
+    return 2 * 1024 ** 3  # 2 GB fallback
+
+
+def _check_memory(n_steps, rows, cols):
+    """Raise MemoryError if the boolean visibility stack exceeds 50% of RAM."""
+    required = int(n_steps) * int(rows) * int(cols) * _BYTES_PER_CELL
+    available = _available_memory_bytes()
+    if required > 0.5 * available:
+        raise MemoryError(
+            f"min_observable_height() on a {rows}x{cols} raster with "
+            f"{n_steps} height steps needs ~{required / 1e9:.1f} GB for "
+            f"the visibility stack, but only ~{available / 1e9:.1f} GB is "
+            f"available. Reduce `max_height` / `precision` ratio or use a "
+            f"smaller raster."
+        )
+
+
 def min_observable_height(
     raster: xarray.DataArray,
     x: Union[int, float],
@@ -116,6 +151,10 @@ def min_observable_height(
     if n_steps < 2:
         n_steps = 2
     heights = np.linspace(0.0, max_height, n_steps)
+
+    # ---- guard against unbounded allocation ------------------------------
+    rows, cols = raster.shape
+    _check_memory(n_steps, rows, cols)
 
     # ---- collect visibility at each height level -------------------------
     # visibility_stack[k] is True where the cell is visible at heights[k].

--- a/xrspatial/tests/test_min_observable_height.py
+++ b/xrspatial/tests/test_min_observable_height.py
@@ -1,8 +1,17 @@
+from unittest import mock
+
 import numpy as np
 import pytest
 import xarray as xa
 
+import sys
+
 from xrspatial.experimental import min_observable_height
+
+# The package __init__ re-exports the function under the same name as the
+# submodule, so we look up the underlying module via sys.modules to patch
+# its memory-probe helper.
+moh_module = sys.modules['xrspatial.experimental.min_observable_height']
 
 
 def _make_raster(data, xs=None, ys=None):
@@ -184,6 +193,53 @@ def test_finer_precision():
     # (finer search can find an equal or lower threshold).
     mask = np.isfinite(fine.values) & np.isfinite(coarse.values)
     assert np.all(fine.values[mask] <= coarse.values[mask] + 1e-10)
+
+
+# ---- accessor integration ------------------------------------------------
+
+# ---- memory guard --------------------------------------------------------
+
+def test_memory_guard_rejects_oversized_stack():
+    """A tiny memory budget should make the guard fire before allocation."""
+    r = _make_raster(np.zeros((100, 100)))
+    # 1 byte of available memory: any stack > 0.5 bytes must error out.
+    with mock.patch.object(
+        moh_module, '_available_memory_bytes', return_value=1
+    ):
+        with pytest.raises(MemoryError, match="visibility stack"):
+            min_observable_height(r, x=50.0, y=50.0,
+                                  max_height=20.0, precision=1.0)
+
+
+def test_memory_guard_message_mentions_dimensions():
+    r = _make_raster(np.zeros((50, 60)))
+    with mock.patch.object(
+        moh_module, '_available_memory_bytes', return_value=1
+    ):
+        with pytest.raises(MemoryError, match=r"50x60"):
+            min_observable_height(r, x=10.0, y=10.0,
+                                  max_height=10.0, precision=1.0)
+
+
+def test_memory_guard_passes_with_ample_memory():
+    """With enough memory the guard does not fire and the call succeeds."""
+    r = _make_raster(np.zeros((4, 4)))
+    with mock.patch.object(
+        moh_module, '_available_memory_bytes', return_value=10 * 1024 ** 3
+    ):
+        result = min_observable_height(r, x=1.0, y=1.0,
+                                       max_height=8.0, precision=1.0)
+    assert result.shape == r.shape
+
+
+def test_memory_guard_runs_after_param_validation():
+    """ValueError on invalid params should still fire even with no RAM."""
+    r = _make_raster(np.zeros((10, 10)))
+    with mock.patch.object(
+        moh_module, '_available_memory_bytes', return_value=1
+    ):
+        with pytest.raises(ValueError, match="max_height must be positive"):
+            min_observable_height(r, x=1.0, y=1.0, max_height=0.0)
 
 
 # ---- accessor integration ------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `_available_memory_bytes()` and `_check_memory(n_steps, rows, cols)` to `min_observable_height()` (1 byte/cell for the bool stack, 50% threshold).
- Guard runs after parameter validation but before `np.empty((n_steps, H, W), bool)`.
- Records the audit result for `experimental` in `.claude/sweep-security-state.csv` (separate commit on main).

Fixes #1317.

## Background

The visibility stack at line 122 was sized directly from `raster.shape` and `n_steps = ceil(log2(max_height / precision)) + 1`. Default args produce `n_steps = 8`, but a caller can drive it much higher: `max_height=1e9, precision=1e-9` gives `n_steps = 60`. On a 50000x50000 raster that is ~150 GB of bool stack before anything errors.

Same asymmetric guard pattern used in sky_view_factor (#1300), sieve (#1296), kde (#1287), resample (#1295), focal (#1284), geodesic (#1283), mahalanobis (#1288), true_color (#1291), diffuse (#1267), erode (#1275), emerging_hotspots (#1274), dasymetric (#1261).

## Test plan

- [x] `pytest xrspatial/tests/test_min_observable_height.py` -- 15 passed (4 new memory-guard cases, 11 existing)
- [x] Oversize stack on numpy raises `MemoryError` with a clear message
- [x] Error message includes raster dimensions
- [x] Normal-size input still succeeds with ample memory
- [x] Invalid `max_height` raises `ValueError` before the memory guard runs