### PR TITLE
Record accuracy sweep results for worley

### DIFF
--- a/.claude/sweep-accuracy-state.csv
+++ b/.claude/sweep-accuracy-state.csv
@@ -22,4 +22,5 @@ sieve,2026-04-13T12:00:00Z,,,,Union-find CCL correct. NaN excluded from labeling
 terrain,2026-04-10T12:00:00Z,,,,Perlin/Worley/ridged noise correct. Dask chunk boundaries produce bit-identical results. No precision issues.
 terrain_metrics,2026-04-30,,LOW,2;5,"LOW: Inf input not rejected, propagates as Inf (consistent across backends but undocumented). LOW: dask+cupy non-nan boundary path double-pads (wasted compute, central output values still correct). No CRIT/HIGH; tests cover NaN propagation, all 4 backends, all 4 boundary modes, dtype acceptance."
 visibility,2026-04-13T12:00:00Z,,,,"Bresenham line, LOS kernel, Fresnel zone all correct. All backends converge to numpy."
+worley,2026-05-01,,MEDIUM,2;5,"MEDIUM: numpy backend uses np.empty_like(data) so integer input dtype produces integer output (distances truncated to 0); cupy/dask paths always produce float32. LOW: freq=inf produces 100000 sentinel (sqrt of initial min_dist=1e10), no validation of freq/seed for non-finite values."
 zonal,2026-03-30T12:00:00Z,1090,,,


### PR DESCRIPTION
Adds the worley row to `.claude/sweep-accuracy-state.csv` after the 2026-05-01 sweep.

## Findings

No CRITICAL/HIGH issues. Two MEDIUM/LOW items, documented but not fixed:

- MEDIUM (Cat 5, dtype inconsistency): `_worley_numpy` allocates output via `np.empty_like(data)`, so an integer input DataArray produces integer output and Worley distances (typically 0..~1.5) get truncated to zero. The cupy and dask paths always allocate `float32`. Other procedural noise functions in this codebase (e.g. perlin) reject non-float input up front.
- LOW (Cat 2, non-finite parameters): `freq=inf` produces a `100000.0` sentinel (sqrt of the `1e10` initial `min_dist`). No validation of `freq` or `seed` for NaN/inf/negative values.

Backend parity for valid float inputs is fine: numpy vs dask+numpy bit-identical with regular and irregular chunks; the 3x3 cell neighborhood works across chunk boundaries because cell coordinates are global.

There is no `xrspatial/tests/test_worley.py`; coverage exists only via the terrain wrapper.