### PR TITLE
Guard flow_path_mfd() against unbounded memory allocations (#1365)

### DIFF
--- a/xrspatial/hydro/flow_path_mfd.py
+++ b/xrspatial/hydro/flow_path_mfd.py
@@ -42,6 +42,90 @@ _DY_NP = np.array([0, 1, 1, 1, 0, -1, -1, -1], dtype=np.int64)
 _DX_NP = np.array([1, 1, 0, -1, -1, -1, 0, 1], dtype=np.int64)
 
 
+# =====================================================================
+# Memory guards
+# =====================================================================
+#
+# CPU peak working set per pixel for ``flow_path_mfd`` numpy dispatch:
+#   data.astype(float64) copy of (8, H, W) fractions -> 64
+#   np.asarray(sp_data, dtype=float64) copy          -> 8
+#   out (H, W) float64                               -> 8
+# Total ~80 B/px.
+_BYTES_PER_PIXEL = 80
+
+# GPU peak working set per pixel for ``_flow_path_mfd_cupy``:
+#   host fr_np = data.get()       -> 64
+#   host sp_np                    -> 8
+#   host out (H, W) float64       -> 8
+#   device output                 -> 8
+# Total ~88 B/px (conservative, treating host residency as the bound).
+_GPU_BYTES_PER_PIXEL = 88
+
+
+def _available_memory_bytes():
+    """Best-effort estimate of available host memory in bytes."""
+    try:
+        with open('/proc/meminfo', 'r') as f:
+            for line in f:
+                if line.startswith('MemAvailable:'):
+                    return int(line.split()[1]) * 1024  # kB -> bytes
+    except (OSError, ValueError, IndexError):
+        pass
+    try:
+        import psutil
+        return psutil.virtual_memory().available
+    except (ImportError, AttributeError):
+        pass
+    return 2 * 1024 ** 3
+
+
+def _available_gpu_memory_bytes():
+    """Best-effort estimate of free GPU memory in bytes.
+
+    Returns 0 if CuPy / CUDA is unavailable or the query fails -- callers
+    use that as a sentinel meaning "no GPU info, skip the guard".
+    """
+    try:
+        import cupy as _cp
+        free, _total = _cp.cuda.runtime.memGetInfo()
+        return int(free)
+    except Exception:
+        return 0
+
+
+def _check_memory(height, width):
+    """Raise MemoryError if the kernel would exceed 50% of available RAM."""
+    required = int(height) * int(width) * _BYTES_PER_PIXEL
+    available = _available_memory_bytes()
+    if required > 0.5 * available:
+        raise MemoryError(
+            f"flow_path_mfd on a {height}x{width} grid requires "
+            f"~{required / 1e9:.1f} GB of working memory but only "
+            f"~{available / 1e9:.1f} GB is available.  Use a "
+            f"dask-backed DataArray for out-of-core processing."
+        )
+
+
+def _check_gpu_memory(height, width):
+    """Raise MemoryError if the CuPy kernel would exceed 50% of free GPU RAM.
+
+    Skips the check (returns silently) when ``_available_gpu_memory_bytes``
+    cannot determine the free memory -- e.g. on hosts without CUDA, where
+    the kernel will fail at the cupy.asarray boundary anyway.
+    """
+    available = _available_gpu_memory_bytes()
+    if available <= 0:
+        return
+    required = int(height) * int(width) * _GPU_BYTES_PER_PIXEL
+    if required > 0.5 * available:
+        raise MemoryError(
+            f"flow_path_mfd on a {height}x{width} grid requires "
+            f"~{required / 1e9:.1f} GB of GPU working memory but only "
+            f"~{available / 1e9:.1f} GB is free on the active device.  "
+            f"Use a dask+cupy DataArray for out-of-core processing."
+        )
+
+
 def _dominant_neighbor_py(fractions, r, c):
     """Pure-Python: find dominant neighbor direction and offset.
 
@@ -345,11 +429,14 @@ def flow_path_mfd(flow_dir_mfd: xr.DataArray,
     _, H, W = data.shape
 
     if isinstance(data, np.ndarray):
+        _check_memory(H, W)
         fr = data.astype(np.float64)
         sp = np.asarray(sp_data, dtype=np.float64)
         out = _flow_path_mfd_cpu(fr, sp, H, W)
 
     elif has_cuda_and_cupy() and is_cupy_array(data):
+        _check_gpu_memory(H, W)
+        _check_memory(H, W)
         out = _flow_path_mfd_cupy(data, sp_data)
 
     elif has_cuda_and_cupy() and is_dask_cupy(flow_dir_mfd):

--- a/xrspatial/hydro/tests/test_flow_path_mfd.py
+++ b/xrspatial/hydro/tests/test_flow_path_mfd.py
@@ -232,6 +232,96 @@ def test_numpy_equals_cupy():
         np_result.data, cp_result.data.get(), equal_nan=True)
 
 
+# ====================================================================
+# Memory guard tests
+# ====================================================================
+
+
+class TestMemoryGuard:
+    """Memory guard on the eager numpy / cupy backends."""
+
+    def test_numpy_huge_raster_raises(self):
+        """Numpy backend raises MemoryError when projected RAM exceeds budget."""
+        from unittest.mock import patch
+
+        fracs = _make_all_east(4, 4)
+        sp = np.full((4, 4), np.nan)
+        sp[0, 0] = 1.0
+        fd_da = _make_mfd_raster(fracs)
+        sp_da = create_test_raster(sp.astype(np.float64))
+
+        with patch(
+            "xrspatial.hydro.flow_path_mfd._available_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match="working memory"):
+                flow_path_mfd(fd_da, sp_da)
+
+    def test_numpy_normal_input_succeeds(self):
+        """Normal-size raster passes the guard with real available memory."""
+        fracs = _make_all_east(3, 5)
+        sp = np.full((3, 5), np.nan)
+        sp[0, 0] = 9.0
+        fd_da = _make_mfd_raster(fracs)
+        sp_da = create_test_raster(sp.astype(np.float64))
+        result = flow_path_mfd(fd_da, sp_da)
+        assert result.shape == (3, 5)
+
+    @dask_array_available
+    def test_dask_path_skips_guard(self):
+        """Dask backend bypasses the guard -- per-tile allocations are bounded."""
+        from unittest.mock import patch
+
+        fracs = _make_all_south(6, 6)
+        sp = np.full((6, 6), np.nan)
+        sp[0, 0] = 1.0
+        fd_da = _make_mfd_raster(fracs, backend='dask', chunks=(3, 3))
+        sp_da = create_test_raster(
+            sp.astype(np.float64), backend='dask', chunks=(3, 3))
+
+        with patch(
+            "xrspatial.hydro.flow_path_mfd._available_memory_bytes",
+            return_value=1,
+        ):
+            result = flow_path_mfd(fd_da, sp_da)
+            assert result is not None
+
+    def test_error_message_mentions_dimensions(self):
+        """Error message should mention grid dimensions and dask alternative."""
+        from unittest.mock import patch
+
+        fracs = _make_all_east(7, 9)
+        sp = np.full((7, 9), np.nan)
+        sp[0, 0] = 1.0
+        fd_da = _make_mfd_raster(fracs)
+        sp_da = create_test_raster(sp.astype(np.float64))
+
+        with patch(
+            "xrspatial.hydro.flow_path_mfd._available_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match=r"7x9.*dask"):
+                flow_path_mfd(fd_da, sp_da)
+
+    @cuda_and_cupy_available
+    def test_cupy_huge_raster_raises(self):
+        """CuPy backend raises MemoryError when projected GPU RAM exceeds budget."""
+        from unittest.mock import patch
+
+        fracs = _make_all_east(4, 4)
+        sp = np.full((4, 4), np.nan)
+        sp[0, 0] = 1.0
+        fd_da = _make_mfd_raster(fracs, backend='cupy')
+        sp_da = create_test_raster(sp.astype(np.float64), backend='cupy')
+
+        with patch(
+            "xrspatial.hydro.flow_path_mfd._available_gpu_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match="GPU working memory"):
+                flow_path_mfd(fd_da, sp_da)
+
+
 @dask_array_available
 @cuda_and_cupy_available
 def test_numpy_equals_dask_cupy():


### PR DESCRIPTION
## Summary

Closes #1365. The numpy and cupy `flow_path_mfd` paths allocate ~80 B/px of host working memory before any path tracing, driven by the `(8, H, W)` float64 cast of the input fractions plus the float64 start-points and output rasters. Without a pre-flight check, a large raster can drive the process into OOM.

This change adds the same memory guard pattern used in #1351 (flow_length_mfd) and #1337 (stream_link_mfd):

- Per-module `_BYTES_PER_PIXEL = 80` and `_GPU_BYTES_PER_PIXEL = 88` constants with a comment breaking down the count.
- `_available_memory_bytes()` reads `/proc/meminfo`, falls back to `psutil`, then a 2 GiB default.
- `_available_gpu_memory_bytes()` queries `cupy.cuda.runtime.memGetInfo`, returns 0 when CUDA is unavailable.
- `_check_memory()` and `_check_gpu_memory()` raise `MemoryError` when projected use exceeds 50% of available host / GPU RAM, with a message that points to the dask backend.
- Both checks are wired into `flow_path_mfd` ahead of the eager allocations. The dask and dask+cupy paths skip the guard.

## Tests

- `test_numpy_huge_raster_raises`
- `test_numpy_normal_input_succeeds`
- `test_dask_path_skips_guard`
- `test_error_message_mentions_dimensions`
- `test_cupy_huge_raster_raises` (skipped without CUDA)

## Test plan

- [x] `pytest xrspatial/hydro/tests/test_flow_path_mfd.py` (21 passed)
- [x] Full hydro suite minus the two known-flaky temp-cleanup tests (731 passed, 2 deselected)