### PR TITLE
Record accuracy sweep results for hydro, flood, emerging_hotspots

### DIFF
--- a/.claude/sweep-accuracy-state.csv
+++ b/.claude/sweep-accuracy-state.csv
@@ -3,9 +3,12 @@ balanced_allocation,2026-04-14T12:00:00Z,1203,,,float32 allocation array caused 
 cost_distance,2026-04-13T12:00:00Z,1191,,,CuPy Bellman-Ford max_iterations = h+w instead of h*w. Fix in PR #1192.
 curvature,2026-03-30T15:00:00Z,,,,Formula matches ArcGIS reference. Backends consistent. No issues found.
 dasymetric,2026-04-14T12:00:00Z,,,,Mass conservation correct. Weighted/binary/limiting_variable all verified. Pycnophylactic Tobler algorithm correct.
+flood,2026-04-30,,MEDIUM,2;5,"MEDIUM (not fixed): dask backend preserves float32 input dtype while numpy promotes to float64 in flood_depth and curve_number_runoff; DataArray inputs for curve_number, mannings_n bypass scalar > 0 (and CN <= 100) range validation, silently producing NaN/garbage."
+emerging_hotspots,2026-04-30,,MEDIUM,2;3,MEDIUM: threshold_90 uses int() (truncation) instead of ceil() so n_times=11 requires only 9/11 (81.8%) instead of 90%. MEDIUM: NaN time steps produce gi_bin=0 which classifier counts as 'non-significant' rather than missing; threshold_90 uses full n_times not valid count. LOW: 'global_std == 0' check does not catch NaN std for fully/mostly NaN inputs.
 focal,2026-03-30T13:00:00Z,1092,,,
 geotiff,2026-04-23,1247,HIGH,1;3;4;5,HIGH fixed: CPU fp_predictor_decode wrong byte-lane layout for multi-sample predictor=3 (GPU was correct). MEDIUMs also fixed on same PR: eager and streaming writers emit LONG8 strip/tile offsets in BigTIFF output (were LONG); VRT read honors AREA_OR_POINT=Point; VRT nodata cast uses source dtype instead of float32. LOW fixed: duplicate LERC codec block removed from _compression.py.
 hillshade,2026-04-10T12:00:00Z,,,,"Horn's method correct. All backends consistent. NaN propagation correct. float32 adequate for [0,1] output."
+hydro,2026-04-30,,LOW,1,Only LOW: twi log(0)=-inf if fa=0 (out-of-contract); MFD weighted sum no Kahan (negligible). No CRIT/HIGH issues.
 kde,2026-04-13T12:00:00Z,1198,,,kde/line_density return zeros for descending-y templates. Fix in PR #1199.
 multispectral,2026-03-30T14:00:00Z,1094,,,
 perlin,2026-04-10T12:00:00Z,,,,Improved Perlin noise implementation correct. Fade/gradient functions verified. Backend-consistent. Continuous at cell boundaries.


### PR DESCRIPTION
## Summary

Records the 2026-04-30 accuracy sweep results for three previously uninspected modules in `.claude/sweep-accuracy-state.csv`. No code changes; state-file only.

| Module | Severity | Categories | Notes |
|--------|----------|------------|-------|
| hydro | LOW | 1 | `twi log(0)=-inf` if `fa=0` (out-of-contract); MFD weighted sum without Kahan (negligible). No CRIT/HIGH issues. |
| flood | MEDIUM | 2;5 | Dask backend preserves float32 input dtype while numpy promotes to float64 in `flood_depth` and `curve_number_runoff`; DataArray inputs for `curve_number` and `mannings_n` bypass the scalar-path range validation, silently producing NaN/garbage. |
| emerging_hotspots | MEDIUM | 2;3 | `threshold_90` uses `int()` truncation instead of `ceil()` so `n_times=11` requires only 9/11 (81.8%) instead of 90%; NaN time steps produce `gi_bin=0` which the classifier counts as "non-significant" rather than missing; `global_std == 0` check does not catch NaN std for fully/mostly NaN inputs. |

No CRITICAL or HIGH findings, so no `/rockout` was triggered. MEDIUM findings are documented in the state notes for future cleanup.

## Test plan

- [ ] CI passes (state-file change only; no functional impact)