### PR TITLE
Add metadata, api-consistency, and test-coverage sweep skills

### DIFF
--- a/.claude/commands/sweep-api-consistency.md
+++ b/.claude/commands/sweep-api-consistency.md
@@ -1,0 +1,256 @@
+# API Consistency Sweep: Dispatch subagents to audit parameter naming and signature drift
+
+Audit xrspatial modules for API consistency issues across analogous public
+functions: parameter naming drift (`cellsize` vs `cell_size` vs `res`,
+`agg` vs `raster` vs `data`), inconsistent return-type shapes, missing or
+mismatched type hints, docstring/signature divergence. Cheap to find; makes
+the library feel polished and predictable. Subagents fix CRITICAL, HIGH,
+and MEDIUM findings via /rockout — but flag deprecation impact in the
+issue since renames are breaking changes.
+
+Optional arguments: $ARGUMENTS
+(e.g. `--top 3`, `--exclude slope,aspect`, `--only-terrain`, `--reset-state`)
+
+---
+
+## Step 1 -- Gather module metadata via git
+
+Enumerate candidate modules:
+
+**Single-file modules:** Every `.py` file directly under `xrspatial/`, excluding
+`__init__.py`, `_version.py`, `__main__.py`, `utils.py`, `accessor.py`,
+`preview.py`, `dataset_support.py`, `diagnostics.py`, `analytics.py`.
+
+**Subpackage modules:** `geotiff/`, `reproject/`, and `hydro/` directories under
+`xrspatial/`. Treat each as a single audit unit.
+
+For every module, collect:
+
+| Field | How |
+|-------|-----|
+| **last_modified** | `git log -1 --format=%aI -- <path>` |
+| **total_commits** | `git log --oneline -- <path> \| wc -l` |
+| **loc** | `wc -l < <path>` |
+| **public_funcs** | count of functions at module level (heuristic: `^def [a-z]`) |
+
+Store results in memory -- do NOT write intermediate files.
+
+## Step 2 -- Load inspection state
+
+Read `.claude/sweep-api-consistency-state.csv`.
+
+If it does not exist, treat every module as never-inspected. If
+`$ARGUMENTS` contains `--reset-state`, delete the file first.
+
+State file schema (one row per module):
+
+```
+module,last_inspected,issue,severity_max,categories_found,notes
+slope,2026-05-01,1042,HIGH,1;3,"optional single-line notes"
+```
+
+The file is registered with `merge=union` in `.gitattributes`.
+
+## Step 3 -- Score each module
+
+```
+days_since_inspected = (today - last_inspected).days   # 9999 if never
+days_since_modified  = (today - last_modified).days
+
+score = (days_since_inspected * 3)
+      + (public_funcs * 8)
+      + (total_commits * 0.3)
+      - (days_since_modified * 0.1)
+      + (loc * 0.03)
+```
+
+Rationale:
+- Public function count weighted heavily — consistency issues are
+  cross-function comparisons, so more functions = more comparison surface
+- Modules never inspected dominate
+- Recently modified slightly deprioritized
+
+## Step 4 -- Apply filters from $ARGUMENTS
+
+Same filter set as other sweeps: `--top N`, `--exclude`, `--only-terrain`,
+`--only-focal`, `--only-hydro`, `--only-io`, `--reset-state`.
+
+## Step 5 -- Print the ranked table and launch subagents
+
+### 5a. Print the ranked table
+
+Print a markdown table showing ALL scored modules sorted by score descending.
+
+### 5b. Launch subagents for the top N modules
+
+For each of the top N modules (default 3), launch an Agent in parallel using
+`isolation: "worktree"` and `mode: "auto"`. All N agents must be dispatched
+in a single message so they run concurrently.
+
+Each agent's prompt must be self-contained:
+
+```
+You are auditing the xrspatial module "{module}" for API consistency issues.
+
+This module has {commits} commits and {loc} lines of code.
+
+Read these files: {module_files}
+
+Also read xrspatial/__init__.py to see what is publicly re-exported, and
+xrspatial/utils.py for shared helpers.
+
+For comparison, read 2-3 sibling modules (analogous functions). Examples:
+- For aspect: also read slope.py and curvature.py
+- For erosion: also read morphology.py
+- For glcm: also read focal.py and convolution.py
+The point is to compare parameter naming and return shapes against
+modules with similar function families.
+
+**Your task:**
+
+1. Read all listed files thoroughly. For each public function, build a
+   small mental table of (function name, signature, return type).
+
+2. Audit for these 5 API-consistency categories. Only flag issues ACTUALLY
+   present.
+
+   **Cat 1 — Parameter naming drift**
+   - HIGH: same concept named differently across analogous public
+     functions in this module or in sibling modules. Common offenders:
+     `cellsize` vs `cell_size` vs `res` vs `resolution`
+     `agg` vs `raster` vs `data` vs `array`
+     `x` vs `xs` vs `x_coords`
+     `nodata` vs `_FillValue` vs `nodata_value`
+     `cmap` vs `color_map` vs `colormap`
+     `kernel` vs `weights` vs `mask`
+   - MEDIUM: same concept named consistently inside this module but
+     different from sibling modules
+   - MEDIUM: positional-vs-keyword convention drift (sibling functions
+     accept the same arg, one as positional, one as keyword-only)
+   Severity: HIGH if both names exist in the public API at the same time
+   (real user-facing inconsistency); MEDIUM otherwise
+
+   **Cat 2 — Return shape drift**
+   - HIGH: analogous functions return different types (one returns
+     DataArray, sibling returns Dataset for the same conceptual op)
+   - HIGH: tuple-return vs single-return drift (one function returns
+     `(slope, aspect)`, analog returns `slope` only — caller cannot
+     interchange)
+   - MEDIUM: result coord/attr conventions differ (one function emits
+     `attrs['units']`, sibling does not)
+   - MEDIUM: in-place vs returned-copy semantics drift
+   Severity: HIGH if it breaks substitutability between sibling functions
+
+   **Cat 3 — Type hints and docstrings**
+   - MEDIUM: missing type hints on a public function while sibling
+     functions in this module have them
+   - MEDIUM: type hint says `xr.DataArray` but the docstring example
+     passes a numpy array (or vice versa) — docs/types disagree
+   - MEDIUM: docstring lists a parameter that does not exist in the
+     signature (or omits one that does)
+   - MEDIUM: docstring says "Returns: DataArray" but the function returns
+     a tuple
+   - LOW: docstring style drift (numpy-style vs google-style mix)
+   Severity: MEDIUM (these are documentation bugs that mislead users)
+
+   **Cat 4 — Default value inconsistency**
+   - HIGH: same parameter has different defaults in analogous functions
+     (e.g. `kernel_size=3` in one function, `kernel_size=5` in sibling,
+     no documented reason)
+   - MEDIUM: default uses a mutable type (`def f(x=[])`) — Python anti-pattern
+   - MEDIUM: default `None` plus internal substitution where a literal
+     default would be clearer and equally correct
+   Severity: HIGH if user-surprise is likely (silent behavior change
+   when switching between sibling functions)
+
+   **Cat 5 — Public API surface drift**
+   - HIGH: function is called by tests and notebooks but is not in
+     `xrspatial/__init__.py` or in the module's `__all__` (orphan API)
+   - HIGH: function in `__all__` but undocumented in the docstring
+   - MEDIUM: deprecated alias still exported with no `DeprecationWarning`
+   - MEDIUM: private-looking name (`_foo`) but is referenced in tests as
+     if public
+   - LOW: `from .module import *` patterns that bring inconsistent
+     symbols into the public namespace
+   Severity: HIGH for orphan APIs (users find them, depend on them, then
+   break when they vanish)
+
+3. For each real issue, assign severity + file:line.
+
+4. If any CRITICAL, HIGH, or MEDIUM issue is found, run /rockout to fix it.
+   IMPORTANT: parameter renames are breaking changes — for HIGH
+   parameter-rename fixes, the rockout PR must add a deprecation
+   shim (accept both old and new names; emit DeprecationWarning on the
+   old name; update docs). Document this in the issue body. For LOW
+   issues, document but do not fix.
+
+5. Update .claude/sweep-api-consistency-state.csv using csv.DictReader/Writer:
+
+   ```python
+   import csv
+   from pathlib import Path
+
+   path = Path(".claude/sweep-api-consistency-state.csv")
+   header = ["module", "last_inspected", "issue", "severity_max",
+             "categories_found", "notes"]
+
+   rows = {}
+   if path.exists():
+       with path.open() as f:
+           for r in csv.DictReader(f):
+               rows[r["module"]] = r
+
+   rows["{module}"] = {
+       "module": "{module}",
+       "last_inspected": "<today's ISO date>",
+       "issue": "<issue number or empty>",
+       "severity_max": "<HIGH|MEDIUM|LOW or empty>",
+       "categories_found": "<semicolon-joined ints or empty>",
+       "notes": "<single-line notes or empty>",
+   }
+
+   with path.open("w", newline="") as f:
+       w = csv.DictWriter(f, fieldnames=header, quoting=csv.QUOTE_MINIMAL)
+       w.writeheader()
+       for m in sorted(rows):
+           w.writerow(rows[m])
+   ```
+
+   Then `git add` and commit.
+
+Important:
+- Only flag real consistency issues. The lib has 40+ modules — do not
+  list every minor naming difference; focus on user-facing surprise.
+- Compare against 2-3 sibling modules. Cross-cutting concerns (e.g.
+  cellsize naming convention) often span the whole library; if a rename
+  is safe in one module but breaks 20 others, surface that as a notes
+  comment, do not file a per-module issue.
+- For the hydro subpackage: pick one variant (d8) and check whether
+  dinf/mfd siblings agree.
+```
+
+### 5c. Print a status line
+
+After dispatching, print:
+
+```
+Launched {N} API consistency audit agents: {module1}, {module2}, {module3}
+```
+
+## Step 6 -- State updates
+
+To reset: `/sweep-api-consistency --reset-state`
+
+---
+
+## General Rules
+
+- Do NOT modify any source files directly. Subagents handle fixes.
+- Keep the output concise.
+- If $ARGUMENTS is empty, use defaults: top 3, no category filter, no
+  exclusions.
+- State file (`.claude/sweep-api-consistency-state.csv`) is tracked in
+  git with `merge=union`.
+- Renames are breaking. The fix path is a deprecation shim, not a
+  hard rename, unless the function has a clearly orphan/private status.
+- False positives are worse than missed issues.

--- a/.claude/commands/sweep-metadata.md
+++ b/.claude/commands/sweep-metadata.md
@@ -1,0 +1,297 @@
+# Metadata Propagation Sweep: Dispatch subagents to audit modules for metadata preservation
+
+Audit xrspatial modules for metadata propagation bugs: attrs (especially
+`res`, `crs`, `transform`, `nodatavals`, `_FillValue`), coords (x/y values
+and dims), and dim names. Spatial libs lose CRS/transform silently and the
+result looks correct but is wrong. The sky_view_factor cellsize bug
+(#1407) was exactly this class of issue. Subagents fix CRITICAL, HIGH, and
+MEDIUM findings via /rockout.
+
+Optional arguments: $ARGUMENTS
+(e.g. `--top 3`, `--exclude slope,aspect`, `--only-terrain`, `--reset-state`)
+
+---
+
+## Step 1 -- Gather module metadata via git
+
+Enumerate candidate modules:
+
+**Single-file modules:** Every `.py` file directly under `xrspatial/`, excluding
+`__init__.py`, `_version.py`, `__main__.py`, `utils.py`, `accessor.py`,
+`preview.py`, `dataset_support.py`, `diagnostics.py`, `analytics.py`.
+
+**Subpackage modules:** `geotiff/`, `reproject/`, and `hydro/` directories under
+`xrspatial/`. Treat each as a single audit unit. List all `.py` files within
+each (excluding `__init__.py`).
+
+For every module, collect:
+
+| Field | How |
+|-------|-----|
+| **last_modified** | `git log -1 --format=%aI -- <path>` (for subpackages, most recent file) |
+| **total_commits** | `git log --oneline -- <path> \| wc -l` |
+| **loc** | `wc -l < <path>` (for subpackages, sum all files) |
+| **public_funcs** | count of functions defined at module level (heuristic: `^def [a-z]` not starting with `_`) |
+
+Store results in memory -- do NOT write intermediate files.
+
+## Step 2 -- Load inspection state
+
+Read `.claude/sweep-metadata-state.csv`.
+
+If it does not exist, treat every module as never-inspected.
+
+If `$ARGUMENTS` contains `--reset-state`, delete the file and treat
+everything as never-inspected.
+
+State file schema (one row per module):
+
+```
+module,last_inspected,issue,severity_max,categories_found,notes
+slope,2026-05-01,1042,HIGH,1;3,"optional single-line notes"
+```
+
+- `categories_found` is a semicolon-separated integer list (empty when null).
+- `notes` is CSV-quoted; newlines must be flattened to spaces on write so
+  every module stays exactly one line.
+
+The file is registered with `merge=union` in `.gitattributes`, so two
+parallel sweeps touching different modules auto-merge without conflict.
+A transient duplicate-row state can occur after a merge if both branches
+modified the same module; the read-update-write cycle in step 5 keys rows
+by `module` and last-write-wins, so the next write cleans up.
+
+## Step 3 -- Score each module
+
+```
+days_since_inspected = (today - last_inspected).days   # 9999 if never
+days_since_modified  = (today - last_modified).days
+
+score = (days_since_inspected * 3)
+      + (public_funcs * 5)
+      + (total_commits * 0.3)
+      - (days_since_modified * 0.2)
+      + (loc * 0.05)
+```
+
+Rationale:
+- Modules never inspected dominate (9999 * 3)
+- More public functions = more API surface that could lose metadata
+- More commits = more refactor risk for metadata propagation
+- Recently modified modules slightly deprioritized
+- Larger files have more surface area
+
+## Step 4 -- Apply filters from $ARGUMENTS
+
+- `--top N` -- only audit the top N modules (default: 3)
+- `--exclude mod1,mod2` -- remove named modules from the list
+- `--only-terrain` -- restrict to: slope, aspect, curvature, terrain,
+  terrain_metrics, hillshade, sky_view_factor
+- `--only-focal` -- restrict to: focal, convolution, morphology, bilateral,
+  edge_detection, glcm
+- `--only-hydro` -- restrict to: flood, cost_distance, geodesic,
+  surface_distance, viewshed, erosion, diffusion, hydro (subpackage)
+- `--only-io` -- restrict to: geotiff, reproject, rasterize, polygonize
+
+## Step 5 -- Print the ranked table and launch subagents
+
+### 5a. Print the ranked table
+
+Print a markdown table showing ALL scored modules sorted by score descending.
+
+### 5b. Launch subagents for the top N modules
+
+For each of the top N modules (default 3), launch an Agent in parallel using
+`isolation: "worktree"` and `mode: "auto"`. All N agents must be dispatched
+in a single message so they run concurrently.
+
+Each agent's prompt must be self-contained and follow this template (adapt
+the module name, paths, and metadata):
+
+```
+You are auditing the xrspatial module "{module}" for metadata propagation issues.
+
+This module has {commits} commits and {loc} lines of code.
+
+Read these files: {module_files}
+
+Also read xrspatial/utils.py to understand:
+- _validate_raster() behavior — what does it accept/reject?
+- get_dataarray_resolution() — what attrs does it pull from?
+- ngjit / ArrayTypeFunctionMapping dispatch helpers
+
+Read xrspatial/tests/general_checks.py for cross-backend test helpers.
+
+**Your task:**
+
+1. Read all listed files thoroughly, including the matching test file(s)
+   under xrspatial/tests/ so you understand expected behavior. Pay
+   particular attention to whether tests assert on attrs/coords/dims of
+   the returned DataArray.
+
+2. Audit for these 5 metadata-propagation categories. Only flag issues
+   ACTUALLY present in the code.
+
+   **Cat 1 — attrs preservation**
+   - HIGH: result DataArray has empty attrs even though input had attrs
+     (`return xr.DataArray(out_data, dims=...)` instead of `dims=in.dims,
+     attrs=in.attrs`)
+   - HIGH: function silently drops `res`, `crs`, `transform`, or
+     `nodatavals` from input attrs
+   - HIGH: function reads `attrs['res']` for math but does not re-emit it
+     on output (downstream callers see no res, recompute from coords,
+     get different answer)
+   - MEDIUM: function copies attrs but adds an inferred attr that
+     overwrites a user-provided value (e.g. always sets `nodatavals` to
+     `[np.nan]` even if input had `[-9999]`)
+   - MEDIUM: attrs propagated for the eager path but lost on the dask path
+     (or vice versa)
+   Severity: HIGH if downstream spatial computation is affected (slope of
+   a no-CRS raster gives wrong cell-size answers); MEDIUM otherwise
+
+   **Cat 2 — coords preservation**
+   - HIGH: result has integer-index coords (0,1,2,...) when input had
+     georeferenced coords (lon/lat or projected x/y)
+   - HIGH: coordinate values are stale by half-a-pixel after resampling
+     (centre vs corner convention drift)
+   - HIGH: coord dtype changes (float64 → float32) silently between input
+     and output
+   - MEDIUM: extra coords from input (e.g. `time`, `band`) are dropped on
+     output even though they should pass through
+   - MEDIUM: coord names renamed without the function documenting why
+     (`x` → `lon`, `y` → `lat`, etc.)
+   Severity: HIGH if downstream coord-based math (clipping, interp) breaks
+
+   **Cat 3 — dim names and order**
+   - HIGH: output dim order differs from input dim order without
+     documentation (e.g. input `(y, x)`, output `(x, y)`)
+   - HIGH: output has fewer/more dims than input without the function
+     docstring saying so (e.g. reduces over `y` but doesn't reflect that
+     in the dim list)
+   - MEDIUM: function assumes hardcoded dim names (`y`, `x`) and silently
+     mis-aligns when input uses (`lat`, `lon`) or (`row`, `col`)
+   - MEDIUM: dask backend preserves dims, numpy backend does not (or vice
+     versa)
+   Severity: HIGH if it breaks chained xarray operations
+
+   **Cat 4 — dtype and nodata semantics**
+   - HIGH: function reads `attrs['nodatavals']` for input mask but does
+     not propagate it to output (so a chained call sees the old nodata,
+     possibly wrong)
+   - HIGH: output dtype hardcoded to float64 even when input was uint8
+     (memory blowup; downstream stats wrong)
+   - MEDIUM: NaN used as the nodata sentinel internally but output dtype
+     is integer (NaN cannot represent — silent conversion to MIN_INT or 0)
+   - MEDIUM: `_FillValue` attr present on input but not on output
+   Severity: HIGH if nodata mask is silently flipped or dtype change
+   causes wrong arithmetic downstream
+
+   **Cat 5 — backend-inconsistent metadata**
+   - HIGH: numpy and cupy backends emit attrs differently (e.g. numpy
+     keeps `crs`, cupy drops it, or numpy emits `_FillValue`, cupy emits
+     `nodatavals`)
+   - HIGH: dask path's metadata is computed from chunk-local stats not
+     global stats (e.g. `attrs['min']` is per-chunk min, not global min)
+   - MEDIUM: only one of the four backends (numpy / cupy / dask+numpy /
+     dask+cupy) preserves attrs
+   - MEDIUM: result name (`.name`) inconsistent across backends
+   Severity: HIGH if a chained pipeline silently produces different
+   numbers depending on which backend is active
+
+3. For each real issue found, assign a severity (CRITICAL/HIGH/MEDIUM/LOW)
+   and note the exact file and line number.
+
+4. If any CRITICAL, HIGH, or MEDIUM issue is found, run /rockout to fix it
+   end-to-end (GitHub issue, worktree branch, fix, tests, and PR). For
+   LOW issues, document them but do not fix.
+
+5. After finishing (whether you found issues or not), update the inspection
+   state file .claude/sweep-metadata-state.csv. Header:
+
+   `module,last_inspected,issue,severity_max,categories_found,notes`
+
+   Use this Python pattern (do NOT hand-edit the file):
+
+   ```python
+   import csv
+   from pathlib import Path
+
+   path = Path(".claude/sweep-metadata-state.csv")
+   header = ["module", "last_inspected", "issue", "severity_max",
+             "categories_found", "notes"]
+
+   rows = {}
+   if path.exists():
+       with path.open() as f:
+           for r in csv.DictReader(f):
+               rows[r["module"]] = r
+
+   rows["{module}"] = {
+       "module": "{module}",
+       "last_inspected": "<today's ISO date, e.g. 2026-05-03>",
+       "issue": "<issue number from rockout, or empty>",
+       "severity_max": "<HIGH|MEDIUM|LOW, or empty>",
+       "categories_found": "<semicolon-joined ints, e.g. 1;3, or empty>",
+       "notes": "<single-line notes (replace any newlines with spaces), or empty>",
+   }
+
+   with path.open("w", newline="") as f:
+       w = csv.DictWriter(f, fieldnames=header, quoting=csv.QUOTE_MINIMAL)
+       w.writeheader()
+       for m in sorted(rows):
+           w.writerow(rows[m])
+   ```
+
+   Use empty strings (not `null`) for missing values.
+
+   Then `git add .claude/sweep-metadata-state.csv` and commit it to the
+   worktree branch so the state update lands in the PR.
+
+Important:
+- Only flag real metadata propagation issues. False positives waste time.
+- Read the tests for this module before flagging — the test may codify
+  the current behavior intentionally (e.g. an aggregation that genuinely
+  drops a dim).
+- Verify by reading the function end-to-end: does the input DataArray's
+  attrs/coords/dims get propagated to the returned DataArray?
+- For ALL backends, not just numpy. Check numpy / cupy / dask+numpy /
+  dask+cupy paths.
+- Do NOT flag the use of numba @jit itself.
+- For the hydro subpackage: focus on one representative variant (d8) in
+  detail, then note which dinf/mfd files share the same pattern.
+```
+
+### 5c. Print a status line
+
+After dispatching, print:
+
+```
+Launched {N} metadata propagation audit agents: {module1}, {module2}, {module3}
+```
+
+## Step 6 -- State updates
+
+State is updated by the subagents themselves. After completion, verify with:
+
+```
+column -t -s, .claude/sweep-metadata-state.csv | less
+```
+
+To reset all tracking: `/sweep-metadata --reset-state`
+
+---
+
+## General Rules
+
+- Do NOT modify any source files directly. Subagents handle fixes via /rockout.
+- Keep the parent output concise — the ranked table and dispatch line are
+  the deliverables.
+- If $ARGUMENTS is empty, use defaults: top 3, no category filter, no
+  exclusions.
+- State file (`.claude/sweep-metadata-state.csv`) is tracked in git, with
+  `merge=union` set in `.gitattributes` so parallel sweeps touching
+  different modules auto-merge.
+- For subpackage modules (geotiff, reproject, hydro), the subagent should
+  read ALL `.py` files in the subpackage directory, not just `__init__.py`.
+- Only flag patterns that are ACTUALLY present in the code.
+- False positives are worse than missed issues. When in doubt, skip.

--- a/.claude/commands/sweep-test-coverage.md
+++ b/.claude/commands/sweep-test-coverage.md
@@ -1,0 +1,255 @@
+# Test Coverage Gap Sweep: Dispatch subagents to audit backend and edge-case test coverage
+
+Audit xrspatial modules for test coverage gaps: missing backend coverage
+(numpy / cupy / dask+numpy / dask+cupy), missing edge cases (NaN, Inf,
+empty input, single-pixel, all-equal input), missing parameter-coverage
+tests. Closes the gaps that the accuracy sweep keeps finding bugs in.
+Subagents fix CRITICAL, HIGH, and MEDIUM findings via /rockout — fixes
+here are *adding tests*, not changing source code.
+
+Optional arguments: $ARGUMENTS
+(e.g. `--top 3`, `--exclude slope,aspect`, `--only-terrain`, `--reset-state`)
+
+---
+
+## Step 1 -- Gather module metadata via git
+
+Enumerate candidate modules:
+
+**Single-file modules:** Every `.py` file directly under `xrspatial/`, excluding
+`__init__.py`, `_version.py`, `__main__.py`, `utils.py`, `accessor.py`,
+`preview.py`, `dataset_support.py`, `diagnostics.py`, `analytics.py`.
+
+**Subpackage modules:** `geotiff/`, `reproject/`, and `hydro/` directories under
+`xrspatial/`. Treat each as a single audit unit.
+
+For every module, collect:
+
+| Field | How |
+|-------|-----|
+| **last_modified** | `git log -1 --format=%aI -- <path>` |
+| **total_commits** | `git log --oneline -- <path> \| wc -l` |
+| **loc** | `wc -l < <path>` |
+| **test_loc** | `wc -l < xrspatial/tests/test_<module>.py` (or 0 if absent) |
+| **public_funcs** | count of `^def [a-z]` in module |
+
+Store results in memory.
+
+## Step 2 -- Load inspection state
+
+Read `.claude/sweep-test-coverage-state.csv`.
+
+If absent, treat every module as never-inspected. If `$ARGUMENTS` has
+`--reset-state`, delete the file first.
+
+State file schema:
+
+```
+module,last_inspected,issue,severity_max,categories_found,notes
+slope,2026-05-01,1042,HIGH,1;3,"optional single-line notes"
+```
+
+`merge=union` is set in `.gitattributes`.
+
+## Step 3 -- Score each module
+
+```
+days_since_inspected = (today - last_inspected).days
+days_since_modified  = (today - last_modified).days
+
+# Coverage ratio: low test_loc relative to source = higher score
+coverage_deficit = max(0, loc - test_loc) / max(loc, 1)
+
+score = (days_since_inspected * 3)
+      + (public_funcs * 5)
+      + (coverage_deficit * 200)
+      + (total_commits * 0.3)
+      - (days_since_modified * 0.1)
+      + (loc * 0.03)
+```
+
+Rationale:
+- Modules never inspected dominate
+- Coverage deficit (test_loc << source_loc) is a strong signal
+- Public functions weighted: each public function is an independent
+  test surface
+- Recently modified slightly deprioritized
+
+## Step 4 -- Apply filters from $ARGUMENTS
+
+Same filter set as other sweeps: `--top N`, `--exclude`, `--only-terrain`,
+`--only-focal`, `--only-hydro`, `--only-io`, `--reset-state`.
+
+## Step 5 -- Print the ranked table and launch subagents
+
+### 5a. Print the ranked table
+
+Show all scored modules sorted by score descending. Include a `Coverage`
+column (`test_loc / source_loc` ratio).
+
+### 5b. Launch subagents for the top N modules
+
+For each of the top N modules (default 3), launch an Agent in parallel
+using `isolation: "worktree"` and `mode: "auto"`. All N must be in a
+single message.
+
+Each agent's prompt must be self-contained:
+
+```
+You are auditing the xrspatial module "{module}" for test coverage gaps.
+
+This module has {commits} commits, {loc} lines of source, and {test_loc}
+lines of tests.
+
+Read these files:
+- {module_files}
+- xrspatial/tests/test_{module}.py (if it exists)
+- xrspatial/tests/general_checks.py (cross-backend test helpers)
+- xrspatial/utils.py (ArrayTypeFunctionMapping, _validate_raster)
+- xrspatial/conftest.py (shared fixtures)
+
+**Your task:**
+
+1. Read the module and its tests thoroughly. Build a mental matrix:
+   for each public function, which backends and which edge cases are
+   currently tested?
+
+2. Audit for these 5 coverage-gap categories. Only flag gaps ACTUALLY
+   present (the test file does not exercise the path).
+
+   **Cat 1 — Backend coverage**
+   - HIGH: function has a numpy path that is tested, but the cupy /
+     dask+numpy / dask+cupy paths are not exercised at all
+   - HIGH: dispatch table (ArrayTypeFunctionMapping) registers a backend
+     but no test invokes it
+   - MEDIUM: cross-backend equivalence not asserted (test_numpy_equals_cupy,
+     test_numpy_equals_dask, test_numpy_equals_dask_cupy missing)
+   - MEDIUM: only the eager path tested with realistic input shapes; the
+     dask path tested only on a 4x4 toy
+   Severity: HIGH if a real bug could ship undetected (the GLCM bug
+   #1408 was caught precisely because backend coverage existed)
+
+   **Cat 2 — NaN / Inf / nodata edge cases**
+   - HIGH: function operates on raster data but no test passes a NaN
+     input
+   - HIGH: NaN appears in tests only as a non-edge cell, never at the
+     boundary or in a position that interacts with the kernel
+   - HIGH: Inf / -Inf inputs not tested at all (often surfaces silent
+     failure modes)
+   - MEDIUM: all-NaN input not tested (boundary of the algorithm)
+   - MEDIUM: NaN input dtype is float; but integer dtype with the
+     module's documented sentinel is not tested
+   Severity: HIGH if NaN-related bugs in this module class have shipped
+   before (see flood, glcm, sky_view_factor) — they have
+
+   **Cat 3 — Geometric edge cases**
+   - HIGH: 1x1 single-pixel raster not tested
+   - HIGH: Nx1 or 1xN strip not tested (kernel boundary degeneracies)
+   - MEDIUM: empty raster (0 rows or 0 cols) not tested
+   - MEDIUM: all-equal-value raster not tested (zero variance, zero
+     gradient → divide-by-zero opportunity)
+   - MEDIUM: very large raster not benchmarked (no asv coverage)
+   - LOW: raster with non-square cells (different cellsize_x and
+     cellsize_y) not tested
+   Severity: HIGH for 1x1 / Nx1 — these reveal kernel-bound bugs
+
+   **Cat 4 — Parameter coverage**
+   - HIGH: a parameter with multiple modes (e.g. `boundary='reflect'`,
+     `'edge'`, `'wrap'`, `'nan'`) has only the default mode tested
+   - HIGH: a `bool` flag has only one branch tested
+   - MEDIUM: a numeric parameter has only one value tested (e.g.
+     `kernel_size` only tested at 3, never at 5 or 7)
+   - MEDIUM: error paths not tested (does invalid input raise the
+     expected exception?)
+   - LOW: kwargs documented in docstring but no test passes them
+   Severity: HIGH if the untested mode is what advanced users rely on
+
+   **Cat 5 — Metadata preservation tests**
+   - HIGH: no test asserts that input attrs (`res`, `crs`, `transform`)
+     are preserved in the output (this is the metadata-propagation
+     sweep's smoke detector)
+   - HIGH: no test asserts that input coords are preserved
+   - MEDIUM: no test asserts that input dim names propagate (function
+     would silently rename `lat`/`lon` → `y`/`x`)
+   - MEDIUM: no test for the eager-vs-dask attrs equivalence
+   Severity: HIGH if this module reads attrs for math (cellsize,
+   resolution) — its result correctness depends on these being correct
+
+3. For each real gap, assign severity + which test should be added.
+
+4. If any CRITICAL, HIGH, or MEDIUM gap is found, run /rockout to add
+   tests. The fix in this sweep is *test-only* — do not modify source
+   unless a test surfaces a bug, in which case file a separate accuracy
+   issue. For LOW gaps, document but do not add tests.
+
+5. Update .claude/sweep-test-coverage-state.csv:
+
+   ```python
+   import csv
+   from pathlib import Path
+
+   path = Path(".claude/sweep-test-coverage-state.csv")
+   header = ["module", "last_inspected", "issue", "severity_max",
+             "categories_found", "notes"]
+
+   rows = {}
+   if path.exists():
+       with path.open() as f:
+           for r in csv.DictReader(f):
+               rows[r["module"]] = r
+
+   rows["{module}"] = {
+       "module": "{module}",
+       "last_inspected": "<today's ISO date>",
+       "issue": "<issue or empty>",
+       "severity_max": "<HIGH|MEDIUM|LOW or empty>",
+       "categories_found": "<semicolon-joined ints or empty>",
+       "notes": "<single-line notes or empty>",
+   }
+
+   with path.open("w", newline="") as f:
+       w = csv.DictWriter(f, fieldnames=header, quoting=csv.QUOTE_MINIMAL)
+       w.writeheader()
+       for m in sorted(rows):
+           w.writerow(rows[m])
+   ```
+
+   Then `git add` and commit.
+
+Important:
+- The "fix" for this sweep is *adding tests*. If adding a test surfaces
+  a bug in the source code, do NOT bundle the source fix — file a
+  separate accuracy / performance / metadata issue and link it from the
+  test PR.
+- Only flag real gaps. If a test exists but is sloppy, that is not a
+  coverage gap — that's a test quality issue out of scope here.
+- Some functions genuinely do not need NaN coverage (procedural noise
+  generators that take no raster input). Use judgment.
+- For the hydro subpackage: focus on one representative variant (d8) and
+  note dinf/mfd parity in the audit notes.
+```
+
+### 5c. Print a status line
+
+After dispatching, print:
+
+```
+Launched {N} test coverage audit agents: {module1}, {module2}, {module3}
+```
+
+## Step 6 -- State updates
+
+To reset: `/sweep-test-coverage --reset-state`
+
+---
+
+## General Rules
+
+- Do NOT modify any source files. Subagents add tests via /rockout.
+- Keep parent output concise.
+- Default: top 3, no filter.
+- State file `.claude/sweep-test-coverage-state.csv` is tracked in git
+  with `merge=union`.
+- The "fix" is *tests, not source*. If a test reveals a bug, file a
+  separate issue — do not change source in this sweep's PRs.
+- False positives are worse than missed issues.

--- a/.claude/sweep-api-consistency-state.csv
+++ b/.claude/sweep-api-consistency-state.csv
@@ -1,0 +1,1 @@
+module,last_inspected,issue,severity_max,categories_found,notes

--- a/.claude/sweep-metadata-state.csv
+++ b/.claude/sweep-metadata-state.csv
@@ -1,0 +1,1 @@
+module,last_inspected,issue,severity_max,categories_found,notes

--- a/.claude/sweep-test-coverage-state.csv
+++ b/.claude/sweep-test-coverage-state.csv
@@ -1,0 +1,1 @@
+module,last_inspected,issue,severity_max,categories_found,notes


### PR DESCRIPTION
## Summary
- Three new sweep skills following the existing dispatch/scoring/state-CSV pattern.
- `/sweep-metadata` — verifies attrs/coords/dims preservation. Targets the class of bugs where "result looks fine but is wrong", like sky_view_factor #1407.
- `/sweep-api-consistency` — parameter naming drift, signature shape, return-type consistency. HIGH renames must add a deprecation shim.
- `/sweep-test-coverage` — backend coverage (numpy/cupy/dask+numpy/dask+cupy) and edge cases (NaN, Inf, 1x1, Nx1, all-equal). The "fix" is test-only.
- Each ships with an empty state CSV; the existing `.gitattributes` glob `.claude/sweep-*-state.csv merge=union` already covers them.

## Test plan
- [ ] Run `/sweep-metadata --top 1` and confirm a module gets audited and a state row appended
- [ ] Run `/sweep-api-consistency --top 1`
- [ ] Run `/sweep-test-coverage --top 1`
- [ ] Verify state CSVs survive parallel sweeps via the `merge=union` glob