### PR TITLE
Guard flow_length_d8() against unbounded memory allocations (#1327)

### DIFF
--- a/xrspatial/hydro/flow_length_d8.py
+++ b/xrspatial/hydro/flow_length_d8.py
@@ -35,6 +35,93 @@ from xrspatial.dataset_support import supports_dataset
 
 
 # =====================================================================
+# Memory guards
+# =====================================================================
+#
+# CPU peak working set per pixel for ``_flow_length_*_cpu``:
+#   flow_len   : float64 -> 8
+#   in_degree  : int32   -> 4
+#   valid      : int8    -> 1
+#   order_r    : int64   -> 8
+#   order_c    : int64   -> 8
+# Total ~29 bytes/pixel.  The caller-provided ``flow_dir`` array already
+# lives in RAM before the kernel runs and is not double-counted here.
+_BYTES_PER_PIXEL = 29
+
+# GPU peak working set per pixel for ``_flow_length_cupy``: that path
+# copies fd to host via ``.get()`` then runs the CPU kernel and copies
+# the output back via ``cp.asarray``.  Device-side residency at peak is
+# the input float64 (8 B/px) plus the output float64 (8 B/px); host-side
+# matches the 29 B/px CPU budget.  Use 32 B/px as a conservative GPU
+# budget covering both copies plus headroom.
+_GPU_BYTES_PER_PIXEL = 32
+
+
+def _available_memory_bytes():
+    """Best-effort estimate of available host memory in bytes."""
+    try:
+        with open('/proc/meminfo', 'r') as f:
+            for line in f:
+                if line.startswith('MemAvailable:'):
+                    return int(line.split()[1]) * 1024  # kB -> bytes
+    except (OSError, ValueError, IndexError):
+        pass
+    try:
+        import psutil
+        return psutil.virtual_memory().available
+    except (ImportError, AttributeError):
+        pass
+    return 2 * 1024 ** 3
+
+
+def _available_gpu_memory_bytes():
+    """Best-effort estimate of free GPU memory in bytes.
+
+    Returns 0 if CuPy / CUDA is unavailable or the query fails -- callers
+    use that as a sentinel meaning "no GPU info, skip the guard".
+    """
+    try:
+        import cupy as _cp
+        free, _total = _cp.cuda.runtime.memGetInfo()
+        return int(free)
+    except Exception:
+        return 0
+
+
+def _check_memory(height, width):
+    """Raise MemoryError if the flow_length kernel would exceed 50% of RAM."""
+    required = int(height) * int(width) * _BYTES_PER_PIXEL
+    available = _available_memory_bytes()
+    if required > 0.5 * available:
+        raise MemoryError(
+            f"flow_length_d8 on a {height}x{width} grid requires "
+            f"~{required / 1e9:.1f} GB of working memory but only "
+            f"~{available / 1e9:.1f} GB is available.  Use a "
+            f"dask-backed DataArray for out-of-core processing."
+        )
+
+
+def _check_gpu_memory(height, width):
+    """Raise MemoryError if the CuPy kernel would exceed 50% of free GPU RAM.
+
+    Skips the check (returns silently) when ``_available_gpu_memory_bytes``
+    cannot determine the free memory -- e.g. on hosts without CUDA, where
+    the kernel will fail at the cupy.asarray boundary anyway.
+    """
+    available = _available_gpu_memory_bytes()
+    if available <= 0:
+        return
+    required = int(height) * int(width) * _GPU_BYTES_PER_PIXEL
+    if required > 0.5 * available:
+        raise MemoryError(
+            f"flow_length_d8 on a {height}x{width} grid requires "
+            f"~{required / 1e9:.1f} GB of GPU working memory but only "
+            f"~{available / 1e9:.1f} GB is free on the active device.  "
+            f"Use a dask+cupy DataArray for out-of-core processing."
+        )
+
+
+# =====================================================================
 # Direction → step distance helper
 # =====================================================================
 
@@ -1056,6 +1143,7 @@ def flow_length_d8(flow_dir: xr.DataArray,
     data = flow_dir.data
 
     if isinstance(data, np.ndarray):
+        _check_memory(*data.shape)
         fd = data.astype(np.float64)
         H, W = fd.shape
         if direction == 'downstream':
@@ -1064,6 +1152,8 @@ def flow_length_d8(flow_dir: xr.DataArray,
             out = _flow_length_upstream_cpu(fd, H, W, cellsize_x, cellsize_y, diag)
 
     elif has_cuda_and_cupy() and is_cupy_array(data):
+        _check_gpu_memory(*data.shape)
+        _check_memory(*data.shape)
         out = _flow_length_cupy(data, direction, cellsize_x, cellsize_y, diag)
 
     elif has_cuda_and_cupy() and is_dask_cupy(flow_dir):

--- a/xrspatial/hydro/tests/test_flow_length_d8.py
+++ b/xrspatial/hydro/tests/test_flow_length_d8.py
@@ -274,6 +274,75 @@ class TestFlowLengthCuPy:
             equal_nan=True, rtol=1e-10)
 
 
+class TestMemoryGuard:
+    """Memory guard on the eager numpy / cupy backends."""
+
+    def test_numpy_huge_raster_raises(self):
+        """Numpy backend raises MemoryError when projected RAM exceeds budget."""
+        from unittest.mock import patch
+
+        fd = np.full((4, 4), 0.0, dtype=np.float64)
+        raster = _make_flow_dir_raster(fd)
+
+        with patch(
+            "xrspatial.hydro.flow_length_d8._available_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match="working memory"):
+                flow_length(raster, direction='downstream')
+
+    def test_numpy_normal_input_succeeds(self):
+        """Normal-size raster passes the guard with real memory."""
+        fd = np.full((10, 10), 0.0, dtype=np.float64)
+        raster = _make_flow_dir_raster(fd)
+        result = flow_length(raster, direction='downstream')
+        assert result.shape == (10, 10)
+
+    @dask_array_available
+    def test_dask_path_skips_guard(self):
+        """Dask backend bypasses the guard -- per-tile allocations are bounded."""
+        from unittest.mock import patch
+
+        fd = np.full((6, 6), 0.0, dtype=np.float64)
+        raster = _make_flow_dir_raster(fd, backend='dask', chunks=(3, 3))
+
+        with patch(
+            "xrspatial.hydro.flow_length_d8._available_memory_bytes",
+            return_value=1,
+        ):
+            result = flow_length(raster, direction='downstream')
+            _ = result.data[:3, :3].compute()
+
+    def test_error_message_mentions_dimensions(self):
+        """The error message should mention the grid dimensions and dask."""
+        from unittest.mock import patch
+
+        fd = np.full((7, 9), 0.0, dtype=np.float64)
+        raster = _make_flow_dir_raster(fd)
+
+        with patch(
+            "xrspatial.hydro.flow_length_d8._available_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match=r"7x9.*dask"):
+                flow_length(raster, direction='upstream')
+
+    @cuda_and_cupy_available
+    def test_cupy_huge_raster_raises(self):
+        """CuPy backend raises MemoryError when projected GPU RAM exceeds budget."""
+        from unittest.mock import patch
+
+        fd = np.full((4, 4), 0.0, dtype=np.float64)
+        raster = _make_flow_dir_raster(fd, backend='cupy')
+
+        with patch(
+            "xrspatial.hydro.flow_length_d8._available_gpu_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match="GPU working memory"):
+                flow_length(raster, direction='downstream')
+
+
 @cuda_and_cupy_available
 @dask_array_available
 class TestFlowLengthDaskCuPy:


### PR DESCRIPTION
## Summary

Adds a memory guard to `flow_length_d8()` matching the pattern from #1319, #1324, #1325, and #1326. The eager numpy and cupy backends now raise `MemoryError` before allocating an HxW working set that would exceed 50% of available host or GPU memory. Dask paths skip the check since per-tile allocations are bounded by chunk size.

Closes #1327.

## Changes

- Per-module helpers: `_BYTES_PER_PIXEL` (29), `_GPU_BYTES_PER_PIXEL` (32), `_available_memory_bytes`, `_available_gpu_memory_bytes`, `_check_memory`, `_check_gpu_memory`.
- Wire `_check_memory` into the numpy branch and `_check_gpu_memory` + `_check_memory` into the cupy branch. The cupy path copies to host and runs the CPU kernel, so both budgets apply.
- 5 new tests: oversize numpy raises, normal numpy passes, dask bypass, error mentions dimensions and dask, cupy raises (gated on cuda+cupy).

## Test plan

- [x] `pytest xrspatial/hydro/tests/test_flow_length_d8.py`, 31 passed
- [x] Full hydro suite, 635 passed (one pre-existing temp-dir cleanup test flakes under parallel runs; unrelated to this change)