### PR TITLE
Reject n_samples<=0 in mcda sensitivity (#1371)

### DIFF
--- a/xrspatial/mcda/sensitivity.py
+++ b/xrspatial/mcda/sensitivity.py
@@ -34,6 +34,7 @@ def sensitivity(
         Perturbation magnitude for one-at-a-time (default 0.05).
     n_samples : int
         Number of random weight vectors for Monte Carlo (default 1000).
+        Must be >= 1 when ``method="monte_carlo"``.
     seed : int
         Random seed for Monte Carlo reproducibility.
     name : str
@@ -57,8 +58,12 @@ def sensitivity(
     if method == "one_at_a_time":
         return _oat(criteria, weights, combine_fn, delta, name)
     elif method == "monte_carlo":
+        if not isinstance(n_samples, (int, np.integer)) or n_samples < 1:
+            raise ValueError(
+                f"n_samples must be a positive integer >= 1, got {n_samples!r}"
+            )
         return _monte_carlo(
-            criteria, weights, combine_fn, n_samples, seed, name
+            criteria, weights, combine_fn, int(n_samples), seed, name
         )
     else:
         raise ValueError(

--- a/xrspatial/tests/test_mcda.py
+++ b/xrspatial/tests/test_mcda.py
@@ -758,6 +758,40 @@ class TestSensitivityMonteCarlo:
                 criteria_dataset, weights_3, combine_method="bad",
             )
 
+    def test_monte_carlo_n_samples_zero_raises(
+        self, criteria_dataset, weights_3,
+    ):
+        # Issue #1371: n_samples=0 used to silently divide by zero and
+        # return a raster of zeros. Should raise ValueError now.
+        with pytest.raises(ValueError, match="n_samples"):
+            sensitivity(
+                criteria_dataset, weights_3,
+                method="monte_carlo", n_samples=0,
+            )
+
+    def test_monte_carlo_n_samples_negative_raises(
+        self, criteria_dataset, weights_3,
+    ):
+        # Issue #1371: range(-1) is empty, so negative values used to
+        # silently return zeros too.
+        with pytest.raises(ValueError, match="n_samples"):
+            sensitivity(
+                criteria_dataset, weights_3,
+                method="monte_carlo", n_samples=-1,
+            )
+
+    def test_monte_carlo_n_samples_one_succeeds(
+        self, criteria_dataset, weights_3,
+    ):
+        # n_samples=1 is the meaningful minimum: variance is zero
+        # everywhere, but the call should still succeed.
+        result = sensitivity(
+            criteria_dataset, weights_3,
+            method="monte_carlo", n_samples=1,
+        )
+        assert result is not None
+        assert not np.any(np.isnan(result.values))
+
 
 @pytest.mark.skipif(not HAS_DASK, reason="Requires dask")
 class TestSensitivityDask:


### PR DESCRIPTION
## Summary

Closes #1371.

`sensitivity(..., method="monte_carlo", n_samples=0)` used to silently divide by zero inside `_monte_carlo` and hand the caller back a raster of zeros. With `n_samples=0` the sample loop never runs, `running_m2` stays zero, and the trailing `np.where(running_mean != 0, ...)` masks the resulting NaN as 0.0. Negative values fell through the same way because `range(-1)` is empty.

Cat 3 sibling of the NaN-weight bug fixed in #1312. Both came out of the same mcda audit; this one was deferred per the one-fix-per-PR convention.

## Changes

- `xrspatial/mcda/sensitivity.py`: validate `n_samples >= 1` at the public `sensitivity()` entry point when `method="monte_carlo"`, raise ValueError naming the parameter. Docstring updated to note the minimum.
- `xrspatial/tests/test_mcda.py`: 3 new tests covering `n_samples=0` (raises), `n_samples=-1` (raises), and `n_samples=1` (succeeds with no NaNs). One sample is the meaningful minimum; `test_single_sample_zero_cv` already exercised `n_samples=1`, so this just adds a sanity assertion that the new check doesn't break it.

All 169 mcda tests pass.

## Test plan

- [x] `pytest xrspatial/tests/test_mcda.py -k "n_samples_zero or n_samples_negative or n_samples_one"` -- 3/3 pass
- [x] `pytest xrspatial/tests/test_mcda.py` -- 169/169 pass
- [x] The reproducer from #1371 now raises ValueError naming `n_samples`