### PR TITLE
Reject mixed-backend arrays in validate_arrays() (#1383)

### DIFF
--- a/xrspatial/tests/test_multispectral.py
+++ b/xrspatial/tests/test_multispectral.py
@@ -880,7 +880,7 @@ def test_true_color_mismatched_backends_raises():
     blue = xr.DataArray(np.ones((4, 4), dtype=np.float32), dims=['y', 'x'])
     blue = blue.assign_coords(y=np.arange(4), x=np.arange(4))
 
-    with pytest.raises(ValueError, match='same type'):
+    with pytest.raises(ValueError, match='same backend'):
         true_color(red, green, blue)
 
 

--- a/xrspatial/tests/test_utils.py
+++ b/xrspatial/tests/test_utils.py
@@ -3,8 +3,27 @@ import xarray as xr
 import pytest
 import warnings
 
+import dask.array as da
 
 from xrspatial import utils
+from xrspatial.utils import validate_arrays
+
+try:
+    import cupy
+
+    _has_cupy = True
+    try:
+        cupy.zeros(1)
+    except Exception:
+        _has_cupy = False
+except ImportError:
+    cupy = None
+    _has_cupy = False
+
+
+cupy_required = pytest.mark.skipif(
+    not _has_cupy, reason="cupy unavailable in this environment"
+)
 
 
 def test_warn_if_unit_mismatch_degrees_horizontal_elevation_vertical(monkeypatch):
@@ -95,3 +114,45 @@ def test_warn_if_unit_mismatch_degrees_but_angle_vertical(monkeypatch):
         utils.warn_if_unit_mismatch(da)
 
     assert len(w) == 0, "Expected no warnings when vertical units are angles"
+
+
+def test_validate_arrays_dask_numpy_pair_passes():
+    a = xr.DataArray(da.from_array(np.zeros((8, 8)), chunks=4))
+    b = xr.DataArray(da.from_array(np.ones((8, 8)), chunks=4))
+    validate_arrays(a, b)  # should not raise
+
+
+def test_validate_arrays_numpy_pair_passes():
+    a = xr.DataArray(np.zeros((6, 6)))
+    b = xr.DataArray(np.ones((6, 6)))
+    validate_arrays(a, b)  # should not raise
+
+
+def test_validate_arrays_mixed_dask_numpy_and_eager_numpy_rejected():
+    a = xr.DataArray(da.from_array(np.zeros((6, 6))))
+    b = xr.DataArray(np.ones((6, 6)))
+    with pytest.raises(ValueError, match="same backend"):
+        validate_arrays(a, b)
+
+
+@cupy_required
+def test_validate_arrays_dask_cupy_pair_passes():
+    a = xr.DataArray(da.from_array(cupy.zeros((8, 8)), chunks=4))
+    b = xr.DataArray(da.from_array(cupy.ones((8, 8)), chunks=4))
+    validate_arrays(a, b)  # should not raise
+
+
+@cupy_required
+def test_validate_arrays_mixed_dask_numpy_and_dask_cupy_rejected():
+    a = xr.DataArray(da.from_array(np.zeros((8, 8))))
+    b = xr.DataArray(da.from_array(cupy.zeros((8, 8))))
+    with pytest.raises(ValueError, match="dask\\+numpy.*dask\\+cupy"):
+        validate_arrays(a, b)
+
+
+@cupy_required
+def test_validate_arrays_mixed_eager_numpy_and_cupy_rejected():
+    a = xr.DataArray(np.zeros((6, 6)))
+    b = xr.DataArray(cupy.zeros((6, 6)))
+    with pytest.raises(ValueError, match="numpy.*cupy"):
+        validate_arrays(a, b)

--- a/xrspatial/utils.py
+++ b/xrspatial/utils.py
@@ -337,6 +337,23 @@ class ArrayTypeFunctionMapping(object):
             raise TypeError("Unsupported Array Type: {}".format(type(arr)))
 
 
+def _classify_backend(arr):
+    """Classify a DataArray's backing storage into one of four buckets that
+    line up with ``ArrayTypeFunctionMapping``: ``"numpy"``, ``"cupy"``,
+    ``"dask+numpy"``, or ``"dask+cupy"``. Returns ``"unknown"`` for anything
+    else so the caller can surface a clear error."""
+    data = arr.data
+    if has_dask_array() and isinstance(data, da.Array):
+        if is_cupy_backed(arr):
+            return "dask+cupy"
+        return "dask+numpy"
+    if is_cupy_array(data):
+        return "cupy"
+    if isinstance(data, np.ndarray):
+        return "numpy"
+    return "unknown"
+
+
 def validate_arrays(*arrays):
     if len(arrays) < 2:
         raise ValueError(
@@ -344,13 +361,20 @@ def validate_arrays(*arrays):
         )
 
     first_array = arrays[0]
+    first_backend = _classify_backend(first_array)
     for i in range(1, len(arrays)):
 
         if not first_array.data.shape == arrays[i].data.shape:
             raise ValueError("input arrays must have equal shapes")
 
-        if not isinstance(first_array.data, type(arrays[i].data)):
-            raise ValueError("input arrays must have same type")
+        other_backend = _classify_backend(arrays[i])
+        if first_backend != other_backend:
+            raise ValueError(
+                "input arrays must share the same backend; got "
+                "'{}' (array 0) and '{}' (array {})".format(
+                    first_backend, other_backend, i
+                )
+            )
 
     # ensure dask chunksizes of all arrays are the same
     if has_dask_array() and isinstance(first_array.data, da.Array):


### PR DESCRIPTION
Closes #1383.

## Summary

`validate_arrays()` checked that input arrays shared a backend by comparing the outer container type:

```python
if not isinstance(first_array.data, type(arrays[i].data)):
    raise ValueError("input arrays must have same type")
```

A NumPy-backed `dask.array.Array` and a CuPy-backed `dask.array.Array` are both `dask.array.Array`, so mixed pairs slipped through the check and crashed inside a numba or cupy kernel later.

The fix classifies each input against the same four buckets that `ArrayTypeFunctionMapping` already uses (`numpy`, `cupy`, `dask+numpy`, `dask+cupy`) by reusing the existing helpers `is_cupy_array`, `is_cupy_backed`, and `da.Array` checks. Any mismatch raises a `ValueError` that names both backends, e.g. `input arrays must share the same backend; got 'dask+numpy' (array 0) and 'dask+cupy' (array 1)`.

The existing `test_true_color_mismatched_backends_raises` was asserting on the old message and has been updated to match the new one.

## Test plan

- [x] `pytest xrspatial/tests/test_utils.py` (9 tests, 6 new)
- [x] `pytest xrspatial/tests/test_multispectral.py` (multispectral callers of `validate_arrays`)
- [x] `pytest xrspatial/tests/test_zonal.py` (zonal callers)
- [x] `pytest xrspatial/tests/test_mahalanobis.py` (mahalanobis caller)
- [x] `pytest xrspatial/tests/test_fire.py` (fire callers)

New tests cover:

- `dask+numpy` pair passes
- pure `numpy` pair passes
- `dask+numpy` mixed with eager `numpy` raises
- `dask+cupy` pair passes (cupy-only)
- `dask+numpy` mixed with `dask+cupy` raises (cupy-only)
- eager `numpy` mixed with eager `cupy` raises (cupy-only)