### PR TITLE
Guard flow_length_dinf() against unbounded memory allocations (#1355)

### DIFF
--- a/xrspatial/hydro/flow_length_dinf.py
+++ b/xrspatial/hydro/flow_length_dinf.py
@@ -38,6 +38,94 @@ from xrspatial.dataset_support import supports_dataset
 
 
 # =====================================================================
+# Memory guards
+# =====================================================================
+#
+# CPU peak working set per pixel for ``_flow_length_dinf_*_cpu``:
+#   in_degree  : int32   -> 4
+#   valid      : int8    -> 1
+#   flow_len   : float64 -> 8
+#   order_r    : int64   -> 8
+#   order_c    : int64   -> 8
+# Total ~29 bytes/pixel.  The caller-provided ``flow_dir`` array already
+# lives in RAM before the kernel runs and is not double-counted here.
+_BYTES_PER_PIXEL = 29
+
+# GPU peak working set per pixel for ``_flow_length_dinf_cupy``: that
+# path copies ``flow_dir`` to host via ``.get().astype()`` and runs the
+# CPU kernel before converting the float64 output back to device via
+# ``cp.asarray``.  Device-side residency at peak is the input float64
+# (8 B/px) plus the output float64 (8 B/px); host-side matches the
+# 29 B/px CPU budget.  Use 32 B/px as a conservative GPU budget covering
+# both copies plus headroom.
+_GPU_BYTES_PER_PIXEL = 32
+
+
+def _available_memory_bytes():
+    """Best-effort estimate of available host memory in bytes."""
+    try:
+        with open('/proc/meminfo', 'r') as f:
+            for line in f:
+                if line.startswith('MemAvailable:'):
+                    return int(line.split()[1]) * 1024  # kB -> bytes
+    except (OSError, ValueError, IndexError):
+        pass
+    try:
+        import psutil
+        return psutil.virtual_memory().available
+    except (ImportError, AttributeError):
+        pass
+    return 2 * 1024 ** 3
+
+
+def _available_gpu_memory_bytes():
+    """Best-effort estimate of free GPU memory in bytes.
+
+    Returns 0 if CuPy / CUDA is unavailable or the query fails -- callers
+    use that as a sentinel meaning "no GPU info, skip the guard".
+    """
+    try:
+        import cupy as _cp
+        free, _total = _cp.cuda.runtime.memGetInfo()
+        return int(free)
+    except Exception:
+        return 0
+
+
+def _check_memory(height, width):
+    """Raise MemoryError if the kernel would exceed 50% of available RAM."""
+    required = int(height) * int(width) * _BYTES_PER_PIXEL
+    available = _available_memory_bytes()
+    if required > 0.5 * available:
+        raise MemoryError(
+            f"flow_length_dinf on a {height}x{width} grid requires "
+            f"~{required / 1e9:.1f} GB of working memory but only "
+            f"~{available / 1e9:.1f} GB is available.  Use a "
+            f"dask-backed DataArray for out-of-core processing."
+        )
+
+
+def _check_gpu_memory(height, width):
+    """Raise MemoryError if the CuPy kernel would exceed 50% of free GPU RAM.
+
+    Skips the check (returns silently) when ``_available_gpu_memory_bytes``
+    cannot determine the free memory -- e.g. on hosts without CUDA, where
+    the kernel will fail at the cupy.asarray boundary anyway.
+    """
+    available = _available_gpu_memory_bytes()
+    if available <= 0:
+        return
+    required = int(height) * int(width) * _GPU_BYTES_PER_PIXEL
+    if required > 0.5 * available:
+        raise MemoryError(
+            f"flow_length_dinf on a {height}x{width} grid requires "
+            f"~{required / 1e9:.1f} GB of GPU working memory but only "
+            f"~{available / 1e9:.1f} GB is free on the active device.  "
+            f"Use a dask+cupy DataArray for out-of-core processing."
+        )
+
+
+# =====================================================================
 # Step-distance helper
 # =====================================================================
 
@@ -908,6 +996,7 @@ def flow_length_dinf(flow_dir: xr.DataArray,
     data = flow_dir.data
 
     if isinstance(data, np.ndarray):
+        _check_memory(*data.shape)
         fd = data.astype(np.float64)
         H, W = fd.shape
         if direction == 'downstream':
@@ -918,6 +1007,8 @@ def flow_length_dinf(flow_dir: xr.DataArray,
                 fd, H, W, cellsize_x, cellsize_y)
 
     elif has_cuda_and_cupy() and is_cupy_array(data):
+        _check_gpu_memory(*data.shape)
+        _check_memory(*data.shape)
         out = _flow_length_dinf_cupy(data, direction, cellsize_x, cellsize_y)
 
     elif has_cuda_and_cupy() and is_dask_cupy(flow_dir):

--- a/xrspatial/hydro/tests/test_flow_length_dinf.py
+++ b/xrspatial/hydro/tests/test_flow_length_dinf.py
@@ -305,3 +305,78 @@ class TestFlowLengthDinfDaskCuPy:
         np.testing.assert_allclose(
             result_np.data, result_dc.data.compute().get(),
             equal_nan=True, rtol=1e-10)
+
+
+# ====================================================================
+# Memory guard tests
+# ====================================================================
+
+class TestMemoryGuard:
+    """Memory guard on the eager numpy / cupy backends."""
+
+    def test_numpy_huge_raster_raises(self):
+        """Numpy backend raises MemoryError when projected RAM exceeds budget."""
+        from unittest.mock import patch
+
+        fd = np.full((4, 4), 0.0, dtype=np.float64)
+        raster = _make_dinf_raster(fd)
+
+        with patch(
+            "xrspatial.hydro.flow_length_dinf._available_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match="working memory"):
+                flow_length_dinf(raster, direction='downstream')
+
+    def test_numpy_normal_input_succeeds(self):
+        """Normal-size raster passes the guard with real memory."""
+        fd = np.full((3, 5), 0.0, dtype=np.float64)
+        fd[:, -1] = -1.0
+        raster = _make_dinf_raster(fd)
+        result = flow_length_dinf(raster, direction='downstream')
+        assert result.shape == (3, 5)
+
+    @dask_array_available
+    def test_dask_path_skips_guard(self):
+        """Dask backend bypasses the guard -- per-tile allocations are bounded."""
+        from unittest.mock import patch
+
+        fd = np.full((6, 6), 0.0, dtype=np.float64)
+        raster = _make_dinf_raster(fd, backend='dask', chunks=(3, 3))
+
+        with patch(
+            "xrspatial.hydro.flow_length_dinf._available_memory_bytes",
+            return_value=1,
+        ):
+            # Dask path must not trigger the guard at dispatch time
+            result = flow_length_dinf(raster, direction='downstream')
+            assert result is not None
+
+    def test_error_message_mentions_dimensions(self):
+        """The error message should mention the grid dimensions and dask."""
+        from unittest.mock import patch
+
+        fd = np.full((7, 9), 0.0, dtype=np.float64)
+        raster = _make_dinf_raster(fd)
+
+        with patch(
+            "xrspatial.hydro.flow_length_dinf._available_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match=r"7x9.*dask"):
+                flow_length_dinf(raster, direction='upstream')
+
+    @cuda_and_cupy_available
+    def test_cupy_huge_raster_raises(self):
+        """CuPy backend raises MemoryError when projected GPU RAM exceeds budget."""
+        from unittest.mock import patch
+
+        fd = np.full((4, 4), 0.0, dtype=np.float64)
+        raster = _make_dinf_raster(fd, backend='cupy')
+
+        with patch(
+            "xrspatial.hydro.flow_length_dinf._available_gpu_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match="GPU working memory"):
+                flow_length_dinf(raster, direction='downstream')


### PR DESCRIPTION
Closes #1355.

`flow_length_dinf` allocates several full-grid working arrays in its eager numpy and cupy backends with no upfront budget check. A 50000x50000 raster asks for ~72 GB of host RAM before anything errors out.

Adds `_check_memory` and `_check_gpu_memory` helpers, wired into the numpy and cupy dispatch in `flow_length_dinf()`. Dask paths are unchanged since per-tile allocations are bounded by chunk size. Same shape as #1332 (d8) and #1353 (mfd).

## Budget

CPU: 29 B/px

| Array     | dtype   | bytes/px |
|-----------|---------|----------|
| in_degree | int32   | 4        |
| valid     | int8    | 1        |
| flow_len  | float64 | 8        |
| order_r   | int64   | 8        |
| order_c   | int64   | 8        |

GPU: 32 B/px (input float64 + output float64 + headroom).

## Tests

Five new tests in `TestMemoryGuard`:

- `test_numpy_huge_raster_raises` -- numpy backend raises MemoryError when `_available_memory_bytes` is patched to 1
- `test_numpy_normal_input_succeeds` -- normal-size raster passes the guard
- `test_dask_path_skips_guard` -- dask backend does not trigger the guard at dispatch
- `test_error_message_mentions_dimensions` -- error mentions `7x9` and `dask`
- `test_cupy_huge_raster_raises` -- cupy backend raises when GPU memory is patched low (gated on cuda_and_cupy_available)

## Test plan

- [x] `pytest xrspatial/hydro/tests/test_flow_length_dinf.py` -- 30 passed
- [x] Full hydro suite -- 643 passed, only known flaky `test_stream_link_dask_temp_cleanup` failed