### PR TITLE
Apply LERC valid-mask on decode so masked pixels become nodata

### DIFF
--- a/xrspatial/geotiff/_compression.py
+++ b/xrspatial/geotiff/_compression.py
@@ -1046,7 +1046,29 @@ except ImportError:
 
 def lerc_decompress(data: bytes, width: int = 0, height: int = 0,
                     samples: int = 1) -> bytes:
-    """Decompress LERC data. Requires the ``lerc`` package."""
+    """Decompress LERC data. Requires the ``lerc`` package.
+
+    Returns the raw decoded pixel bytes.  Any LERC valid-mask is dropped
+    here; masked pixels are returned as LERC's zero fill (the wire
+    format's default).  Callers that need to honour the file's nodata
+    value should use :func:`lerc_decompress_with_mask` instead and apply
+    nodata at the array level once dtype is known.
+    """
+    decoded_bytes, _mask = lerc_decompress_with_mask(data)
+    return decoded_bytes
+
+
+def lerc_decompress_with_mask(data: bytes):
+    """Decompress LERC data and return ``(bytes, valid_mask_or_None)``.
+
+    ``valid_mask`` is ``None`` when LERC reports the block is fully
+    valid (no encoded mask, or a mask that is True everywhere);
+    otherwise it is a numpy array whose shape matches the decoded data
+    (height, width) or (height, width, samples), with ``0`` marking
+    pixels the encoder flagged as invalid.  LERC zero fills masked
+    positions in the data array, so the returned mask is the only
+    signal that lets a reader restore the file's nodata sentinel.
+    """
     if not LERC_AVAILABLE:
         raise ImportError(
             "lerc is required to read LERC-compressed TIFFs. "
@@ -1056,7 +1078,13 @@ def lerc_decompress(data: bytes, width: int = 0, height: int = 0,
     if result[0] != 0:
         raise RuntimeError(f"LERC decode failed with error code {result[0]}")
     arr = result[1]
-    return arr.tobytes()
+    valid_mask = result[2] if len(result) > 2 else None
+    if valid_mask is None:
+        return arr.tobytes(), None
+    valid_mask = np.asarray(valid_mask)
+    if valid_mask.size == 0 or bool(valid_mask.all()):
+        return arr.tobytes(), None
+    return arr.tobytes(), valid_mask
 
 
 def lerc_compress(data: bytes, width: int, height: int,

--- a/xrspatial/geotiff/_reader.py
+++ b/xrspatial/geotiff/_reader.py
@@ -12,9 +12,11 @@ from concurrent.futures import ThreadPoolExecutor
 import numpy as np
 
 from ._compression import (
+    COMPRESSION_LERC,
     COMPRESSION_NONE,
     decompress,
     fp_predictor_decode,
+    lerc_decompress_with_mask,
     predictor_decode,
     unpack_bits,
 )
@@ -525,9 +527,33 @@ def _packed_byte_count(pixel_count: int, bps: int) -> int:
     return (pixel_count * bps + 7) // 8
 
 
+def _resolve_masked_fill(nodata_str: str | None, dtype: np.dtype):
+    """Resolve the value to use when restoring LERC-masked pixels.
+
+    Mirrors :func:`_sparse_fill_value` but defaults to NaN for floating
+    dtypes when the file does not declare a nodata sentinel.  Float
+    rasters with no GDAL_NODATA tag still benefit from NaN propagation
+    because LERC's zero fill would silently masquerade as a real
+    measurement at z == 0.
+    """
+    if nodata_str is not None:
+        try:
+            v = float(nodata_str)
+            if dtype.kind == 'f':
+                return dtype.type(v)
+            if not math.isnan(v) and not math.isinf(v):
+                return dtype.type(int(v))
+        except (TypeError, ValueError):
+            pass
+    if dtype.kind == 'f':
+        return dtype.type(np.nan)
+    return dtype.type(0)
+
+
 def _decode_strip_or_tile(data_slice, compression, width, height, samples,
                           bps, bytes_per_sample, is_sub_byte, dtype, pred,
-                          byte_order='<', jpeg_tables=None):
+                          byte_order='<', jpeg_tables=None,
+                          masked_fill=None):
     """Decompress, apply predictor, unpack sub-byte, and reshape a strip/tile.
 
     Parameters
@@ -551,9 +577,18 @@ def _decode_strip_or_tile(data_slice, compression, width, height, samples,
     else:
         expected = pixel_count * bytes_per_sample
 
-    chunk = decompress(data_slice, compression, expected,
-                       width=width, height=height, samples=samples,
-                       jpeg_tables=jpeg_tables)
+    lerc_mask = None
+    if compression == COMPRESSION_LERC:
+        # LERC needs special handling: lerc.decode also returns a
+        # valid-mask which the generic decompress() dispatcher discards.
+        # We capture it here so masked pixels can be restored to nodata
+        # below, instead of leaking LERC's zero fill into the output.
+        decoded_bytes, lerc_mask = lerc_decompress_with_mask(data_slice)
+        chunk = np.frombuffer(decoded_bytes, dtype=np.uint8)
+    else:
+        chunk = decompress(data_slice, compression, expected,
+                           width=width, height=height, samples=samples,
+                           jpeg_tables=jpeg_tables)
 
     # Validate the decompressed byte count.  A truncated deflate stream or a
     # buggy compressor can produce fewer or more bytes than expected.  Without
@@ -587,8 +622,23 @@ def _decode_strip_or_tile(data_slice, compression, width, height, samples,
             pixels = pixels.astype(dtype)
 
     if samples > 1:
-        return pixels.reshape(height, width, samples)
-    return pixels.reshape(height, width)
+        out = pixels.reshape(height, width, samples)
+    else:
+        out = pixels.reshape(height, width)
+
+    # Restore nodata in positions LERC flagged as invalid.  LERC
+    # zero-fills masked pixels in the data array, which would otherwise
+    # be indistinguishable from real zero readings downstream.
+    if lerc_mask is not None and masked_fill is not None:
+        mask_arr = np.asarray(lerc_mask)
+        if mask_arr.ndim == 2 and out.ndim == 3:
+            mask_arr = mask_arr[..., None]
+        invalid = np.broadcast_to(mask_arr == 0, out.shape)
+        if invalid.any():
+            if not out.flags.writeable:
+                out = out.copy()
+            np.putmask(out, invalid, masked_fill)
+    return out
 
 
 import sys as _sys
@@ -667,6 +717,8 @@ def _read_strips(data: bytes, ifd: IFD, header: TIFFHeader,
     bytes_per_sample = bps // 8
     is_sub_byte = bps in SUB_BYTE_BPS
     jpeg_tables = ifd.jpeg_tables
+    masked_fill = (_resolve_masked_fill(ifd.nodata_str, dtype)
+                   if compression == COMPRESSION_LERC else None)
 
     if offsets is None or byte_counts is None:
         raise ValueError("Missing strip offsets or byte counts")
@@ -727,7 +779,8 @@ def _read_strips(data: bytes, ifd: IFD, header: TIFFHeader,
                     strip_data, compression, width, strip_rows, 1,
                     bps, bytes_per_sample, is_sub_byte, dtype, pred,
                     byte_order=header.byte_order,
-                    jpeg_tables=jpeg_tables)
+                    jpeg_tables=jpeg_tables,
+                    masked_fill=masked_fill)
 
                 src_r0 = max(r0 - strip_row, 0)
                 src_r1 = min(r1 - strip_row, strip_rows)
@@ -753,7 +806,8 @@ def _read_strips(data: bytes, ifd: IFD, header: TIFFHeader,
                 strip_data, compression, width, strip_rows, samples,
                 bps, bytes_per_sample, is_sub_byte, dtype, pred,
                 byte_order=header.byte_order,
-                jpeg_tables=jpeg_tables)
+                jpeg_tables=jpeg_tables,
+                masked_fill=masked_fill)
 
             src_r0 = max(r0 - strip_row, 0)
             src_r1 = min(r1 - strip_row, strip_rows)
@@ -804,6 +858,8 @@ def _read_tiles(data: bytes, ifd: IFD, header: TIFFHeader,
     bytes_per_sample = bps // 8
     is_sub_byte = bps in SUB_BYTE_BPS
     jpeg_tables = ifd.jpeg_tables
+    masked_fill = (_resolve_masked_fill(ifd.nodata_str, dtype)
+                   if compression == COMPRESSION_LERC else None)
 
     offsets = ifd.tile_offsets
     byte_counts = ifd.tile_byte_counts
@@ -900,7 +956,8 @@ def _read_tiles(data: bytes, ifd: IFD, header: TIFFHeader,
             tile_data, compression, tw, th, tile_samples,
             bps, bytes_per_sample, is_sub_byte, dtype, pred,
             byte_order=header.byte_order,
-            jpeg_tables=jpeg_tables)
+            jpeg_tables=jpeg_tables,
+            masked_fill=masked_fill)
 
     if use_parallel:
         from concurrent.futures import ThreadPoolExecutor
@@ -1012,6 +1069,8 @@ def _read_cog_http(url: str, overview_level: int | None = None,
     bytes_per_sample = bps // 8
     is_sub_byte = bps in SUB_BYTE_BPS
     jpeg_tables = ifd.jpeg_tables
+    masked_fill = (_resolve_masked_fill(ifd.nodata_str, dtype)
+                   if compression == COMPRESSION_LERC else None)
 
     offsets = ifd.tile_offsets
     byte_counts = ifd.tile_byte_counts
@@ -1079,7 +1138,8 @@ def _read_cog_http(url: str, overview_level: int | None = None,
             tile_data, compression, tw, th, samples,
             bps, bytes_per_sample, is_sub_byte, dtype, pred,
             byte_order=header.byte_order,
-            jpeg_tables=jpeg_tables)
+            jpeg_tables=jpeg_tables,
+            masked_fill=masked_fill)
 
         y0 = tr * th
         x0 = tc * tw

--- a/xrspatial/geotiff/_reader.py
+++ b/xrspatial/geotiff/_reader.py
@@ -535,6 +535,13 @@ def _resolve_masked_fill(nodata_str: str | None, dtype: np.dtype):
     rasters with no GDAL_NODATA tag still benefit from NaN propagation
     because LERC's zero fill would silently masquerade as a real
     measurement at z == 0.
+
+    Note: integer dtypes with no GDAL_NODATA tag fall back to ``0``,
+    which is the same value LERC zero-fills masked pixels with -- in
+    that case the mask application is intentionally a no-op.  We avoid
+    inventing an integer sentinel (e.g. iinfo.max) because doing so
+    would silently change pixel values for files that never declared
+    one, breaking downstream consumers that key off the original data.
     """
     if nodata_str is not None:
         try:
@@ -568,6 +575,14 @@ def _decode_strip_or_tile(data_slice, compression, width, height, samples,
         once in this tag and each tile is a JPEG fragment that depends on
         them; the JPEG decoder splices the tables in before handing the
         tile to libjpeg. Ignored for non-JPEG compressions.
+    masked_fill : scalar or None
+        Fill value written into pixels that the LERC valid-mask flags as
+        invalid.  Only consulted for ``compression == COMPRESSION_LERC``
+        when the decoder returns a non-trivial mask; ignored for every
+        other codec.  Callers should compute it once per IFD via
+        :func:`_resolve_masked_fill` (typically NaN for float dtypes or
+        the parsed ``GDAL_NODATA`` sentinel).  When ``None``, masked
+        pixels are left at LERC's zero fill.
 
     Returns an array shaped (height, width) or (height, width, samples).
     """

--- a/xrspatial/geotiff/tests/test_lerc_valid_mask.py
+++ b/xrspatial/geotiff/tests/test_lerc_valid_mask.py
@@ -1,0 +1,239 @@
+"""Tests for LERC valid-mask handling on decode (issue #A4).
+
+LERC's ``decode`` returns ``(rc, data, valid_mask, ...)``.  When a file
+was encoded with a NoData mask, masked pixels in ``data`` are zero
+filled.  Without consulting ``valid_mask`` the reader cannot tell those
+zeros from real measurements, so any nodata-based downstream masking
+silently misses them.
+
+These tests cover:
+
+* The low-level wrapper ``lerc_decompress_with_mask`` returns the mask
+  and ``lerc_decompress`` still returns raw bytes for backwards compat.
+* TIFF round-trip with a NaN nodata float file: NaN comes back at every
+  masked position.
+* TIFF round-trip with an explicit float sentinel (-9999): masked
+  positions land on the sentinel.
+* TIFF round-trip with an integer sentinel (uint16): masked positions
+  land on the sentinel.
+* Files with no mask round-trip bit-exactly (regression guard).
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+lerc = pytest.importorskip("lerc")
+
+from xrspatial.geotiff._compression import (  # noqa: E402
+    LERC_AVAILABLE,
+    lerc_decompress,
+    lerc_decompress_with_mask,
+)
+
+pytestmark = pytest.mark.skipif(
+    not LERC_AVAILABLE,
+    reason="lerc not installed",
+)
+
+
+def _encode_with_mask(arr: np.ndarray, mask: np.ndarray | None,
+                      max_z_error: float = 0.0) -> bytes:
+    """Encode an array with LERC, optionally with a per-pixel valid mask."""
+    has_mask = mask is not None
+    result = lerc.encode(arr, 1, has_mask, mask, max_z_error, 1)
+    assert result[0] == 0, f"lerc.encode returned error {result[0]}"
+    return bytes(result[2])
+
+
+# ---------------------------------------------------------------------------
+# Wrapper-level tests (no TIFF writer involvement)
+# ---------------------------------------------------------------------------
+
+class TestLercDecompressWithMask:
+    """Direct tests of the new ``lerc_decompress_with_mask`` wrapper."""
+
+    def test_no_mask_returns_none(self):
+        arr = np.arange(12, dtype=np.float32).reshape(3, 4)
+        blob = _encode_with_mask(arr, None)
+        decoded_bytes, mask = lerc_decompress_with_mask(blob)
+        out = np.frombuffer(decoded_bytes, dtype=np.float32).reshape(3, 4)
+        np.testing.assert_array_equal(out, arr)
+        assert mask is None
+
+    def test_all_valid_mask_collapses_to_none(self):
+        arr = np.arange(12, dtype=np.float32).reshape(3, 4)
+        valid = np.ones((3, 4), dtype=np.uint8)
+        blob = _encode_with_mask(arr, valid)
+        decoded_bytes, mask = lerc_decompress_with_mask(blob)
+        out = np.frombuffer(decoded_bytes, dtype=np.float32).reshape(3, 4)
+        np.testing.assert_array_equal(out, arr)
+        # All-True mask carries no information, treated as no mask.
+        assert mask is None
+
+    def test_partial_mask_returns_array(self):
+        arr = np.array([[1.0, 2.0, 3.0]], dtype=np.float32)
+        valid = np.array([[1, 0, 1]], dtype=np.uint8)
+        blob = _encode_with_mask(arr, valid)
+        decoded_bytes, mask = lerc_decompress_with_mask(blob)
+        out = np.frombuffer(decoded_bytes, dtype=np.float32).reshape(1, 3)
+        # LERC zero-fills masked positions in the data array.
+        np.testing.assert_array_equal(out, np.array([[1.0, 0.0, 3.0]],
+                                                    dtype=np.float32))
+        assert mask is not None
+        np.testing.assert_array_equal(np.asarray(mask).reshape(1, 3),
+                                      np.array([[1, 0, 1]], dtype=np.uint8))
+
+    def test_legacy_decompress_drops_mask(self):
+        """``lerc_decompress`` still returns just raw bytes."""
+        arr = np.array([[1.0, 2.0, 3.0]], dtype=np.float32)
+        valid = np.array([[1, 0, 1]], dtype=np.uint8)
+        blob = _encode_with_mask(arr, valid)
+        out_bytes = lerc_decompress(blob)
+        assert isinstance(out_bytes, bytes)
+        out = np.frombuffer(out_bytes, dtype=np.float32).reshape(1, 3)
+        np.testing.assert_array_equal(out, np.array([[1.0, 0.0, 3.0]],
+                                                    dtype=np.float32))
+
+
+# ---------------------------------------------------------------------------
+# Reader-level (TIFF round-trip) tests
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def lerc_writer_with_mask(monkeypatch):
+    """Patch ``lerc_compress`` to embed a valid-mask the writer can't pass.
+
+    The writer hard-codes ``hasMask=False`` in its call to ``lerc.encode``
+    because there's no plumbing for per-pixel mask data.  The fixture
+    swaps in an encoder that derives the mask from a holder ``invalid``
+    callable: given the (height, width) tile shape and the decoded
+    pixel array it returns a uint8 valid mask (1=valid, 0=invalid) the
+    same shape.  This lets the test specify masking by predicate so the
+    mask matches whatever tile padding the writer emits.
+    """
+    holder = {"invalid": None}
+
+    def _patched(data, width, height, samples=1,
+                 dtype=np.dtype('float32'), max_z_error=0.0):
+        if samples == 1:
+            arr = np.frombuffer(data, dtype=dtype).reshape(height, width)
+        else:
+            arr = np.frombuffer(data, dtype=dtype).reshape(
+                height, width, samples)
+        invalid_pred = holder["invalid"]
+        if invalid_pred is None:
+            mask = None
+            has_mask = False
+        else:
+            invalid = invalid_pred(arr)
+            mask = np.where(invalid, np.uint8(0), np.uint8(1))
+            has_mask = True
+        result = lerc.encode(arr, samples, has_mask, mask, max_z_error, 1)
+        if result[0] != 0:
+            raise RuntimeError(
+                f"LERC encode failed with error code {result[0]}")
+        return bytes(result[2])
+
+    monkeypatch.setattr(
+        "xrspatial.geotiff._compression.lerc_compress", _patched,
+    )
+    return holder
+
+
+class TestLercTiffRoundTripWithMask:
+    """End-to-end TIFF round-trips that exercise the reader's mask merge."""
+
+    def test_float32_nan_nodata(self, tmp_path, lerc_writer_with_mask):
+        from xrspatial.geotiff._writer import write
+        from xrspatial.geotiff._reader import read_to_array
+
+        arr = np.arange(1, 65, dtype=np.float32).reshape(8, 8)
+        # Mask positions (0, 1) and (5, 4); the rest stays valid.
+        invalid_positions = {(0, 1), (5, 4)}
+
+        def invalid_pred(a):
+            m = np.zeros(a.shape[:2], dtype=bool)
+            for r, c in invalid_positions:
+                m[r, c] = True
+            return m
+        lerc_writer_with_mask["invalid"] = invalid_pred
+
+        path = str(tmp_path / "lerc_mask_nan.tif")
+        write(arr, path, compression="lerc", tiled=True, tile_size=8,
+              nodata=float("nan"))
+
+        out, _geo = read_to_array(path)
+        for r in range(8):
+            for c in range(8):
+                if (r, c) in invalid_positions:
+                    assert np.isnan(out[r, c]), \
+                        f"expected NaN at ({r},{c}), got {out[r, c]}"
+                else:
+                    assert out[r, c] == arr[r, c], \
+                        f"value mismatch at ({r},{c})"
+
+    def test_float32_sentinel_nodata(self, tmp_path, lerc_writer_with_mask):
+        from xrspatial.geotiff._writer import write
+        from xrspatial.geotiff._reader import read_to_array
+
+        arr = np.arange(1, 65, dtype=np.float32).reshape(8, 8)
+        invalid_positions = {(0, 1), (3, 3), (7, 7)}
+
+        def invalid_pred(a):
+            m = np.zeros(a.shape[:2], dtype=bool)
+            for r, c in invalid_positions:
+                m[r, c] = True
+            return m
+        lerc_writer_with_mask["invalid"] = invalid_pred
+
+        path = str(tmp_path / "lerc_mask_sentinel_f32.tif")
+        write(arr, path, compression="lerc", tiled=True, tile_size=8,
+              nodata=-9999.0)
+
+        out, _geo = read_to_array(path)
+        for r in range(8):
+            for c in range(8):
+                if (r, c) in invalid_positions:
+                    assert out[r, c] == np.float32(-9999.0), \
+                        f"expected sentinel at ({r},{c}), got {out[r, c]}"
+                else:
+                    assert out[r, c] == arr[r, c]
+
+    def test_uint16_sentinel_nodata(self, tmp_path, lerc_writer_with_mask):
+        from xrspatial.geotiff._writer import write
+        from xrspatial.geotiff._reader import read_to_array
+
+        arr = (np.arange(1, 65, dtype=np.uint16) * 100).reshape(8, 8)
+        invalid_positions = {(0, 1), (4, 4)}
+
+        def invalid_pred(a):
+            m = np.zeros(a.shape[:2], dtype=bool)
+            for r, c in invalid_positions:
+                m[r, c] = True
+            return m
+        lerc_writer_with_mask["invalid"] = invalid_pred
+
+        path = str(tmp_path / "lerc_mask_uint16.tif")
+        write(arr, path, compression="lerc", tiled=True, tile_size=8,
+              nodata=65535)
+
+        out, _geo = read_to_array(path)
+        for r in range(8):
+            for c in range(8):
+                if (r, c) in invalid_positions:
+                    assert out[r, c] == np.uint16(65535)
+                else:
+                    assert out[r, c] == arr[r, c]
+
+    def test_no_mask_roundtrip_bitexact(self, tmp_path):
+        """Sanity: an all-valid LERC file (no mask) still round-trips."""
+        from xrspatial.geotiff._writer import write
+        from xrspatial.geotiff._reader import read_to_array
+
+        arr = np.arange(64, dtype=np.float32).reshape(8, 8)
+        path = str(tmp_path / "lerc_no_mask.tif")
+        write(arr, path, compression="lerc", tiled=True, tile_size=8)
+
+        out, _geo = read_to_array(path)
+        np.testing.assert_array_equal(out, arr)


### PR DESCRIPTION
`lerc.decode` returns `(rc, data, valid_mask, ...)` but the wrapper only forwarded `data.tobytes()`. GDAL writes LERC TIFFs with a NoData mask whose masked pixels are zero-filled in the data array, so downstream code that masks by nodata silently sees those zeros as real measurements.

## What changed

`_compression.py`: new `lerc_decompress_with_mask(data) -> (bytes, valid_mask_or_None)`. `lerc_decompress` now calls it and drops the mask, so its existing signature is preserved. An all-True mask collapses to `None` so callers skip the fill pass.

`_reader.py`: `_decode_strip_or_tile` takes a separate path for LERC, calls the new wrapper, and writes nodata into masked positions after reshape. A small `_resolve_masked_fill` helper reads `ifd.nodata_str` and falls back to NaN for float dtypes or 0 for integer dtypes when no GDAL_NODATA is set. Each `_decode_strip_or_tile` call site (strip reader, tile reader, COG-over-HTTP reader) passes a precomputed `masked_fill`.

`tests/test_lerc_valid_mask.py`: 8 new tests. Direct wrapper tests cover the no-mask path, the all-True-mask collapse, and a partial mask. TIFF round-trip tests cover float32 with NaN nodata, float32 with -9999, uint16 with 65535, and a regression that an unmasked LERC file still round-trips bit-exact. The round-trip tests monkeypatch `lerc_compress` to inject a per-tile mask through a predicate, since the writer hard-codes `hasMask=False`.

## Reproducer (fails before, passes after)

```python
import lerc, numpy as np
arr = np.array([[1.0, 2.0, 3.0]], dtype=np.float32)
mask = np.array([[1, 0, 1]], dtype=np.uint8)
raw = bytes(lerc.encode(arr, 1, True, mask, 0.0, 1)[2])
dec = lerc.decode(raw)
assert np.array_equal(dec[1], np.array([[1.0, 0.0, 3.0]], dtype=np.float32))
```

After the fix, when this blob is read through a TIFF whose `GDAL_NODATA` is set, position `(0,1)` lands on the file's nodata sentinel (or NaN for float dtypes with no nodata tag) instead of `0.0`.

## Why Option A

Option A (plumb nodata into the decode path) was chosen. Option B (return the mask from `decompress()`) would have required changing the dispatcher's return shape, which has callers in tests and in `_gpu_decode.py`.

## Tests

- New: `pytest xrspatial/geotiff/tests/test_lerc_valid_mask.py -x -q` -> 8 passed.
- Regression: `pytest xrspatial/geotiff/tests/test_lerc.py xrspatial/geotiff/tests/test_lerc_max_z_error.py -x -q` -> 19 passed.
- Three pre-existing failures in `test_features.py::TestPalette` reproduce on `main` and are unrelated.

## Out of scope

The GPU LERC path in `_gpu_decode.py` still drops the mask. The change scope excluded that file. Worth a follow-up.