### PR TITLE
Merge sink_d8 labels across dask tile boundaries (#1394)

### DIFF
--- a/xrspatial/hydro/sink_d8.py
+++ b/xrspatial/hydro/sink_d8.py
@@ -272,6 +272,156 @@ def _run_numpy(data):
     return _sink_cpu(data.astype(np.float64), h, w, 0, 0, w)
 
 
+# =====================================================================
+# Cross-tile union-find for dask CCL
+# =====================================================================
+#
+# Per-tile CCL produces globally unique IDs but does not merge
+# components that span tile boundaries.  After the per-tile pass we
+# walk each shared edge, record an equivalence whenever two adjacent
+# boundary cells are both sinks, then union and remap labels.
+
+def _uf_find(parent, x):
+    """Path-halving find on a dict-backed union-find."""
+    while parent[x] != x:
+        parent[x] = parent[parent[x]]
+        x = parent[x]
+    return x
+
+
+def _uf_union(parent, a, b):
+    """Union two label roots; smaller root wins so labels stay deterministic."""
+    ra = _uf_find(parent, a)
+    rb = _uf_find(parent, b)
+    if ra == rb:
+        return
+    if ra < rb:
+        parent[rb] = ra
+    else:
+        parent[ra] = rb
+
+
+def _collect_boundary_equivalences(labels_np):
+    """Return a list of (label_a, label_b) pairs from interior tile edges.
+
+    *labels_np* is the materialized numpy result of the per-tile CCL pass.
+    We scan every interior row/column boundary plus the two diagonal
+    pairs (NE/SW and NW/SE) so 8-connectivity is preserved across tiles.
+
+    Pairs where either side is NaN or 0 are skipped.  Pairs with the
+    same label on both sides are skipped too.
+    """
+    pairs = []
+
+    def _scan(a, b):
+        # a and b are matched-shape slices; record (la, lb) where both
+        # are sink labels (non-NaN, non-zero).
+        if a.size == 0:
+            return
+        valid = ~(np.isnan(a) | np.isnan(b))
+        if not valid.any():
+            return
+        am = a[valid]
+        bm = b[valid]
+        diff = am != bm
+        if not diff.any():
+            return
+        la = am[diff].astype(np.int64)
+        lb = bm[diff].astype(np.int64)
+        for i in range(la.size):
+            pairs.append((int(la[i]), int(lb[i])))
+
+    # Vertical neighbors (up-down): every row boundary
+    _scan(labels_np[:-1, :], labels_np[1:, :])
+    # Horizontal neighbors (left-right)
+    _scan(labels_np[:, :-1], labels_np[:, 1:])
+    # Diagonal NW-SE
+    _scan(labels_np[:-1, :-1], labels_np[1:, 1:])
+    # Diagonal NE-SW
+    _scan(labels_np[:-1, 1:], labels_np[1:, :-1])
+    return pairs
+
+
+def _build_label_remap(labels_np):
+    """Build a {label: root_label} mapping for cross-tile sink merges.
+
+    Only labels whose root differs from themselves end up in the dict;
+    callers can short-circuit when the result is empty.
+    """
+    pairs = _collect_boundary_equivalences(labels_np)
+    if not pairs:
+        return {}
+
+    parent = {}
+    for a, b in pairs:
+        if a not in parent:
+            parent[a] = a
+        if b not in parent:
+            parent[b] = b
+        _uf_union(parent, a, b)
+
+    remap = {}
+    for label in list(parent):
+        root = _uf_find(parent, label)
+        if root != label:
+            remap[label] = root
+    return remap
+
+
+def _apply_label_remap(block, remap_keys, remap_vals):
+    """Replace each label in *block* with its root from the remap arrays."""
+    if remap_keys.size == 0:
+        return block
+    out = block.copy()
+    # np.searchsorted gives O(N log K) lookup which beats a Python dict
+    # in the inner loop and is easy to vectorize.
+    flat = out.ravel()
+    valid = ~np.isnan(flat)
+    if not valid.any():
+        return out
+    vals = flat[valid].astype(np.int64)
+    idx = np.searchsorted(remap_keys, vals)
+    in_range = idx < remap_keys.size
+    hits = np.zeros_like(vals, dtype=bool)
+    hits[in_range] = remap_keys[idx[in_range]] == vals[in_range]
+    if hits.any():
+        new_vals = vals.astype(np.float64)
+        new_vals[hits] = remap_vals[idx[hits]].astype(np.float64)
+        flat[valid] = new_vals
+        out = flat.reshape(block.shape)
+    return out
+
+
+def _merge_cross_tile_labels(labels_da):
+    """Merge sink labels across tile boundaries.
+
+    Materializes the per-tile CCL result so we can scan all boundaries,
+    runs union-find, and applies the remap lazily via map_blocks.
+    """
+    # Materialize once to scan boundaries.  CCL is fundamentally a global
+    # operation so we can't avoid touching every cell; the per-tile pass
+    # already streamed.
+    labels_np = labels_da.compute()
+    remap = _build_label_remap(labels_np)
+    if not remap:
+        # Nothing to merge — wrap the materialized result back into dask
+        # so the caller still gets a dask array with the original chunks.
+        return da.from_array(labels_np, chunks=labels_da.chunks)
+
+    keys = np.array(sorted(remap), dtype=np.int64)
+    vals = np.array([remap[k] for k in keys], dtype=np.int64)
+
+    def _remap_block(block, _keys=keys, _vals=vals):
+        return _apply_label_remap(block, _keys, _vals)
+
+    merged = da.from_array(labels_np, chunks=labels_da.chunks)
+    return merged.map_blocks(
+        _remap_block,
+        dtype=np.float64,
+        meta=np.array((), dtype=np.float64),
+    )
+
+
 def _run_dask_numpy(data):
     total_w = data.shape[1]
 
@@ -284,11 +434,13 @@ def _run_dask_numpy(data):
         return _sink_cpu(np.asarray(block, dtype=np.float64),
                          h, w, row_off, col_off, total_w)
 
-    return da.map_blocks(
+    per_tile = da.map_blocks(
         _tile_fn, data,
         dtype=np.float64,
         meta=np.array((), dtype=np.float64),
     )
+
+    return _merge_cross_tile_labels(per_tile)
 
 
 def _run_dask_cupy(data):

--- a/xrspatial/hydro/tests/test_sink_d8.py
+++ b/xrspatial/hydro/tests/test_sink_d8.py
@@ -140,6 +140,178 @@ def test_dask_nan_positions(chunks):
 
 
 # -------------------------------------------------------------------
+# Cross-tile connected components -- regression for #1394
+# -------------------------------------------------------------------
+#
+# Per-tile CCL must be merged across tile boundaries so a connected
+# sink that straddles a chunk gets one label, matching the numpy
+# backend's behavior.
+
+def _equiv_labels(arr_a, arr_b):
+    """Return True if two label rasters describe the same partitioning.
+
+    Two outputs are equivalent when they agree on which cells are sinks
+    (NaN pattern matches) and when same-label-in-A pairs are also
+    same-label-in-B.  We don't require literal label equality because
+    the dask path uses position-based IDs that differ from the numpy
+    path's IDs after cross-tile merging.
+    """
+    if arr_a.shape != arr_b.shape:
+        return False
+    nan_a = np.isnan(arr_a)
+    nan_b = np.isnan(arr_b)
+    if not np.array_equal(nan_a, nan_b):
+        return False
+
+    valid = ~nan_a
+    a_vals = arr_a[valid]
+    b_vals = arr_b[valid]
+    # Build mapping a_label -> b_label and check it's consistent.
+    mapping = {}
+    for a, b in zip(a_vals.tolist(), b_vals.tolist()):
+        if a in mapping:
+            if mapping[a] != b:
+                return False
+        else:
+            mapping[a] = b
+    # And the reverse mapping must also be 1:1.
+    rev = {}
+    for a, b in mapping.items():
+        if b in rev:
+            return False
+        rev[b] = a
+    return True
+
+
+@dask_array_available
+@pytest.mark.parametrize("chunks", [
+    (1, 1), (1, 2), (1, 3),
+])
+def test_dask_horizontal_sink_across_tiles(chunks):
+    """Horizontal connected sink straddling a chunk boundary."""
+    flow_dir = np.array([[1.0, 0.0, 0.0, 16.0]], dtype=np.float64)
+    np_agg = create_test_raster(flow_dir, backend='numpy')
+    dk_agg = create_test_raster(flow_dir, backend='dask', chunks=chunks)
+    np_result = sink(np_agg).data
+    dk_result = sink(dk_agg).data.compute()
+    assert _equiv_labels(np_result, dk_result), (
+        f"chunks={chunks}: dask result {dk_result} does not match "
+        f"numpy partitioning {np_result}"
+    )
+    # Specifically, the two sink cells should share a label
+    assert dk_result[0, 1] == dk_result[0, 2]
+
+
+@dask_array_available
+@pytest.mark.parametrize("chunks", [
+    (1, 1), (2, 1), (3, 1),
+])
+def test_dask_vertical_sink_across_tiles(chunks):
+    """Vertical connected sink straddling a chunk boundary."""
+    flow_dir = np.array([
+        [1.0, 1.0, 16.0],
+        [1.0, 0.0, 16.0],
+        [1.0, 0.0, 16.0],
+        [1.0, 1.0, 16.0],
+    ], dtype=np.float64)
+    np_agg = create_test_raster(flow_dir, backend='numpy')
+    dk_agg = create_test_raster(flow_dir, backend='dask', chunks=chunks)
+    np_result = sink(np_agg).data
+    dk_result = sink(dk_agg).data.compute()
+    assert _equiv_labels(np_result, dk_result)
+    assert dk_result[1, 1] == dk_result[2, 1]
+
+
+@dask_array_available
+@pytest.mark.parametrize("chunks", [
+    (1, 1), (2, 2), (1, 2), (2, 1),
+])
+def test_dask_diagonal_sink_across_tiles(chunks):
+    """Diagonal connected sink across a corner-shared tile boundary.
+
+    8-connectivity means a sink chain along the NW-SE diagonal must
+    survive a chunk boundary that separates the two cells corner-to-corner.
+    """
+    flow_dir = np.array([
+        [0.0, 1.0, 1.0, 1.0],
+        [1.0, 0.0, 1.0, 1.0],
+        [1.0, 1.0, 0.0, 1.0],
+        [1.0, 1.0, 1.0, 0.0],
+    ], dtype=np.float64)
+    np_agg = create_test_raster(flow_dir, backend='numpy')
+    dk_agg = create_test_raster(flow_dir, backend='dask', chunks=chunks)
+    np_result = sink(np_agg).data
+    dk_result = sink(dk_agg).data.compute()
+    assert _equiv_labels(np_result, dk_result)
+    # All four diagonal cells are one connected sink under 8-connectivity
+    sink_cells = [(0, 0), (1, 1), (2, 2), (3, 3)]
+    first = dk_result[sink_cells[0]]
+    for r, c in sink_cells[1:]:
+        assert dk_result[r, c] == first
+
+
+@dask_array_available
+@pytest.mark.parametrize("chunks", [
+    (1, 1), (2, 2), (1, 2), (2, 1), (3, 3),
+])
+def test_dask_block_sink_across_four_tiles(chunks):
+    """Sink block spanning a 2x2 grid of tiles (all four corners meet)."""
+    flow_dir = np.array([
+        [1.0, 0.0, 0.0, 0.0, 16.0],
+        [1.0, 0.0, 0.0, 0.0, 16.0],
+    ], dtype=np.float64)
+    np_agg = create_test_raster(flow_dir, backend='numpy')
+    dk_agg = create_test_raster(flow_dir, backend='dask', chunks=chunks)
+    np_result = sink(np_agg).data
+    dk_result = sink(dk_agg).data.compute()
+    assert _equiv_labels(np_result, dk_result)
+    # All six sink cells should share one label
+    sink_cells = [(r, c) for r in range(2) for c in range(1, 4)]
+    first = dk_result[sink_cells[0]]
+    for r, c in sink_cells[1:]:
+        assert dk_result[r, c] == first
+
+
+@dask_array_available
+def test_dask_separate_sinks_stay_separate():
+    """Two distinct sinks separated by a non-sink chunk keep distinct labels."""
+    flow_dir = np.array([
+        [0.0, 1.0, 1.0, 1.0, 0.0],
+    ], dtype=np.float64)
+    np_agg = create_test_raster(flow_dir, backend='numpy')
+    dk_agg = create_test_raster(flow_dir, backend='dask', chunks=(1, 2))
+    np_result = sink(np_agg).data
+    dk_result = sink(dk_agg).data.compute()
+    assert _equiv_labels(np_result, dk_result)
+    # Different sinks -> different labels in both
+    assert dk_result[0, 0] != dk_result[0, 4]
+
+
+@dask_array_available
+@pytest.mark.parametrize("chunks", [(1, 1), (2, 2), (3, 3)])
+def test_dask_label_count_matches_numpy(chunks):
+    """Number of unique labels in dask output equals numpy output."""
+    flow_dir = np.array([
+        [0.0, 0.0, 1.0, 0.0, 0.0],
+        [1.0, 0.0, 1.0, 0.0, 1.0],
+        [1.0, 1.0, 0.0, 1.0, 1.0],
+        [0.0, 1.0, 0.0, 1.0, 0.0],
+        [0.0, 1.0, 1.0, 1.0, 0.0],
+    ], dtype=np.float64)
+    np_agg = create_test_raster(flow_dir, backend='numpy')
+    dk_agg = create_test_raster(flow_dir, backend='dask', chunks=chunks)
+    np_result = sink(np_agg).data
+    dk_result = sink(dk_agg).data.compute()
+    np_labels = np.unique(np_result[~np.isnan(np_result)])
+    dk_labels = np.unique(dk_result[~np.isnan(dk_result)])
+    assert len(np_labels) == len(dk_labels), (
+        f"chunks={chunks}: numpy found {len(np_labels)} sinks, "
+        f"dask found {len(dk_labels)}"
+    )
+    assert _equiv_labels(np_result, dk_result)
+
+
+# -------------------------------------------------------------------
 # GPU cross-backend tests
 # -------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #1394.

## Summary
- `_run_dask_numpy` in `xrspatial/hydro/sink_d8.py` ran per-tile CCL with globally unique IDs but never merged equivalent labels across tile boundaries, so a single connected sink that spanned a chunk showed up as several separate sinks.
- Added a union-find pass that walks every interior tile edge (4-connected) plus both diagonals (so 8-connectivity is preserved across corner-shared tiles), records label equivalences, and remaps labels to their roots via a second `map_blocks` pass.
- The dask+cupy path delegates to the numpy dask path, so it inherits the fix.

## Test plan
- [x] `pytest xrspatial/hydro/tests/test_sink_d8.py` — 40 passing (21 original + 19 new)
- [x] `pytest xrspatial/hydro/tests/` — full hydro suite still passes (772 tests)
- [x] Original reproducer from #1394 now matches the numpy result
- [x] Added regression tests for horizontal, vertical, diagonal, four-tile-block, and separation cases at multiple chunk shapes
- [x] Added a `_label_count_matches_numpy` test so the number of unique sink labels stays equal across backends

## Notes
- Cross-tile merging needs a global view of the labeled raster, so the implementation calls `.compute()` once on the per-tile result. The streaming benefit of dask is preserved during the per-tile CCL phase; only the boundary scan and label remap require the materialized array. CCL is fundamentally a global operation, so this matches what `xrspatial/sieve.py` already does for its dask path.
- Labels in the dask output are not byte-identical to the numpy output (the dask path uses position-based IDs from each tile, then merges, while the numpy path uses one position-based ID across the whole raster). The new tests check label-partition equivalence (cells in the same numpy component are in the same dask component) rather than literal ID equality.