### PR TITLE
Guard stream_order_d8() against unbounded memory allocations (#1328)

### DIFF
--- a/xrspatial/hydro/stream_order_d8.py
+++ b/xrspatial/hydro/stream_order_d8.py
@@ -49,6 +49,100 @@ from xrspatial.dataset_support import supports_dataset
 from xrspatial.hydro.flow_accumulation_d8 import _code_to_offset, _code_to_offset_py
 
 
+# =====================================================================
+# Memory guards
+# =====================================================================
+#
+# CPU peak working set per pixel for the eager Strahler/Shreve kernels:
+#   order     : float64 -> 8
+#   in_degree : int32   -> 4
+#   max_in    : float64 -> 8   (Strahler only; Shreve omits it)
+#   cnt_max   : int32   -> 4   (Strahler only)
+#   queue_r   : int64   -> 8
+#   queue_c   : int64   -> 8
+# Total ~40 bytes/pixel for Strahler, ~32 for Shreve.  We budget for the
+# worst case.  Caller-provided ``flow_dir`` and ``flow_accum`` already
+# live in RAM before the kernel runs and are not double-counted here.
+_BYTES_PER_PIXEL = 40
+
+# GPU peak working set per pixel for ``_stream_order_cupy``:
+#   flow_dir_f64   : float64 -> 8
+#   stream_mask_i8 : int8    -> 1
+#   in_degree      : int32   -> 4
+#   state          : int32   -> 4
+#   order          : float64 -> 8
+#   max_in         : float64 -> 8
+#   cnt_max        : int32   -> 4
+# Total ~37 bytes/pixel.  The ``fa`` input copy adds 8 B/px on the
+# device but is created from the caller's CuPy array.  Use 40 B/px as
+# a conservative budget.
+_GPU_BYTES_PER_PIXEL = 40
+
+
+def _available_memory_bytes():
+    """Best-effort estimate of available host memory in bytes."""
+    try:
+        with open('/proc/meminfo', 'r') as f:
+            for line in f:
+                if line.startswith('MemAvailable:'):
+                    return int(line.split()[1]) * 1024  # kB -> bytes
+    except (OSError, ValueError, IndexError):
+        pass
+    try:
+        import psutil
+        return psutil.virtual_memory().available
+    except (ImportError, AttributeError):
+        pass
+    return 2 * 1024 ** 3
+
+
+def _available_gpu_memory_bytes():
+    """Best-effort estimate of free GPU memory in bytes.
+
+    Returns 0 if CuPy / CUDA is unavailable or the query fails -- callers
+    use that as a sentinel meaning "no GPU info, skip the guard".
+    """
+    try:
+        import cupy as _cp
+        free, _total = _cp.cuda.runtime.memGetInfo()
+        return int(free)
+    except Exception:
+        return 0
+
+
+def _check_memory(height, width):
+    """Raise MemoryError if the kernel would exceed 50% of RAM."""
+    required = int(height) * int(width) * _BYTES_PER_PIXEL
+    available = _available_memory_bytes()
+    if required > 0.5 * available:
+        raise MemoryError(
+            f"stream_order_d8 on a {height}x{width} grid requires "
+            f"~{required / 1e9:.1f} GB of working memory but only "
+            f"~{available / 1e9:.1f} GB is available.  Use a "
+            f"dask-backed DataArray for out-of-core processing."
+        )
+
+
+def _check_gpu_memory(height, width):
+    """Raise MemoryError if the CuPy kernel would exceed 50% of free GPU RAM.
+
+    Skips the check (returns silently) when ``_available_gpu_memory_bytes``
+    cannot determine the free memory -- e.g. on hosts without CUDA, where
+    the kernel will fail at the cupy.asarray boundary anyway.
+    """
+    available = _available_gpu_memory_bytes()
+    if available <= 0:
+        return
+    required = int(height) * int(width) * _GPU_BYTES_PER_PIXEL
+    if required > 0.5 * available:
+        raise MemoryError(
+            f"stream_order_d8 on a {height}x{width} grid requires "
+            f"~{required / 1e9:.1f} GB of GPU working memory but only "
+            f"~{available / 1e9:.1f} GB is free on the active device.  "
+            f"Use a dask+cupy DataArray for out-of-core processing."
+        )
+
+
 def _to_numpy_f64(arr):
     """Convert *arr* to a contiguous numpy float64 array (handles CuPy)."""
     if hasattr(arr, 'get'):
@@ -1510,6 +1604,7 @@ def stream_order_d8(flow_dir: xr.DataArray,
     fa_data = flow_accum.data
 
     if isinstance(fd_data, np.ndarray):
+        _check_memory(*fd_data.shape)
         fd = fd_data.astype(np.float64)
         fa = np.asarray(fa_data, dtype=np.float64)
         stream_mask = np.where(fa >= threshold, 1, 0).astype(np.int8)
@@ -1523,6 +1618,7 @@ def stream_order_d8(flow_dir: xr.DataArray,
             out = _shreve_cpu(fd, stream_mask, h, w)
 
     elif has_cuda_and_cupy() and is_cupy_array(fd_data):
+        _check_gpu_memory(*fd_data.shape)
         import cupy as cp
         fa_cp = cp.asarray(fa_data, dtype=cp.float64)
         fd_cp = fd_data.astype(cp.float64)

--- a/xrspatial/hydro/tests/test_stream_order_d8.py
+++ b/xrspatial/hydro/tests/test_stream_order_d8.py
@@ -467,3 +467,80 @@ def test_dask_cupy_random(method):
         np.testing.assert_allclose(
             np_result.data, dcp_result.data.compute().get(), equal_nan=True,
         ), f"Mismatch with chunks={chunks}, method={method}"
+
+
+# ====================================================================
+# Memory guard tests
+# ====================================================================
+
+class TestMemoryGuard:
+    """Memory guard on the eager numpy / cupy backends."""
+
+    def test_numpy_huge_raster_raises(self):
+        """Numpy backend raises MemoryError when projected RAM exceeds budget."""
+        from unittest.mock import patch
+
+        flow_dir = np.zeros((4, 4), dtype=np.float64)
+        flow_accum = np.ones((4, 4), dtype=np.float64)
+
+        with patch(
+            "xrspatial.hydro.stream_order_d8._available_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match="working memory"):
+                _make_stream_order(flow_dir, flow_accum, threshold=1)
+
+    def test_numpy_normal_input_succeeds(self):
+        """Normal-size raster passes the guard with real memory."""
+        flow_dir = np.array([[1.0, 1.0, 0.0]], dtype=np.float64)
+        flow_accum = np.array([[1.0, 2.0, 3.0]], dtype=np.float64)
+        result = _make_stream_order(flow_dir, flow_accum, threshold=1)
+        assert result.shape == (1, 3)
+
+    @dask_array_available
+    def test_dask_path_skips_guard(self):
+        """Dask backend bypasses the guard -- per-tile allocations are bounded."""
+        from unittest.mock import patch
+
+        flow_dir = np.zeros((6, 6), dtype=np.float64)
+        flow_accum = np.ones((6, 6), dtype=np.float64)
+        da_fd = create_test_raster(flow_dir, backend='dask', chunks=(3, 3))
+        da_fa = create_test_raster(flow_accum, backend='dask', chunks=(3, 3))
+
+        with patch(
+            "xrspatial.hydro.stream_order_d8._available_memory_bytes",
+            return_value=1,
+        ):
+            result = stream_order(da_fd, da_fa, threshold=1)
+            _ = result.data[:3, :3].compute()
+
+    def test_error_message_mentions_dimensions(self):
+        """The error message should mention the grid dimensions and dask."""
+        from unittest.mock import patch
+
+        flow_dir = np.zeros((7, 9), dtype=np.float64)
+        flow_accum = np.ones((7, 9), dtype=np.float64)
+
+        with patch(
+            "xrspatial.hydro.stream_order_d8._available_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match=r"7x9.*dask"):
+                _make_stream_order(flow_dir, flow_accum, threshold=1)
+
+    @cuda_and_cupy_available
+    def test_cupy_huge_raster_raises(self):
+        """CuPy backend raises MemoryError when projected GPU RAM exceeds budget."""
+        from unittest.mock import patch
+
+        flow_dir = np.zeros((4, 4), dtype=np.float64)
+        flow_accum = np.ones((4, 4), dtype=np.float64)
+        cp_fd = create_test_raster(flow_dir, backend='cupy')
+        cp_fa = create_test_raster(flow_accum, backend='cupy')
+
+        with patch(
+            "xrspatial.hydro.stream_order_d8._available_gpu_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match="GPU working memory"):
+                stream_order(cp_fd, cp_fa, threshold=1)


### PR DESCRIPTION
Closes #1328.

Mirrors the asymmetric guard pattern from PR #1319 (`flow_accumulation_d8`) and #1326 (`hand_d8`). The numpy and cupy backends now check the projected working set against 50% of available memory before allocating any H*W arrays. Dask backends skip the check since per-tile allocations are already bounded by the caller's chunk size.

## Byte budget

CPU peak working set per pixel for `_strahler_cpu` (the worse of the two CPU kernels):

| Array      | dtype   | bytes/px |
|------------|---------|----------|
| order      | float64 | 8        |
| in_degree  | int32   | 4        |
| max_in     | float64 | 8        |
| cnt_max    | int32   | 4        |
| queue_r    | int64   | 8        |
| queue_c    | int64   | 8        |
| Total      |         | 40       |

GPU peak working set per pixel for `_stream_order_cupy`: 37 B/px from
`flow_dir_f64` + `stream_mask_i8` + `in_degree` + `state` + `order` +
`max_in` + `cnt_max`. Budgeted at 40 B/px conservatively to cover the
`fa` device cast.

## Tests

Added a `TestMemoryGuard` class with five tests:

- `test_numpy_huge_raster_raises` -- patches `_available_memory_bytes` to 1 byte and expects `MemoryError`.
- `test_numpy_normal_input_succeeds` -- real-world raster passes the guard.
- `test_dask_path_skips_guard` -- dask backend bypasses the guard even when patched memory is tiny.
- `test_error_message_mentions_dimensions` -- error message includes the grid shape and points users to dask.
- `test_cupy_huge_raster_raises` -- CuPy backend raises when GPU memory probe is patched low.

Full hydro suite passes (635 tests, one pre-existing tmp-cleanup test deselected -- unrelated).

`stream_order_dinf` and `stream_order_mfd` will be addressed in separate follow-up issues per the one-fix-per-security-PR policy.