### PR TITLE
Guard snap_pour_point_d8() against unbounded memory allocations (#1362)

### DIFF
--- a/xrspatial/hydro/snap_pour_point_d8.py
+++ b/xrspatial/hydro/snap_pour_point_d8.py
@@ -45,6 +45,92 @@ from xrspatial.utils import (
 from xrspatial.dataset_support import supports_dataset
 
 
+# =====================================================================
+# Memory guards
+# =====================================================================
+#
+# CPU peak working set per pixel for the numpy dispatch + ``_snap_pour_point_cpu``:
+#   fa  (float64 cast)   -> 8
+#   pp  (float64 cast)   -> 8
+#   out (float64)        -> 8
+# Total 24 bytes/pixel.  The caller's input arrays already live in RAM
+# before dispatch and are not double-counted here.
+_BYTES_PER_PIXEL = 24
+
+# GPU peak working set per pixel for ``_snap_pour_point_cupy``:
+#   fa  (float64 cast)   -> 8
+#   pp  (float64 cast)   -> 8
+#   out (float64)        -> 8
+# Total 24 bytes/pixel on the device.  The sparse pour-point coordinate
+# arrays scale with the number of pour points (typically << H*W) and are
+# not counted here.
+_GPU_BYTES_PER_PIXEL = 24
+
+
+def _available_memory_bytes():
+    """Best-effort estimate of available host memory in bytes."""
+    try:
+        with open('/proc/meminfo', 'r') as f:
+            for line in f:
+                if line.startswith('MemAvailable:'):
+                    return int(line.split()[1]) * 1024  # kB -> bytes
+    except (OSError, ValueError, IndexError):
+        pass
+    try:
+        import psutil
+        return psutil.virtual_memory().available
+    except (ImportError, AttributeError):
+        pass
+    return 2 * 1024 ** 3
+
+
+def _available_gpu_memory_bytes():
+    """Best-effort estimate of free GPU memory in bytes.
+
+    Returns 0 if CuPy / CUDA is unavailable or the query fails -- callers
+    use that as a sentinel meaning "no GPU info, skip the guard".
+    """
+    try:
+        import cupy as _cp
+        free, _total = _cp.cuda.runtime.memGetInfo()
+        return int(free)
+    except Exception:
+        return 0
+
+
+def _check_memory(height, width):
+    """Raise MemoryError if the snap kernel would exceed 50% of RAM."""
+    required = int(height) * int(width) * _BYTES_PER_PIXEL
+    available = _available_memory_bytes()
+    if required > 0.5 * available:
+        raise MemoryError(
+            f"snap_pour_point_d8 on a {height}x{width} grid requires "
+            f"~{required / 1e9:.1f} GB of working memory but only "
+            f"~{available / 1e9:.1f} GB is available.  Use a "
+            f"dask-backed DataArray for out-of-core processing."
+        )
+
+
+def _check_gpu_memory(height, width):
+    """Raise MemoryError if the CuPy kernel would exceed 50% of free GPU RAM.
+
+    Skips the check (returns silently) when ``_available_gpu_memory_bytes``
+    cannot determine the free memory -- e.g. on hosts without CUDA, where
+    the kernel will fail at the cupy.asarray boundary anyway.
+    """
+    available = _available_gpu_memory_bytes()
+    if available <= 0:
+        return
+    required = int(height) * int(width) * _GPU_BYTES_PER_PIXEL
+    if required > 0.5 * available:
+        raise MemoryError(
+            f"snap_pour_point_d8 on a {height}x{width} grid requires "
+            f"~{required / 1e9:.1f} GB of GPU working memory but only "
+            f"~{available / 1e9:.1f} GB is free on the active device.  "
+            f"Use a dask+cupy DataArray for out-of-core processing."
+        )
+
+
 def _to_numpy_f64(arr):
     """Convert *arr* to a contiguous numpy float64 array (handles CuPy)."""
     if hasattr(arr, 'get'):
@@ -484,12 +570,14 @@ def snap_pour_point_d8(flow_accum: xr.DataArray,
     pp_data = pour_points.data
 
     if isinstance(fa_data, np.ndarray):
+        _check_memory(*fa_data.shape)
         fa = fa_data.astype(np.float64)
         pp = np.asarray(pp_data, dtype=np.float64)
         H, W = fa.shape
         out = _snap_pour_point_cpu(fa, pp, search_radius, H, W)
 
     elif has_cuda_and_cupy() and is_cupy_array(fa_data):
+        _check_gpu_memory(*fa_data.shape)
         out = _snap_pour_point_cupy(fa_data, pp_data, search_radius)
 
     elif has_cuda_and_cupy() and is_dask_cupy(flow_accum):

--- a/xrspatial/hydro/tests/test_snap_pour_point_d8.py
+++ b/xrspatial/hydro/tests/test_snap_pour_point_d8.py
@@ -328,3 +328,87 @@ def test_dask_cupy_chunk_configs(chunks):
     np.testing.assert_allclose(
         np_result.data, dcp_result.data.compute().get(), equal_nan=True,
     ), f"Mismatch with chunks={chunks}"
+
+
+# ====================================================================
+# Memory guard tests
+# ====================================================================
+
+class TestMemoryGuard:
+    """Memory guard on the eager numpy / cupy backends."""
+
+    def test_numpy_huge_raster_raises(self):
+        """Numpy backend raises MemoryError when projected RAM exceeds budget."""
+        from unittest.mock import patch
+
+        accum = np.zeros((4, 4), dtype=np.float64)
+        pp = np.full((4, 4), np.nan, dtype=np.float64)
+        pp[0, 0] = 1.0
+        fa, pour = _make_accum_and_pp(accum, pp, backend='numpy')
+
+        with patch(
+            "xrspatial.hydro.snap_pour_point_d8._available_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match="working memory"):
+                snap_pour_point(fa, pour, search_radius=2)
+
+    def test_numpy_normal_input_succeeds(self):
+        """Normal-size raster passes the guard with real memory."""
+        accum = np.arange(100, dtype=np.float64).reshape(10, 10)
+        pp = np.full((10, 10), np.nan, dtype=np.float64)
+        pp[0, 0] = 1.0
+        fa, pour = _make_accum_and_pp(accum, pp, backend='numpy')
+        result = snap_pour_point(fa, pour, search_radius=3)
+        assert result.shape == (10, 10)
+
+    def test_error_message_mentions_dask(self):
+        """The error message should suggest the dask alternative."""
+        from unittest.mock import patch
+
+        accum = np.zeros((4, 4), dtype=np.float64)
+        pp = np.full((4, 4), np.nan, dtype=np.float64)
+        pp[0, 0] = 1.0
+        fa, pour = _make_accum_and_pp(accum, pp, backend='numpy')
+
+        with patch(
+            "xrspatial.hydro.snap_pour_point_d8._available_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match="dask"):
+                snap_pour_point(fa, pour, search_radius=2)
+
+    @dask_array_available
+    def test_dask_path_skips_guard(self):
+        """Dask backend bypasses the guard -- per-window allocations are bounded."""
+        from unittest.mock import patch
+
+        accum = np.arange(400, dtype=np.float64).reshape(20, 20)
+        pp = np.full((20, 20), np.nan, dtype=np.float64)
+        pp[0, 0] = 1.0
+        fa, pour = _make_accum_and_pp(
+            accum, pp, backend='dask+numpy', chunks=(5, 5))
+
+        with patch(
+            "xrspatial.hydro.snap_pour_point_d8._available_memory_bytes",
+            return_value=1,
+        ):
+            result = snap_pour_point(fa, pour, search_radius=3)
+            # Force compute -- dask path must not consult the host guard.
+            _ = np.asarray(result.data)
+
+    def test_error_message_includes_grid_size(self):
+        """The error message should report the requested grid dimensions."""
+        from unittest.mock import patch
+
+        accum = np.zeros((7, 9), dtype=np.float64)
+        pp = np.full((7, 9), np.nan, dtype=np.float64)
+        pp[0, 0] = 1.0
+        fa, pour = _make_accum_and_pp(accum, pp, backend='numpy')
+
+        with patch(
+            "xrspatial.hydro.snap_pour_point_d8._available_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match=r"7x9"):
+                snap_pour_point(fa, pour, search_radius=2)


### PR DESCRIPTION
Closes #1362.

## Summary

- The numpy and cupy dispatches in `snap_pour_point_d8` each allocate three full H*W float64 buffers (flow_accum cast, pour_points cast, output) -- ~24 B/px with no memory check.
- Add per-module `_check_memory` and `_check_gpu_memory` helpers modeled on the #1318/#1319 flow_accumulation_d8 guard. Threshold is 50% of available host RAM (or free GPU RAM).
- Wire the checks into the public dispatch before the eager allocations. The dask and dask+cupy paths process small windows around sparse pour points and skip the guard.
- Error messages report the grid size and point users at the dask backend.

## Test plan

- [x] `pytest xrspatial/hydro/tests/test_snap_pour_point_d8.py` -- 27 passed (5 new memory-guard tests under `TestMemoryGuard`)
- [x] Full hydro suite: 731 passed, 2 deselected (known flakes `test_basin_dask_temp_cleanup`, `test_stream_link_dask_temp_cleanup`)