### PR TITLE
Reject underflowing sigma_spatial in bilateral() (#1390)

### DIFF
--- a/xrspatial/bilateral.py
+++ b/xrspatial/bilateral.py
@@ -255,11 +255,14 @@ def bilateral(agg, sigma_spatial=1.0, sigma_range=10.0,
     sigma_spatial : float, default 1.0
         Standard deviation of the spatial Gaussian.  Controls the size
         of the neighbourhood: kernel radius = ceil(2 * sigma_spatial).
-        Must be > 0.
+        Must be at least ``sqrt(np.finfo(float64).tiny)`` (~1.49e-154)
+        so that ``2 * sigma_spatial**2`` does not underflow to a
+        denormal and turn the Gaussian weight into NaN.
     sigma_range : float, default 10.0
         Standard deviation of the range (value-similarity) Gaussian.
         Larger values allow more smoothing across value differences;
-        smaller values preserve more edges.  Must be > 0.
+        smaller values preserve more edges.  Same lower bound as
+        ``sigma_spatial``.
     name : str, default 'bilateral'
         Name for the output DataArray.
     boundary : str, default 'nan'
@@ -297,12 +300,17 @@ def bilateral(agg, sigma_spatial=1.0, sigma_range=10.0,
     ICCV 1998.
     """
     _validate_raster(agg, func_name='bilateral', name='agg', ndim=(2, 3))
+    # Lower bound on each sigma so 2*sigma**2 stays a normal float64.  Below
+    # sqrt(tiny) the squared term denormalises to zero and 1/(2*sigma**2)
+    # becomes +inf (or raises ZeroDivisionError under numba), and exp(-d *
+    # inf) -> 0*inf -> NaN propagates through the whole output.
+    _sigma_min = float(np.sqrt(np.finfo(np.float64).tiny))
     _validate_scalar(sigma_spatial, func_name='bilateral',
                      name='sigma_spatial', dtype=(int, float),
-                     min_val=0, min_exclusive=True)
+                     min_val=_sigma_min)
     _validate_scalar(sigma_range, func_name='bilateral',
                      name='sigma_range', dtype=(int, float),
-                     min_val=0, min_exclusive=True)
+                     min_val=_sigma_min)
     _validate_boundary(boundary)
 
     sigma_spatial = float(sigma_spatial)

--- a/xrspatial/tests/test_bilateral.py
+++ b/xrspatial/tests/test_bilateral.py
@@ -135,6 +135,52 @@ def test_bilateral_validation_errors():
         bilateral(agg, boundary='invalid')
 
 
+def test_bilateral_rejects_underflow_sigma_spatial():
+    """sigma_spatial small enough to denormalise 2*sigma**2 must raise.
+
+    Below ``sqrt(np.finfo(float64).tiny)`` the squared term underflows to
+    zero (or to a denormal that makes ``1/(2*sigma**2)`` infinite), and
+    ``exp(-dist2 * inf) = 0 * inf = NaN`` propagates through the whole
+    output.  Regression test for issue #1390.
+    """
+    agg = xr.DataArray(np.ones((10, 10)))
+    with pytest.raises(ValueError, match='sigma_spatial'):
+        bilateral(agg, sigma_spatial=1e-200, sigma_range=1.0)
+    # Also reject the denormal-but-nonzero case that previously yielded
+    # all-NaN output instead of an error.
+    with pytest.raises(ValueError, match='sigma_spatial'):
+        bilateral(agg, sigma_spatial=1e-160, sigma_range=1.0)
+    # And the same bound applies to sigma_range.
+    with pytest.raises(ValueError, match='sigma_range'):
+        bilateral(agg, sigma_spatial=1.0, sigma_range=1e-200)
+
+
+def test_bilateral_rejects_zero_sigma():
+    """sigma_spatial=0 and sigma_range=0 still raise (regression).
+
+    The lower bound was previously ``> 0``; tightening it to
+    ``>= sqrt(tiny)`` must keep rejecting zero.
+    """
+    agg = xr.DataArray(np.ones((5, 5)))
+    with pytest.raises(ValueError, match='sigma_spatial'):
+        bilateral(agg, sigma_spatial=0.0, sigma_range=1.0)
+    with pytest.raises(ValueError, match='sigma_range'):
+        bilateral(agg, sigma_spatial=1.0, sigma_range=0.0)
+
+
+def test_bilateral_accepts_normal_sigma():
+    """Realistic sigma values must still produce a finite result.
+
+    Guards against an overly aggressive lower bound regression.
+    """
+    rng = np.random.default_rng(1390)
+    data = rng.standard_normal((8, 8)).astype(np.float64)
+    agg = xr.DataArray(data)
+    result = bilateral(agg, sigma_spatial=1.0, sigma_range=1.0)
+    assert result.shape == agg.shape
+    assert np.all(np.isfinite(result.data))
+
+
 def test_bilateral_clamps_oversize_sigma_spatial():
     """An oversized sigma_spatial should be clamped internally so that the
     derived kernel radius never exceeds max(rows, cols).


### PR DESCRIPTION
## Summary

Fixes #1390. `bilateral()` validated `sigma_spatial > 0` only. Values small enough that `2 * sigma**2` underflows to a denormal or to zero made `1/(2*sigma**2)` either `+inf` (`exp(-dist2 * inf) = 0 * inf = NaN`, all-NaN output) or raised `ZeroDivisionError` under numba. This is the MEDIUM-severity Cat 3 finding deferred from PR #1238.

The bound on both `sigma_spatial` and `sigma_range` is tightened to `>= sqrt(np.finfo(float64).tiny)` (~1.49e-154), the smallest value that keeps the squared term a normal float64. Realistic sigmas are unaffected; nonsense values now raise `ValueError` naming the parameter.

The same threshold is applied to `sigma_range` for symmetry, since the same underflow occurs in `inv_2_sr`.

## Test plan

- [x] `pytest xrspatial/tests/test_bilateral.py` -- 22 passed (19 prior + 3 new)
- [x] `test_bilateral_rejects_underflow_sigma_spatial` covers `sigma_spatial=1e-200` (would `ZeroDivisionError`), `1e-160` (would all-NaN), and `sigma_range=1e-200`
- [x] `test_bilateral_rejects_zero_sigma` regresses the previous `> 0` rejection for `sigma_spatial=0` and `sigma_range=0`
- [x] `test_bilateral_accepts_normal_sigma` confirms `sigma_spatial=sigma_range=1.0` still produces a finite result