### PR TITLE
Record accuracy sweep results for edge_detection

### DIFF
--- a/.claude/sweep-accuracy-state.csv
+++ b/.claude/sweep-accuracy-state.csv
@@ -3,6 +3,7 @@ balanced_allocation,2026-04-14T12:00:00Z,1203,,,float32 allocation array caused 
 cost_distance,2026-04-13T12:00:00Z,1191,,,CuPy Bellman-Ford max_iterations = h+w instead of h*w. Fix in PR #1192.
 curvature,2026-03-30T15:00:00Z,,,,Formula matches ArcGIS reference. Backends consistent. No issues found.
 dasymetric,2026-04-14T12:00:00Z,,,,Mass conservation correct. Weighted/binary/limiting_variable all verified. Pycnophylactic Tobler algorithm correct.
+edge_detection,2026-05-01,,,,Thin wrappers around convolve_2d with fixed Sobel/Prewitt/Laplacian kernels; no issues found
 emerging_hotspots,2026-04-30,,MEDIUM,2;3,MEDIUM: threshold_90 uses int() (truncation) instead of ceil() so n_times=11 requires only 9/11 (81.8%) instead of 90%. MEDIUM: NaN time steps produce gi_bin=0 which classifier counts as 'non-significant' rather than missing; threshold_90 uses full n_times not valid count. LOW: 'global_std == 0' check does not catch NaN std for fully/mostly NaN inputs.
 fire,2026-04-30,,,,All ops per-pixel (no accumulation/stencil/projected distance). NaN handled via x!=x; CUDA bounds use strict <; rdnbr and ros divisions guarded; CPU/GPU/dask paths algorithmically identical. No accuracy issues found.
 flood,2026-04-30,,MEDIUM,2;5,"MEDIUM (not fixed): dask backend preserves float32 input dtype while numpy promotes to float64 in flood_depth and curve_number_runoff; DataArray inputs for curve_number, mannings_n bypass scalar > 0 (and CN <= 100) range validation, silently producing NaN/garbage."


### PR DESCRIPTION
Audited xrspatial/edge_detection.py for the five accuracy categories (FP precision, NaN/Inf, off-by-one, projection, backend parity).

The module is a set of thin wrappers around convolve_2d with fixed 3x3 Sobel, Prewitt, and Laplacian kernels. Boundary handling, NaN propagation, and backend dispatch (numpy/cupy/dask) are delegated to convolve_2d, which already has its own coverage. Tests in test_edge_detection.py exercise kernel symmetry, hand-computed values on a ramp, NaN edge effects, NaN propagation, constant-field zero response, input validation, all four boundary modes, and full numpy/dask/cupy/dask+cupy parity.

No issues found. Updates .claude/sweep-accuracy-state.csv to record the inspection.