### PR TITLE
Guard stream_link_mfd() against unbounded memory allocations (#1337)

### DIFF
--- a/xrspatial/hydro/stream_link_mfd.py
+++ b/xrspatial/hydro/stream_link_mfd.py
@@ -53,6 +53,98 @@ from xrspatial.hydro.stream_order_d8 import _to_numpy_f64
 
 
 # =====================================================================
+# Memory guards
+# =====================================================================
+#
+# CPU peak working set per pixel for ``_stream_link_mfd_cpu``:
+#   frac input copy : (8,H,W) float64 -> 64
+#   stream_mask     : int8           -> 1
+#   link_id         : float64        -> 8
+#   in_degree       : int32          -> 4
+#   orig_indeg      : int32          -> 4
+#   queue_r         : int64          -> 8
+#   queue_c         : int64          -> 8
+# Total ~97 bytes/pixel.  The caller-provided ``flow_accum`` array
+# already lives in RAM before the kernel runs and is not double-counted.
+_BYTES_PER_PIXEL = 97
+
+# GPU peak working set per pixel for ``_stream_link_mfd_cupy``:
+#   fractions_f64   : (8,H,W) float64 -> 64
+#   stream_mask_i8  : int8            -> 1
+#   in_degree       : int32           -> 4
+#   orig_indeg      : int32           -> 4
+#   state           : int32           -> 4
+#   link_id         : float64         -> 8
+#   fa_cp           : float64         -> 8
+# Total ~93 B/px.  Use 100 B/px as a conservative budget.
+_GPU_BYTES_PER_PIXEL = 100
+
+
+def _available_memory_bytes():
+    """Best-effort estimate of available host memory in bytes."""
+    try:
+        with open('/proc/meminfo', 'r') as f:
+            for line in f:
+                if line.startswith('MemAvailable:'):
+                    return int(line.split()[1]) * 1024  # kB -> bytes
+    except (OSError, ValueError, IndexError):
+        pass
+    try:
+        import psutil
+        return psutil.virtual_memory().available
+    except (ImportError, AttributeError):
+        pass
+    return 2 * 1024 ** 3
+
+
+def _available_gpu_memory_bytes():
+    """Best-effort estimate of free GPU memory in bytes.
+
+    Returns 0 if CuPy / CUDA is unavailable or the query fails -- callers
+    use that as a sentinel meaning "no GPU info, skip the guard".
+    """
+    try:
+        import cupy as _cp
+        free, _total = _cp.cuda.runtime.memGetInfo()
+        return int(free)
+    except Exception:
+        return 0
+
+
+def _check_memory(height, width):
+    """Raise MemoryError if the kernel would exceed 50% of available RAM."""
+    required = int(height) * int(width) * _BYTES_PER_PIXEL
+    available = _available_memory_bytes()
+    if required > 0.5 * available:
+        raise MemoryError(
+            f"stream_link_mfd on a {height}x{width} grid requires "
+            f"~{required / 1e9:.1f} GB of working memory but only "
+            f"~{available / 1e9:.1f} GB is available.  Use a "
+            f"dask-backed DataArray for out-of-core processing."
+        )
+
+
+def _check_gpu_memory(height, width):
+    """Raise MemoryError if the CuPy kernel would exceed 50% of free GPU RAM.
+
+    Skips the check (returns silently) when ``_available_gpu_memory_bytes``
+    cannot determine the free memory -- e.g. on hosts without CUDA, where
+    the kernel will fail at the cupy.asarray boundary anyway.
+    """
+    available = _available_gpu_memory_bytes()
+    if available <= 0:
+        return
+    required = int(height) * int(width) * _GPU_BYTES_PER_PIXEL
+    if required > 0.5 * available:
+        raise MemoryError(
+            f"stream_link_mfd on a {height}x{width} grid requires "
+            f"~{required / 1e9:.1f} GB of GPU working memory but only "
+            f"~{available / 1e9:.1f} GB is free on the active device.  "
+            f"Use a dask+cupy DataArray for out-of-core processing."
+        )
+
+
+# =====================================================================
 # CPU kernel
 # =====================================================================
 
@@ -934,6 +1026,7 @@ def stream_link_mfd(fractions: xr.DataArray,
     fa_data = flow_accum.data
 
     if isinstance(data, np.ndarray):
+        _check_memory(data.shape[1], data.shape[2])
         frac = data.astype(np.float64)
         fa = np.asarray(fa_data, dtype=np.float64)
         stream_mask = np.where(fa >= threshold, 1, 0).astype(np.int8)
@@ -944,6 +1037,7 @@ def stream_link_mfd(fractions: xr.DataArray,
         out = _stream_link_mfd_cpu(frac, stream_mask, h, w)
 
     elif has_cuda_and_cupy() and is_cupy_array(data):
+        _check_gpu_memory(data.shape[1], data.shape[2])
         import cupy as cp
         fa_cp = cp.asarray(fa_data, dtype=cp.float64)
         frac_cp = data.astype(cp.float64)

--- a/xrspatial/hydro/tests/test_stream_link_mfd.py
+++ b/xrspatial/hydro/tests/test_stream_link_mfd.py
@@ -181,3 +181,97 @@ def test_dask_matches_numpy():
     np.testing.assert_array_equal(
         np.nan_to_num(np_result.values, nan=-999),
         np.nan_to_num(dask_result.values, nan=-999))
+
+
+# ====================================================================
+# Memory guard tests
+# ====================================================================
+
+class TestMemoryGuard:
+    """Memory guard on the eager numpy / cupy backends."""
+
+    def test_numpy_huge_raster_raises(self):
+        """Numpy backend raises MemoryError when projected RAM exceeds budget."""
+        from unittest.mock import patch
+
+        fracs = _make_fractions({(0, 0): []}, (4, 4))
+        accum = np.ones((4, 4), dtype=np.float64)
+
+        with patch(
+            "xrspatial.hydro.stream_link_mfd._available_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match="working memory"):
+                _call(fracs, accum, threshold=1)
+
+    def test_numpy_normal_input_succeeds(self):
+        """Normal-size raster passes the guard with real memory."""
+        fracs = _make_fractions({
+            (0, 0): [(0, 1.0)],
+            (0, 1): [(0, 1.0)],
+            (0, 2): [],
+        }, (1, 3))
+        accum = np.array([[1.0, 2.0, 3.0]], dtype=np.float64)
+        result = _call(fracs, accum, threshold=1)
+        assert result.shape == (1, 3)
+
+    @dask_array_available
+    def test_dask_path_skips_guard(self):
+        """Dask backend bypasses the guard -- per-tile allocations are bounded."""
+        from unittest.mock import patch
+        import dask.array as da
+
+        fracs = _make_fractions({(0, 0): []}, (6, 6))
+        # Replace NaN with zeros so dask path doesn't choke
+        fracs = np.nan_to_num(fracs, nan=0.0)
+        accum = np.ones((6, 6), dtype=np.float64)
+
+        frac_dask = xr.DataArray(
+            da.from_array(fracs, chunks=(8, 3, 3)),
+            dims=['neighbor', 'y', 'x'])
+        fa_dask = xr.DataArray(
+            da.from_array(accum, chunks=(3, 3)),
+            dims=['y', 'x'])
+
+        with patch(
+            "xrspatial.hydro.stream_link_mfd._available_memory_bytes",
+            return_value=1,
+        ):
+            # Dask path must not trigger the guard at dispatch time
+            result = stream_link_mfd(frac_dask, fa_dask, threshold=1)
+            # We don't need to fully compute -- just assert no MemoryError
+            assert result is not None
+
+    def test_error_message_mentions_dimensions(self):
+        """The error message should mention the grid dimensions and dask."""
+        from unittest.mock import patch
+
+        fracs = _make_fractions({(0, 0): []}, (7, 9))
+        accum = np.ones((7, 9), dtype=np.float64)
+
+        with patch(
+            "xrspatial.hydro.stream_link_mfd._available_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match=r"7x9.*dask"):
+                _call(fracs, accum, threshold=1)
+
+    @cuda_and_cupy_available
+    def test_cupy_huge_raster_raises(self):
+        """CuPy backend raises MemoryError when projected GPU RAM exceeds budget."""
+        from unittest.mock import patch
+        import cupy as cp
+
+        fracs = _make_fractions({(0, 0): []}, (4, 4))
+        accum = np.ones((4, 4), dtype=np.float64)
+
+        frac_cp = xr.DataArray(
+            cp.asarray(fracs), dims=['neighbor', 'y', 'x'])
+        fa_cp = xr.DataArray(cp.asarray(accum), dims=['y', 'x'])
+
+        with patch(
+            "xrspatial.hydro.stream_link_mfd._available_gpu_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match="GPU working memory"):
+                stream_link_mfd(frac_cp, fa_cp, threshold=1)


### PR DESCRIPTION
Fixes #1337.

## Summary

- Add `_BYTES_PER_PIXEL = 97` and `_GPU_BYTES_PER_PIXEL = 100` to `xrspatial/hydro/stream_link_mfd.py` plus the four helpers (`_available_memory_bytes`, `_available_gpu_memory_bytes`, `_check_memory`, `_check_gpu_memory`) used in #1335.
- Wire `_check_memory` / `_check_gpu_memory` into the numpy and cupy branches of `stream_link_mfd` before any H*W allocation. Dask and dask+cupy are left untouched (per-tile allocation already bounded).
- 50% threshold, MemoryError mentions grid dimensions and the dask alternative.
- 5 new tests covering: oversize numpy raises, normal numpy succeeds, dask path skips guard, error message includes dimensions, oversize cupy raises (gated).

## Byte budget

CPU peak working set per pixel:
- frac input copy (8, H, W) float64 -> 64
- stream_mask int8 -> 1
- link_id float64 -> 8
- in_degree int32 -> 4
- orig_indeg int32 -> 4
- queue_r int64 -> 8
- queue_c int64 -> 8

Total ~97 B/px (vs. ~32 B/px for stream_link_d8). The (8, H, W) fractions copy dominates.

GPU peak working set per pixel: fractions_f64 (8, H, W) 64 + stream_mask_i8 1 + in_degree 4 + orig_indeg 4 + state 4 + link_id 8 + fa_cp 8 = ~93 B/px. Use 100 B/px as the budget.

## Test plan
- [x] `pytest xrspatial/hydro/tests/test_stream_link_mfd.py` (11 passed)
- [x] full hydro suite (635 passed; one unrelated pre-existing failure in `test_basin_d8.py::test_basin_dask_temp_cleanup` deselected)