### PR TITLE
Guard flow_path_d8() against unbounded memory allocations (#1364)

### DIFF
--- a/xrspatial/hydro/flow_path_d8.py
+++ b/xrspatial/hydro/flow_path_d8.py
@@ -44,6 +44,91 @@ from xrspatial.dataset_support import supports_dataset
 
 
 # =====================================================================
+# Memory guards
+# =====================================================================
+#
+# CPU peak working set per pixel for ``flow_path_d8`` numpy path:
+#   fd float64 copy   -> 8
+#   sp float64 copy   -> 8
+#   out float64       -> 8
+# Measured peak via tracemalloc on a 2000x2000 grid: ~21 B/pixel.
+# Use 24 B/pixel as a small safety margin.
+_BYTES_PER_PIXEL = 24
+
+# GPU peak working set per pixel for ``_flow_path_cupy``: that path
+# copies fd and sp to host via ``.get()`` then runs the CPU kernel and
+# copies the output back via ``cp.asarray``.  Device-side residency at
+# peak is the input float64 (8 B/px) plus the output float64 (8 B/px);
+# host-side matches the 24 B/px CPU budget.  Use 32 B/px as a
+# conservative GPU budget covering both copies plus headroom.
+_GPU_BYTES_PER_PIXEL = 32
+
+
+def _available_memory_bytes():
+    """Best-effort estimate of available host memory in bytes."""
+    try:
+        with open('/proc/meminfo', 'r') as f:
+            for line in f:
+                if line.startswith('MemAvailable:'):
+                    return int(line.split()[1]) * 1024  # kB -> bytes
+    except (OSError, ValueError, IndexError):
+        pass
+    try:
+        import psutil
+        return psutil.virtual_memory().available
+    except (ImportError, AttributeError):
+        pass
+    return 2 * 1024 ** 3
+
+
+def _available_gpu_memory_bytes():
+    """Best-effort estimate of free GPU memory in bytes.
+
+    Returns 0 if CuPy / CUDA is unavailable or the query fails -- callers
+    use that as a sentinel meaning "no GPU info, skip the guard".
+    """
+    try:
+        import cupy as _cp
+        free, _total = _cp.cuda.runtime.memGetInfo()
+        return int(free)
+    except Exception:
+        return 0
+
+
+def _check_memory(height, width):
+    """Raise MemoryError if the flow_path kernel would exceed 50% of RAM."""
+    required = int(height) * int(width) * _BYTES_PER_PIXEL
+    available = _available_memory_bytes()
+    if required > 0.5 * available:
+        raise MemoryError(
+            f"flow_path_d8 on a {height}x{width} grid requires "
+            f"~{required / 1e9:.1f} GB of working memory but only "
+            f"~{available / 1e9:.1f} GB is available.  Use a "
+            f"dask-backed DataArray for out-of-core processing."
+        )
+
+
+def _check_gpu_memory(height, width):
+    """Raise MemoryError if the CuPy kernel would exceed 50% of free GPU RAM.
+
+    Skips the check (returns silently) when ``_available_gpu_memory_bytes``
+    cannot determine the free memory -- e.g. on hosts without CUDA, where
+    the kernel will fail at the cupy.asarray boundary anyway.
+    """
+    available = _available_gpu_memory_bytes()
+    if available <= 0:
+        return
+    required = int(height) * int(width) * _GPU_BYTES_PER_PIXEL
+    if required > 0.5 * available:
+        raise MemoryError(
+            f"flow_path_d8 on a {height}x{width} grid requires "
+            f"~{required / 1e9:.1f} GB of GPU working memory but only "
+            f"~{available / 1e9:.1f} GB is free on the active device.  "
+            f"Use a dask+cupy DataArray for out-of-core processing."
+        )
+
+
+# =====================================================================
 # CPU kernel
 # =====================================================================
 
@@ -378,12 +463,15 @@ def flow_path_d8(flow_dir: xr.DataArray,
     sp_data = start_points.data
 
     if isinstance(fd_data, np.ndarray):
+        _check_memory(*fd_data.shape)
         fd = fd_data.astype(np.float64)
         sp = np.asarray(sp_data, dtype=np.float64)
         H, W = fd.shape
         out = _flow_path_cpu(fd, sp, H, W)
 
     elif has_cuda_and_cupy() and is_cupy_array(fd_data):
+        _check_gpu_memory(*fd_data.shape)
+        _check_memory(*fd_data.shape)
         out = _flow_path_cupy(fd_data, sp_data)
 
     elif has_cuda_and_cupy() and is_dask_cupy(flow_dir):

--- a/xrspatial/hydro/tests/test_flow_path_d8.py
+++ b/xrspatial/hydro/tests/test_flow_path_d8.py
@@ -297,6 +297,85 @@ def test_numpy_equals_cupy():
 # Cross-backend tests: Dask+CuPy
 # -------------------------------------------------------------------
 
+class TestMemoryGuard:
+    """Memory guard on the eager numpy / cupy backends."""
+
+    def test_numpy_huge_raster_raises(self):
+        """Numpy backend raises MemoryError when projected RAM exceeds budget."""
+        from unittest.mock import patch
+
+        fd = np.zeros((4, 4), dtype=np.float64)
+        sp = np.full((4, 4), np.nan, dtype=np.float64)
+        sp[0, 0] = 1.0
+        fd_da, sp_da = _make_fd_and_sp(fd, sp)
+
+        with patch(
+            "xrspatial.hydro.flow_path_d8._available_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match="working memory"):
+                flow_path(fd_da, sp_da)
+
+    def test_numpy_normal_input_succeeds(self):
+        """Normal-size raster passes the guard with real memory."""
+        fd = np.zeros((10, 10), dtype=np.float64)
+        sp = np.full((10, 10), np.nan, dtype=np.float64)
+        sp[0, 0] = 1.0
+        fd_da, sp_da = _make_fd_and_sp(fd, sp)
+        result = flow_path(fd_da, sp_da)
+        assert result.shape == (10, 10)
+
+    @dask_array_available
+    def test_dask_path_skips_guard(self):
+        """Dask backend bypasses the guard -- per-tile allocations are bounded."""
+        from unittest.mock import patch
+
+        fd = np.zeros((6, 6), dtype=np.float64)
+        sp = np.full((6, 6), np.nan, dtype=np.float64)
+        sp[0, 0] = 1.0
+        fd_da, sp_da = _make_fd_and_sp(fd, sp, backend='dask', chunks=(3, 3))
+
+        with patch(
+            "xrspatial.hydro.flow_path_d8._available_memory_bytes",
+            return_value=1,
+        ):
+            result = flow_path(fd_da, sp_da)
+            _ = result.data[:3, :3].compute()
+
+    def test_error_message_mentions_dimensions(self):
+        """The error message should mention the grid dimensions and dask."""
+        from unittest.mock import patch
+
+        fd = np.zeros((7, 9), dtype=np.float64)
+        sp = np.full((7, 9), np.nan, dtype=np.float64)
+        sp[0, 0] = 1.0
+        fd_da, sp_da = _make_fd_and_sp(fd, sp)
+
+        with patch(
+            "xrspatial.hydro.flow_path_d8._available_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match=r"7x9.*dask"):
+                flow_path(fd_da, sp_da)
+
+    @cuda_and_cupy_available
+    def test_cupy_huge_raster_raises(self):
+        """CuPy backend raises MemoryError when projected GPU RAM exceeds budget."""
+        from unittest.mock import patch
+
+        fd = np.zeros((4, 4), dtype=np.float64)
+        sp = np.full((4, 4), np.nan, dtype=np.float64)
+        sp[0, 0] = 1.0
+        fd_da, sp_da = _make_fd_and_sp(fd, sp, backend='cupy')
+
+        with patch(
+            "xrspatial.hydro.flow_path_d8._available_gpu_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match="GPU working memory"):
+                flow_path(fd_da, sp_da)
+
+
 @dask_array_available
 @cuda_and_cupy_available
 def test_numpy_equals_dask_cupy():


### PR DESCRIPTION
## Summary

Closes #1364.

Add a 50%-of-available-memory guard to the eager numpy and cupy backends of `flow_path_d8()`. The dask and dask+cupy backends already stream chunks lazily and skip the guard.

The numpy path holds a float64 working copy of `flow_dir`, a float64 copy of `start_points`, and the float64 output. Measured peak via `tracemalloc` on a 2000x2000 grid: ~21 B/pixel; budgeted at 24 B/pixel. The cupy path detours through the CPU kernel, so it pays the same host budget plus device input + output (~32 B/pixel device).

Pattern follows #1318, #1319, #1303, #1334, #1338, #1339, #1344, #1355.

## Test plan

- [x] `pytest xrspatial/hydro/tests/test_flow_path_d8.py` — 22 passed (17 existing + 5 new)
- [x] `pytest xrspatial/hydro/tests/` — 731 passed (2 known-flaky temp-cleanup tests deselected)
- [x] numpy backend raises `MemoryError` when host memory is patched low
- [x] cupy backend raises `MemoryError` when GPU memory is patched low
- [x] dask backend bypasses the guard
- [x] normal-size raster passes the guard with real memory
- [x] error message names the grid dimensions and points to dask
