### PR TITLE
Guard _idw knearest against unbounded grid x k allocation (#1377)

### DIFF
--- a/xrspatial/interpolate/_idw.py
+++ b/xrspatial/interpolate/_idw.py
@@ -232,6 +232,37 @@ def _idw_dask_cupy(x_pts, y_pts, z_pts, x_grid, y_grid,
 # Public API
 # ---------------------------------------------------------------------------
 
+def _check_idw_memory(grid_pixels, k):
+    """Raise MemoryError if the k-nearest IDW path would exceed memory.
+
+    ``scipy.spatial.cKDTree.query(query_pts, k=k)`` returns two arrays of
+    shape ``(grid_pixels, k)``: a float64 distance array (8 B/cell) and an
+    int64 index array (8 B/cell), for a peak of ``grid_pixels * k * 16``
+    bytes before any IDW arithmetic runs.  Downstream ``weights``,
+    ``z_vals``, and ``wz`` arrays share the same shape, so this estimate
+    bounds the dominant allocation.
+    """
+    g = int(grid_pixels)
+    kk = int(k)
+    estimate = g * kk * 16
+
+    try:
+        from xrspatial.zonal import _available_memory_bytes
+        avail = _available_memory_bytes()
+    except ImportError:
+        avail = 2 * 1024 ** 3
+
+    if estimate > 0.8 * avail:
+        raise MemoryError(
+            f"idw() needs ~{estimate / 1e9:.1f} GB to allocate the "
+            f"(grid_pixels, k) distance and index arrays of shape "
+            f"({g}, {kk}) for the k-nearest cKDTree query, but only "
+            f"~{avail / 1e9:.1f} GB is available.  Reduce the template "
+            f"grid size, reduce k, or use a chunked dask-backed template "
+            f"so the guard runs per chunk."
+        )
+
+
 def idw(x, y, z, template, power=2.0, k=None,
         fill_value=np.nan, name='idw'):
     """Inverse Distance Weighting interpolation.
@@ -256,6 +287,13 @@ def idw(x, y, z, template, power=2.0, k=None,
     Returns
     -------
     xr.DataArray
+
+    Raises
+    ------
+    MemoryError
+        When ``k`` is set on a numpy-backed template and the
+        ``(grid_pixels, k)`` distance and index arrays from the
+        ``cKDTree`` query would exceed 80% of available memory.
     """
     _validate_raster(template, func_name='idw', name='template')
     x_arr, y_arr, z_arr = validate_points(x, y, z, func_name='idw')
@@ -268,6 +306,18 @@ def idw(x, y, z, template, power=2.0, k=None,
         k = min(k, len(x_arr))
 
     x_grid, y_grid = extract_grid_coords(template, func_name='idw')
+
+    # Memory guard for the k-nearest scipy.cKDTree path.  Runs only on the
+    # numpy backend, which materialises the full (grid_pixels, k) distance
+    # and index arrays in one call.  The dask+numpy backend dispatches
+    # _idw_knearest_numpy per chunk via map_blocks, so per-chunk grid size
+    # bounds the allocation and the guard would refuse legitimate chunked
+    # workloads.  GPU backends reject k early.
+    if k is not None:
+        is_dask = da is not None and isinstance(template.data, da.Array)
+        if not is_dask:
+            grid_pixels = int(np.prod(template.shape))
+            _check_idw_memory(grid_pixels, k)
 
     mapper = ArrayTypeFunctionMapping(
         numpy_func=_idw_numpy,

--- a/xrspatial/tests/test_interpolation.py
+++ b/xrspatial/tests/test_interpolation.py
@@ -486,3 +486,64 @@ class TestKrigingMemoryGuard:
         # n=10, grid_pixels=100000 -> k0 ~ 26 MB > 1 MB * 0.8.
         with pytest.raises(MemoryError, match='prediction matrix'):
             _check_kriging_memory(n_points=10, grid_pixels=100_000)
+
+
+class TestIDWMemoryGuard:
+    """Verify idw(k=...) refuses to allocate more than ~80% of RAM.
+
+    The k-nearest path materialises a ``(grid_pixels, k)`` float64
+    distance array and an int64 index array via ``cKDTree.query``.  Peak
+    use is ``grid_pixels * k * 16`` bytes.  The guard is monkeypatched
+    against a small memory budget so tests can simulate "too big"
+    without allocating GB.
+    """
+
+    def test_oversize_grid_raises(self, monkeypatch):
+        """Large grid x k allocation triggers the guard."""
+        # 32 MB available.  2000x2000 grid * k=4 * 16 B = 256 MB > 0.8*32 MB.
+        monkeypatch.setattr(
+            'xrspatial.zonal._available_memory_bytes',
+            lambda: 32 * 1024 ** 2,
+        )
+
+        x, y, z = _grid_points()
+        template = _make_template(
+            np.arange(2000, dtype=np.float64),
+            np.arange(2000, dtype=np.float64),
+        )
+
+        with pytest.raises(MemoryError, match='idw'):
+            idw(x, y, z, template, k=4)
+
+    def test_normal_succeeds(self, monkeypatch):
+        """Small inputs pass the guard with a tight memory budget."""
+        # 16 MB available is plenty for a 9-point, 3x3 grid problem.
+        monkeypatch.setattr(
+            'xrspatial.zonal._available_memory_bytes',
+            lambda: 16 * 1024 ** 2,
+        )
+
+        x, y, z = _grid_points()
+        template = _make_template([0.0, 1.0, 2.0], [0.0, 1.0, 2.0])
+
+        # Should not raise.
+        result = idw(x, y, z, template, k=3)
+        assert result.shape == template.shape
+
+    def test_message_names_grid_and_k(self, monkeypatch):
+        """Error message identifies grid size and k for the user."""
+        from xrspatial.interpolate._idw import _check_idw_memory
+
+        monkeypatch.setattr(
+            'xrspatial.zonal._available_memory_bytes',
+            lambda: 1 * 1024 ** 2,  # 1 MB
+        )
+
+        # grid_pixels=1_000_000, k=8 -> 128 MB > 0.8 MB.
+        with pytest.raises(MemoryError) as excinfo:
+            _check_idw_memory(grid_pixels=1_000_000, k=8)
+
+        msg = str(excinfo.value)
+        assert '1000000' in msg
+        assert '8' in msg
+        assert 'GB' in msg


### PR DESCRIPTION
Closes #1377.

## Summary

- Add `_check_idw_memory(grid_pixels, k)` in `xrspatial/interpolate/_idw.py`. Estimates `grid_pixels * k * 16` bytes (the float64 distance array plus the int64 index array returned by `scipy.spatial.cKDTree.query`) and raises `MemoryError` if it exceeds `0.8 * _available_memory_bytes()`.
- Wire the guard into the public `idw()` entrypoint when `k` is set, gated to non-dask templates. The dask+numpy backend dispatches `_idw_knearest_numpy` per chunk via `map_blocks`, so chunk size already bounds the per-chunk allocation. GPU backends reject `k` early.
- Three tests covering oversize-raises, normal-succeeds, and the error message naming `grid_pixels` and `k`.

## Why

Without the guard, a 50000 x 50000 template with `k=12` allocates about 480 GB inside scipy with no message that identifies the template grid or `k`. Same shape as the kriging guard from #1309 and the spline guard from #1374.

## Test plan

- [x] `pytest xrspatial/tests/test_interpolation.py` passes (37 tests, 3 new)
- [x] New tests exercise the oversize and normal paths with monkeypatched `_available_memory_bytes`
- [x] Existing IDW, kriging, spline tests still pass