### PR TITLE
Guard hand_mfd() against unbounded memory allocations (#1338)

### DIFF
--- a/xrspatial/hydro/hand_mfd.py
+++ b/xrspatial/hydro/hand_mfd.py
@@ -36,6 +36,97 @@ from xrspatial.utils import (
 
 
 # =====================================================================
+# Memory guards
+# =====================================================================
+#
+# CPU peak working set per pixel for ``_hand_mfd_cpu``:
+#   in_degree  : int32   -> 4
+#   valid      : int8    -> 1
+#   is_stream  : int8    -> 1
+#   drain_elev : float64 -> 8
+#   hand_out   : float64 -> 8
+#   order_r    : int64   -> 8
+#   order_c    : int64   -> 8
+# Total ~38 bytes/pixel.  The caller-provided ``fractions`` (8, H, W),
+# ``flow_accum``, and ``elevation`` arrays already live in RAM before the
+# kernel runs and are not double-counted here.
+_BYTES_PER_PIXEL = 38
+
+# GPU peak working set per pixel for ``_hand_mfd_cupy``: that path copies
+# fractions/fa/elev to host via ``.get()`` then runs ``_hand_mfd_cpu``.
+# Host working set is dominated by the same 38 B/px as the numpy path; on
+# the device we keep the fractions array (8 * float64 = 64 B/px), the two
+# 2D inputs (2 * float64 = 16 B/px) and the output (float64 = 8 B/px),
+# but the input copies already exist before dispatch.  Use 32 B/px as a
+# conservative budget mirroring the d8 sibling guard.
+_GPU_BYTES_PER_PIXEL = 32
+
+
+def _available_memory_bytes():
+    """Best-effort estimate of available host memory in bytes."""
+    try:
+        with open('/proc/meminfo', 'r') as f:
+            for line in f:
+                if line.startswith('MemAvailable:'):
+                    return int(line.split()[1]) * 1024  # kB -> bytes
+    except (OSError, ValueError, IndexError):
+        pass
+    try:
+        import psutil
+        return psutil.virtual_memory().available
+    except (ImportError, AttributeError):
+        pass
+    return 2 * 1024 ** 3
+
+
+def _available_gpu_memory_bytes():
+    """Best-effort estimate of free GPU memory in bytes.
+
+    Returns 0 if CuPy / CUDA is unavailable or the query fails -- callers
+    use that as a sentinel meaning "no GPU info, skip the guard".
+    """
+    try:
+        import cupy as _cp
+        free, _total = _cp.cuda.runtime.memGetInfo()
+        return int(free)
+    except Exception:
+        return 0
+
+
+def _check_memory(height, width):
+    """Raise MemoryError if the HAND kernel would exceed 50% of RAM."""
+    required = int(height) * int(width) * _BYTES_PER_PIXEL
+    available = _available_memory_bytes()
+    if required > 0.5 * available:
+        raise MemoryError(
+            f"hand_mfd on a {height}x{width} grid requires "
+            f"~{required / 1e9:.1f} GB of working memory but only "
+            f"~{available / 1e9:.1f} GB is available.  Use a "
+            f"dask-backed DataArray for out-of-core processing."
+        )
+
+
+def _check_gpu_memory(height, width):
+    """Raise MemoryError if the CuPy kernel would exceed 50% of free GPU RAM.
+
+    Skips the check (returns silently) when ``_available_gpu_memory_bytes``
+    cannot determine the free memory -- e.g. on hosts without CUDA, where
+    the kernel will fail at the cupy.asarray boundary anyway.
+    """
+    available = _available_gpu_memory_bytes()
+    if available <= 0:
+        return
+    required = int(height) * int(width) * _GPU_BYTES_PER_PIXEL
+    if required > 0.5 * available:
+        raise MemoryError(
+            f"hand_mfd on a {height}x{width} grid requires "
+            f"~{required / 1e9:.1f} GB of GPU working memory but only "
+            f"~{available / 1e9:.1f} GB is free on the active device.  "
+            f"Use a dask+cupy DataArray for out-of-core processing."
+        )
+
+
+# =====================================================================
 # CPU kernel
 # =====================================================================
 
@@ -601,12 +692,15 @@ def hand_mfd(flow_dir_mfd: xr.DataArray,
     _, H, W = data.shape
 
     if isinstance(data, np.ndarray):
+        _check_memory(H, W)
         fr = data.astype(np.float64)
         fa = np.asarray(fa_data, dtype=np.float64)
         el = np.asarray(el_data, dtype=np.float64)
         out = _hand_mfd_cpu(fr, fa, el, H, W, float(threshold))
 
     elif has_cuda_and_cupy() and is_cupy_array(data):
+        _check_gpu_memory(H, W)
+        _check_memory(H, W)
         out = _hand_mfd_cupy(data, fa_data, el_data, float(threshold))
 
     elif has_cuda_and_cupy() and is_dask_cupy(flow_dir_mfd):

--- a/xrspatial/hydro/tests/test_hand_mfd.py
+++ b/xrspatial/hydro/tests/test_hand_mfd.py
@@ -192,6 +192,90 @@ class TestHandMfdCuPy:
             equal_nan=True, rtol=1e-10)
 
 
+class TestMemoryGuard:
+    """Memory guard on the eager numpy / cupy backends."""
+
+    def test_numpy_huge_raster_raises(self):
+        """Numpy backend raises MemoryError when projected RAM exceeds budget."""
+        from unittest.mock import patch
+
+        fracs = _make_all_east(4, 4)
+        fa = np.zeros((4, 4), dtype=np.float64)
+        elev = np.zeros((4, 4), dtype=np.float64)
+        fd_r, fa_r, el_r = _make_hand_mfd_rasters(
+            fracs, fa, elev, backend='numpy')
+
+        with patch(
+            "xrspatial.hydro.hand_mfd._available_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match="working memory"):
+                hand_mfd(fd_r, fa_r, el_r, threshold=1)
+
+    def test_numpy_normal_input_succeeds(self):
+        """Normal-size raster passes the guard with real memory."""
+        fracs = _make_all_east(10, 10)
+        fa = np.ones((10, 10), dtype=np.float64)
+        elev = np.zeros((10, 10), dtype=np.float64)
+        fd_r, fa_r, el_r = _make_hand_mfd_rasters(
+            fracs, fa, elev, backend='numpy')
+        result = hand_mfd(fd_r, fa_r, el_r, threshold=1)
+        assert result.shape == (10, 10)
+
+    @dask_array_available
+    def test_dask_path_skips_guard(self):
+        """Dask backend bypasses the guard -- per-tile allocations are bounded."""
+        from unittest.mock import patch
+
+        fracs = _make_all_east(6, 6)
+        fa = np.ones((6, 6), dtype=np.float64)
+        elev = np.zeros((6, 6), dtype=np.float64)
+        fd_r, fa_r, el_r = _make_hand_mfd_rasters(
+            fracs, fa, elev, backend='dask', chunks=(3, 3))
+
+        with patch(
+            "xrspatial.hydro.hand_mfd._available_memory_bytes",
+            return_value=1,
+        ):
+            result = hand_mfd(fd_r, fa_r, el_r, threshold=1)
+            _ = result.data[:3, :3].compute()
+
+    def test_error_message_mentions_dimensions(self):
+        """The error message should mention the grid dimensions and dask."""
+        from unittest.mock import patch
+
+        fracs = _make_all_east(7, 9)
+        fa = np.ones((7, 9), dtype=np.float64)
+        elev = np.zeros((7, 9), dtype=np.float64)
+        fd_r, fa_r, el_r = _make_hand_mfd_rasters(
+            fracs, fa, elev, backend='numpy')
+
+        with patch(
+            "xrspatial.hydro.hand_mfd._available_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match=r"7x9.*dask"):
+                hand_mfd(fd_r, fa_r, el_r, threshold=1)
+
+    @cuda_and_cupy_available
+    def test_cupy_huge_raster_raises(self):
+        """CuPy backend raises MemoryError when projected GPU RAM exceeds budget."""
+        from unittest.mock import patch
+
+        fracs = _make_all_east(4, 4)
+        fa = np.zeros((4, 4), dtype=np.float64)
+        elev = np.zeros((4, 4), dtype=np.float64)
+        fd_r, fa_r, el_r = _make_hand_mfd_rasters(
+            fracs, fa, elev, backend='cupy')
+
+        with patch(
+            "xrspatial.hydro.hand_mfd._available_gpu_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match="GPU working memory"):
+                hand_mfd(fd_r, fa_r, el_r, threshold=1)
+
+
 @cuda_and_cupy_available
 @dask_array_available
 class TestHandMfdDaskCuPy:


### PR DESCRIPTION
Closes #1338.

## Summary

- Add `_check_memory` and `_check_gpu_memory` helpers to `xrspatial/hydro/hand_mfd.py` modelled on the d8 fix in #1326.
- Wire the checks into `hand_mfd()` ahead of the numpy and cupy dispatch. Dask paths skip the guard; per-tile allocations are bounded by chunk size.
- 38 B/px on the CPU and a conservative 32 B/px on the GPU. The MFD `fractions` input is `(8, H, W) float64` — 64 B/px — but it is caller-provided and already in RAM before `hand_mfd()` runs, so it is not double-counted in the working-set budget.
- Five tests on the guard: numpy oversize rejection, dask bypass, valid pass-through, dimensions in error message, and cupy oversize rejection.

## Test plan

- [x] `pytest xrspatial/hydro/tests/test_hand_mfd.py` — 18 passed
- [x] `pytest xrspatial/hydro/tests/` — 636 passed
