### PR TITLE
Guard _spline TPS against unbounded memory allocations (#1372)

### DIFF
--- a/xrspatial/interpolate/_spline.py
+++ b/xrspatial/interpolate/_spline.py
@@ -226,6 +226,62 @@ def _spline_dask_cupy(x_pts, y_pts, z_pts, x_grid, y_grid,
 # Public API
 # ---------------------------------------------------------------------------
 
+def _check_spline_memory(n_points, grid_pixels):
+    """Raise MemoryError if spline() would exceed available memory.
+
+    Two allocations dominate TPS memory use:
+
+    * Kernel build.  Lines 67-70 construct ``dx``, ``dy``, ``r2`` and
+      ``K`` each as N x N float64.  About ``4 * N**2 * 8`` bytes during
+      construction.
+    * Augmented system.  Line 81 builds ``A`` of shape ``(N+3, N+3)``
+      float64, and ``np.linalg.solve`` copies it during LU
+      factorization.  About ``2 * (N+3)**2 * 8`` bytes peak.
+
+    The kernel build runs first and is freed before the solve, so peak
+    usage is bounded by the larger of the two.  The grid is iterated
+    point-by-point inside a numba kernel, so prediction does not
+    materialize a grid x N matrix.
+    """
+    n = int(n_points)
+
+    if n < 3:
+        return  # short-circuit path, no big allocations
+
+    kernel_bytes = 4 * n * n * 8
+    solve_bytes = 2 * (n + 3) * (n + 3) * 8
+
+    estimate = max(kernel_bytes, solve_bytes)
+
+    try:
+        from xrspatial.zonal import _available_memory_bytes
+        avail = _available_memory_bytes()
+    except ImportError:
+        avail = 2 * 1024 ** 3
+
+    # Match the kriging guard's 0.8 fraction (PR #1309) so users get
+    # consistent behaviour across interpolators.  The TPS solve and the
+    # kernel build do not run concurrently with other large arrays in
+    # this function, so 80% of available RAM is the right ceiling.
+    if estimate > 0.8 * avail:
+        if estimate == solve_bytes:
+            culprit = (
+                f"augmented system A of shape ({n + 3}, {n + 3}) "
+                f"plus its LU factorization copy"
+            )
+        else:
+            culprit = (
+                f"radial-basis kernel block K of shape ({n}, {n}) "
+                f"(plus dx, dy, r2 of the same shape)"
+            )
+
+        raise MemoryError(
+            f"spline() needs ~{estimate / 1e9:.1f} GB to allocate the "
+            f"{culprit}, but only ~{avail / 1e9:.1f} GB is available. "
+            f"Reduce the number of input points."
+        )
+
+
 def spline(x, y, z, template, smoothing=0.0, name='spline'):
     """Thin Plate Spline interpolation.
 
@@ -244,6 +300,12 @@ def spline(x, y, z, template, smoothing=0.0, name='spline'):
     Returns
     -------
     xr.DataArray
+
+    Raises
+    ------
+    MemoryError
+        If the worst-case allocation (kernel block K or augmented
+        system A) would exceed 80% of available memory.
     """
     _validate_raster(template, func_name='spline', name='template')
     x_arr, y_arr, z_arr = validate_points(x, y, z, func_name='spline')
@@ -251,6 +313,11 @@ def spline(x, y, z, template, smoothing=0.0, name='spline'):
                      min_val=0.0)
 
     x_grid, y_grid = extract_grid_coords(template, func_name='spline')
+
+    # Memory guard.  Runs after input validation so we know N, but
+    # before the TPS system is built.
+    grid_pixels = int(np.prod(template.shape))
+    _check_spline_memory(len(x_arr), grid_pixels)
 
     # Solve TPS system once on CPU
     weights = _tps_build_and_solve(x_arr, y_arr, z_arr, smoothing)

--- a/xrspatial/tests/test_interpolation.py
+++ b/xrspatial/tests/test_interpolation.py
@@ -486,3 +486,84 @@ class TestKrigingMemoryGuard:
         # n=10, grid_pixels=100000 -> k0 ~ 26 MB > 1 MB * 0.8.
         with pytest.raises(MemoryError, match='prediction matrix'):
             _check_kriging_memory(n_points=10, grid_pixels=100_000)
+
+
+# ===================================================================
+# Spline memory guard tests (issue #1372)
+# ===================================================================
+
+class TestSplineMemoryGuard:
+    """Verify spline() refuses to allocate more than ~80% of RAM.
+
+    The TPS solver builds N x N kernel matrices (K, dx, dy, r2) and an
+    (N+3) x (N+3) augmented system.  Tests monkeypatch the
+    available-memory helper so we can simulate "too big" without
+    actually allocating gigabytes.
+    """
+
+    def test_kernel_block_exceeds_memory(self, monkeypatch):
+        """Large N triggers the kernel-block guard."""
+        monkeypatch.setattr(
+            'xrspatial.zonal._available_memory_bytes',
+            lambda: 8 * 1024 ** 2,  # 8 MB
+        )
+
+        # N=600 -> kernel_bytes = 4 * 600**2 * 8 = ~11.5 MB > 8*0.8 MB.
+        n = 600
+        rng = np.random.RandomState(0)
+        x = rng.uniform(0, 10, n)
+        y = rng.uniform(0, 10, n)
+        z = rng.uniform(0, 10, n)
+        template = _make_template([0.0, 1.0], [0.0, 1.0])
+
+        with pytest.raises(MemoryError, match='kernel block K'):
+            spline(x, y, z, template)
+
+    def test_grid_size_irrelevant_to_guard(self, monkeypatch):
+        """Guard fires on N alone; grid pixels do not enter the estimate.
+
+        TPS evaluates the spline cell-by-cell inside a numba kernel,
+        so no grid x N prediction matrix is materialized.  A huge grid
+        with a small N must still pass the guard.
+        """
+        monkeypatch.setattr(
+            'xrspatial.zonal._available_memory_bytes',
+            lambda: 8 * 1024 ** 2,  # 8 MB
+        )
+
+        x = np.array([0.0, 1.0, 2.0, 0.5])
+        y = np.array([0.0, 0.0, 1.0, 1.5])
+        z = np.array([1.0, 2.0, 3.0, 4.0])
+        # Big grid, but N is tiny -> guard must let it through.
+        template = _make_template(
+            np.arange(1000, dtype=np.float64),
+            np.arange(1000, dtype=np.float64),
+        )
+        result = spline(x, y, z, template)
+        assert result.shape == template.shape
+
+    def test_small_input_allowed(self, monkeypatch):
+        """Tiny inputs pass the guard even with very low available memory."""
+        monkeypatch.setattr(
+            'xrspatial.zonal._available_memory_bytes',
+            lambda: 16 * 1024 ** 2,  # 16 MB
+        )
+
+        x, y, z = _grid_points()
+        template = _make_template([0.0, 1.0, 2.0], [0.0, 1.0, 2.0])
+        # Should not raise.
+        result = spline(x, y, z, template)
+        assert result.shape == template.shape
+
+    def test_check_helper_estimate_message(self, monkeypatch):
+        """_check_spline_memory reports GB and identifies the culprit."""
+        from xrspatial.interpolate._spline import _check_spline_memory
+
+        monkeypatch.setattr(
+            'xrspatial.zonal._available_memory_bytes',
+            lambda: 1 * 1024 ** 2,  # 1 MB
+        )
+
+        # N=500 -> kernel_bytes = 4 * 500**2 * 8 = 8 MB > 1*0.8 MB.
+        with pytest.raises(MemoryError, match='kernel block K'):
+            _check_spline_memory(n_points=500, grid_pixels=100)


### PR DESCRIPTION
## Summary

Closes #1372.

`spline()` (Thin Plate Spline) builds N x N kernel matrices and an (N+3) x (N+3) augmented system before any guard runs. With ~10000 points the K matrix alone is ~800 MB; with ~40000 points it is ~13 GB. A user with a moderately large point set hits this silently — the process either OOMs or numpy raises a raw error without naming the input that drove the allocation.

This adds `_check_spline_memory(n_points, grid_pixels)` that estimates the peak allocation and raises `MemoryError` against 80% of `_available_memory_bytes()`. Same pattern as the kriging guard added in #1309 (issue #1307).

Estimate is the larger of:

- kernel build: `4 * N**2 * 8` bytes (`dx`, `dy`, `r2`, `K` each N x N float64)
- solve peak: `2 * (N+3)**2 * 8` bytes (`A` plus its LU factorization copy)

The TPS evaluator iterates the grid cell-by-cell inside a numba kernel, so prediction does not materialize a grid x N matrix. The guard only depends on N.

The 0.8 fraction matches the kriging guard so users get the same behaviour across interpolators.

## Test plan

- [x] `pytest xrspatial/tests/test_interpolation.py` — 38 passed (was 34, four new in `TestSplineMemoryGuard`)
- [x] kernel-block trigger: N=600 with 8 MB available raises `MemoryError` matching "kernel block K"
- [x] grid size irrelevant: 1000x1000 template with N=4 passes the guard at 8 MB available
- [x] small input passes at 16 MB available
- [x] helper-level test confirms the GB-formatted message names the culprit