### PR TITLE
Guard owa() against unbounded criteria stack (#1370)

### DIFF
--- a/xrspatial/mcda/combine.py
+++ b/xrspatial/mcda/combine.py
@@ -10,6 +10,63 @@ import numpy as np
 import xarray as xr
 
 
+# =====================================================================
+# Memory guards
+# =====================================================================
+#
+# ``owa()`` builds a temporary stack of every weighted criterion layer
+# along a new ``__mcda_criterion`` axis, then sorts that stack
+# descending along axis 0.  Peak working set on the eager numpy path
+# is dominated by the float64 stack itself:
+#
+#   stack : float64 -> 8 bytes per pixel per criterion
+#
+# So bytes per output pixel scale with the criterion count rather than
+# being a fixed constant, which is why this module's check takes
+# ``n_criteria`` as input instead of using a per-pixel constant.
+_BYTES_PER_VALUE = 8
+
+
+def _available_memory_bytes():
+    """Best-effort estimate of available host memory in bytes."""
+    try:
+        with open('/proc/meminfo', 'r') as f:
+            for line in f:
+                if line.startswith('MemAvailable:'):
+                    return int(line.split()[1]) * 1024  # kB -> bytes
+    except (OSError, ValueError, IndexError):
+        pass
+    try:
+        import psutil
+        return psutil.virtual_memory().available
+    except (ImportError, AttributeError):
+        pass
+    return 2 * 1024 ** 3
+
+
+def _check_owa_memory(n_criteria, shape):
+    """Raise MemoryError if the OWA stack would exceed 50% of RAM.
+
+    The eager numpy path materializes the full
+    ``(n_criteria,) + shape`` float64 stack, which is the dominant
+    working buffer.  The dask path is bounded per chunk and skips this
+    check at the call site.
+    """
+    pixels = 1
+    for dim in shape:
+        pixels *= int(dim)
+    required = int(n_criteria) * pixels * _BYTES_PER_VALUE
+    available = _available_memory_bytes()
+    if required > 0.5 * available:
+        shape_str = "x".join(str(int(d)) for d in shape)
+        raise MemoryError(
+            f"owa with {int(n_criteria)} criteria on a {shape_str} "
+            f"grid requires ~{required / 1e9:.1f} GB of working memory "
+            f"but only ~{available / 1e9:.1f} GB is available.  Use a "
+            f"dask-backed Dataset for out-of-core processing."
+        )
+
+
 def _validate_criteria(criteria: xr.Dataset) -> None:
     if not isinstance(criteria, xr.Dataset):
         raise TypeError(
@@ -202,6 +259,21 @@ def owa(
 
     order_weights_arr = np.array(order_weights, dtype=np.float64)
 
+    # Memory guard: the eager path materializes the full
+    # (n, *shape) float64 stack via xr.concat below, so refuse early
+    # when that buffer would dominate available RAM.  Dask-backed
+    # inputs are bounded per chunk and skip the check.
+    first_var = list(criteria.data_vars)[0]
+    first_data = criteria[first_var].data
+    is_dask = False
+    try:
+        import dask.array as _da
+        is_dask = isinstance(first_data, _da.Array)
+    except ImportError:
+        pass
+    if not is_dask:
+        _check_owa_memory(n, criteria[first_var].shape)
+
     # First apply criterion weights
     weighted_layers = []
     for var_name in criteria.data_vars:
@@ -229,7 +301,6 @@ def owa(
     result_data = (sorted_data * ow).sum(axis=0)
 
     # Pick dims/coords from first data var
-    first_var = list(criteria.data_vars)[0]
     template = criteria[first_var]
     return xr.DataArray(
         result_data, name=name, dims=template.dims,

--- a/xrspatial/tests/test_mcda.py
+++ b/xrspatial/tests/test_mcda.py
@@ -1828,3 +1828,50 @@ class TestNonFiniteWeights1311:
             {("a", "b"): 2.0, ("a", "c"): 4.0, ("b", "c"): 2.0},
         )
         assert all(np.isfinite(v) for v in weights.values())
+
+
+# ===========================================================================
+# Memory guard for owa() (#1370)
+# ===========================================================================
+
+class TestOWAMemoryGuard:
+    """Memory guard on the eager owa() path."""
+
+    def test_oversize_raises(self, criteria_dataset, weights_3):
+        """owa raises MemoryError when the criteria stack exceeds the budget."""
+        from unittest.mock import patch
+
+        with patch(
+            "xrspatial.mcda.combine._available_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError, match="working memory"):
+                owa(criteria_dataset, weights_3, [0.5, 0.3, 0.2])
+
+    def test_normal_succeeds(self, criteria_dataset, weights_3):
+        """A normal-size dataset passes the guard with real available memory."""
+        result = owa(criteria_dataset, weights_3, [0.5, 0.3, 0.2])
+        assert result.shape == criteria_dataset["slope"].shape
+        assert np.all(np.isfinite(result.values))
+
+    def test_error_message_names_dimensions_and_count(
+        self, criteria_dataset, weights_3,
+    ):
+        """The error message identifies the criterion count and grid shape."""
+        from unittest.mock import patch
+
+        n = len(criteria_dataset.data_vars)
+        h, w = criteria_dataset["slope"].shape
+        shape_token = f"{h}x{w}"
+
+        with patch(
+            "xrspatial.mcda.combine._available_memory_bytes",
+            return_value=1,
+        ):
+            with pytest.raises(MemoryError) as exc_info:
+                owa(criteria_dataset, weights_3, [0.5, 0.3, 0.2])
+
+        msg = str(exc_info.value)
+        assert f"{n} criteria" in msg
+        assert shape_token in msg
+        assert "dask" in msg


### PR DESCRIPTION
## Summary

- Adds a host-memory guard to `owa()` that estimates the float64 criteria stack size (`n_criteria * H * W * 8`) and raises `MemoryError` when it would exceed 50% of available RAM.
- Dask-backed inputs skip the guard, since per-chunk allocations are bounded by the chunk size.
- Three new tests in `TestOWAMemoryGuard`: oversize raises, normal succeeds, error message names the criterion count and grid shape.

Closes #1370.

## Test plan

- [ ] `pytest xrspatial/tests/test_mcda.py` passes (169 tests, including the 3 new ones).
- [ ] Manual smoke check: `owa()` on a small Dataset returns the expected composite surface.