### PR TITLE
Guard flow_accumulation_dinf() against unbounded memory allocations (#1322)

### DIFF
--- a/xrspatial/hydro/flow_accumulation_dinf.py
+++ b/xrspatial/hydro/flow_accumulation_dinf.py
@@ -45,6 +45,96 @@ from xrspatial.hydro.flow_accumulation_d8 import (
 )
 
 
+# =====================================================================
+# Memory guards
+# =====================================================================
+#
+# CPU peak working set per pixel for ``_flow_accum_dinf_cpu``:
+#   accum    : float64 -> 8
+#   in_degree: int32   -> 4
+#   valid    : int8    -> 1
+#   queue_r  : int64   -> 8
+#   queue_c  : int64   -> 8
+# Total ~29 bytes/pixel.  D-inf splits flow between two neighbours by a
+# fractional weight, but the weights are computed inline from the angle
+# and do not need their own H*W buffer, so the per-pixel cost matches the
+# d8 BFS kernel.  The caller-provided ``flow_dir`` array already lives in
+# RAM before the kernel runs and is not double-counted here.
+_BYTES_PER_PIXEL = 29
+
+# GPU peak working set per pixel for ``_flow_accum_dinf_cupy``:
+#   accum     : float64 -> 8
+#   in_degree : int32   -> 4
+#   state     : int32   -> 4
+# Total ~16 bytes/pixel.  ``flow_dir_data`` already lives on the device
+# before the kernel runs and is not double-counted here.
+_GPU_BYTES_PER_PIXEL = 16
+
+
+def _available_memory_bytes():
+    """Best-effort estimate of available host memory in bytes."""
+    try:
+        with open('/proc/meminfo', 'r') as f:
+            for line in f:
+                if line.startswith('MemAvailable:'):
+                    return int(line.split()[1]) * 1024  # kB -> bytes
+    except (OSError, ValueError, IndexError):
+        pass
+    try:
+        import psutil
+        return psutil.virtual_memory().available
+    except (ImportError, AttributeError):
+        pass
+    return 2 * 1024 ** 3
+
+
+def _available_gpu_memory_bytes():
+    """Best-effort estimate of free GPU memory in bytes.
+
+    Returns 0 if CuPy / CUDA is unavailable or the query fails -- callers
+    use that as a sentinel meaning "no GPU info, skip the guard".
+    """
+    try:
+        import cupy as _cp
+        free, _total = _cp.cuda.runtime.memGetInfo()
+        return int(free)
+    except Exception:
+        return 0
+
+
+def _check_memory(height, width):
+    """Raise MemoryError if the BFS kernel would exceed 50% of RAM."""
+    required = int(height) * int(width) * _BYTES_PER_PIXEL
+    available = _available_memory_bytes()
+    if required > 0.5 * available:
+        raise MemoryError(
+            f"flow_accumulation_dinf on a {height}x{width} grid requires "
+            f"~{required / 1e9:.1f} GB of working memory but only "
+            f"~{available / 1e9:.1f} GB is available.  Use a "
+            f"dask-backed DataArray for out-of-core processing."
+        )
+
+
+def _check_gpu_memory(height, width):
+    """Raise MemoryError if the CuPy kernel would exceed 50% of free GPU RAM.
+
+    Skips the check (returns silently) when ``_available_gpu_memory_bytes``
+    cannot determine the free memory -- e.g. on hosts without CUDA, where
+    the kernel will fail at the cupy.asarray boundary anyway.
+    """
+    available = _available_gpu_memory_bytes()
+    if available <= 0:
+        return
+    required = int(height) * int(width) * _GPU_BYTES_PER_PIXEL
+    if required > 0.5 * available:
+        raise MemoryError(
+            f"flow_accumulation_dinf on a {height}x{width} grid requires "
+            f"~{required / 1e9:.1f} GB of GPU working memory but only "
+            f"~{available / 1e9:.1f} GB is free on the active device.  "
+            f"Use a dask+cupy DataArray for out-of-core processing."
+        )
+
+
 def _to_numpy_f64(arr):
     """Convert *arr* to a contiguous numpy float64 array.
 
@@ -885,8 +975,10 @@ def flow_accumulation_dinf(flow_dir: xr.DataArray,
     data = flow_dir.data
 
     if isinstance(data, np.ndarray):
+        _check_memory(*data.shape)
         out = _flow_accum_dinf_cpu(data.astype(np.float64), *data.shape)
     elif has_cuda_and_cupy() and is_cupy_array(data):
+        _check_gpu_memory(*data.shape)
         out = _flow_accum_dinf_cupy(data)
     elif has_cuda_and_cupy() and is_dask_cupy(flow_dir):
         out = _flow_accum_dinf_dask_cupy(data)

--- a/xrspatial/hydro/tests/test_flow_accumulation_dinf.py
+++ b/xrspatial/hydro/tests/test_flow_accumulation_dinf.py
@@ -214,3 +214,61 @@ def test_dinf_dask_cupy_matches_numpy():
     dcp_result = flow_accumulation_dinf(dask_cupy_agg)
     np.testing.assert_allclose(
         np_result.data, dcp_result.data.compute().get(), equal_nan=True)
+
+
+# ===========================================================================
+# Memory guard
+# ===========================================================================
+
+class TestMemoryGuard:
+    """Memory guard on the eager numpy / cupy backends for D-inf."""
+
+    def test_numpy_huge_raster_raises(self):
+        """Numpy backend raises MemoryError when projected RAM exceeds budget."""
+        from unittest.mock import patch
+
+        flow_dir = np.zeros((4, 4), dtype=np.float64)
+        agg = create_test_raster(flow_dir, backend='numpy')
+
+        with patch(
+            "xrspatial.hydro.flow_accumulation_dinf._available_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match="working memory"):
+                flow_accumulation_dinf(agg)
+
+    def test_numpy_normal_input_succeeds(self):
+        """Normal-size raster passes the guard with real memory."""
+        flow_dir = np.zeros((10, 10), dtype=np.float64)
+        agg = create_test_raster(flow_dir, backend='numpy')
+        result = flow_accumulation_dinf(agg)
+        assert result.shape == (10, 10)
+
+    @dask_array_available
+    def test_dask_path_skips_guard(self):
+        """Dask backend bypasses the guard -- per-tile allocations are bounded."""
+        from unittest.mock import patch
+
+        flow_dir = np.zeros((20, 20), dtype=np.float64)
+        agg = create_test_raster(flow_dir, backend='dask+numpy', chunks=(5, 5))
+
+        with patch(
+            "xrspatial.hydro.flow_accumulation_dinf._available_memory_bytes",
+            return_value=1,
+        ):
+            result = flow_accumulation_dinf(agg)
+            _ = result.data[:4, :4].compute()
+
+    def test_error_message_mentions_dimensions(self):
+        """The error message names the grid dimensions so callers know what to shrink."""
+        from unittest.mock import patch
+
+        flow_dir = np.zeros((7, 11), dtype=np.float64)
+        agg = create_test_raster(flow_dir, backend='numpy')
+
+        with patch(
+            "xrspatial.hydro.flow_accumulation_dinf._available_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match=r"7x11"):
+                flow_accumulation_dinf(agg)


### PR DESCRIPTION
## Summary

- Adds `_check_memory` / `_check_gpu_memory` budget checks (29 B/px CPU, 16 B/px GPU, 50% threshold) to the eager numpy and cupy backends in `flow_accumulation_dinf.py`.
- Dask backends skip the guard because per-tile allocations are already bounded by chunk size.
- Adds 4 memory-guard tests (numpy raise, normal-input pass, dask bypass, error message names dimensions).

Fixes #1322.

## Background

`_flow_accum_dinf_cpu` allocates `accum` (float64), `in_degree` (int32), `valid` (int8), and two `H*W` int64 BFS queues, ~29 B/pixel of working memory plus the caller's input.  `_flow_accum_dinf_cupy` allocates `accum` (float64) + `in_degree` (int32) + `state` (int32) ~16 B/pixel of GPU memory.  Neither backend checked against available memory, so a 50000x50000 numpy raster asked for ~72 GB of host memory before anything errored out.

D-inf splits flow between two neighbours by a fractional weight, but the weights are computed inline from the angle and do not need their own H*W buffer, so the per-pixel cost matches the d8 BFS kernel.

Same root cause and fix shape as #1318 / #1319.  The mfd variant has the same shape and will be handled in a separate follow-up PR per the one-fix-per-security-PR policy.

## Test plan

- [x] `pytest xrspatial/hydro/tests/test_flow_accumulation_dinf.py` -- 23 passed (19 existing + 4 new memory-guard cases)
- [x] Mocked tiny memory budget on numpy raises `MemoryError` with a "working memory" / dimension message
- [x] Normal-size input still succeeds
- [x] Dask backend bypasses the guard with mocked 1-byte budget
- [x] `pytest xrspatial/hydro/tests/` -- 635 passed (full hydro suite)