### PR TITLE
Record accuracy sweep results for bilateral

### DIFF
--- a/.claude/sweep-accuracy-state.csv
+++ b/.claude/sweep-accuracy-state.csv
@@ -1,5 +1,6 @@
 module,last_inspected,issue,severity_max,categories_found,notes
 balanced_allocation,2026-04-14T12:00:00Z,1203,,,float32 allocation array caused source ID mismatch for non-integer IDs. Fix in PR #1205.
+bilateral,2026-05-01,,,,"No CRIT/HIGH/MEDIUM. Sigma underflow validated via sqrt(tiny) bound; oversize sigma clamped. float64 throughout numpy/cupy. NaN center returns NaN; NaN neighbors skipped (denom not incremented). w_sum>0 guard avoids div-by-zero. map_overlap depth==kernel radius. CUDA bounds correct. Inf input could yield 0*inf=NaN in v_sum but unvalidated input is general xrspatial pattern, not bilateral-specific."
 cost_distance,2026-04-13T12:00:00Z,1191,,,CuPy Bellman-Ford max_iterations = h+w instead of h*w. Fix in PR #1192.
 curvature,2026-03-30T15:00:00Z,,,,Formula matches ArcGIS reference. Backends consistent. No issues found.
 dasymetric,2026-04-14T12:00:00Z,,,,Mass conservation correct. Weighted/binary/limiting_variable all verified. Pycnophylactic Tobler algorithm correct.


### PR DESCRIPTION
## Summary

Records accuracy sweep results for the `bilateral` module in `.claude/sweep-accuracy-state.csv`. No issues found.

Audit covered all five accuracy categories across numpy, cupy, dask+numpy, and dask+cupy backends:

- Floating point: float64 used throughout. Sigma underflow already validated via `sqrt(np.finfo(float64).tiny)` lower bound; oversize sigma clamped to `max(rows, cols)`.
- NaN handling: NaN center returns NaN; NaN neighbors are skipped without incrementing the denominator. The `w_sum > 0.0` guard prevents division by zero.
- Off-by-one: `map_overlap` depth equals kernel radius. CUDA bounds use strict `<`. Loop bounds are symmetric and inclusive of `y+radius`.
- Earth curvature: not applicable (pixel space).
- Backend consistency: numpy and cupy paths use identical algorithms with float64 dtype. Dask paths route through the same chunk function.

## Test plan
- [x] Read `xrspatial/bilateral.py`, `xrspatial/utils.py`, `xrspatial/tests/general_checks.py`, `xrspatial/tests/test_bilateral.py`
- [x] CSV update visible in diff