### PR TITLE
Record performance re-audit results for multispectral

### DIFF
--- a/.claude/sweep-performance-state.csv
+++ b/.claude/sweep-performance-state.csv
@@ -24,7 +24,7 @@ hillshade,2026-04-16T12:00:00Z,SAFE,compute-bound,0,,"Re-audit after Horn's meth
 kde,2026-04-14T12:00:00Z,SAFE,compute-bound,0,,Graph construction serialized per-tile. _filter_points_to_tile scans all points per tile. No HIGH findings.
 mahalanobis,2026-03-31T18:00:00Z,SAFE,compute-bound,0,,False positive. Numpy path materializes by design. Dask path uses lazy reductions + map_blocks.
 morphology,2026-03-31T18:00:00Z,SAFE,compute-bound,0,,
-multispectral,2026-03-31T18:00:00Z,SAFE,compute-bound,0,,
+multispectral,2026-05-02,SAFE,compute-bound,0,,"Re-audit 2026-05-02 after PRs 1292 (true_color memory guard) and 1301 (validate_arrays in true_color). Verified SAFE. No HIGH. MEDIUM: da.stack in _true_color_dask/_true_color_dask_cupy at L1702/L1731 creates (1,1,1,1) chunks along band axis (4 bands so impact is minor, scheduling overhead not OOM). LOW: np.zeros((h,w,4)) at L1681 then full overwrite -- np.empty would suffice. All 17 indices use plain map_blocks with no halo; 8192x8192 ndvi graph is 80 tasks, evi/arvi/ebbi 112 tasks."
 normalize,2026-03-31T18:00:00Z,SAFE,compute-bound,0,1124,Boolean indexing replaced with lazy nanmin/nanmax/nanmean/nanstd.
 pathfinding,2026-04-15T12:00:00Z,SAFE,compute-bound,0,false-positive,Downgraded. CuPy .get() is required -- A* has no GPU kernel. Per-pixel .compute() is only 2 calls for start/goal validation. seg.values in multi_stop_search collects already-computed results for stitching.
 perlin,2026-03-31T18:00:00Z,WILL OOM,memory-bound,0,,


### PR DESCRIPTION
## Summary
- Re-audited multispectral on 2026-05-02 after PRs #1292 (true_color memory guard) and #1301 (validate_arrays in true_color). Verdict remains SAFE / compute-bound, no HIGH findings.
- Updated `.claude/sweep-performance-state.csv` row for multispectral with the new inspection date and notes from this pass.

## Notes recorded
- MEDIUM: `_true_color_dask` and `_true_color_dask_cupy` use `da.stack` on the band axis without `rechunk`, producing chunks of size 1 along that axis. With 4 bands the impact is scheduling overhead only.
- LOW: `_true_color_numpy` allocates `np.zeros((h, w, 4))` before fully overwriting all four channels; `np.empty` would suffice.
- All 17 index functions use plain `map_blocks` with no halo. An 8192x8192 ndvi graph is 80 tasks; evi/arvi/ebbi 112 tasks.

## Test plan
- [x] CSV row parses with `csv.DictReader`/`DictWriter`.
- [x] Graph audit script `/tmp/multispectral_graph_1.py` builds (never computes) ndvi/evi/arvi/msavi2/savi/ebbi/true_color graphs and reports linear task counts.