### PR TITLE
Reject non-positive inputs in wpm() (#1382)

### DIFF
--- a/xrspatial/mcda/combine.py
+++ b/xrspatial/mcda/combine.py
@@ -100,6 +100,41 @@ def wlc(
     return result
 
 
+def _check_wpm_positive(criteria: xr.Dataset) -> None:
+    """Reject criterion layers with zero or negative values.
+
+    ``wpm`` computes ``prod(x_i ** w_i)``. For non-integer weights this is
+    only well-defined when ``x_i > 0``: a single zero collapses the
+    product to zero (masking upstream bugs) and a negative base produces
+    NaN with no error. NaN values are allowed through so the documented
+    NaN-propagation behaviour is preserved.
+    """
+    bad = []
+    for var_name in criteria.data_vars:
+        arr = criteria[var_name].data
+        # Mask NaN so they pass through; we only want to flag <= 0.
+        try:
+            import dask.array as da
+            if isinstance(arr, da.Array):
+                # Compute once; cheap relative to the full product pass.
+                min_val = float(da.nanmin(arr).compute())
+            else:
+                min_val = float(np.nanmin(arr))
+        except ImportError:
+            min_val = float(np.nanmin(arr))
+        except ValueError:
+            # All-NaN slice; nothing to flag.
+            continue
+        if not np.isnan(min_val) and min_val <= 0.0:
+            bad.append((var_name, min_val))
+    if bad:
+        details = ", ".join(f"{n!r} (min={v})" for n, v in bad)
+        raise ValueError(
+            "wpm requires strictly positive criterion values; got "
+            f"non-positive value(s) in: {details}"
+        )
+
+
 def wpm(
     criteria: xr.Dataset,
     weights: dict[str, float],
@@ -113,7 +148,10 @@ def wpm(
     Parameters
     ----------
     criteria : xr.Dataset
-        Standardized criterion layers (0-1).
+        Standardized criterion layers. Values must be strictly positive
+        (``> 0``); zero or negative inputs raise ``ValueError`` because
+        ``x ** w`` is undefined or collapses to zero for non-integer
+        weights. NaN values propagate through to the output.
     weights : dict
         ``{criterion_name: weight}``, must sum to ~1.0.
     name : str
@@ -126,6 +164,7 @@ def wpm(
     """
     _validate_criteria(criteria)
     _validate_weights(weights, criteria)
+    _check_wpm_positive(criteria)
 
     result = None
     for var_name in criteria.data_vars:

--- a/xrspatial/tests/test_mcda.py
+++ b/xrspatial/tests/test_mcda.py
@@ -517,14 +517,55 @@ class TestWPM:
         expected = 0.2 ** 0.4 * 0.5 ** 0.35 * 0.6 ** 0.25
         assert float(result.values[0, 0]) == pytest.approx(expected)
 
-    def test_zero_value_kills_product(self):
-        """A zero criterion value should produce zero output."""
+    def test_zero_value_raises(self):
+        """A zero criterion value is rejected.
+
+        ``0 ** w`` collapses the whole product to zero for any positive
+        weight, which masks bugs in upstream standardization. ``wpm``
+        now requires strictly positive inputs.
+        """
         ds = xr.Dataset({
             "a": xr.DataArray(np.array([[0.0]]), dims=["y", "x"]),
             "b": xr.DataArray(np.array([[0.8]]), dims=["y", "x"]),
         })
+        with pytest.raises(ValueError, match="non-positive"):
+            wpm(ds, {"a": 0.5, "b": 0.5})
+
+    def test_negative_value_raises(self):
+        """A negative criterion value is rejected.
+
+        ``(-x) ** w`` is NaN for non-integer ``w``; without validation
+        the function silently returns NaN.
+        """
+        ds = xr.Dataset({
+            "a": xr.DataArray(np.array([[-0.1, 0.5]]), dims=["y", "x"]),
+            "b": xr.DataArray(np.array([[0.7, 0.7]]), dims=["y", "x"]),
+        })
+        with pytest.raises(ValueError, match="non-positive"):
+            wpm(ds, {"a": 0.5, "b": 0.5})
+
+    def test_error_names_offending_variable(self):
+        """The error message identifies which variable is bad."""
+        ds = xr.Dataset({
+            "ok": xr.DataArray(np.array([[0.5]]), dims=["y", "x"]),
+            "bad": xr.DataArray(np.array([[-1.0]]), dims=["y", "x"]),
+        })
+        with pytest.raises(ValueError, match="bad"):
+            wpm(ds, {"ok": 0.5, "bad": 0.5})
+
+    def test_strictly_positive_inputs_work(self):
+        """The positive path is unchanged."""
+        ds = xr.Dataset({
+            "a": xr.DataArray(np.array([[0.2, 0.5]]), dims=["y", "x"]),
+            "b": xr.DataArray(np.array([[0.8, 0.4]]), dims=["y", "x"]),
+        })
         result = wpm(ds, {"a": 0.5, "b": 0.5})
-        assert float(result.values[0, 0]) == pytest.approx(0.0)
+        assert float(result.values[0, 0]) == pytest.approx(
+            0.2 ** 0.5 * 0.8 ** 0.5
+        )
+        assert float(result.values[0, 1]) == pytest.approx(
+            0.5 ** 0.5 * 0.4 ** 0.5
+        )
 
 
 class TestWLCNaN:
@@ -1118,14 +1159,14 @@ class TestWPMEdgeCases:
         r = wpm(ds, {"a": 0.3, "b": 0.7})
         assert float(r.values[0, 0]) == pytest.approx(1.0)
 
-    def test_all_zeros(self):
-        """All criteria at 0.0 should produce 0.0."""
+    def test_all_zeros_raises(self):
+        """All criteria at 0.0 is rejected by the positive-input check."""
         ds = xr.Dataset({
             "a": xr.DataArray(np.array([[0.0]]), dims=["y", "x"]),
             "b": xr.DataArray(np.array([[0.0]]), dims=["y", "x"]),
         })
-        r = wpm(ds, {"a": 0.5, "b": 0.5})
-        assert float(r.values[0, 0]) == pytest.approx(0.0)
+        with pytest.raises(ValueError, match="non-positive"):
+            wpm(ds, {"a": 0.5, "b": 0.5})
 
 
 class TestConstrainEdgeCases:


### PR DESCRIPTION
## Summary

Closes #1382.

`wpm` computes `prod(x_i ** w_i)`. For non-integer weights this is only well-defined when `x_i > 0`: a zero base collapses the whole product to zero and masks upstream bugs in standardization, and a negative base produces NaN with no error. The docstring said inputs should be standardized 0-1 but nothing enforced that at runtime.

Sibling Cat 3 follow-up to the NaN-weight fix in #1311 / #1312, which flagged this case as deferred.

## Changes

- `xrspatial/mcda/combine.py`: added `_check_wpm_positive`, called from `wpm` after the existing weight checks. It runs `nanmin` per variable (eager compute for dask, since correctness here is worth one extra pass) and raises `ValueError` listing every variable whose minimum is `<= 0`. NaN values pass through, so the documented NaN-propagation behaviour is preserved. Updated the docstring to spell out the positivity requirement.
- `xrspatial/tests/test_mcda.py`: rewrote the two tests that asserted zero-collapses-to-zero (`test_zero_value_kills_product`, `test_all_zeros`) to expect the new error, and added three more tests: negative input, error message names the offending variable, and a positive-path baseline.

## Test plan

- [x] `pytest xrspatial/tests/test_mcda.py` -- 169/169 pass
- [x] Reproduction from the issue now raises `ValueError` naming `'a'` and `'b'`
- [x] NaN inputs still propagate through to the output (existing `test_wpm_nan` passes)