### PR TITLE
Guard stream_order_dinf() against unbounded memory allocations (#1350)

### DIFF
--- a/xrspatial/hydro/stream_order_dinf.py
+++ b/xrspatial/hydro/stream_order_dinf.py
@@ -57,6 +57,103 @@ from xrspatial.dataset_support import supports_dataset
 from xrspatial.hydro.stream_order_d8 import _to_numpy_f64
 
 
+# =====================================================================
+# Memory guards
+# =====================================================================
+#
+# CPU peak working set per pixel for the eager Strahler/Shreve D-inf
+# kernels:
+#   order     : float64 -> 8
+#   in_degree : int32   -> 4
+#   max_in    : float64 -> 8   (Strahler only; Shreve omits it)
+#   cnt_max   : int32   -> 4   (Strahler only)
+#   queue_r   : int64   -> 8
+#   queue_c   : int64   -> 8
+# Total ~40 bytes/pixel for Strahler, ~32 for Shreve.  D-inf encodes one
+# continuous downstream angle per cell, not an 8-channel weight buffer
+# like MFD, so the working set matches the d8 budget.  We budget for the
+# worst case.  Caller-provided ``flow_dir`` and ``flow_accum`` already
+# live in RAM before the kernel runs and are not double-counted here.
+_BYTES_PER_PIXEL = 40
+
+# GPU peak working set per pixel for ``_stream_order_dinf_cupy``:
+#   angles_f64     : float64 -> 8
+#   stream_mask_i8 : int8    -> 1
+#   in_degree      : int32   -> 4
+#   state          : int32   -> 4
+#   order          : float64 -> 8
+#   max_in         : float64 -> 8
+#   cnt_max        : int32   -> 4
+# Total ~37 bytes/pixel.  The ``fa_cp`` input copy adds 8 B/px on the
+# device but is created from the caller's CuPy array.  Use 40 B/px as
+# a conservative budget.
+_GPU_BYTES_PER_PIXEL = 40
+
+
+def _available_memory_bytes():
+    """Best-effort estimate of available host memory in bytes."""
+    try:
+        with open('/proc/meminfo', 'r') as f:
+            for line in f:
+                if line.startswith('MemAvailable:'):
+                    return int(line.split()[1]) * 1024  # kB -> bytes
+    except (OSError, ValueError, IndexError):
+        pass
+    try:
+        import psutil
+        return psutil.virtual_memory().available
+    except (ImportError, AttributeError):
+        pass
+    return 2 * 1024 ** 3
+
+
+def _available_gpu_memory_bytes():
+    """Best-effort estimate of free GPU memory in bytes.
+
+    Returns 0 if CuPy / CUDA is unavailable or the query fails -- callers
+    use that as a sentinel meaning "no GPU info, skip the guard".
+    """
+    try:
+        import cupy as _cp
+        free, _total = _cp.cuda.runtime.memGetInfo()
+        return int(free)
+    except Exception:
+        return 0
+
+
+def _check_memory(height, width):
+    """Raise MemoryError if the kernel would exceed 50% of available RAM."""
+    required = int(height) * int(width) * _BYTES_PER_PIXEL
+    available = _available_memory_bytes()
+    if required > 0.5 * available:
+        raise MemoryError(
+            f"stream_order_dinf on a {height}x{width} grid requires "
+            f"~{required / 1e9:.1f} GB of working memory but only "
+            f"~{available / 1e9:.1f} GB is available.  Use a "
+            f"dask-backed DataArray for out-of-core processing."
+        )
+
+
+def _check_gpu_memory(height, width):
+    """Raise MemoryError if the CuPy kernel would exceed 50% of free GPU RAM.
+
+    Skips the check (returns silently) when ``_available_gpu_memory_bytes``
+    cannot determine the free memory -- e.g. on hosts without CUDA, where
+    the kernel will fail at the cupy.asarray boundary anyway.
+    """
+    available = _available_gpu_memory_bytes()
+    if available <= 0:
+        return
+    required = int(height) * int(width) * _GPU_BYTES_PER_PIXEL
+    if required > 0.5 * available:
+        raise MemoryError(
+            f"stream_order_dinf on a {height}x{width} grid requires "
+            f"~{required / 1e9:.1f} GB of GPU working memory but only "
+            f"~{available / 1e9:.1f} GB is free on the active device.  "
+            f"Use a dask+cupy DataArray for out-of-core processing."
+        )
+
+
 # Neighbor offsets: counterclockwise from East
 # E, NE, N, NW, W, SW, S, SE
 _NB_DY = np.array([0, -1, -1, -1, 0, 1, 1, 1], dtype=np.int64)
@@ -1847,6 +1944,7 @@ def stream_order_dinf(flow_dir_dinf: xr.DataArray,
     fa_data = flow_accum.data
 
     if isinstance(fd_data, np.ndarray):
+        _check_memory(*fd_data.shape)
         fd = fd_data.astype(np.float64)
         fa = np.asarray(fa_data, dtype=np.float64)
         stream_mask = np.where(fa >= threshold, 1, 0).astype(np.int8)
@@ -1859,6 +1957,7 @@ def stream_order_dinf(flow_dir_dinf: xr.DataArray,
             out = _shreve_dinf_cpu(fd, stream_mask, h, w)
 
     elif has_cuda_and_cupy() and is_cupy_array(fd_data):
+        _check_gpu_memory(*fd_data.shape)
         import cupy as cp
         fa_cp = cp.asarray(fa_data, dtype=cp.float64)
         fd_cp = fd_data.astype(cp.float64)

--- a/xrspatial/hydro/tests/test_stream_order_dinf.py
+++ b/xrspatial/hydro/tests/test_stream_order_dinf.py
@@ -201,3 +201,83 @@ def test_dask_matches_numpy():
     np.testing.assert_array_equal(
         np.nan_to_num(np_result.values, nan=-999),
         np.nan_to_num(dask_result.values, nan=-999))
+
+
+# ====================================================================
+# Memory guard tests
+# ====================================================================
+
+class TestMemoryGuard:
+    """Memory guard on the eager numpy / cupy backends."""
+
+    def test_numpy_huge_raster_raises(self):
+        """Numpy backend raises MemoryError when projected RAM exceeds budget."""
+        from unittest.mock import patch
+
+        angles = np.zeros((4, 4), dtype=np.float64)
+        accum = np.ones((4, 4), dtype=np.float64)
+
+        with patch(
+            "xrspatial.hydro.stream_order_dinf._available_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match="working memory"):
+                _call(angles, accum, threshold=1)
+
+    def test_numpy_normal_input_succeeds(self):
+        """Normal-size raster passes the guard with real memory."""
+        angles = np.array([[ANGLE_E, ANGLE_E, PIT]], dtype=np.float64)
+        accum = np.array([[1.0, 2.0, 3.0]], dtype=np.float64)
+        result = _call(angles, accum, threshold=1)
+        assert result.shape == (1, 3)
+
+    @dask_array_available
+    def test_dask_path_skips_guard(self):
+        """Dask backend bypasses the guard -- per-tile allocations are bounded."""
+        from unittest.mock import patch
+        import dask.array as da
+
+        angles = np.zeros((6, 6), dtype=np.float64)
+        accum = np.ones((6, 6), dtype=np.float64)
+        a_dask = xr.DataArray(
+            da.from_array(angles, chunks=(3, 3)), dims=['y', 'x'])
+        fa_dask = xr.DataArray(
+            da.from_array(accum, chunks=(3, 3)), dims=['y', 'x'])
+
+        with patch(
+            "xrspatial.hydro.stream_order_dinf._available_memory_bytes",
+            return_value=1,
+        ):
+            result = stream_order_dinf(a_dask, fa_dask, threshold=1)
+            _ = result.data[:3, :3].compute()
+
+    def test_error_message_mentions_dimensions(self):
+        """The error message should mention the grid dimensions and dask."""
+        from unittest.mock import patch
+
+        angles = np.zeros((7, 9), dtype=np.float64)
+        accum = np.ones((7, 9), dtype=np.float64)
+
+        with patch(
+            "xrspatial.hydro.stream_order_dinf._available_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match=r"7x9.*dask"):
+                _call(angles, accum, threshold=1)
+
+    @cuda_and_cupy_available
+    def test_cupy_huge_raster_raises(self):
+        """CuPy backend raises MemoryError when projected GPU RAM exceeds budget."""
+        from unittest.mock import patch
+
+        angles = np.zeros((4, 4), dtype=np.float64)
+        accum = np.ones((4, 4), dtype=np.float64)
+        cp_a = create_test_raster(angles, backend='cupy')
+        cp_fa = create_test_raster(accum, backend='cupy')
+
+        with patch(
+            "xrspatial.hydro.stream_order_dinf._available_gpu_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match="GPU working memory"):
+                stream_order_dinf(cp_a, cp_fa, threshold=1)


### PR DESCRIPTION
Fixes #1350.

Adds memory guards to `stream_order_dinf`, matching the pattern used for `stream_order_d8` (#1331) and `stream_link_dinf` (#1347):

- `_check_memory`: 40 B/px CPU (Strahler kernel peak: order f64, in_degree i32, max_in f64, cnt_max i32, queue_r i64, queue_c i64). Shreve drops `max_in`/`cnt_max` and is ~32 B/px. We budget for the worst case.
- `_check_gpu_memory`: 40 B/px GPU (37 B/px kernel + 8 B/px `fa_cp` cast).
- 50% of available RAM / GPU RAM threshold, same as the d8 fix.
- Dask backend skips the guard since per-tile allocations are already bounded by chunk size.

D-inf encodes one continuous downstream angle per cell (two bracketing neighbors with proportional fractions), so there is no (8, H, W) per-neighbor weight buffer like MFD. The working set matches the d8 budget.

Tests (5):
- numpy oversize raises MemoryError
- numpy normal input succeeds
- dask path bypasses the guard
- error message mentions HxW dimensions and "dask"
- cupy oversize raises MemoryError

Full hydro suite passes apart from the known flake `test_stream_link_dask_temp_cleanup`.