### PR TITLE
Fix MEDIUM findings in sweep skills, not just CRITICAL/HIGH

### DIFF
--- a/.claude/commands/sweep-accuracy.md
+++ b/.claude/commands/sweep-accuracy.md
@@ -193,9 +193,9 @@ xrspatial/tests/general_checks.py for the cross-backend comparison helpers.
 3. For each real issue found, assign a severity (CRITICAL/HIGH/MEDIUM/LOW)
    and note the exact file and line number.
 
-4. If any CRITICAL or HIGH issue is found, run /rockout to fix it end-to-end
-   (GitHub issue, worktree branch, fix, tests, and PR).
-   For MEDIUM/LOW issues, document them but do not fix.
+4. If any CRITICAL, HIGH, or MEDIUM issue is found, run /rockout to fix it
+   end-to-end (GitHub issue, worktree branch, fix, tests, and PR).
+   For LOW issues, document them but do not fix.
 
 5. After finishing (whether you found issues or not), update the inspection
    state file .claude/sweep-accuracy-state.csv. The file is row-per-module

--- a/.claude/commands/sweep-performance.md
+++ b/.claude/commands/sweep-performance.md
@@ -1,8 +1,9 @@
 # Performance Sweep: Dispatch subagents to audit and fix performance issues
 
 Audit xrspatial modules for performance bottlenecks, OOM risk under 30TB dask
-workloads, and backend-specific anti-patterns. Subagents fix HIGH-severity
-findings via /rockout in the same agent that did the audit, in parallel.
+workloads, and backend-specific anti-patterns. Subagents fix HIGH and
+MEDIUM-severity findings via /rockout in the same agent that did the audit,
+in parallel.
 
 Optional arguments: $ARGUMENTS
 (e.g. `--top 5`, `--exclude slope,aspect`, `--only-io`, `--reset-state`)
@@ -214,10 +215,11 @@ xrspatial/tests/general_checks.py for cross-backend test helpers.
 4. For each real issue found, assign a severity (CRITICAL/HIGH/MEDIUM/LOW)
    and note the exact file and line number.
 
-5. If any CRITICAL or HIGH issue is found, run /rockout to fix it end-to-end
-   (GitHub issue, worktree branch, fix, tests, and PR). Include the OOM
-   verdict, bottleneck classification, and affected backends in the rockout
-   prompt so it has full performance context.
+5. If any CRITICAL, HIGH, or MEDIUM issue is found, run /rockout to fix it
+   end-to-end (GitHub issue, worktree branch, fix, tests, and PR). Include
+   the OOM verdict, bottleneck classification, and affected backends in the
+   rockout prompt so it has full performance context. For LOW issues,
+   document them but do not fix.
 
    Skip step 5 entirely if `--no-fix` was passed to the parent sweep.
 

--- a/.claude/commands/sweep-security.md
+++ b/.claude/commands/sweep-security.md
@@ -3,7 +3,7 @@
 Audit xrspatial modules for security issues specific to numeric/GPU raster
 libraries: unbounded allocations, integer overflow, NaN logic bombs, GPU
 kernel bounds, file path injection, and dtype confusion. Subagents fix
-CRITICAL/HIGH issues via /rockout.
+CRITICAL, HIGH, and MEDIUM severity issues via /rockout.
 
 Optional arguments: $ARGUMENTS
 (e.g. `--top 3`, `--exclude slope,aspect`, `--only-io`, `--reset-state`)
@@ -192,9 +192,9 @@ Also read xrspatial/utils.py to understand _validate_raster() behavior.
 3. For each real issue found, assign a severity (CRITICAL/HIGH/MEDIUM/LOW)
    and note the exact file and line number.
 
-4. If any CRITICAL or HIGH issue is found, run /rockout to fix it end-to-end
-   (GitHub issue, worktree branch, fix, tests, and PR).
-   For MEDIUM/LOW issues, document them but do not fix.
+4. If any CRITICAL, HIGH, or MEDIUM issue is found, run /rockout to fix it
+   end-to-end (GitHub issue, worktree branch, fix, tests, and PR).
+   For LOW issues, document them but do not fix.
 
 5. After finishing (whether you found issues or not), update the inspection
    state file .claude/sweep-security-state.csv. The file is row-per-module


### PR DESCRIPTION
## Summary
- Subagents dispatched by `/sweep-accuracy`, `/sweep-performance`, and `/sweep-security` now run `/rockout` for MEDIUM-severity findings in addition to CRITICAL and HIGH.
- Only LOW-severity findings remain documented-but-not-fixed.
- Updates the agent prompt template and the header summary in each skill.

## Test plan
- [ ] Run `/sweep-accuracy --top 1` and confirm a module with only MEDIUM findings produces a fix PR
- [ ] Same for `/sweep-performance --top 1` and `/sweep-security --top 1`