### PR TITLE
Probe: capture copilot-review event payload

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -1,3 +1,4 @@
+# Probe PR: trigger debug-event job to capture author_association at event time.
 name: Request Copilot review
 
 on:


### PR DESCRIPTION
## Summary
- One-line comment touch to fire the `copilot-review` workflow so the unconditional `debug-event` job (landed in #1592) prints the event payload values for this PR.

## Test plan
- [ ] Inspect the `debug-event` job logs and record the printed `assoc` value
- [ ] Use that to fix the `if:` gate in a follow-up, then revert this PR and remove the debug job