### PR TITLE
Use sized slice in dask morph chunk writeback (#1399)

### DIFF
--- a/xrspatial/morphology.py
+++ b/xrspatial/morphology.py
@@ -334,7 +334,7 @@ def _morph_chunk_numpy(chunk, kernel, op, block_info=None):
     else:
         interior = _dilate_kernel_numpy(chunk, kernel, rows, cols, ky, kx)
     result = chunk.copy()
-    result[hy:-hy, hx:-hx] = interior
+    result[hy:hy + rows, hx:hx + cols] = interior
     return result
 
 
@@ -388,7 +388,7 @@ def _morph_chunk_cupy(chunk, kernel, op, block_info=None):
     else:
         _dilate_gpu[bpg, tpb](chunk, kern_dev, out, hy, hx, ky, kx)
     result = chunk.copy()
-    result[hy:-hy, hx:-hx] = out
+    result[hy:hy + rows, hx:hx + cols] = out
     return result
 
 

--- a/xrspatial/tests/test_morphology.py
+++ b/xrspatial/tests/test_morphology.py
@@ -284,6 +284,30 @@ def test_closing_dask_equals_numpy():
     assert_numpy_equals_dask_numpy(numpy_agg, dask_agg, morph_closing, nan_edges=True)
 
 
+@dask_array_available
+@pytest.mark.parametrize("kernel", [
+    np.array([[1, 1, 1]], dtype=np.uint8),
+    np.array([[1], [1], [1]], dtype=np.uint8),
+])
+def test_erode_dask_1d_kernel_matches_numpy(kernel):
+    numpy_agg = create_test_raster(_DATA, backend='numpy')
+    dask_agg = create_test_raster(_DATA, backend='dask')
+    fn = partial(morph_erode, kernel=kernel)
+    assert_numpy_equals_dask_numpy(numpy_agg, dask_agg, fn, nan_edges=False)
+
+
+@dask_array_available
+@pytest.mark.parametrize("kernel", [
+    np.array([[1, 1, 1]], dtype=np.uint8),
+    np.array([[1], [1], [1]], dtype=np.uint8),
+])
+def test_dilate_dask_1d_kernel_matches_numpy(kernel):
+    numpy_agg = create_test_raster(_DATA, backend='numpy')
+    dask_agg = create_test_raster(_DATA, backend='dask')
+    fn = partial(morph_dilate, kernel=kernel)
+    assert_numpy_equals_dask_numpy(numpy_agg, dask_agg, fn, nan_edges=False)
+
+
 # ---------------------------------------------------------------------------
 # CuPy backend
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Replaces `result[hy:-hy, hx:-hx] = interior` with `result[hy:hy + rows, hx:hx + cols] = interior` in both `_morph_chunk_numpy` and `_morph_chunk_cupy`. The old form became the empty slice `0:-0` for 1xN or Nx1 kernels, raising ValueError on the dask backends while numpy and cupy paths handled them.
- Adds parametrized 1x3 and 3x1 dask regression tests for `morph_erode` and `morph_dilate`.

Closes #1399

## Test plan

- [x] `pytest xrspatial/tests/test_morphology.py` (39 passed, including the 4 new parametrized cases)