### PR TITLE
Guard stream_order_mfd() against unbounded memory allocations (#1349)

### DIFF
--- a/xrspatial/hydro/stream_order_mfd.py
+++ b/xrspatial/hydro/stream_order_mfd.py
@@ -47,6 +47,103 @@ from xrspatial.utils import (
 from xrspatial.hydro._boundary_store import BoundaryStore
 from xrspatial.dataset_support import supports_dataset
 
+
+# =====================================================================
+# Memory guards
+# =====================================================================
+#
+# CPU peak working set per pixel for the eager Strahler/Shreve MFD
+# kernels, dominated by the (8, H, W) fractions copy:
+#   frac input copy : (8,H,W) float64 -> 64
+#   stream_mask     : int8           -> 1
+#   order           : float64        -> 8
+#   in_degree       : int32          -> 4
+#   max_in          : float64        -> 8   (Strahler only)
+#   cnt_max         : int32          -> 4   (Strahler only)
+#   queue_r         : int64          -> 8
+#   queue_c         : int64          -> 8
+# Total ~105 bytes/pixel for Strahler, ~97 for Shreve.  We budget for the
+# worst case.  Caller-provided ``flow_accum`` already lives in RAM
+# before the kernel runs and is not double-counted here.
+_BYTES_PER_PIXEL = 105
+
+# GPU peak working set per pixel for ``_stream_order_mfd_cupy``:
+#   fractions_f64   : (8,H,W) float64 -> 64
+#   stream_mask_i8  : int8            -> 1
+#   in_degree       : int32           -> 4
+#   state           : int32           -> 4
+#   order           : float64         -> 8
+#   max_in          : float64         -> 8
+#   cnt_max         : int32           -> 4
+#   fa_cp           : float64         -> 8
+# Total ~101 B/px.  Use 105 B/px as a conservative budget.
+_GPU_BYTES_PER_PIXEL = 105
+
+
+def _available_memory_bytes():
+    """Best-effort estimate of available host memory in bytes."""
+    try:
+        with open('/proc/meminfo', 'r') as f:
+            for line in f:
+                if line.startswith('MemAvailable:'):
+                    return int(line.split()[1]) * 1024  # kB -> bytes
+    except (OSError, ValueError, IndexError):
+        pass
+    try:
+        import psutil
+        return psutil.virtual_memory().available
+    except (ImportError, AttributeError):
+        pass
+    return 2 * 1024 ** 3
+
+
+def _available_gpu_memory_bytes():
+    """Best-effort estimate of free GPU memory in bytes.
+
+    Returns 0 if CuPy / CUDA is unavailable or the query fails -- callers
+    use that as a sentinel meaning "no GPU info, skip the guard".
+    """
+    try:
+        import cupy as _cp
+        free, _total = _cp.cuda.runtime.memGetInfo()
+        return int(free)
+    except Exception:
+        return 0
+
+
+def _check_memory(height, width):
+    """Raise MemoryError if the kernel would exceed 50% of available RAM."""
+    required = int(height) * int(width) * _BYTES_PER_PIXEL
+    available = _available_memory_bytes()
+    if required > 0.5 * available:
+        raise MemoryError(
+            f"stream_order_mfd on a {height}x{width} grid requires "
+            f"~{required / 1e9:.1f} GB of working memory but only "
+            f"~{available / 1e9:.1f} GB is available.  Use a "
+            f"dask-backed DataArray for out-of-core processing."
+        )
+
+
+def _check_gpu_memory(height, width):
+    """Raise MemoryError if the CuPy kernel would exceed 50% of free GPU RAM.
+
+    Skips the check (returns silently) when ``_available_gpu_memory_bytes``
+    cannot determine the free memory -- e.g. on hosts without CUDA, where
+    the kernel will fail at the cupy.asarray boundary anyway.
+    """
+    available = _available_gpu_memory_bytes()
+    if available <= 0:
+        return
+    required = int(height) * int(width) * _GPU_BYTES_PER_PIXEL
+    if required > 0.5 * available:
+        raise MemoryError(
+            f"stream_order_mfd on a {height}x{width} grid requires "
+            f"~{required / 1e9:.1f} GB of GPU working memory but only "
+            f"~{available / 1e9:.1f} GB is free on the active device.  "
+            f"Use a dask+cupy DataArray for out-of-core processing."
+        )
+
+
 # Neighbor offsets: E, SE, S, SW, W, NW, N, NE
 _DY = np.array([0, 1, 1, 1, 0, -1, -1, -1], dtype=np.int64)
 _DX = np.array([1, 1, 0, -1, -1, -1, 0, 1], dtype=np.int64)
@@ -1414,6 +1511,7 @@ def stream_order_mfd(fractions: xr.DataArray,
         )
 
     if isinstance(frac_data, np.ndarray):
+        _check_memory(frac_data.shape[1], frac_data.shape[2])
         frac = frac_data.astype(np.float64)
         fa = np.asarray(fa_data, dtype=np.float64)
         stream_mask = np.where(fa >= threshold, 1, 0).astype(np.int8)
@@ -1428,6 +1526,7 @@ def stream_order_mfd(fractions: xr.DataArray,
             out = _shreve_mfd_cpu(frac, stream_mask, h, w)
 
     elif has_cuda_and_cupy() and is_cupy_array(frac_data):
+        _check_gpu_memory(frac_data.shape[1], frac_data.shape[2])
         import cupy as cp
         fa_cp = cp.asarray(fa_data, dtype=cp.float64)
         frac_cp = frac_data.astype(cp.float64)

--- a/xrspatial/hydro/tests/test_stream_order_mfd.py
+++ b/xrspatial/hydro/tests/test_stream_order_mfd.py
@@ -236,3 +236,95 @@ def test_dask_matches_numpy():
     np.testing.assert_array_equal(
         np.nan_to_num(np_result.values, nan=-999),
         np.nan_to_num(dask_result.values, nan=-999))
+
+
+# ====================================================================
+# Memory guard tests
+# ====================================================================
+
+class TestMemoryGuard:
+    """Memory guard on the eager numpy / cupy backends."""
+
+    def test_numpy_huge_raster_raises(self):
+        """Numpy backend raises MemoryError when projected RAM exceeds budget."""
+        from unittest.mock import patch
+
+        fracs = _make_fractions({(0, 0): []}, (4, 4))
+        accum = np.ones((4, 4), dtype=np.float64)
+
+        with patch(
+            "xrspatial.hydro.stream_order_mfd._available_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match="working memory"):
+                _call(fracs, accum, threshold=1)
+
+    def test_numpy_normal_input_succeeds(self):
+        """Normal-size raster passes the guard with real memory."""
+        fracs = _make_fractions({
+            (0, 0): [(0, 1.0)],
+            (0, 1): [(0, 1.0)],
+            (0, 2): [],
+        }, (1, 3))
+        accum = np.array([[1.0, 2.0, 3.0]], dtype=np.float64)
+        result = _call(fracs, accum, threshold=1)
+        assert result.shape == (1, 3)
+
+    @dask_array_available
+    def test_dask_path_skips_guard(self):
+        """Dask backend bypasses the guard -- per-tile allocations are bounded."""
+        from unittest.mock import patch
+        import dask.array as da
+
+        fracs = _make_fractions({(0, 0): []}, (6, 6))
+        # Replace NaN with zeros so dask path doesn't choke
+        fracs = np.nan_to_num(fracs, nan=0.0)
+        accum = np.ones((6, 6), dtype=np.float64)
+
+        frac_dask = xr.DataArray(
+            da.from_array(fracs, chunks=(8, 3, 3)),
+            dims=['neighbor', 'y', 'x'])
+        fa_dask = xr.DataArray(
+            da.from_array(accum, chunks=(3, 3)),
+            dims=['y', 'x'])
+
+        with patch(
+            "xrspatial.hydro.stream_order_mfd._available_memory_bytes",
+            return_value=1,
+        ):
+            result = stream_order_mfd(frac_dask, fa_dask, threshold=1)
+            assert result is not None
+
+    def test_error_message_mentions_dimensions(self):
+        """The error message should mention the grid dimensions and dask."""
+        from unittest.mock import patch
+
+        fracs = _make_fractions({(0, 0): []}, (7, 9))
+        accum = np.ones((7, 9), dtype=np.float64)
+
+        with patch(
+            "xrspatial.hydro.stream_order_mfd._available_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match=r"7x9.*dask"):
+                _call(fracs, accum, threshold=1)
+
+    @cuda_and_cupy_available
+    def test_cupy_huge_raster_raises(self):
+        """CuPy backend raises MemoryError when projected GPU RAM exceeds budget."""
+        from unittest.mock import patch
+        import cupy as cp
+
+        fracs = _make_fractions({(0, 0): []}, (4, 4))
+        accum = np.ones((4, 4), dtype=np.float64)
+
+        frac_da_cp = xr.DataArray(
+            cp.asarray(fracs), dims=['neighbor', 'y', 'x'])
+        fa_da_cp = xr.DataArray(cp.asarray(accum), dims=['y', 'x'])
+
+        with patch(
+            "xrspatial.hydro.stream_order_mfd._available_gpu_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match="GPU working memory"):
+                stream_order_mfd(frac_da_cp, fa_da_cp, threshold=1)


### PR DESCRIPTION
Fixes #1349.

`stream_order_mfd` allocated several `H*W` working arrays in its eager numpy and cupy backends and a `(8, H, W)` float64 fractions copy on top, with no upfront check that the result will fit in memory. A 50000x50000 raster wants ~262 GB on the CPU path, so the failure mode was an OOM kill rather than a clean Python exception.

This adds the per-module memory guard helpers (`_BYTES_PER_PIXEL`, `_GPU_BYTES_PER_PIXEL`, `_available_memory_bytes`, `_available_gpu_memory_bytes`, `_check_memory`, `_check_gpu_memory`) used across the rest of the hydro series and wires them into the public dispatch before any allocations.

## Bytes per pixel

CPU peak working set, Strahler worst case:

| array | dtype | B/px |
|---|---|---|
| `frac` input copy `(8,H,W)` | float64 | 64 |
| `stream_mask` | int8 | 1 |
| `order` | float64 | 8 |
| `in_degree` | int32 | 4 |
| `max_in` | float64 | 8 |
| `cnt_max` | int32 | 4 |
| `queue_r` | int64 | 8 |
| `queue_c` | int64 | 8 |

Total ~105 B/px.

GPU peak working set ~101 B/px. Use 105 B/px for both as a conservative budget.

## Behaviour

- numpy and cupy paths now raise `MemoryError` with a clear message when projected use exceeds 50% of available memory.
- dask paths skip the guard. Per-tile allocations are bounded by the chunk size and the dask scheduler handles spilling.
- The error message names the grid dimensions and points users at dask for out-of-core processing.

## Tests

Five new tests in `TestMemoryGuard`:
- numpy path raises with patched memory
- normal-size raster passes the guard
- dask path bypasses the guard
- error message mentions dimensions and dask
- cupy path raises with patched GPU memory

Full file: 14 tests pass. Full hydro suite: 643/644 pass; the one failure is the known `test_stream_link_dask_temp_cleanup` flake unrelated to this change.

## Companion issues

Same pattern as #1318 / #1319, #1321 / #1324, #1322, #1328 / #1331, #1333, #1337 / #1341, #1343.