### PR TITLE
Add transform_precision parameter to merge()

### DIFF
--- a/xrspatial/reproject/__init__.py
+++ b/xrspatial/reproject/__init__.py
@@ -1340,6 +1340,7 @@ def merge(
     nodata=None,
     strategy='first',
     chunk_size=None,
+    transform_precision=16,
     name=None,
 ):
     """Merge multiple rasters into a single mosaic.
@@ -1366,12 +1367,22 @@ def merge(
         Merge strategy: 'first', 'last', 'mean', 'max', 'min'.
     chunk_size : int or (int, int) or None
         Chunk size for dask output.
+    transform_precision : int
+        Control-grid subdivisions for the coordinate transform (default 16).
+        Higher values increase accuracy at the cost of more pyproj calls.
+        Set to 0 for exact per-pixel transforms matching GDAL/rasterio.
     name : str or None
         Name for the output DataArray.
 
     Returns
     -------
     xr.DataArray
+
+    Notes
+    -----
+    There is no streaming in-memory path; for very large output mosaics,
+    pass dask-backed inputs (or rely on the automatic promotion to the
+    dask path) so that each output chunk is computed independently.
     """
     if not rasters:
         raise ValueError("merge(): rasters list must not be empty")
@@ -1385,7 +1396,7 @@ def merge(
         bounds=bounds,
         width=None,
         height=None,
-        transform_precision=None,
+        transform_precision=transform_precision,
         func_name='merge',
     )
 
@@ -1473,12 +1484,12 @@ def merge(
     if any_dask:
         result_data = _merge_dask(
             raster_infos, tgt_wkt, out_bounds, out_shape,
-            resampling, nd, strategy, chunk_size,
+            resampling, nd, strategy, chunk_size, transform_precision,
         )
     else:
         result_data = _merge_inmemory(
             raster_infos, tgt_wkt, out_bounds, out_shape,
-            resampling, nd, strategy,
+            resampling, nd, strategy, transform_precision,
         )
 
     y_coords, x_coords = _make_output_coords(out_bounds, out_shape)
@@ -1563,7 +1574,7 @@ def _place_same_crs(src_data, src_bounds, src_shape, y_desc,
 
 def _merge_inmemory(
     raster_infos, tgt_wkt, out_bounds, out_shape,
-    resampling, nodata, strategy,
+    resampling, nodata, strategy, transform_precision,
 ):
     """In-memory merge using numpy.
 
@@ -1591,7 +1602,7 @@ def _merge_inmemory(
                 info['src_bounds'], info['src_shape'], info['y_desc'],
                 info['src_wkt'], tgt_wkt,
                 out_bounds, out_shape,
-                resampling, nodata, 16,
+                resampling, nodata, transform_precision,
             )
             arrays.append(reprojected)
     return _merge_arrays_numpy(arrays, nodata, strategy)
@@ -1650,7 +1661,7 @@ def _merge_block_adapter(
 
 def _merge_dask(
     raster_infos, tgt_wkt, out_bounds, out_shape,
-    resampling, nodata, strategy, chunk_size,
+    resampling, nodata, strategy, chunk_size, transform_precision,
 ):
     """Dask merge backend using ``map_blocks``."""
     import functools
@@ -1696,7 +1707,7 @@ def _merge_dask(
         resampling=resampling,
         nodata=nodata,
         strategy=strategy,
-        precision=16,
+        precision=transform_precision,
         src_footprints_tgt=footprints,
         same_crs_list=same_crs_list,
     )

--- a/xrspatial/tests/test_reproject.py
+++ b/xrspatial/tests/test_reproject.py
@@ -1678,6 +1678,56 @@ class TestValidateMergeGridParams:
         with pytest.raises(ValueError, match="right"):
             merge([self._raster()], bounds=(10, 0, 0, 10))
 
+    def test_merge_accepts_transform_precision_zero(self):
+        """``transform_precision=0`` requests exact per-pixel transforms."""
+        from xrspatial.reproject import merge
+        raster = _gradient_raster(h=8, w=8)
+        result = merge([raster], transform_precision=0, resolution=1.0)
+        assert result.shape[0] > 0
+        assert result.shape[1] > 0
+
+    def test_merge_accepts_transform_precision_default(self):
+        """Default ``transform_precision`` (16) leaves merge() callable."""
+        from xrspatial.reproject import merge
+        raster = _gradient_raster(h=8, w=8)
+        result = merge([raster], resolution=1.0)
+        assert result.shape[0] > 0
+        assert result.shape[1] > 0
+
+    def test_merge_rejects_negative_transform_precision(self):
+        from xrspatial.reproject import merge
+        with pytest.raises(ValueError, match="transform_precision"):
+            merge([self._raster()], transform_precision=-1)
+
+    def test_merge_rejects_float_transform_precision(self):
+        from xrspatial.reproject import merge
+        with pytest.raises(ValueError, match="transform_precision"):
+            merge([self._raster()], transform_precision=1.5)
+
+    def test_merge_transform_precision_threaded_to_chunks(self):
+        """precision=0 (exact) and precision=16 should agree on smooth inputs.
+
+        For inputs where the control-grid approximation is already very
+        close to the per-pixel transform, the two paths should give the
+        same merged output to floating-point tolerance.
+        """
+        from xrspatial.reproject import merge
+        # Two adjacent same-CRS gradients in EPSG:4326 reprojected to
+        # the same CRS: the control grid is dense enough that precision=16
+        # and precision=0 produce identical numbers.
+        a = _gradient_raster(h=16, w=16, x_range=(-5, 0), y_range=(-5, 5))
+        b = _gradient_raster(h=16, w=16, x_range=(0, 5), y_range=(-5, 5))
+        out16 = merge([a, b], target_crs='EPSG:4326',
+                      resolution=1.0, transform_precision=16)
+        out0 = merge([a, b], target_crs='EPSG:4326',
+                     resolution=1.0, transform_precision=0)
+        assert out16.shape == out0.shape
+        v16 = out16.values
+        v0 = out0.values
+        valid = ~np.isnan(v16) & ~np.isnan(v0)
+        assert valid.any()
+        np.testing.assert_allclose(v0[valid], v16[valid], rtol=1e-10)
+
 
 # =====================================================================
 # Issue #1435: NaN/Inf rejection in scalar inputs


### PR DESCRIPTION
## Summary

- Adds `transform_precision=16` to `merge()` and plumbs it through `_merge_inmemory` and `_merge_dask` (previously hardcoded to 16). Set to 0 for exact per-pixel transforms matching GDAL/rasterio.
- Passes the value through `_validate_grid_params` so the existing validation runs.
- Updates the `merge()` docstring with the parameter description and adds a Notes line saying the dask path should be used for very large outputs.
- `max_memory` is not added; `merge()` has no streaming path that would consume it.

Closes #1452

## Test plan

- [x] `pytest xrspatial/tests/test_reproject.py -x` (153 passed, including 5 new tests under `TestValidateMergeGridParams`)
- [x] `merge([raster], transform_precision=0)` runs and produces a result
- [x] Default `transform_precision=16` (no kwarg) still works
- [x] Negative and float values raise `ValueError` matching `transform_precision`
- [x] `transform_precision=0` and `transform_precision=16` produce numerically identical merged output (rtol=1e-10) on smooth EPSG:4326 inputs