### PR TITLE
Guard flow_accumulation_mfd() against unbounded memory allocations (#1321)

### DIFF
--- a/xrspatial/hydro/flow_accumulation_mfd.py
+++ b/xrspatial/hydro/flow_accumulation_mfd.py
@@ -40,6 +40,95 @@ from xrspatial.utils import (
 from xrspatial.hydro._boundary_store import BoundaryStore
 from xrspatial.dataset_support import supports_dataset
 
+
+# =====================================================================
+# Memory guards
+# =====================================================================
+#
+# CPU peak working set per pixel for ``_flow_accum_mfd_cpu``:
+#   accum    : float64 -> 8
+#   in_degree: int32   -> 4
+#   valid    : int8    -> 1
+#   queue_r  : int64   -> 8
+#   queue_c  : int64   -> 8
+# Total ~29 bytes/pixel.  The caller-provided ``flow_dir_mfd`` array
+# already lives in RAM before the kernel runs and is not double-counted
+# here -- this matches the convention in ``flow_accumulation_d8``.
+_BYTES_PER_PIXEL = 29
+
+# GPU peak working set per pixel for ``_flow_accum_mfd_cupy``:
+#   accum     : float64 -> 8
+#   in_degree : int32   -> 4
+#   state     : int32   -> 4
+# Total ~16 bytes/pixel.  ``fractions_data`` already lives on the device
+# before the kernel runs and is not double-counted here.
+_GPU_BYTES_PER_PIXEL = 16
+
+
+def _available_memory_bytes():
+    """Best-effort estimate of available host memory in bytes."""
+    try:
+        with open('/proc/meminfo', 'r') as f:
+            for line in f:
+                if line.startswith('MemAvailable:'):
+                    return int(line.split()[1]) * 1024  # kB -> bytes
+    except (OSError, ValueError, IndexError):
+        pass
+    try:
+        import psutil
+        return psutil.virtual_memory().available
+    except (ImportError, AttributeError):
+        pass
+    return 2 * 1024 ** 3
+
+
+def _available_gpu_memory_bytes():
+    """Best-effort estimate of free GPU memory in bytes.
+
+    Returns 0 if CuPy / CUDA is unavailable or the query fails -- callers
+    use that as a sentinel meaning "no GPU info, skip the guard".
+    """
+    try:
+        import cupy as _cp
+        free, _total = _cp.cuda.runtime.memGetInfo()
+        return int(free)
+    except Exception:
+        return 0
+
+
+def _check_memory(height, width):
+    """Raise MemoryError if the BFS kernel would exceed 50% of RAM."""
+    required = int(height) * int(width) * _BYTES_PER_PIXEL
+    available = _available_memory_bytes()
+    if required > 0.5 * available:
+        raise MemoryError(
+            f"flow_accumulation_mfd on a {height}x{width} grid requires "
+            f"~{required / 1e9:.1f} GB of working memory but only "
+            f"~{available / 1e9:.1f} GB is available.  Use a "
+            f"dask-backed DataArray for out-of-core processing."
+        )
+
+
+def _check_gpu_memory(height, width):
+    """Raise MemoryError if the CuPy kernel would exceed 50% of free GPU RAM.
+
+    Skips the check (returns silently) when ``_available_gpu_memory_bytes``
+    cannot determine the free memory -- e.g. on hosts without CUDA, where
+    the kernel will fail at the cupy.asarray boundary anyway.
+    """
+    available = _available_gpu_memory_bytes()
+    if available <= 0:
+        return
+    required = int(height) * int(width) * _GPU_BYTES_PER_PIXEL
+    if required > 0.5 * available:
+        raise MemoryError(
+            f"flow_accumulation_mfd on a {height}x{width} grid requires "
+            f"~{required / 1e9:.1f} GB of GPU working memory but only "
+            f"~{available / 1e9:.1f} GB is free on the active device.  "
+            f"Use a dask+cupy DataArray for out-of-core processing."
+        )
+
+
 # Neighbor offsets: E, SE, S, SW, W, NW, N, NE
 _DY = np.array([0, 1, 1, 1, 0, -1, -1, -1], dtype=np.int64)
 _DX = np.array([1, 1, 0, -1, -1, -1, 0, 1], dtype=np.int64)
@@ -754,9 +843,11 @@ def flow_accumulation_mfd(flow_dir_mfd: xr.DataArray,
         )
 
     if isinstance(data, np.ndarray):
+        _check_memory(data.shape[1], data.shape[2])
         out = _flow_accum_mfd_cpu(
             data.astype(np.float64), data.shape[1], data.shape[2])
     elif has_cuda_and_cupy() and is_cupy_array(data):
+        _check_gpu_memory(data.shape[1], data.shape[2])
         out = _flow_accum_mfd_cupy(data)
     elif has_cuda_and_cupy() and is_dask_cupy(flow_dir_mfd):
         # Spatial chunk sizes from dims 1 and 2

--- a/xrspatial/hydro/tests/test_flow_accumulation_mfd.py
+++ b/xrspatial/hydro/tests/test_flow_accumulation_mfd.py
@@ -357,3 +357,60 @@ class TestFlowAccumulationMFDDataset:
         np.testing.assert_allclose(
             accum_ds['mfd'].values, accum_da.values,
             atol=1e-10, equal_nan=True)
+
+
+# =====================================================================
+# Memory guard
+# =====================================================================
+
+class TestMemoryGuard:
+    """Memory guard on the eager numpy / cupy backends."""
+
+    def test_numpy_huge_raster_raises(self):
+        """Numpy backend raises MemoryError when projected RAM exceeds budget."""
+        from unittest.mock import patch
+
+        elev = _make_bowl(7)
+        mfd = flow_direction_mfd(elev)
+
+        with patch(
+            "xrspatial.hydro.flow_accumulation_mfd._available_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match="working memory"):
+                flow_accumulation_mfd(mfd)
+
+    def test_numpy_normal_input_succeeds(self):
+        """Normal-size raster passes the guard with real memory."""
+        elev = _make_bowl(7)
+        mfd = flow_direction_mfd(elev)
+        result = flow_accumulation_mfd(mfd)
+        assert result.shape == (7, 7)
+
+    def test_error_message_mentions_dimensions(self):
+        """Error message should mention the offending grid dimensions."""
+        from unittest.mock import patch
+
+        elev = _make_bowl(7)
+        mfd = flow_direction_mfd(elev)
+
+        with patch(
+            "xrspatial.hydro.flow_accumulation_mfd._available_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match="7x7"):
+                flow_accumulation_mfd(mfd)
+
+    def test_error_message_mentions_dask(self):
+        """The error message should suggest the dask alternative."""
+        from unittest.mock import patch
+
+        elev = _make_bowl(7)
+        mfd = flow_direction_mfd(elev)
+
+        with patch(
+            "xrspatial.hydro.flow_accumulation_mfd._available_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match="dask"):
+                flow_accumulation_mfd(mfd)


### PR DESCRIPTION
## Summary

- Adds `_check_memory` / `_check_gpu_memory` budget checks (29 B/px CPU, 16 B/px GPU, 50% threshold) to the eager numpy and cupy backends in `flow_accumulation_mfd.py`, mirroring #1319.
- Dask backends skip the guard because per-tile allocations are already bounded by chunk size.
- Adds 4 memory-guard tests (numpy raise, normal-input pass, dimension in message, dask suggestion in message).

Fixes #1321.

## Background

`_flow_accum_mfd_cpu` allocated `accum` (float64), `in_degree` (int32), `valid` (int8), and two `H*W` int64 BFS queues -- ~29 B/px of working memory plus the caller's input. `_flow_accum_mfd_cupy` allocated `accum` (float64) + `in_degree` (int32) + `state` (int32) -- ~16 B/px of GPU memory. Neither backend checked against available memory, so a 50000x50000 numpy raster asked for ~72 GB of host memory before anything errored out.

The `(8, H, W)` input cast on top of the working set makes MFD's exposure roughly 64 B/px worse than D8's, but the 29 / 16 split for the kernel itself matches D8 exactly, so the same constants apply.

The dinf variant is in a separate PR.

## Test plan

- [x] `pytest xrspatial/hydro/tests/test_flow_accumulation_mfd.py` -- 27 passed (23 existing + 4 new memory-guard cases)
- [x] `pytest xrspatial/hydro/tests/` -- 635 passed (no regressions)
- [x] Mocked tiny memory budget on numpy raises `MemoryError` with a "working memory" / "dask" / dimensions message
- [x] Normal-size input still succeeds