### PR TITLE
Fix copilot-review gate: use head==base, drop author_association check

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -8,22 +8,13 @@ permissions:
   pull-requests: write
 
 jobs:
-  debug-event:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Print gate inputs
-        run: |
-          echo "action=${{ github.event.action }}"
-          echo "draft=${{ github.event.pull_request.draft }}"
-          echo "assoc=${{ github.event.pull_request.author_association }}"
-          echo "user=${{ github.event.pull_request.user.login }}"
-          echo "head_repo=${{ github.event.pull_request.head.repo.full_name }}"
-          echo "base_repo=${{ github.event.pull_request.base.repo.full_name }}"
-
   request-copilot-review:
+    # Same-repo PRs only. author_association in the pull_request_target payload
+    # reports CONTRIBUTOR for org members on same-repo branches, so head==base
+    # is the reliable maintainer signal (it requires push access to the base repo).
     if: >-
       github.event.pull_request.draft == false &&
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+      github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
     steps:
       - name: Request Copilot review


### PR DESCRIPTION
## Summary
- Replace the `author_association` allowlist with `head.repo.full_name == base.repo.full_name`
- Remove the temporary `debug-event` job added in #1592

## Why
The `debug-event` job (landed in #1592, fired by probe PR #1593) printed:

\`\`\`
action=opened
draft=false
assoc=CONTRIBUTOR
user=brendancol
head_repo=xarray-contrib/xarray-spatial
base_repo=xarray-contrib/xarray-spatial
\`\`\`

The REST API reports `author_association: "MEMBER"` for the same PR, but the `pull_request_target` webhook payload reports `CONTRIBUTOR` for org members on same-repo branches. That's why every maintainer PR since the workflow landed (#1589, the issue-1560 PR, #1592, #1593) had the job silently skipped.

Same-repo branches imply push access to the base repo, which is the maintainer signal we actually want. Fork PRs still get filtered out.

## Test plan
- [ ] Open a same-repo non-draft PR as a maintainer → Copilot review is requested
- [ ] Open a same-repo draft PR → job is skipped
- [ ] Open a PR from a fork → job is skipped

## Follow-up
- Close #1593 (probe PR — no longer needed)