### PR TITLE
Auto-request Copilot review on maintainer PRs (#1587)

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -1,0 +1,27 @@
+name: Request Copilot review
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  request-copilot-review:
+    if: >-
+      github.event.pull_request.draft == false &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request Copilot review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${REPO}/pulls/${PR_NUMBER}/requested_reviewers" \
+            -f "reviewers[]=Copilot"


### PR DESCRIPTION
Closes #1587.

Adds `.github/workflows/copilot-review.yml`. It fires on `pull_request_target` for `opened`, `reopened`, and `ready_for_review`, and requests Copilot as a reviewer only when `author_association` is `OWNER`, `MEMBER`, or `COLLABORATOR`. Drafts are skipped.

`pull_request_target` (not `pull_request`) is intentional — the job needs `pull-requests: write`, and that token scope is denied on PRs from forks under the `pull_request` event. Since the workflow does not check out PR code and only calls the reviewers REST API, running in the base-repo context is safe.

## Test plan
- [ ] Open a draft PR as a maintainer → workflow runs but the job is skipped.
- [ ] Mark draft ready for review → workflow re-runs and requests Copilot.
- [ ] Open a PR from an outside contributor fork → workflow runs, job is skipped (no review requested).
- [ ] Open a normal PR as a maintainer → Copilot review is requested.