### PR TITLE
Guard fill_d8() against unbounded memory allocations (#1334)

### DIFF
--- a/xrspatial/hydro/fill_d8.py
+++ b/xrspatial/hydro/fill_d8.py
@@ -41,6 +41,92 @@ from xrspatial.dataset_support import supports_dataset
 
 
 # =====================================================================
+# Memory guards
+# =====================================================================
+#
+# CPU peak working set per pixel for the eager numpy path:
+#   dem_f64        : float64 -> 8   (data.astype(np.float64) copy)
+#   ring           : float64 -> ~8  ((h+2, w+2), small overhead)
+#   fill (output)  : float64 -> 8   (returned by kernel)
+#   z_limit branch : float64 -> 8   (np.where(...) extra copy)
+# Total ~32 bytes/pixel.  The caller's input array is already in RAM
+# before dispatch and is not double-counted here.
+_BYTES_PER_PIXEL = 32
+
+# GPU peak working set per pixel for ``_fill_cupy``:
+#   dem_f64        : float64 -> 8
+#   fill           : float64 -> 8
+#   cp.where output: float64 -> 8
+#   z_limit branch : float64 -> 8
+# Total ~32 bytes/pixel on the device.
+_GPU_BYTES_PER_PIXEL = 32
+
+
+def _available_memory_bytes():
+    """Best-effort estimate of available host memory in bytes."""
+    try:
+        with open('/proc/meminfo', 'r') as f:
+            for line in f:
+                if line.startswith('MemAvailable:'):
+                    return int(line.split()[1]) * 1024  # kB -> bytes
+    except (OSError, ValueError, IndexError):
+        pass
+    try:
+        import psutil
+        return psutil.virtual_memory().available
+    except (ImportError, AttributeError):
+        pass
+    return 2 * 1024 ** 3
+
+
+def _available_gpu_memory_bytes():
+    """Best-effort estimate of free GPU memory in bytes.
+
+    Returns 0 if CuPy / CUDA is unavailable or the query fails -- callers
+    use that as a sentinel meaning "no GPU info, skip the guard".
+    """
+    try:
+        import cupy as _cp
+        free, _total = _cp.cuda.runtime.memGetInfo()
+        return int(free)
+    except Exception:
+        return 0
+
+
+def _check_memory(height, width):
+    """Raise MemoryError if the fill kernel would exceed 50% of RAM."""
+    required = int(height) * int(width) * _BYTES_PER_PIXEL
+    available = _available_memory_bytes()
+    if required > 0.5 * available:
+        raise MemoryError(
+            f"fill_d8 on a {height}x{width} grid requires "
+            f"~{required / 1e9:.1f} GB of working memory but only "
+            f"~{available / 1e9:.1f} GB is available.  Use a "
+            f"dask-backed DataArray for out-of-core processing."
+        )
+
+
+def _check_gpu_memory(height, width):
+    """Raise MemoryError if the CuPy kernel would exceed 50% of free GPU RAM.
+
+    Skips the check (returns silently) when ``_available_gpu_memory_bytes``
+    cannot determine the free memory -- e.g. on hosts without CUDA, where
+    the kernel will fail at the cupy.asarray boundary anyway.
+    """
+    available = _available_gpu_memory_bytes()
+    if available <= 0:
+        return
+    required = int(height) * int(width) * _GPU_BYTES_PER_PIXEL
+    if required > 0.5 * available:
+        raise MemoryError(
+            f"fill_d8 on a {height}x{width} grid requires "
+            f"~{required / 1e9:.1f} GB of GPU working memory but only "
+            f"~{available / 1e9:.1f} GB is free on the active device.  "
+            f"Use a dask+cupy DataArray for out-of-core processing."
+        )
+
+
+# =====================================================================
 # CPU tile kernel
 # =====================================================================
 
@@ -483,6 +569,7 @@ def fill_d8(dem: xr.DataArray,
     data = dem.data
 
     if isinstance(data, np.ndarray):
+        _check_memory(*data.shape)
         dem_f64 = data.astype(np.float64)
         h, w = dem_f64.shape
         ring = np.full((h + 2, w + 2), -1e308, dtype=np.float64)
@@ -491,6 +578,7 @@ def fill_d8(dem: xr.DataArray,
             out = np.where(out - dem_f64 > z_limit, dem_f64, out)
 
     elif has_cuda_and_cupy() and is_cupy_array(data):
+        _check_gpu_memory(*data.shape)
         out = _fill_cupy(data)
         if z_limit is not None:
             import cupy as cp

--- a/xrspatial/hydro/tests/test_fill_d8.py
+++ b/xrspatial/hydro/tests/test_fill_d8.py
@@ -242,3 +242,76 @@ def test_numpy_equals_dask_cupy():
     dcp_result = fill(dcp_agg)
     np.testing.assert_allclose(
         np_result.data, dcp_result.data.compute().get(), equal_nan=True)
+
+
+# ---------------------------------------------------------------------------
+# Memory guard
+# ---------------------------------------------------------------------------
+
+class TestMemoryGuard:
+    """Memory guard on the eager numpy / cupy backends."""
+
+    def test_numpy_huge_raster_raises(self):
+        """Numpy backend raises MemoryError when projected RAM exceeds budget."""
+        from unittest.mock import patch
+
+        dem = np.zeros((4, 4), dtype=np.float64)
+        agg = create_test_raster(dem)
+
+        with patch(
+            "xrspatial.hydro.fill_d8._available_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match="working memory"):
+                fill(agg)
+
+    def test_numpy_normal_input_succeeds(self):
+        """Normal-size raster passes the guard with real memory."""
+        dem = np.zeros((10, 10), dtype=np.float64)
+        agg = create_test_raster(dem)
+        result = fill(agg)
+        assert result.shape == (10, 10)
+
+    @dask_array_available
+    def test_dask_path_skips_guard(self):
+        """Dask backend bypasses the guard -- per-tile allocations are bounded."""
+        from unittest.mock import patch
+
+        dem = np.zeros((6, 6), dtype=np.float64)
+        agg = create_test_raster(dem, backend='dask', chunks=(3, 3))
+
+        with patch(
+            "xrspatial.hydro.fill_d8._available_memory_bytes",
+            return_value=1,
+        ):
+            result = fill(agg)
+            _ = result.data[:3, :3].compute()
+
+    def test_error_message_mentions_dimensions(self):
+        """The error message should mention the grid dimensions and dask."""
+        from unittest.mock import patch
+
+        dem = np.zeros((7, 9), dtype=np.float64)
+        agg = create_test_raster(dem)
+
+        with patch(
+            "xrspatial.hydro.fill_d8._available_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match=r"7x9.*dask"):
+                fill(agg)
+
+    @cuda_and_cupy_available
+    def test_cupy_huge_raster_raises(self):
+        """CuPy backend raises MemoryError when projected GPU RAM exceeds budget."""
+        from unittest.mock import patch
+
+        dem = np.zeros((4, 4), dtype=np.float64)
+        agg = create_test_raster(dem, backend='cupy')
+
+        with patch(
+            "xrspatial.hydro.fill_d8._available_gpu_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match="GPU working memory"):
+                fill(agg)


### PR DESCRIPTION
## Summary

- Adds `_check_memory` / `_check_gpu_memory` budget checks (32 B/px CPU, 32 B/px GPU, 50% threshold) to the eager numpy and cupy backends in `fill_d8.py`.
- Dask backends skip the guard because per-tile allocations are already bounded by chunk size.
- Adds 5 memory-guard tests (numpy raise, normal-input pass, dask bypass, error message, cupy raise).

Fixes #1334.

## Background

The eager numpy path allocated `dem_f64` (float64 copy), `ring` ((h+2, w+2) float64), `fill` (kernel output, float64), and an extra `np.where(...)` copy when `z_limit` is set, ~32 B/pixel of working memory plus the caller's input. `_fill_cupy` allocated `dem_f64` + `fill` + a `cp.where(...)` output + an optional `z_limit` `cp.where(...)`, ~32 B/pixel of GPU memory. Neither backend checked against available memory, so a 50000x50000 numpy DEM asked for ~60 GB of host memory before anything errored out.

Same guard pattern was added in flow_accumulation (#1318/#1319), sieve (#1296), kde (#1287), resample (#1295), focal (#1286), geodesic (#1283), mahalanobis (#1288), true_color (#1291), diffuse (#1267), erode (#1275), emerging_hotspots (#1274), dasymetric (#1261), sky_view_factor (#1299), surface_distance (#1303).

`fill_d8` is the depression-filling preprocessing step most hydrology pipelines run first on the full DEM, so it needs the same guard.

## Test plan

- [x] `pytest xrspatial/hydro/tests/test_fill_d8.py` -- 24 passed
- [x] Full hydro suite: `pytest xrspatial/hydro/tests/` -- 636 passed
