### PR TITLE
Update RELEASE.md to reference main branch

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,7 +3,7 @@
 ### Preparation
 - Create a new branch containing the following changes:
   - Update CHANGELOG.md with new version number and list of changes extracted from `git log --pretty=oneline --pretty=format:"- %s" <lastest_release_tag>..HEAD`.
-- Commit changes and submit them as a PR to the `master` branch.
+- Commit changes and submit them as a PR to the `main` branch.
 - If the CI passes OK, merge the PR.
 
 ### Tag release


### PR DESCRIPTION
## Summary
- Updates the release process docs to reference the `main` branch instead of `master`, following the default branch rename.

## Test plan
- [x] Visual review of `RELEASE.md` diff