### PR TITLE
Guard watershed_d8() against unbounded memory allocations (#1329)

### DIFF
--- a/xrspatial/hydro/tests/test_watershed_d8.py
+++ b/xrspatial/hydro/tests/test_watershed_d8.py
@@ -331,6 +331,94 @@ def test_watershed_numpy_equals_dask_cupy():
         np_result.data, dcp_result.data.compute().get(), equal_nan=True)
 
 
+# ====================================================================
+# Memory guard tests
+# ====================================================================
+
+class TestMemoryGuard:
+    """Memory guard on the eager numpy / cupy backends."""
+
+    def test_numpy_huge_raster_raises(self):
+        """Numpy backend raises MemoryError when projected RAM exceeds budget."""
+        from unittest.mock import patch
+
+        flow_dir = np.zeros((4, 4), dtype=np.float64)
+        pour_points = np.full((4, 4), np.nan, dtype=np.float64)
+        pour_points[0, 0] = 1.0
+        fd_da = create_test_raster(flow_dir, backend='numpy')
+        pp_da = create_test_raster(pour_points, backend='numpy')
+
+        with patch(
+            "xrspatial.hydro.watershed_d8._available_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match="working memory"):
+                watershed(fd_da, pp_da)
+
+    def test_numpy_normal_input_succeeds(self):
+        """Normal-size raster passes the guard with real memory."""
+        flow_dir = np.zeros((10, 10), dtype=np.float64)
+        pour_points = np.full((10, 10), np.nan, dtype=np.float64)
+        pour_points[0, 0] = 1.0
+        fd_da = create_test_raster(flow_dir, backend='numpy')
+        pp_da = create_test_raster(pour_points, backend='numpy')
+        result = watershed(fd_da, pp_da)
+        assert result.shape == (10, 10)
+
+    @dask_array_available
+    def test_dask_path_skips_guard(self):
+        """Dask backend bypasses the guard -- per-tile allocations are bounded."""
+        from unittest.mock import patch
+
+        flow_dir = np.zeros((6, 6), dtype=np.float64)
+        pour_points = np.full((6, 6), np.nan, dtype=np.float64)
+        pour_points[0, 0] = 1.0
+        fd_da = create_test_raster(flow_dir, backend='dask', chunks=(3, 3))
+        pp_da = create_test_raster(pour_points, backend='dask', chunks=(3, 3))
+
+        with patch(
+            "xrspatial.hydro.watershed_d8._available_memory_bytes",
+            return_value=1,
+        ):
+            result = watershed(fd_da, pp_da)
+            _ = result.data[:3, :3].compute()
+
+    def test_error_message_mentions_dimensions(self):
+        """The error message should mention the grid dimensions and dask."""
+        from unittest.mock import patch
+
+        flow_dir = np.zeros((7, 9), dtype=np.float64)
+        pour_points = np.full((7, 9), np.nan, dtype=np.float64)
+        pour_points[0, 0] = 1.0
+        fd_da = create_test_raster(flow_dir, backend='numpy')
+        pp_da = create_test_raster(pour_points, backend='numpy')
+
+        with patch(
+            "xrspatial.hydro.watershed_d8._available_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match=r"7x9.*dask"):
+                watershed(fd_da, pp_da)
+
+    @cuda_and_cupy_available
+    def test_cupy_huge_raster_raises(self):
+        """CuPy backend raises MemoryError when projected GPU RAM exceeds budget."""
+        from unittest.mock import patch
+
+        flow_dir = np.zeros((4, 4), dtype=np.float64)
+        pour_points = np.full((4, 4), np.nan, dtype=np.float64)
+        pour_points[0, 0] = 1.0
+        fd_da = create_test_raster(flow_dir, backend='cupy')
+        pp_da = create_test_raster(pour_points, backend='cupy')
+
+        with patch(
+            "xrspatial.hydro.watershed_d8._available_gpu_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match="GPU working memory"):
+                watershed(fd_da, pp_da)
+
+
 @dask_array_available
 @cuda_and_cupy_available
 def test_watershed_dask_cupy_random():

--- a/xrspatial/hydro/watershed_d8.py
+++ b/xrspatial/hydro/watershed_d8.py
@@ -51,6 +51,93 @@ def _to_numpy_f64(arr):
 
 
 # =====================================================================
+# Memory guards
+# =====================================================================
+#
+# CPU peak working set per pixel for the numpy dispatch + ``_watershed_cpu``:
+#   fd (float64 cast)    -> 8
+#   labels (float64)     -> 8
+#   state  (int8)        -> 1
+#   path_r (int64)       -> 8
+#   path_c (int64)       -> 8
+# Total ~33 bytes/pixel.  The caller's ``flow_dir`` and ``pour_points``
+# arrays already live in RAM before dispatch and are not double-counted.
+_BYTES_PER_PIXEL = 33
+
+# GPU peak working set per pixel for ``_watershed_cupy``:
+#   flow_dir_f64 (float64) -> 8
+#   pp_f64       (float64) -> 8
+#   labels       (float64) -> 8
+#   state        (int32)   -> 4
+# Total 28 bytes/pixel on the device.
+_GPU_BYTES_PER_PIXEL = 28
+
+
+def _available_memory_bytes():
+    """Best-effort estimate of available host memory in bytes."""
+    try:
+        with open('/proc/meminfo', 'r') as f:
+            for line in f:
+                if line.startswith('MemAvailable:'):
+                    return int(line.split()[1]) * 1024  # kB -> bytes
+    except (OSError, ValueError, IndexError):
+        pass
+    try:
+        import psutil
+        return psutil.virtual_memory().available
+    except (ImportError, AttributeError):
+        pass
+    return 2 * 1024 ** 3
+
+
+def _available_gpu_memory_bytes():
+    """Best-effort estimate of free GPU memory in bytes.
+
+    Returns 0 if CuPy / CUDA is unavailable or the query fails -- callers
+    use that as a sentinel meaning "no GPU info, skip the guard".
+    """
+    try:
+        import cupy as _cp
+        free, _total = _cp.cuda.runtime.memGetInfo()
+        return int(free)
+    except Exception:
+        return 0
+
+
+def _check_memory(height, width):
+    """Raise MemoryError if the watershed kernel would exceed 50% of RAM."""
+    required = int(height) * int(width) * _BYTES_PER_PIXEL
+    available = _available_memory_bytes()
+    if required > 0.5 * available:
+        raise MemoryError(
+            f"watershed_d8 on a {height}x{width} grid requires "
+            f"~{required / 1e9:.1f} GB of working memory but only "
+            f"~{available / 1e9:.1f} GB is available.  Use a "
+            f"dask-backed DataArray for out-of-core processing."
+        )
+
+
+def _check_gpu_memory(height, width):
+    """Raise MemoryError if the CuPy kernel would exceed 50% of free GPU RAM.
+
+    Skips the check (returns silently) when ``_available_gpu_memory_bytes``
+    cannot determine the free memory -- e.g. on hosts without CUDA, where
+    the kernel will fail at the cupy.asarray boundary anyway.
+    """
+    available = _available_gpu_memory_bytes()
+    if available <= 0:
+        return
+    required = int(height) * int(width) * _GPU_BYTES_PER_PIXEL
+    if required > 0.5 * available:
+        raise MemoryError(
+            f"watershed_d8 on a {height}x{width} grid requires "
+            f"~{required / 1e9:.1f} GB of GPU working memory but only "
+            f"~{available / 1e9:.1f} GB is free on the active device.  "
+            f"Use a dask+cupy DataArray for out-of-core processing."
+        )
+
+
+# =====================================================================
 # Direction helpers
 # =====================================================================
 
@@ -963,6 +1050,7 @@ def watershed_d8(flow_dir: xr.DataArray,
     pp_data = pour_points.data
 
     if isinstance(data, np.ndarray):
+        _check_memory(*data.shape)
         fd = data.astype(np.float64)
         pp = np.asarray(pp_data, dtype=np.float64)
         h, w = fd.shape
@@ -982,6 +1070,7 @@ def watershed_d8(flow_dir: xr.DataArray,
         out = _watershed_cpu(fd, labels, state, h, w)
 
     elif has_cuda_and_cupy() and is_cupy_array(data):
+        _check_gpu_memory(*data.shape)
         out = _watershed_cupy(data, pp_data)
 
     elif has_cuda_and_cupy() and is_dask_cupy(flow_dir):


### PR DESCRIPTION
## Summary

Closes #1329.

`watershed_d8()` had no memory guard on the numpy and cupy backends. A 50000x50000 numpy raster would silently try to allocate ~83 GB of working memory before failing.

- CPU: 33 B/pixel — float64 cast (8) + labels (8) + state int8 (1) + path_r int64 (8) + path_c int64 (8)
- GPU: 28 B/pixel — flow_dir_f64 (8) + pp_f64 (8) + labels (8) + state int32 (4)

`_check_memory` / `_check_gpu_memory` raise `MemoryError` with the grid dimensions when the projected working set exceeds 50% of available memory. Dask paths skip the guard since per-tile allocations are bounded by the user's chunk size.

Same pattern as #1319 (flow_accumulation_d8), #1325 (flow_accumulation_dinf), #1324 (flow_accumulation_mfd), #1326 (hand_d8).

## Test plan

- [x] `pytest xrspatial/hydro/tests/test_watershed_d8.py` — 29 passed
- [x] `pytest xrspatial/hydro/` — 636 passed
- [x] Numpy oversize raises `MemoryError`
- [x] Normal-size input passes
- [x] Dask backend bypasses the guard
- [x] Error message names the grid dimensions and points at dask
- [x] CuPy oversize raises (gated on CUDA)