### PR TITLE
Decode predictor=2 on big-endian TIFFs by swapping to native order

### DIFF
--- a/xrspatial/geotiff/_compression.py
+++ b/xrspatial/geotiff/_compression.py
@@ -452,16 +452,21 @@ def _predictor_encode_u64(view, width, height, samples_per_pixel):
             view[idx] = np.uint64(view[idx]) - np.uint64(view[idx - samples_per_pixel])
 
 
-def _sample_view(buf: np.ndarray, bytes_per_sample: int,
-                 byte_order: str = '<') -> np.ndarray:
-    """Return *buf* viewed as a 1-D array of unsigned samples.
+import sys as _sys
+_NATIVE_BO = '<' if _sys.byteorder == 'little' else '>'
 
-    The view shares memory with *buf* and uses the file's byte order so
-    that the sample-resolution differencing wraps at the correct width.
+
+def _sample_view(buf: np.ndarray, bytes_per_sample: int) -> np.ndarray:
+    """Return *buf* viewed as a 1-D array of native-byte-order samples.
+
+    The view shares memory with *buf*. Numba's nopython mode rejects arrays
+    with a non-native byte order ("Unsupported array dtype: >u2" etc.), so
+    callers that need to operate on data from a big-endian file must
+    byteswap the underlying bytes before and after invoking the kernels.
     """
     if bytes_per_sample == 1:
         return buf
-    sample_dtype = np.dtype(f'{byte_order}u{bytes_per_sample}')
+    sample_dtype = np.dtype(f'u{bytes_per_sample}')
     return buf.view(sample_dtype)
 
 
@@ -499,7 +504,14 @@ def predictor_decode(data: np.ndarray, width: int, height: int,
         _predictor_decode_u8(buf, width, height, samples)
         return buf
 
-    view = _sample_view(buf, bytes_per_sample, byte_order)
+    # Numba can't compile non-native-byte-order arrays. For big-endian
+    # files, swap the bytes in place so the native-order kernel sees
+    # correct sample values, then swap back so the caller's downstream
+    # ``chunk.view(file_dtype)`` reads the bytes in the file's order.
+    swap = (byte_order != _NATIVE_BO)
+    view = _sample_view(buf, bytes_per_sample)
+    if swap:
+        view.byteswap(inplace=True)
     if bytes_per_sample == 2:
         _predictor_decode_u16(view, width, height, samples)
     elif bytes_per_sample == 4:
@@ -507,11 +519,15 @@ def predictor_decode(data: np.ndarray, width: int, height: int,
     elif bytes_per_sample == 8:
         _predictor_decode_u64(view, width, height, samples)
     else:
+        if swap:
+            view.byteswap(inplace=True)
         raise ValueError(
             f"predictor=2 with bytes_per_sample={bytes_per_sample} is not "
             "supported (TIFF specifies sample-level differencing for 1/2/4/8 "
             "byte samples)."
         )
+    if swap:
+        view.byteswap(inplace=True)
     return buf
 
 
@@ -545,7 +561,14 @@ def predictor_encode(data: np.ndarray, width: int, height: int,
         _predictor_encode_u8(buf, width, height, samples)
         return buf
 
-    view = _sample_view(buf, bytes_per_sample, byte_order)
+    # Mirror the decode path: byteswap to native around the kernel call so
+    # numba can compile the in-place differencing. The writer always emits
+    # ``BO='<'`` today so this is normally a no-op, but the function stays
+    # robust to callers that pass the BE branch.
+    swap = (byte_order != _NATIVE_BO)
+    view = _sample_view(buf, bytes_per_sample)
+    if swap:
+        view.byteswap(inplace=True)
     if bytes_per_sample == 2:
         _predictor_encode_u16(view, width, height, samples)
     elif bytes_per_sample == 4:
@@ -553,11 +576,15 @@ def predictor_encode(data: np.ndarray, width: int, height: int,
     elif bytes_per_sample == 8:
         _predictor_encode_u64(view, width, height, samples)
     else:
+        if swap:
+            view.byteswap(inplace=True)
         raise ValueError(
             f"predictor=2 with bytes_per_sample={bytes_per_sample} is not "
             "supported (TIFF specifies sample-level differencing for 1/2/4/8 "
             "byte samples)."
         )
+    if swap:
+        view.byteswap(inplace=True)
     return buf
 
 

--- a/xrspatial/geotiff/tests/test_predictor2_big_endian.py
+++ b/xrspatial/geotiff/tests/test_predictor2_big_endian.py
@@ -1,0 +1,55 @@
+"""Predictor=2 big-endian read tests.
+
+PR #1498 reworked the predictor=2 (horizontal differencing) decode to run
+sample-wise via a numpy view at the file's byte order. Numba's nopython
+mode rejects arrays with a non-native byte order, so reading a big-endian
+TIFF with uint16/uint32/uint64 + predictor=2 raised a ``TypingError``
+("Unsupported array dtype: >u2"). The fix byte-swaps the underlying
+buffer to native order around the kernel call and swaps it back, keeping
+the on-disk representation intact for the downstream
+``chunk.view(file_dtype)`` step in ``_decode_strip_or_tile``.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from xrspatial.geotiff._reader import read_to_array
+
+tifffile = pytest.importorskip("tifffile")
+
+
+@pytest.mark.parametrize("dtype", [np.uint16, np.int16, np.uint32, np.int32])
+def test_big_endian_predictor2_round_trip(tmp_path, dtype):
+    """xrspatial reads a big-endian predictor=2 file exactly."""
+    info = np.iinfo(dtype)
+    arr = np.linspace(info.min // 2, info.max // 2, 64, dtype=np.int64)
+    arr = arr.astype(dtype).reshape(8, 8)
+    path = tmp_path / f"be_pred2_{np.dtype(dtype).name}.tif"
+    tifffile.imwrite(
+        str(path), arr, byteorder=">", predictor=2, compression="deflate")
+
+    out, _ = read_to_array(str(path))
+    np.testing.assert_array_equal(out, arr)
+
+
+def test_little_endian_predictor2_still_round_trips(tmp_path):
+    """Sanity: the BE byteswap did not break the LE path."""
+    arr = np.arange(64, dtype=np.uint16).reshape(8, 8) * 100
+    path = tmp_path / "le_pred2_u16.tif"
+    tifffile.imwrite(
+        str(path), arr, byteorder="<", predictor=2, compression="deflate")
+
+    out, _ = read_to_array(str(path))
+    np.testing.assert_array_equal(out, arr)
+
+
+def test_big_endian_predictor2_uint8_unaffected(tmp_path):
+    """uint8 takes the byte-wise kernel path, which never needed swapping."""
+    arr = np.arange(64, dtype=np.uint8).reshape(8, 8)
+    path = tmp_path / "be_pred2_u8.tif"
+    tifffile.imwrite(
+        str(path), arr, byteorder=">", predictor=2, compression="deflate")
+
+    out, _ = read_to_array(str(path))
+    np.testing.assert_array_equal(out, arr)


### PR DESCRIPTION
## Summary

PR #1498 reworked predictor=2 (horizontal differencing) to run sample-wise via a numpy view in the file's byte order. Numba's nopython mode rejects arrays with a non-native byte order, so reading a big-endian TIFF with uint16/uint32/uint64 + predictor=2 raised `TypingError: Unsupported array dtype: >u2` instead of returning the pixel data.

`predictor_decode` and `predictor_encode` now byte-swap the buffer in place around the kernel call when the file byte order differs from native, then swap back so the on-disk representation stays intact for the `chunk.view(file_dtype)` step in `_decode_strip_or_tile`. uint8 is unaffected since the single-byte path skips the view.

## Test plan

- [x] New `test_predictor2_big_endian.py` covers uint16/int16/uint32/int32 round-trips through tifffile-built BE predictor=2 deflate files.
- [x] Little-endian predictor=2 still round-trips (sanity).
- [x] uint8 BE+pred2 still works (single-byte byte-wise path).
- [x] Full geotiff test suite passes (552 passed; pre-existing matplotlib `test_features` recursion issue is unrelated).