### PR TITLE
Guard hand_d8() against unbounded memory allocations (#1323)

### DIFF
--- a/xrspatial/hydro/hand_d8.py
+++ b/xrspatial/hydro/hand_d8.py
@@ -36,6 +36,97 @@ from xrspatial.utils import (
 
 
 # =====================================================================
+# Memory guards
+# =====================================================================
+#
+# CPU peak working set per pixel for ``_hand_cpu``:
+#   in_degree  : int32   -> 4
+#   valid      : int8    -> 1
+#   is_stream  : int8    -> 1
+#   drain_elev : float64 -> 8
+#   hand_out   : float64 -> 8
+#   order_r    : int64   -> 8
+#   order_c    : int64   -> 8
+# Total ~38 bytes/pixel.  Caller-provided ``flow_dir``, ``flow_accum``,
+# and ``elevation`` arrays already live in RAM before the kernel runs
+# and are not double-counted here.
+_BYTES_PER_PIXEL = 38
+
+# GPU peak working set per pixel for ``_hand_cupy``: that path copies
+# fd/fa/elev to host via ``.get()`` then runs ``_hand_cpu``.  Host
+# working set is dominated by the same 38 B/px as the numpy path; on
+# the device we keep the three input arrays (3 * float64 = 24 B/px)
+# and the output (float64 = 8 B/px) -- 32 B/px total on the GPU side,
+# but the input copies already exist before dispatch, so the marginal
+# device allocation is 8 B/px.  Use 32 B/px as a conservative budget.
+_GPU_BYTES_PER_PIXEL = 32
+
+
+def _available_memory_bytes():
+    """Best-effort estimate of available host memory in bytes."""
+    try:
+        with open('/proc/meminfo', 'r') as f:
+            for line in f:
+                if line.startswith('MemAvailable:'):
+                    return int(line.split()[1]) * 1024  # kB -> bytes
+    except (OSError, ValueError, IndexError):
+        pass
+    try:
+        import psutil
+        return psutil.virtual_memory().available
+    except (ImportError, AttributeError):
+        pass
+    return 2 * 1024 ** 3
+
+
+def _available_gpu_memory_bytes():
+    """Best-effort estimate of free GPU memory in bytes.
+
+    Returns 0 if CuPy / CUDA is unavailable or the query fails -- callers
+    use that as a sentinel meaning "no GPU info, skip the guard".
+    """
+    try:
+        import cupy as _cp
+        free, _total = _cp.cuda.runtime.memGetInfo()
+        return int(free)
+    except Exception:
+        return 0
+
+
+def _check_memory(height, width):
+    """Raise MemoryError if the HAND kernel would exceed 50% of RAM."""
+    required = int(height) * int(width) * _BYTES_PER_PIXEL
+    available = _available_memory_bytes()
+    if required > 0.5 * available:
+        raise MemoryError(
+            f"hand_d8 on a {height}x{width} grid requires "
+            f"~{required / 1e9:.1f} GB of working memory but only "
+            f"~{available / 1e9:.1f} GB is available.  Use a "
+            f"dask-backed DataArray for out-of-core processing."
+        )
+
+
+def _check_gpu_memory(height, width):
+    """Raise MemoryError if the CuPy kernel would exceed 50% of free GPU RAM.
+
+    Skips the check (returns silently) when ``_available_gpu_memory_bytes``
+    cannot determine the free memory -- e.g. on hosts without CUDA, where
+    the kernel will fail at the cupy.asarray boundary anyway.
+    """
+    available = _available_gpu_memory_bytes()
+    if available <= 0:
+        return
+    required = int(height) * int(width) * _GPU_BYTES_PER_PIXEL
+    if required > 0.5 * available:
+        raise MemoryError(
+            f"hand_d8 on a {height}x{width} grid requires "
+            f"~{required / 1e9:.1f} GB of GPU working memory but only "
+            f"~{available / 1e9:.1f} GB is free on the active device.  "
+            f"Use a dask+cupy DataArray for out-of-core processing."
+        )
+
+
+# =====================================================================
 # CPU kernel
 # =====================================================================
 
@@ -883,6 +974,7 @@ def hand_d8(flow_dir: xr.DataArray,
     el_data = elevation.data
 
     if isinstance(fd_data, np.ndarray):
+        _check_memory(*fd_data.shape)
         fd = fd_data.astype(np.float64)
         fa = np.asarray(fa_data, dtype=np.float64)
         el = np.asarray(el_data, dtype=np.float64)
@@ -890,6 +982,8 @@ def hand_d8(flow_dir: xr.DataArray,
         out = _hand_cpu(fd, fa, el, H, W, float(threshold))
 
     elif has_cuda_and_cupy() and is_cupy_array(fd_data):
+        _check_gpu_memory(*fd_data.shape)
+        _check_memory(*fd_data.shape)
         out = _hand_cupy(fd_data, fa_data, el_data, float(threshold))
 
     elif has_cuda_and_cupy() and is_dask_cupy(flow_dir):

--- a/xrspatial/hydro/tests/test_hand_d8.py
+++ b/xrspatial/hydro/tests/test_hand_d8.py
@@ -260,3 +260,87 @@ class TestHandDaskCuPy:
         np.testing.assert_allclose(
             result_np.data, result_dc.data.compute().get(),
             equal_nan=True, rtol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# Memory guard
+# ---------------------------------------------------------------------------
+
+class TestMemoryGuard:
+    """Memory guard on the eager numpy / cupy backends."""
+
+    def test_numpy_huge_raster_raises(self):
+        """Numpy backend raises MemoryError when projected RAM exceeds budget."""
+        from unittest.mock import patch
+
+        fd = np.zeros((4, 4), dtype=np.float64)
+        fa = np.zeros((4, 4), dtype=np.float64)
+        el = np.zeros((4, 4), dtype=np.float64)
+        fd_r, fa_r, el_r = _make_hand_rasters(fd, fa, el, backend='numpy')
+
+        with patch(
+            "xrspatial.hydro.hand_d8._available_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match="working memory"):
+                hand(fd_r, fa_r, el_r, threshold=1)
+
+    def test_numpy_normal_input_succeeds(self):
+        """Normal-size raster passes the guard with real memory."""
+        fd = np.zeros((10, 10), dtype=np.float64)
+        fa = np.zeros((10, 10), dtype=np.float64)
+        el = np.zeros((10, 10), dtype=np.float64)
+        fd_r, fa_r, el_r = _make_hand_rasters(fd, fa, el, backend='numpy')
+        result = hand(fd_r, fa_r, el_r, threshold=1)
+        assert result.shape == (10, 10)
+
+    @dask_array_available
+    def test_dask_path_skips_guard(self):
+        """Dask backend bypasses the guard -- per-tile allocations are bounded."""
+        from unittest.mock import patch
+
+        fd = np.zeros((6, 6), dtype=np.float64)
+        fa = np.zeros((6, 6), dtype=np.float64)
+        el = np.zeros((6, 6), dtype=np.float64)
+        fd_r, fa_r, el_r = _make_hand_rasters(
+            fd, fa, el, backend='dask', chunks=(3, 3))
+
+        with patch(
+            "xrspatial.hydro.hand_d8._available_memory_bytes",
+            return_value=1,
+        ):
+            result = hand(fd_r, fa_r, el_r, threshold=1)
+            _ = result.data[:3, :3].compute()
+
+    def test_error_message_mentions_dimensions(self):
+        """The error message should mention the grid dimensions and dask."""
+        from unittest.mock import patch
+
+        fd = np.zeros((7, 9), dtype=np.float64)
+        fa = np.zeros((7, 9), dtype=np.float64)
+        el = np.zeros((7, 9), dtype=np.float64)
+        fd_r, fa_r, el_r = _make_hand_rasters(fd, fa, el, backend='numpy')
+
+        with patch(
+            "xrspatial.hydro.hand_d8._available_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match=r"7x9.*dask"):
+                hand(fd_r, fa_r, el_r, threshold=1)
+
+    @cuda_and_cupy_available
+    def test_cupy_huge_raster_raises(self):
+        """CuPy backend raises MemoryError when projected GPU RAM exceeds budget."""
+        from unittest.mock import patch
+
+        fd = np.zeros((4, 4), dtype=np.float64)
+        fa = np.zeros((4, 4), dtype=np.float64)
+        el = np.zeros((4, 4), dtype=np.float64)
+        fd_r, fa_r, el_r = _make_hand_rasters(fd, fa, el, backend='cupy')
+
+        with patch(
+            "xrspatial.hydro.hand_d8._available_gpu_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match="GPU working memory"):
+                hand(fd_r, fa_r, el_r, threshold=1)


### PR DESCRIPTION
## Summary

- Adds `_check_memory` / `_check_gpu_memory` budget checks (38 B/px CPU, 32 B/px GPU, 50% threshold) to the eager numpy and cupy backends in `hand_d8.py`.
- Dask backends skip the guard since per-tile allocations are already bounded by chunk size.
- Adds 5 memory-guard tests (numpy raise, normal-input pass, dask bypass, error message + dimension check, cupy raise gated on CUDA).

Fixes #1323.

## Background

`_hand_cpu` allocates `in_degree` (int32), `valid` (int8), `is_stream` (int8), `drain_elev` (float64), `hand_out` (float64), and two H*W int64 BFS order arrays. About 38 B/px of working memory. The cupy backend rides on top of the same CPU kernel via `.get()`. Neither backend checked available memory, so a 50000x50000 numpy raster asked for ~95 GB of host memory before anything errored out.

Hydro is safety-critical. Same asymmetric guard as #1319 (flow_accumulation_d8), sieve (#1298), kde (#1289), resample (#1297), sky_view_factor (#1300), surface_distance (#1305).

The dinf and mfd HAND variants share the same shape and will be handled in separate follow-up PRs per the one-fix-per-security-PR policy.

## Test plan

- [x] `pytest xrspatial/hydro/tests/test_hand_d8.py`: 19 passed (15 existing + 4 new memory-guard cases on this host; cupy guard test skipped without CUDA)
- [x] `pytest xrspatial/hydro/tests/`: 636 passed, no regressions
- [x] Mocked tiny memory budget on numpy raises `MemoryError` with a "working memory" / "dask" message
- [x] Normal-size input still succeeds
- [x] Dask backend bypasses the guard with mocked 1-byte budget
- [x] Error message includes the requested HxW dimensions and recommends dask