### PR TITLE
Reject complex dtypes in _validate_raster() (#1384)

### DIFF
--- a/xrspatial/tests/test_utils.py
+++ b/xrspatial/tests/test_utils.py
@@ -95,3 +95,25 @@ def test_warn_if_unit_mismatch_degrees_but_angle_vertical(monkeypatch):
         utils.warn_if_unit_mismatch(da)
 
     assert len(w) == 0, "Expected no warnings when vertical units are angles"
+
+
+# ---------------------------------------------------------------------------
+# _validate_raster dtype handling
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("dtype", [np.complex64, np.complex128])
+def test_validate_raster_rejects_complex_dtype(dtype):
+    """Complex dtypes are not real numeric and must be rejected."""
+    raster = xr.DataArray(np.zeros((4, 4), dtype=dtype))
+    with pytest.raises(ValueError, match="real numeric"):
+        utils._validate_raster(raster, func_name="example")
+
+
+@pytest.mark.parametrize(
+    "dtype", [np.float32, np.float64, np.int32, np.int64, np.uint8],
+)
+def test_validate_raster_accepts_real_numeric_dtypes(dtype):
+    """Integer and float dtypes pass the default numeric check."""
+    raster = xr.DataArray(np.zeros((4, 4), dtype=dtype))
+    # Should not raise.
+    utils._validate_raster(raster, func_name="example")

--- a/xrspatial/utils.py
+++ b/xrspatial/utils.py
@@ -63,7 +63,9 @@ def _validate_raster(
     ndim : int, tuple of int, or None
         Allowed number of dimensions.  ``None`` skips the check.
     numeric : bool
-        If True, require a numeric dtype (int or float).
+        If True, require a real numeric dtype (integer or float).
+        Complex dtypes are rejected because xrspatial operations
+        assume real-valued raster data.
     integer_only : bool
         If True, require an integer dtype specifically.
 
@@ -97,10 +99,13 @@ def _validate_raster(
                     f"got {agg.dtype}"
                 )
         else:
-            if not np.issubdtype(agg.dtype, np.number):
+            if (
+                not np.issubdtype(agg.dtype, np.number)
+                or np.issubdtype(agg.dtype, np.complexfloating)
+            ):
                 raise ValueError(
-                    f"{func_name}(): `{name}` must have a numeric dtype "
-                    f"(integer or float), got {agg.dtype}"
+                    f"{func_name}(): `{name}` must have a real numeric "
+                    f"dtype (integer or float), got {agg.dtype}"
                 )
 
 


### PR DESCRIPTION
Closes #1384.

## Summary

- `_validate_raster()` checked `np.issubdtype(dtype, np.number)`, which is True for `complex64` and `complex128`. xrspatial consumers all expect real-valued data, so complex inputs either crashed mid-kernel or silently lost the imaginary part.
- Tighten the check to also exclude `np.complexfloating` and update the docstring to say "real numeric".
- Two new parametrized tests: complex64/128 raise a clear ValueError, and float32/float64/int32/int64/uint8 still pass.

## Test plan

- [x] `pytest xrspatial/tests/test_utils.py` (10 passed)
- [x] `pytest xrspatial/tests/test_aspect.py xrspatial/tests/test_slope.py xrspatial/tests/test_classify.py xrspatial/tests/test_focal.py xrspatial/tests/test_hillshade.py xrspatial/tests/test_normalize.py` (413 passed)
- [x] `pytest xrspatial/tests/test_cost_distance.py xrspatial/tests/test_curvature.py xrspatial/tests/test_terrain.py xrspatial/tests/test_corridor.py xrspatial/tests/test_perlin.py` (206 passed)