### PR TITLE
Fix read_geotiff_gpu/read_vrt docstring gaps and stale read_geotiff refs (#1637)

### DIFF
--- a/xrspatial/geotiff/__init__.py
+++ b/xrspatial/geotiff/__init__.py
@@ -1591,7 +1591,7 @@ def read_geotiff_dask(source: str, *, dtype=None, chunks: int | tuple = 512,
 
     source = _coerce_path(source)
 
-    # ``read_geotiff`` already routes ``.vrt`` to ``read_vrt`` before
+    # ``open_geotiff`` already routes ``.vrt`` to ``read_vrt`` before
     # reaching here, so this branch is only hit when ``read_geotiff_dask``
     # is called directly with a VRT path. Keep it as a defensive fallback
     # rather than letting the windowed-read path try to parse VRT XML as
@@ -2161,6 +2161,10 @@ def read_geotiff_gpu(source: str, *,
     ----------
     source : str
         File path.
+    dtype : str, numpy.dtype, or None
+        Cast the result to this dtype after reading. None keeps the
+        file's native dtype. Float-to-int casts raise ValueError, mirroring
+        ``open_geotiff`` / ``read_geotiff_dask``.
     overview_level : int or None
         Overview level (0 = full resolution).
     window : tuple or None
@@ -3009,6 +3013,11 @@ def read_vrt(source: str, *, dtype=None, window=None,
         (row, col) tuple for rectangular.
     gpu : bool
         If True, return a CuPy-backed DataArray on GPU.
+    max_pixels : int or None
+        Maximum allowed pixel count (width * height * samples) for the
+        assembled VRT region. None uses the reader default (~1 billion).
+        Matches ``open_geotiff`` / ``read_geotiff_dask`` /
+        ``read_geotiff_gpu``.
 
     Returns
     -------

--- a/xrspatial/tests/bench_reproject_vs_rioxarray.py
+++ b/xrspatial/tests/bench_reproject_vs_rioxarray.py
@@ -324,8 +324,8 @@ def _load_for_both(path):
     import os
     path = os.path.expanduser(path)
 
-    from xrspatial.geotiff import read_geotiff
-    da_xrs = read_geotiff(path)
+    from xrspatial.geotiff import open_geotiff
+    da_xrs = open_geotiff(path)
 
     da_rio = rioxarray.open_rasterio(path).squeeze(drop=True)
     return da_xrs, da_rio


### PR DESCRIPTION
## Summary

Closes #1637. Three doc/comment fixes and one stale import. No signature
or behavior change.

- `read_geotiff_gpu`: add the missing `dtype` entry to the Parameters
  block. The signature already accepted it; sibling read functions
  (`open_geotiff`, `read_geotiff_dask`, `read_vrt`) all documented it.
- `read_vrt`: add the missing `max_pixels` entry to the Parameters
  block. Signature already accepted it; the three sibling read
  functions all documented it.
- `read_geotiff_dask`: fix the stale `read_geotiff` reference in a
  comment to say `open_geotiff` (the function it refers to).
- `xrspatial/tests/bench_reproject_vs_rioxarray.py`: switch the stale
  `from xrspatial.geotiff import read_geotiff` import to `open_geotiff`.
  Not in CI; the script never ran since the rename.

Found by `/sweep-api-consistency` Cat 3 (docstring/signature drift).

## Test plan

- [x] Local: signature-vs-docstring parity script confirms all four
      public read functions document every signature param.
- [x] Local: `to_geotiff` -> `open_geotiff` round-trip with `dtype=` and
      `max_pixels=` kwargs.
- [ ] CI: existing geotiff suite stays green (no behavior change).