### PR TITLE
flood: validate mannings_n DataArray values

### DIFF
--- a/xrspatial/flood.py
+++ b/xrspatial/flood.py
@@ -38,6 +38,25 @@ from xrspatial.utils import (
 # Minimum tan(slope) clamp: tan(0.001 deg), same as TWI
 _TAN_MIN = np.tan(np.radians(0.001))
 
+
+def _validate_mannings_n_dataarray(mannings_n):
+    """Enforce finite, strictly positive values on a mannings_n DataArray.
+
+    Mirrors the scalar-path check (`if mannings_n <= 0: raise`).  Without
+    this guard, a roughness raster containing 0 silently produces inf
+    velocity / 0 travel time, and negatives produce negative travel time.
+    """
+    _validate_raster(mannings_n, func_name='flood',
+                     name='mannings_n', ndim=2)
+    arr = np.asarray(mannings_n.values)
+    if arr.size and (
+        not np.isfinite(arr).all() or not (arr > 0).all()
+    ):
+        raise ValueError(
+            "mannings_n DataArray must contain finite, strictly positive "
+            "values (no zeros, negatives, NaN, or Inf)."
+        )
+
 # ---------------------------------------------------------------------------
 # NLCD-to-Manning's n lookup (Chow 1959; Arcement & Schneider 1989)
 # ---------------------------------------------------------------------------
@@ -416,6 +435,7 @@ def travel_time(
     _validate_raster(slope_agg, func_name='travel_time', name='slope_agg')
 
     if isinstance(mannings_n, xr.DataArray):
+        _validate_mannings_n_dataarray(mannings_n)
         n_data = mannings_n.data
     elif isinstance(mannings_n, (int, float)):
         if mannings_n <= 0:
@@ -850,6 +870,7 @@ def flood_depth_vegetation(
         raise ValueError("unit_discharge must be > 0")
 
     if isinstance(mannings_n, xr.DataArray):
+        _validate_mannings_n_dataarray(mannings_n)
         n_data = mannings_n.data
     elif isinstance(mannings_n, (int, float)):
         if mannings_n <= 0:

--- a/xrspatial/tests/test_flood.py
+++ b/xrspatial/tests/test_flood.py
@@ -981,3 +981,71 @@ class TestFDVDaskCuPy:
 
         general_output_checks(h_dc, result_dc,
                               expected_results=result_np.data)
+
+
+# =====================================================================
+# Issue #1437: mannings_n DataArray validation
+# =====================================================================
+
+class TestMannigsNDataArrayValidation:
+    """travel_time and flood_depth_vegetation enforce mannings_n>0 on DataArrays (#1437)."""
+
+    @staticmethod
+    def _good_raster(value=1.0):
+        return xr.DataArray(
+            np.full((4, 4), value, dtype=np.float64),
+            dims=('y', 'x'),
+            coords={'y': np.arange(4), 'x': np.arange(4)},
+        )
+
+    def test_travel_time_rejects_zero_mannings_n_dataarray(self):
+        from xrspatial.flood import travel_time
+        fl = self._good_raster(10.0)
+        slope = self._good_raster(5.0)
+        bad_n = self._good_raster(0.0)
+        with pytest.raises(ValueError, match="mannings_n"):
+            travel_time(fl, slope, bad_n)
+
+    def test_travel_time_rejects_negative_mannings_n_dataarray(self):
+        from xrspatial.flood import travel_time
+        fl = self._good_raster(10.0)
+        slope = self._good_raster(5.0)
+        bad_n = self._good_raster(-0.05)
+        with pytest.raises(ValueError, match="mannings_n"):
+            travel_time(fl, slope, bad_n)
+
+    def test_travel_time_rejects_nan_mannings_n_dataarray(self):
+        from xrspatial.flood import travel_time
+        fl = self._good_raster(10.0)
+        slope = self._good_raster(5.0)
+        bad_n = xr.DataArray(
+            np.array([[0.05, np.nan, 0.05, 0.05]] * 4, dtype=np.float64),
+            dims=('y', 'x'),
+            coords={'y': np.arange(4), 'x': np.arange(4)},
+        )
+        with pytest.raises(ValueError, match="mannings_n"):
+            travel_time(fl, slope, bad_n)
+
+    def test_travel_time_accepts_valid_mannings_n_dataarray(self):
+        from xrspatial.flood import travel_time
+        fl = self._good_raster(10.0)
+        slope = self._good_raster(5.0)
+        good_n = self._good_raster(0.05)
+        result = travel_time(fl, slope, good_n)
+        assert result.shape == (4, 4)
+
+    def test_flood_depth_vegetation_rejects_zero_mannings_n_dataarray(self):
+        from xrspatial.flood import flood_depth_vegetation
+        hand = self._good_raster(2.0)
+        slope = self._good_raster(0.5)
+        bad_n = self._good_raster(0.0)
+        with pytest.raises(ValueError, match="mannings_n"):
+            flood_depth_vegetation(hand, slope, bad_n, unit_discharge=1.0)
+
+    def test_flood_depth_vegetation_rejects_negative_mannings_n_dataarray(self):
+        from xrspatial.flood import flood_depth_vegetation
+        hand = self._good_raster(2.0)
+        slope = self._good_raster(0.5)
+        bad_n = self._good_raster(-0.1)
+        with pytest.raises(ValueError, match="mannings_n"):
+            flood_depth_vegetation(hand, slope, bad_n, unit_discharge=1.0)


### PR DESCRIPTION
Closes #1437.

## Summary

- Add `_validate_mannings_n_dataarray()` helper that enforces finite, strictly positive values when `mannings_n` is supplied as a DataArray (the scalar path already enforces this).
- Wired into `travel_time` and `flood_depth_vegetation`.
- Bad mannings_n DataArrays now raise `ValueError` instead of silently producing inf velocity / 0 / NaN output.

## Test plan

- [x] 6 new tests in `TestMannigsNDataArrayValidation`.
- [x] Full flood suite: 88 passed (82 existing + 6 new).
- [ ] CI run on full suite.