### PR TITLE
Validate dtypes per band in mahalanobis() (#1376)

### DIFF
--- a/xrspatial/mahalanobis.py
+++ b/xrspatial/mahalanobis.py
@@ -15,6 +15,7 @@ import xarray as xr
 
 from xrspatial.utils import (
     ArrayTypeFunctionMapping,
+    _validate_raster,
     has_cuda_and_cupy,
     has_dask_array,
     is_cupy_array,
@@ -393,6 +394,17 @@ def mahalanobis(
     # --- input validation ---
     if len(bands) < 2:
         raise ValueError("At least 2 bands are required.")
+
+    # Per-band dtype/ndim check.  ``validate_arrays`` only enforces matching
+    # shape and array-type, so without this loop a boolean or other
+    # non-numeric DataArray would silently coerce to float64.
+    for i, band in enumerate(bands):
+        _validate_raster(
+            band,
+            func_name='mahalanobis',
+            name=f'bands[{i}]',
+            ndim=2,
+        )
 
     validate_arrays(*bands)
 

--- a/xrspatial/tests/test_mahalanobis.py
+++ b/xrspatial/tests/test_mahalanobis.py
@@ -254,6 +254,43 @@ def test_error_inv_cov_wrong_shape():
         mahalanobis([b1, b2], mean=np.zeros(2), inv_cov=np.eye(3))
 
 
+def test_error_bool_band_rejected():
+    """Boolean DataArrays must be rejected up front, not silently coerced."""
+    rng = np.random.default_rng(0)
+    b1 = xr.DataArray(
+        rng.integers(0, 2, size=(8, 8)).astype(bool), dims=['y', 'x']
+    )
+    b2 = xr.DataArray(
+        rng.integers(0, 2, size=(8, 8)).astype(bool), dims=['y', 'x']
+    )
+    with pytest.raises(ValueError, match="numeric dtype"):
+        mahalanobis([b1, b2])
+
+
+def test_error_string_band_rejected():
+    """String-dtype DataArrays must raise rather than fail deep inside numpy."""
+    data = np.array([['a', 'b'], ['c', 'd']])
+    b1 = xr.DataArray(data, dims=['y', 'x'])
+    b2 = xr.DataArray(data.copy(), dims=['y', 'x'])
+    with pytest.raises(ValueError, match="numeric dtype"):
+        mahalanobis([b1, b2])
+
+
+def test_mixed_numeric_dtypes_accepted():
+    """Mixing float and int bands is a valid numeric input."""
+    rng = np.random.default_rng(1)
+    b1 = xr.DataArray(
+        rng.standard_normal((6, 5)).astype(np.float64), dims=['y', 'x']
+    )
+    b2 = xr.DataArray(
+        rng.integers(0, 100, size=(6, 5)).astype(np.int32), dims=['y', 'x']
+    )
+    result = mahalanobis([b1, b2])
+    assert result.shape == (6, 5)
+    assert result.dtype == np.float64
+    assert np.all(np.isfinite(result.values))
+
+
 # --- output metadata ---
 
 def test_output_metadata():


### PR DESCRIPTION
## Summary

- `mahalanobis()` only ran `validate_arrays()` on its bands, which checks matching shape and array-type but not dtype.  Boolean and other non-numeric DataArrays were silently coerced to float64 instead of being rejected.
- Call `_validate_raster()` on each band first, then the existing shape/array-type check, then the memory guard, then compute.
- Closes #1376.

## Changes

- `xrspatial/mahalanobis.py`: import `_validate_raster` and loop over `bands` at the top of `mahalanobis()`, validating each as a 2-D numeric DataArray.
- `xrspatial/tests/test_mahalanobis.py`: three tests covering the bool reject path, the string reject path, and the mixed-numeric (float + int) positive path.

## Related

- #1288 -- mahalanobis HIGH-severity memory guard, the original audit fix; this Cat 6 dtype-validation gap was deferred to keep one fix per PR.

## Test plan

- [x] `pytest xrspatial/tests/test_mahalanobis.py` -- 24 passed (21 prior + 3 new).