### PR TITLE
Record accuracy sweep results for reproject

### DIFF
--- a/.claude/sweep-accuracy-state.csv
+++ b/.claude/sweep-accuracy-state.csv
@@ -17,6 +17,7 @@ perlin,2026-04-10T12:00:00Z,,,,Improved Perlin noise implementation correct. Fad
 polygon_clip,2026-04-13T12:00:00Z,1197,,,crop=True + all_touched=True drops boundary pixels. Fix in PR #1200.
 polygonize,2026-04-13T12:00:00Z,1190,,,NaN pixels not masked in numpy/dask backends. Fix in PR #1194.
 proximity,2026-03-30T15:00:00Z,,,,Direction >= boundary fragile but works due to truncated constant. Float32 truncation is design choice. No wrong-results bugs found.
+reproject,2026-05-01,,MEDIUM,1;5,MEDIUM: GPU dispatcher (_projections_cuda.py) uses _is_geographic_wgs84_or_nad83 (only 4326/4269) and lacks the NAD27/Helmert datum-shift wrapper that CPU has — silently falls back to pyproj for NAD27 inputs; functionally correct but inconsistent fast-path coverage. LOW: _lcc_params line 376 dead variable m2 (cosphi2 is recomputed correctly so math is right but naming misleading). LOW: _interp_geoid_point uses %w column wrap (correct for global EGM grids only). LOW: _ecef_to_geodetic fixed 10-iter no early-exit (converges fine). LOW: bilinear/cubic wsum>1e-10 threshold loose. No CRIT/HIGH issues; CPU/GPU Krueger/authalic/Helmert math is float64 and matches.
 resample,2026-04-14T12:00:00Z,1202,,,Interpolation used edge-aligned coords instead of block-centered. Fix in PR #1204.
 sieve,2026-04-13T12:00:00Z,,,,Union-find CCL correct. NaN excluded from labeling. All backends funnel through _sieve_numpy.
 terrain,2026-04-10T12:00:00Z,,,,Perlin/Worley/ridged noise correct. Dask chunk boundaries produce bit-identical results. No precision issues.


### PR DESCRIPTION
## Summary
- Audited the reproject subpackage for numerical accuracy issues
- No critical or high-severity issues found
- Records one MEDIUM and several LOW observations in the sweep CSV

## Findings

**MEDIUM (Cat 5)**: GPU dispatcher in `_projections_cuda.py` uses `_is_geographic_wgs84_or_nad83` (only EPSG 4326/4269) and lacks the NAD27/Helmert datum-shift wrapper that the CPU path has. This means NAD27 inputs silently fall back to pyproj on the GPU path. Functionally correct, just no fast path on GPU.

**LOW**:
- `_lcc_params` line 376 has a dead `m2` variable (the math is still right because `cosphi2` is divided to produce the correct m-coefficient).
- `_interp_geoid_point` wraps columns with `% w`, correct for global EGM grids only.
- `_ecef_to_geodetic` runs a fixed 10-iteration loop without an early-exit; converges fine for Earth.
- Bilinear/cubic `wsum > 1e-10` threshold is loose but practical impact is negligible.

CPU/GPU parity for Krueger transverse Mercator, authalic latitude inverse, Helmert datum shifts, and resampling kernels (nearest/bilinear/cubic) is faithful, all running float64.

## Test plan
- [ ] CSV row added for `reproject` with `last_inspected=2026-05-01`