### PR TITLE
Validate raster dtype in convolve_2d() (#1389)

### DIFF
--- a/xrspatial/convolution.py
+++ b/xrspatial/convolution.py
@@ -6,8 +6,8 @@ import xarray as xr
 from numba import cuda, jit, prange
 
 from xrspatial.utils import (ArrayTypeFunctionMapping, _boundary_to_dask, _pad_array,
-                             _validate_boundary, cuda_args, get_dataarray_resolution,
-                             not_implemented_func)
+                             _validate_boundary, _validate_raster, cuda_args,
+                             get_dataarray_resolution, not_implemented_func)
 
 # 3rd-party
 try:
@@ -469,6 +469,10 @@ def _convolve_2d_dask_cupy(data, kernel, boundary='nan'):
 
 
 def convolve_2d(data, kernel, boundary='nan'):
+    # Wrap raw arrays so _validate_raster can check dtype/ndim consistently
+    # across numpy, cupy, and dask backends before the kernel runs.
+    agg = xr.DataArray(data)
+    _validate_raster(agg, func_name='convolve_2d', ndim=2)
     _validate_boundary(boundary)
     mapper = ArrayTypeFunctionMapping(
         numpy_func=_convolve_2d_numpy_boundary,
@@ -476,7 +480,7 @@ def convolve_2d(data, kernel, boundary='nan'):
         dask_func=_convolve_2d_dask_numpy,
         dask_cupy_func=_convolve_2d_dask_cupy
     )
-    out = mapper(xr.DataArray(data))(data, kernel, boundary)
+    out = mapper(agg)(data, kernel, boundary)
     return out
 
 

--- a/xrspatial/tests/test_convolution.py
+++ b/xrspatial/tests/test_convolution.py
@@ -1,0 +1,38 @@
+import numpy as np
+import pytest
+import xarray as xr
+
+from xrspatial.convolution import circle_kernel, convolve_2d
+
+
+KERNEL = circle_kernel(1, 1, 1)
+
+
+def test_convolve_2d_rejects_boolean_dtype():
+    # Boolean DataArrays used to crash deep inside numba with a
+    # cryptic TypingError; _validate_raster should reject up front.
+    agg = xr.DataArray(np.ones((10, 10), dtype=bool))
+    with pytest.raises(ValueError, match="numeric dtype"):
+        convolve_2d(agg.data, KERNEL)
+
+
+def test_convolve_2d_rejects_string_dtype():
+    agg = xr.DataArray(np.array([['a', 'b'], ['c', 'd']]))
+    with pytest.raises(ValueError, match="numeric dtype"):
+        convolve_2d(agg.data, KERNEL)
+
+
+def test_convolve_2d_rejects_wrong_ndim():
+    # 1D input should be rejected before reaching the kernel
+    with pytest.raises(ValueError, match="must be 2D"):
+        convolve_2d(np.zeros(10, dtype=np.float64), KERNEL)
+
+
+def test_convolve_2d_accepts_float64():
+    # Positive path: a float64 raster still works end-to-end.
+    data = np.arange(25, dtype=np.float64).reshape(5, 5)
+    out = convolve_2d(data, KERNEL)
+    assert out.shape == data.shape
+    # Centre cell is finite; edges are NaN by default boundary mode.
+    assert np.isfinite(out[2, 2])
+    assert np.isnan(out[0, 0])


### PR DESCRIPTION
Closes #1389.

## Summary

`convolve_2d()` skipped `_validate_raster`, so boolean, string, or wrong-ndim inputs reached numba/cupy and produced confusing internal errors. This wraps the input in `xr.DataArray` once and validates it before the kernel dispatch.

PR #1384 already taught `_validate_raster` to reject complex dtypes, so the single call covers boolean, string, and complex.

## Changes

- `xrspatial/convolution.py`: wrap input in `xr.DataArray` and call `_validate_raster(agg, func_name='convolve_2d', ndim=2)` at the top of `convolve_2d()`. The same DataArray feeds the existing `ArrayTypeFunctionMapping` dispatch.
- `xrspatial/tests/test_convolution.py`: 4 new tests (boolean rejected, string rejected, 1D rejected, float64 still works).

## Test plan

- [x] `pytest xrspatial/tests/test_convolution.py` passes (4/4)
- [x] `pytest xrspatial/tests/test_focal.py` still passes (134/134)