### PR TITLE
Record performance re-audit results for geotiff

### DIFF
--- a/.claude/sweep-performance-state.csv
+++ b/.claude/sweep-performance-state.csv
@@ -18,7 +18,7 @@ fire,2026-03-31T18:00:00Z,SAFE,compute-bound,0,,
 flood,2026-03-31T18:00:00Z,SAFE,compute-bound,0,,
 focal,2026-03-31T18:00:00Z,SAFE,compute-bound,0,,
 geodesic,2026-03-31T18:00:00Z,N/A,compute-bound,0,,
-geotiff,2026-04-16T18:00:00Z,SAFE,IO-bound,0,fixed-in-tree,"Fixed-in-tree 2026-04-16: (1) read_geotiff_dask caps total chunk count at 1M and auto-scales chunks with a UserWarning when exceeded (linear graph scaling confirmed: 16384 tasks/1109ms vs 16 tasks/65ms baseline). (2) _nvcomp_batch_compress deflate path now batches GPU->CPU adler32 transfers via a single contiguous .get() and memoryview slicing, eliminating N per-tile sync points. 435 geotiff tests pass (2 pre-existing matplotlib deepcopy unrelated)."
+geotiff,2026-05-02,SAFE,IO-bound,0,,"re-audit 2026-05-02: 6 commits since 2026-04-16 (predictor=3 CPU encode/decode, GPU predictor stride fix, validate_tile_layout, BigTIFF LONG8 offsets, AREA_OR_POINT VRT, per-tile alloc guard). 1M dask chunk cap intact at __init__.py:948; adler32 batch transfer intact at _gpu_decode.py:1825. New code is metadata validation and dispatcher logic with no extra materialization or per-tile sync points. No HIGH/MEDIUM regressions."
 glcm,2026-03-31T18:00:00Z,SAFE,compute-bound,0,,"Downgraded to MEDIUM. da.stack without rechunk is scheduling overhead, not OOM risk."
 hillshade,2026-04-16T12:00:00Z,SAFE,compute-bound,0,,"Re-audit after Horn's method rewrite (PR 1175): clean stencil, map_overlap depth=(1,1), no materialization. Zero findings."
 kde,2026-04-14T12:00:00Z,SAFE,compute-bound,0,,Graph construction serialized per-tile. _filter_points_to_tile scans all points per tile. No HIGH findings.


### PR DESCRIPTION
## Summary

- 16-day re-audit on top of the 2026-04-16 baseline. Six commits landed in `xrspatial/geotiff/` in the window: per-tile allocation guards, the malformed-tile-grid rejection, the GPU predictor stride fix, the CPU fp_predictor multi-band fix, BigTIFF LONG8 offsets, AREA_OR_POINT in VRT reads, and predictor=3 on the CPU write path.
- Verified the two safety nets from the prior audit are intact: the 1M dask chunk cap at `__init__.py:948` and the batched adler32 transfer at `_gpu_decode.py:1825`.
- The new code in this window is metadata validation and dispatcher logic. No new materialization, no new per-tile sync points, no register-pressure changes. SAFE / IO-bound, 0 HIGH.

## Test plan

- [ ] CSV diff is the only change in the PR.