### PR TITLE
Debug: print copilot-review gate inputs

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -8,6 +8,18 @@ permissions:
   pull-requests: write
 
 jobs:
+  debug-event:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print gate inputs
+        run: |
+          echo "action=${{ github.event.action }}"
+          echo "draft=${{ github.event.pull_request.draft }}"
+          echo "assoc=${{ github.event.pull_request.author_association }}"
+          echo "user=${{ github.event.pull_request.user.login }}"
+          echo "head_repo=${{ github.event.pull_request.head.repo.full_name }}"
+          echo "base_repo=${{ github.event.pull_request.base.repo.full_name }}"
+
   request-copilot-review:
     if: >-
       github.event.pull_request.draft == false &&


### PR DESCRIPTION
## Summary
- Adds an unconditional `debug-event` job to `.github/workflows/copilot-review.yml` that prints `action`, `draft`, `author_association`, `user.login`, and head/base repo on every `pull_request_target` event.

## Why
The `request-copilot-review` job has been silently skipped on every PR since the workflow landed (e.g. #1589, plus the next maintainer PR after it). The REST view of those PRs shows `draft: false` and `author_association: "MEMBER"`, which should satisfy the gate, so the event payload likely contains a different value at trigger time. The debug job will surface that value once any PR fires the workflow.

## Test plan
- [ ] After this PR is open, check the `debug-event` job logs and confirm what `assoc` actually is at event time
- [ ] Once diagnosed, fix the `if:` condition (or drop the `author_association` gate) and remove the debug job