### PR TITLE
Typed warnings + XRSPATIAL_GEOTIFF_STRICT for silent geotiff fallbacks (#1662)

### DIFF
--- a/docs/source/reference/geotiff.rst
+++ b/docs/source/reference/geotiff.rst
@@ -20,3 +20,24 @@ Writing
     xrspatial.geotiff.to_geotiff
     xrspatial.geotiff.write_geotiff_gpu
     xrspatial.geotiff.write_vrt
+
+Strict mode (``XRSPATIAL_GEOTIFF_STRICT``)
+==========================================
+
+Several internal helpers historically returned ``None`` when something went
+wrong: pyproj failing to parse a WKT string, a VRT source file being
+missing, a GPU helper (GDS, nvCOMP, nvJPEG, nvJPEG2000) hitting a CUDA or
+library error. These now emit :class:`xrspatial.geotiff.GeoTIFFFallbackWarning`
+with the original exception type and message.
+
+Set ``XRSPATIAL_GEOTIFF_STRICT=1`` (or ``true``, ``yes``) to promote those
+warnings into raised exceptions. The same env var also forces
+``read_geotiff_gpu(on_gpu_failure='auto')`` to behave like
+``on_gpu_failure='strict'`` so CI can fail loudly when the GPU fast path
+silently falls back to CPU.
+
+.. code-block:: bash
+
+    XRSPATIAL_GEOTIFF_STRICT=1 pytest xrspatial/geotiff/tests/
+
+See issue #1662 for the audit and the full list of affected call sites.

--- a/xrspatial/geotiff/__init__.py
+++ b/xrspatial/geotiff/__init__.py
@@ -50,6 +50,7 @@ from ._writer import write
 # is intentionally omitted: it is deprecated in favour of ``da.xrs.plot()``
 # and emits a ``DeprecationWarning`` when called.
 __all__ = [
+    'GeoTIFFFallbackWarning',
     'open_geotiff',
     'read_geotiff_gpu',
     'read_geotiff_dask',

--- a/xrspatial/geotiff/__init__.py
+++ b/xrspatial/geotiff/__init__.py
@@ -32,6 +32,7 @@ write_vrt(vrt_path, source_files, ...)
 from __future__ import annotations
 
 import math
+import os
 import warnings
 from typing import TYPE_CHECKING
 
@@ -79,17 +80,50 @@ _ON_GPU_FAILURE_SENTINEL = object()
 _BAND_DIM_NAMES = ('band', 'bands', 'channel')
 
 
+class GeoTIFFFallbackWarning(UserWarning):
+    """Warning emitted when a geotiff helper falls back to a slower path.
+
+    Raised in the same call sites that would silently return ``None`` under
+    the historic ``except Exception: return None`` pattern. See issue #1662
+    for the audit and the ``XRSPATIAL_GEOTIFF_STRICT=1`` env var that
+    promotes these warnings to exceptions.
+    """
+
+
+def _geotiff_strict_mode() -> bool:
+    """Return True when ``XRSPATIAL_GEOTIFF_STRICT`` is set to a truthy value.
+
+    Strict mode promotes the silent fallbacks audited in issue #1662 into
+    raised exceptions. Useful in CI to catch GPU-path or VRT regressions
+    that would otherwise hide behind a CPU fallback or a missing tile.
+    """
+    return os.environ.get(
+        'XRSPATIAL_GEOTIFF_STRICT', '').lower() in ('1', 'true', 'yes')
+
+
 def _wkt_to_epsg(wkt_or_proj: str) -> int | None:
     """Try to extract an EPSG code from a WKT or PROJ string.
 
     Returns None if pyproj is not installed or the string can't be parsed.
+
+    Under ``XRSPATIAL_GEOTIFF_STRICT=1`` the underlying exception is
+    re-raised instead of being swallowed. In the default mode a
+    ``GeoTIFFFallbackWarning`` is emitted so callers can tell
+    pyproj-missing from pyproj-broken-input.
     """
     try:
         from pyproj import CRS
         crs = CRS.from_user_input(wkt_or_proj)
         epsg = crs.to_epsg()
         return epsg
-    except Exception:
+    except Exception as e:
+        if _geotiff_strict_mode():
+            raise
+        warnings.warn(
+            f"_wkt_to_epsg failed ({type(e).__name__}: {e}); returning None.",
+            GeoTIFFFallbackWarning,
+            stacklevel=2,
+        )
         return None
 
 
@@ -1975,7 +2009,7 @@ def _gpu_decode_single_band_tiles(
             byte_order=byte_order,
         )
     except Exception as e:
-        if gpu == 'strict':
+        if gpu == 'strict' or _geotiff_strict_mode():
             raise
         warnings.warn(
             f"read_geotiff_gpu: GPU decode failed "
@@ -1999,7 +2033,7 @@ def _gpu_decode_single_band_tiles(
                 byte_order=byte_order,
             )
         except Exception as e:
-            if gpu == 'strict':
+            if gpu == 'strict' or _geotiff_strict_mode():
                 raise
             warnings.warn(
                 f"read_geotiff_gpu: GPU decode failed "
@@ -2596,7 +2630,7 @@ def read_geotiff_gpu(source: str, *,
                 masked_fill=masked_fill,
             )
         except Exception as e:
-            if gpu == 'strict':
+            if gpu == 'strict' or _geotiff_strict_mode():
                 raise
             warnings.warn(
                 f"read_geotiff_gpu: GPU decode failed "
@@ -2628,7 +2662,7 @@ def read_geotiff_gpu(source: str, *,
                 masked_fill=masked_fill,
             )
         except Exception as e:
-            if gpu == 'strict':
+            if gpu == 'strict' or _geotiff_strict_mode():
                 raise
             warnings.warn(
                 f"read_geotiff_gpu: GPU decode failed "

--- a/xrspatial/geotiff/_geotags.py
+++ b/xrspatial/geotiff/_geotags.py
@@ -244,11 +244,24 @@ def _epsg_to_wkt(epsg: int) -> str | None:
     """Resolve an EPSG code to a WKT string using pyproj.
 
     Returns None if pyproj is not installed or the code is unknown.
+
+    Under ``XRSPATIAL_GEOTIFF_STRICT=1`` the underlying exception is
+    re-raised instead of being swallowed. See issue #1662.
     """
     try:
         from pyproj import CRS
         return CRS.from_epsg(epsg).to_wkt()
-    except Exception:
+    except Exception as e:
+        import warnings
+        from . import _geotiff_strict_mode, GeoTIFFFallbackWarning
+        if _geotiff_strict_mode():
+            raise
+        warnings.warn(
+            f"_epsg_to_wkt({epsg!r}) failed "
+            f"({type(e).__name__}: {e}); returning None.",
+            GeoTIFFFallbackWarning,
+            stacklevel=2,
+        )
         return None
 
 

--- a/xrspatial/geotiff/_gpu_decode.py
+++ b/xrspatial/geotiff/_gpu_decode.py
@@ -7,9 +7,30 @@ thread (LZW is sequential per-stream), but all tiles run in parallel.
 from __future__ import annotations
 
 import math
+import warnings
 
 import numpy as np
 from numba import cuda
+
+
+def _warn_or_raise_gpu_fallback(stage: str, exc: BaseException) -> None:
+    """Report a GPU helper falling back to None (issue #1662).
+
+    Under ``XRSPATIAL_GEOTIFF_STRICT=1`` the original exception is
+    re-raised so CI catches silent fast-path regressions. In the default
+    mode a ``GeoTIFFFallbackWarning`` is emitted with the exception type
+    and message; the caller still receives ``None`` and chooses its own
+    next step (typically another decoder or CPU fallback).
+    """
+    from . import _geotiff_strict_mode, GeoTIFFFallbackWarning
+    if _geotiff_strict_mode():
+        raise exc
+    warnings.warn(
+        f"{stage} fell back to None "
+        f"({type(exc).__name__}: {exc}).",
+        GeoTIFFFallbackWarning,
+        stacklevel=3,
+    )
 
 #: Fraction of free GPU memory we're willing to allocate in a single call.
 #: Above this, raise MemoryError up-front so the caller gets an actionable
@@ -941,14 +962,17 @@ def _try_kvikio_read_tiles(file_path, tile_offsets, tile_byte_counts, tile_bytes
                 d_tiles.append(buf)
         cupy.cuda.Device().synchronize()
         return d_tiles
-    except Exception:
-        # GDS not available, version mismatch, or CUDA error
-        # Reset CUDA error state if possible
+    except Exception as e:
+        # GDS not available, version mismatch, or CUDA error.
+        # Reset CUDA error state if possible (the inner pass stays broad
+        # because a failed synchronize() during error recovery has no
+        # better recovery path; see issue #1662).
         try:
             import cupy
             cupy.cuda.Device().synchronize()
         except Exception:
             pass
+        _warn_or_raise_gpu_fallback("_gds_read_tiles", e)
         return None
 
 
@@ -1051,7 +1075,9 @@ def _try_nvcomp_batch_decompress(compressed_tiles, tile_bytes, compression):
             ]
             d_decompressed = manager.decompress(d_compressed)
             return cupy.concatenate([d.ravel() for d in d_decompressed])
-        except Exception:
+        except Exception as e:
+            _warn_or_raise_gpu_fallback(
+                "_try_nvcomp_batch_decompress (kvikio DeflateManager)", e)
             return None
 
     # Direct ctypes nvCOMP C API
@@ -1170,7 +1196,9 @@ def _try_nvcomp_batch_decompress(compressed_tiles, tile_bytes, compression):
 
         return d_decomp
 
-    except Exception:
+    except Exception as e:
+        _warn_or_raise_gpu_fallback(
+            "_try_nvcomp_batch_decompress (ctypes nvCOMP C API)", e)
         return None
 
 
@@ -1347,7 +1375,8 @@ def _try_nvjpeg_batch_decode(compressed_tiles, tile_width, tile_height,
             if destroy_fn is not None:
                 destroy_fn(nvjpeg_handle)
 
-    except Exception:
+    except Exception as e:
+        _warn_or_raise_gpu_fallback("_try_nvjpeg_batch_decode", e)
         return None
 
 
@@ -1491,7 +1520,8 @@ def _nvjpeg_batch_encode(d_tile_bufs, tile_width, tile_height, samples,
             if destroy_fn is not None:
                 destroy_fn(nvjpeg_handle)
 
-    except Exception:
+    except Exception as e:
+        _warn_or_raise_gpu_fallback("_nvjpeg_batch_encode", e)
         return None
 
 
@@ -1649,7 +1679,8 @@ def _try_nvcomp_from_device_bufs(d_tiles, tile_bytes, compression):
         return d_decomp
     except MemoryError:
         raise
-    except Exception:
+    except Exception as e:
+        _warn_or_raise_gpu_fallback("_try_nvcomp_from_device_bufs", e)
         return None
 
 
@@ -2435,7 +2466,8 @@ def _nvcomp_batch_compress(d_tile_bufs, tile_byte_counts, tile_bytes,
 
         return result
 
-    except Exception:
+    except Exception as e:
+        _warn_or_raise_gpu_fallback("_nvcomp_batch_compress", e)
         return None
 
 
@@ -2624,7 +2656,8 @@ def _try_nvjpeg2k_batch_decode(compressed_tiles, tile_width, tile_height,
 
         return d_all_tiles
 
-    except Exception:
+    except Exception as e:
+        _warn_or_raise_gpu_fallback("_try_nvjpeg2k_batch_decode", e)
         return None
 
 
@@ -2769,7 +2802,8 @@ def _nvjpeg2k_batch_encode(d_tile_bufs, tile_width, tile_height,
 
         return result
 
-    except Exception:
+    except Exception as e:
+        _warn_or_raise_gpu_fallback("_nvjpeg2k_batch_encode", e)
         return None
 
 

--- a/xrspatial/geotiff/_gpu_decode.py
+++ b/xrspatial/geotiff/_gpu_decode.py
@@ -13,24 +13,28 @@ import numpy as np
 from numba import cuda
 
 
-def _warn_or_raise_gpu_fallback(stage: str, exc: BaseException) -> None:
+def _warn_or_raise_gpu_fallback(stage: str, exc: BaseException) -> bool:
     """Report a GPU helper falling back to None (issue #1662).
 
-    Under ``XRSPATIAL_GEOTIFF_STRICT=1`` the original exception is
-    re-raised so CI catches silent fast-path regressions. In the default
-    mode a ``GeoTIFFFallbackWarning`` is emitted with the exception type
-    and message; the caller still receives ``None`` and chooses its own
-    next step (typically another decoder or CPU fallback).
+    Returns ``True`` when ``XRSPATIAL_GEOTIFF_STRICT=1`` is set; callers
+    should then re-raise the live exception with a bare ``raise`` so the
+    original traceback is preserved (re-raising ``exc`` here would reset
+    ``__traceback__`` to this helper's frame). Returns ``False`` in the
+    default mode after emitting a ``GeoTIFFFallbackWarning`` with the
+    exception type and message; the caller still returns ``None`` and
+    chooses its own next step (typically another decoder or CPU
+    fallback).
     """
     from . import _geotiff_strict_mode, GeoTIFFFallbackWarning
     if _geotiff_strict_mode():
-        raise exc
+        return True
     warnings.warn(
         f"{stage} fell back to None "
         f"({type(exc).__name__}: {exc}).",
         GeoTIFFFallbackWarning,
         stacklevel=3,
     )
+    return False
 
 #: Fraction of free GPU memory we're willing to allocate in a single call.
 #: Above this, raise MemoryError up-front so the caller gets an actionable
@@ -972,7 +976,8 @@ def _try_kvikio_read_tiles(file_path, tile_offsets, tile_byte_counts, tile_bytes
             cupy.cuda.Device().synchronize()
         except Exception:
             pass
-        _warn_or_raise_gpu_fallback("_try_kvikio_read_tiles", e)
+        if _warn_or_raise_gpu_fallback("_try_kvikio_read_tiles", e):
+            raise
         return None
 
 
@@ -1076,8 +1081,9 @@ def _try_nvcomp_batch_decompress(compressed_tiles, tile_bytes, compression):
             d_decompressed = manager.decompress(d_compressed)
             return cupy.concatenate([d.ravel() for d in d_decompressed])
         except Exception as e:
-            _warn_or_raise_gpu_fallback(
-                "_try_nvcomp_batch_decompress (kvikio DeflateManager)", e)
+            stage = "_try_nvcomp_batch_decompress (kvikio DeflateManager)"
+            if _warn_or_raise_gpu_fallback(stage, e):
+                raise
             return None
 
     # Direct ctypes nvCOMP C API
@@ -1197,8 +1203,9 @@ def _try_nvcomp_batch_decompress(compressed_tiles, tile_bytes, compression):
         return d_decomp
 
     except Exception as e:
-        _warn_or_raise_gpu_fallback(
-            "_try_nvcomp_batch_decompress (ctypes nvCOMP C API)", e)
+        stage = "_try_nvcomp_batch_decompress (ctypes nvCOMP C API)"
+        if _warn_or_raise_gpu_fallback(stage, e):
+            raise
         return None
 
 
@@ -1376,7 +1383,8 @@ def _try_nvjpeg_batch_decode(compressed_tiles, tile_width, tile_height,
                 destroy_fn(nvjpeg_handle)
 
     except Exception as e:
-        _warn_or_raise_gpu_fallback("_try_nvjpeg_batch_decode", e)
+        if _warn_or_raise_gpu_fallback("_try_nvjpeg_batch_decode", e):
+            raise
         return None
 
 
@@ -1521,7 +1529,8 @@ def _nvjpeg_batch_encode(d_tile_bufs, tile_width, tile_height, samples,
                 destroy_fn(nvjpeg_handle)
 
     except Exception as e:
-        _warn_or_raise_gpu_fallback("_nvjpeg_batch_encode", e)
+        if _warn_or_raise_gpu_fallback("_nvjpeg_batch_encode", e):
+            raise
         return None
 
 
@@ -1680,7 +1689,8 @@ def _try_nvcomp_from_device_bufs(d_tiles, tile_bytes, compression):
     except MemoryError:
         raise
     except Exception as e:
-        _warn_or_raise_gpu_fallback("_try_nvcomp_from_device_bufs", e)
+        if _warn_or_raise_gpu_fallback("_try_nvcomp_from_device_bufs", e):
+            raise
         return None
 
 
@@ -2467,7 +2477,8 @@ def _nvcomp_batch_compress(d_tile_bufs, tile_byte_counts, tile_bytes,
         return result
 
     except Exception as e:
-        _warn_or_raise_gpu_fallback("_nvcomp_batch_compress", e)
+        if _warn_or_raise_gpu_fallback("_nvcomp_batch_compress", e):
+            raise
         return None
 
 
@@ -2657,7 +2668,8 @@ def _try_nvjpeg2k_batch_decode(compressed_tiles, tile_width, tile_height,
         return d_all_tiles
 
     except Exception as e:
-        _warn_or_raise_gpu_fallback("_try_nvjpeg2k_batch_decode", e)
+        if _warn_or_raise_gpu_fallback("_try_nvjpeg2k_batch_decode", e):
+            raise
         return None
 
 
@@ -2803,7 +2815,8 @@ def _nvjpeg2k_batch_encode(d_tile_bufs, tile_width, tile_height,
         return result
 
     except Exception as e:
-        _warn_or_raise_gpu_fallback("_nvjpeg2k_batch_encode", e)
+        if _warn_or_raise_gpu_fallback("_nvjpeg2k_batch_encode", e):
+            raise
         return None
 
 

--- a/xrspatial/geotiff/_gpu_decode.py
+++ b/xrspatial/geotiff/_gpu_decode.py
@@ -972,7 +972,7 @@ def _try_kvikio_read_tiles(file_path, tile_offsets, tile_byte_counts, tile_bytes
             cupy.cuda.Device().synchronize()
         except Exception:
             pass
-        _warn_or_raise_gpu_fallback("_gds_read_tiles", e)
+        _warn_or_raise_gpu_fallback("_try_kvikio_read_tiles", e)
         return None
 
 

--- a/xrspatial/geotiff/_vrt.py
+++ b/xrspatial/geotiff/_vrt.py
@@ -356,7 +356,22 @@ def read_vrt(vrt_path: str, *, window=None,
                     window=(src_r0, src_c0, src_r1, src_c1),
                     band=src.band - 1,  # convert 1-based to 0-based
                 )
-            except Exception:
+            except Exception as e:
+                # Under XRSPATIAL_GEOTIFF_STRICT=1, surface the read failure
+                # so partial mosaics are caught in CI. Default mode warns
+                # once per missing source then continues, preserving the
+                # historical behaviour. See issue #1662.
+                import warnings
+                from . import _geotiff_strict_mode, GeoTIFFFallbackWarning
+                if _geotiff_strict_mode():
+                    raise
+                warnings.warn(
+                    f"VRT source {src.filename!r} could not be read "
+                    f"({type(e).__name__}: {e}); skipping. The output "
+                    f"mosaic will have a hole at this tile.",
+                    GeoTIFFFallbackWarning,
+                    stacklevel=2,
+                )
                 continue  # skip missing/unreadable sources
 
             # Handle source nodata.  Cast the sentinel to the *source*

--- a/xrspatial/geotiff/tests/test_features.py
+++ b/xrspatial/geotiff/tests/test_features.py
@@ -2642,6 +2642,7 @@ class TestPublicAPI:
         # public API. If any of these gets removed or renamed, that is a
         # breaking change and should go through a deprecation cycle.
         expected = {
+            'GeoTIFFFallbackWarning',
             'open_geotiff',
             'read_geotiff_gpu',
             'read_geotiff_dask',

--- a/xrspatial/geotiff/tests/test_strict_mode_1662.py
+++ b/xrspatial/geotiff/tests/test_strict_mode_1662.py
@@ -1,0 +1,255 @@
+"""Regression tests for #1662: typed warnings + ``XRSPATIAL_GEOTIFF_STRICT``.
+
+The audit in issue #1662 flagged ten ``except Exception: return None``
+sites in the geotiff module that silently swallowed errors. Each site
+now emits a ``GeoTIFFFallbackWarning`` (or re-raises in strict mode).
+This module pins the contract:
+
+* Default mode: a fallback returns ``None`` (or skips) and a
+  ``GeoTIFFFallbackWarning`` is emitted with the original exception
+  type and message.
+* ``XRSPATIAL_GEOTIFF_STRICT=1``: the same code paths re-raise the
+  original exception. CI can flip the env var to fail loudly on any
+  silent fallback.
+
+The GPU helper sites in ``_gpu_decode.py`` are exercised indirectly
+through ``read_geotiff_gpu`` when CuPy is available; tests gated on
+``importlib.util.find_spec('cupy')`` are skipped otherwise.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import warnings
+
+import pytest
+
+from xrspatial.geotiff import (
+    GeoTIFFFallbackWarning,
+    _geotiff_strict_mode,
+    _wkt_to_epsg,
+)
+from xrspatial.geotiff._geotags import _epsg_to_wkt
+
+
+@pytest.fixture
+def clear_strict_env(monkeypatch):
+    """Ensure the strict-mode env var is unset for the default-mode test."""
+    monkeypatch.delenv('XRSPATIAL_GEOTIFF_STRICT', raising=False)
+
+
+@pytest.fixture
+def set_strict_env(monkeypatch):
+    """Set ``XRSPATIAL_GEOTIFF_STRICT=1`` for strict-mode tests."""
+    monkeypatch.setenv('XRSPATIAL_GEOTIFF_STRICT', '1')
+
+
+# ---------------------------------------------------------------------------
+# _geotiff_strict_mode() helper
+# ---------------------------------------------------------------------------
+
+def test_strict_mode_default_false(clear_strict_env):
+    assert _geotiff_strict_mode() is False
+
+
+@pytest.mark.parametrize('value', ['1', 'true', 'True', 'yes', 'YES'])
+def test_strict_mode_truthy_values(monkeypatch, value):
+    monkeypatch.setenv('XRSPATIAL_GEOTIFF_STRICT', value)
+    assert _geotiff_strict_mode() is True
+
+
+@pytest.mark.parametrize('value', ['0', 'false', 'no', '', 'maybe'])
+def test_strict_mode_falsy_values(monkeypatch, value):
+    monkeypatch.setenv('XRSPATIAL_GEOTIFF_STRICT', value)
+    assert _geotiff_strict_mode() is False
+
+
+# ---------------------------------------------------------------------------
+# _wkt_to_epsg
+# ---------------------------------------------------------------------------
+
+def test_wkt_to_epsg_default_warns_returns_none(clear_strict_env):
+    """In default mode a broken WKT input warns and returns None."""
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        result = _wkt_to_epsg('not-a-valid-wkt-string-1662')
+
+    assert result is None
+    fallback_warnings = [
+        x for x in w if issubclass(x.category, GeoTIFFFallbackWarning)
+    ]
+    assert len(fallback_warnings) == 1
+    assert '_wkt_to_epsg failed' in str(fallback_warnings[0].message)
+
+
+def test_wkt_to_epsg_strict_reraises(set_strict_env):
+    """Under XRSPATIAL_GEOTIFF_STRICT=1, _wkt_to_epsg re-raises."""
+    with pytest.raises(Exception):
+        _wkt_to_epsg('not-a-valid-wkt-string-1662')
+
+
+def test_wkt_to_epsg_valid_input_no_warning(clear_strict_env):
+    """A real WKT string returns its EPSG without any warning."""
+    pyproj = pytest.importorskip('pyproj')
+    wkt = pyproj.CRS.from_epsg(4326).to_wkt()
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        result = _wkt_to_epsg(wkt)
+
+    assert result == 4326
+    fallback_warnings = [
+        x for x in w if issubclass(x.category, GeoTIFFFallbackWarning)
+    ]
+    assert fallback_warnings == []
+
+
+# ---------------------------------------------------------------------------
+# _epsg_to_wkt
+# ---------------------------------------------------------------------------
+
+def test_epsg_to_wkt_default_warns_returns_none(clear_strict_env):
+    """An unknown EPSG warns and returns None in default mode."""
+    pytest.importorskip('pyproj')
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        # EPSG 999999 is unassigned; pyproj raises CRSError.
+        result = _epsg_to_wkt(999999)
+
+    assert result is None
+    fallback_warnings = [
+        x for x in w if issubclass(x.category, GeoTIFFFallbackWarning)
+    ]
+    assert len(fallback_warnings) == 1
+    assert '_epsg_to_wkt' in str(fallback_warnings[0].message)
+
+
+def test_epsg_to_wkt_strict_reraises(set_strict_env):
+    """Strict mode re-raises rather than warning."""
+    pytest.importorskip('pyproj')
+    with pytest.raises(Exception):
+        _epsg_to_wkt(999999)
+
+
+# ---------------------------------------------------------------------------
+# VRT source skip
+# ---------------------------------------------------------------------------
+
+def test_vrt_missing_source_default_warns_then_continues(
+    clear_strict_env, tmp_path,
+):
+    """A VRT referencing a missing source file warns once and skips it."""
+    from xrspatial.geotiff import read_vrt
+
+    vrt_path = tmp_path / 'mosaic_1662_missing.vrt'
+    vrt_path.write_text(
+        '<VRTDataset rasterXSize="4" rasterYSize="4">\n'
+        '  <SRS></SRS>\n'
+        '  <GeoTransform>0, 1, 0, 0, 0, -1</GeoTransform>\n'
+        '  <VRTRasterBand dataType="Float32" band="1">\n'
+        '    <NoDataValue>-9999</NoDataValue>\n'
+        '    <SimpleSource>\n'
+        f'      <SourceFilename relativeToVRT="0">{tmp_path}/does_not_exist_1662.tif</SourceFilename>\n'
+        '      <SourceBand>1</SourceBand>\n'
+        '      <SrcRect xOff="0" yOff="0" xSize="4" ySize="4"/>\n'
+        '      <DstRect xOff="0" yOff="0" xSize="4" ySize="4"/>\n'
+        '    </SimpleSource>\n'
+        '  </VRTRasterBand>\n'
+        '</VRTDataset>\n'
+    )
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        da = read_vrt(str(vrt_path))
+
+    # The mosaic should still load (with a hole) and one warning should
+    # describe the skipped source.
+    assert da.shape == (4, 4)
+    fallback_warnings = [
+        x for x in w if issubclass(x.category, GeoTIFFFallbackWarning)
+    ]
+    assert len(fallback_warnings) >= 1
+    msgs = ' '.join(str(x.message) for x in fallback_warnings)
+    assert 'VRT source' in msgs
+    assert 'does_not_exist_1662' in msgs
+
+
+def test_vrt_missing_source_strict_raises(set_strict_env, tmp_path):
+    """In strict mode the missing source surfaces as an exception."""
+    from xrspatial.geotiff import read_vrt
+
+    vrt_path = tmp_path / 'mosaic_1662_missing_strict.vrt'
+    vrt_path.write_text(
+        '<VRTDataset rasterXSize="4" rasterYSize="4">\n'
+        '  <SRS></SRS>\n'
+        '  <GeoTransform>0, 1, 0, 0, 0, -1</GeoTransform>\n'
+        '  <VRTRasterBand dataType="Float32" band="1">\n'
+        '    <NoDataValue>-9999</NoDataValue>\n'
+        '    <SimpleSource>\n'
+        f'      <SourceFilename relativeToVRT="0">{tmp_path}/does_not_exist_1662_strict.tif</SourceFilename>\n'
+        '      <SourceBand>1</SourceBand>\n'
+        '      <SrcRect xOff="0" yOff="0" xSize="4" ySize="4"/>\n'
+        '      <DstRect xOff="0" yOff="0" xSize="4" ySize="4"/>\n'
+        '    </SimpleSource>\n'
+        '  </VRTRasterBand>\n'
+        '</VRTDataset>\n'
+    )
+
+    with pytest.raises(Exception):
+        read_vrt(str(vrt_path))
+
+
+# ---------------------------------------------------------------------------
+# _warn_or_raise_gpu_fallback pins the warn-vs-raise contract for every
+# GPU helper site flagged in #1662. Exercised directly so the test does
+# not depend on having a working CUDA/GDS/nvCOMP stack.
+# ---------------------------------------------------------------------------
+
+CUPY_AVAILABLE = importlib.util.find_spec('cupy') is not None
+
+
+def test_warn_or_raise_gpu_fallback_default_warns(clear_strict_env):
+    """Default mode emits one GeoTIFFFallbackWarning carrying type + msg."""
+    from xrspatial.geotiff._gpu_decode import _warn_or_raise_gpu_fallback
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        _warn_or_raise_gpu_fallback(
+            "_try_nvjpeg_batch_decode", RuntimeError("bogus 1662"))
+
+    fallback_warnings = [
+        x for x in w if issubclass(x.category, GeoTIFFFallbackWarning)
+    ]
+    assert len(fallback_warnings) == 1
+    msg = str(fallback_warnings[0].message)
+    assert '_try_nvjpeg_batch_decode' in msg
+    assert 'RuntimeError' in msg
+    assert 'bogus 1662' in msg
+
+
+def test_warn_or_raise_gpu_fallback_strict_reraises(set_strict_env):
+    """Strict mode re-raises the original exception."""
+    from xrspatial.geotiff._gpu_decode import _warn_or_raise_gpu_fallback
+
+    with pytest.raises(RuntimeError, match='bogus 1662 strict'):
+        _warn_or_raise_gpu_fallback(
+            "_try_nvjpeg_batch_decode", RuntimeError("bogus 1662 strict"))
+
+
+# ---------------------------------------------------------------------------
+# read_geotiff_gpu on_gpu_failure='auto' + env var integration
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(
+    not CUPY_AVAILABLE,
+    reason="cupy required for read_geotiff_gpu fallback test",
+)
+def test_read_geotiff_gpu_env_var_promotes_to_strict(set_strict_env, tmp_path):
+    """With on_gpu_failure='auto' but XRSPATIAL_GEOTIFF_STRICT=1, a GPU
+    decode failure surfaces instead of falling back to CPU."""
+    from xrspatial.geotiff import read_geotiff_gpu
+
+    # A non-existent path triggers a failure before any decode runs;
+    # the env var should still bubble it up.
+    bogus = str(tmp_path / 'no_such_file_1662_promote.tif')
+    with pytest.raises(Exception):
+        read_geotiff_gpu(bogus)

--- a/xrspatial/geotiff/tests/test_strict_mode_1662.py
+++ b/xrspatial/geotiff/tests/test_strict_mode_1662.py
@@ -13,13 +13,12 @@ This module pins the contract:
   silent fallback.
 
 The GPU helper sites in ``_gpu_decode.py`` are exercised indirectly
-through ``read_geotiff_gpu`` when CuPy is available; tests gated on
-``importlib.util.find_spec('cupy')`` are skipped otherwise.
+through ``read_geotiff_gpu`` when CuPy + CUDA are available; tests
+gated on ``_gpu_available()`` are skipped otherwise.
 """
 from __future__ import annotations
 
 import importlib.util
-import os
 import warnings
 
 import pytest
@@ -141,6 +140,7 @@ def test_vrt_missing_source_default_warns_then_continues(
     from xrspatial.geotiff import read_vrt
 
     vrt_path = tmp_path / 'mosaic_1662_missing.vrt'
+    missing_src = f'{tmp_path}/does_not_exist_1662.tif'
     vrt_path.write_text(
         '<VRTDataset rasterXSize="4" rasterYSize="4">\n'
         '  <SRS></SRS>\n'
@@ -148,7 +148,8 @@ def test_vrt_missing_source_default_warns_then_continues(
         '  <VRTRasterBand dataType="Float32" band="1">\n'
         '    <NoDataValue>-9999</NoDataValue>\n'
         '    <SimpleSource>\n'
-        f'      <SourceFilename relativeToVRT="0">{tmp_path}/does_not_exist_1662.tif</SourceFilename>\n'
+        f'      <SourceFilename relativeToVRT="0">{missing_src}'
+        '</SourceFilename>\n'
         '      <SourceBand>1</SourceBand>\n'
         '      <SrcRect xOff="0" yOff="0" xSize="4" ySize="4"/>\n'
         '      <DstRect xOff="0" yOff="0" xSize="4" ySize="4"/>\n'
@@ -178,6 +179,7 @@ def test_vrt_missing_source_strict_raises(set_strict_env, tmp_path):
     from xrspatial.geotiff import read_vrt
 
     vrt_path = tmp_path / 'mosaic_1662_missing_strict.vrt'
+    missing_src = f'{tmp_path}/does_not_exist_1662_strict.tif'
     vrt_path.write_text(
         '<VRTDataset rasterXSize="4" rasterYSize="4">\n'
         '  <SRS></SRS>\n'
@@ -185,7 +187,8 @@ def test_vrt_missing_source_strict_raises(set_strict_env, tmp_path):
         '  <VRTRasterBand dataType="Float32" band="1">\n'
         '    <NoDataValue>-9999</NoDataValue>\n'
         '    <SimpleSource>\n'
-        f'      <SourceFilename relativeToVRT="0">{tmp_path}/does_not_exist_1662_strict.tif</SourceFilename>\n'
+        f'      <SourceFilename relativeToVRT="0">{missing_src}'
+        '</SourceFilename>\n'
         '      <SourceBand>1</SourceBand>\n'
         '      <SrcRect xOff="0" yOff="0" xSize="4" ySize="4"/>\n'
         '      <DstRect xOff="0" yOff="0" xSize="4" ySize="4"/>\n'
@@ -204,8 +207,6 @@ def test_vrt_missing_source_strict_raises(set_strict_env, tmp_path):
 # not depend on having a working CUDA/GDS/nvCOMP stack.
 # ---------------------------------------------------------------------------
 
-CUPY_AVAILABLE = importlib.util.find_spec('cupy') is not None
-
 
 def test_warn_or_raise_gpu_fallback_default_warns(clear_strict_env):
     """Default mode emits one GeoTIFFFallbackWarning carrying type + msg."""
@@ -213,9 +214,11 @@ def test_warn_or_raise_gpu_fallback_default_warns(clear_strict_env):
 
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
-        _warn_or_raise_gpu_fallback(
+        result = _warn_or_raise_gpu_fallback(
             "_try_nvjpeg_batch_decode", RuntimeError("bogus 1662"))
 
+    # Default mode returns False so the caller falls back to None.
+    assert result is False
     fallback_warnings = [
         x for x in w if issubclass(x.category, GeoTIFFFallbackWarning)
     ]
@@ -226,30 +229,128 @@ def test_warn_or_raise_gpu_fallback_default_warns(clear_strict_env):
     assert 'bogus 1662' in msg
 
 
-def test_warn_or_raise_gpu_fallback_strict_reraises(set_strict_env):
-    """Strict mode re-raises the original exception."""
+def test_warn_or_raise_gpu_fallback_strict_returns_true(set_strict_env):
+    """Strict mode returns True so the caller can ``raise`` itself.
+
+    The helper deliberately does not raise here -- re-raising the
+    captured exception from inside this frame would clobber the
+    original traceback. Returning True lets each call site bubble the
+    live exception up via a bare ``raise`` from its own ``except``
+    block.
+    """
     from xrspatial.geotiff._gpu_decode import _warn_or_raise_gpu_fallback
 
-    with pytest.raises(RuntimeError, match='bogus 1662 strict'):
-        _warn_or_raise_gpu_fallback(
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        result = _warn_or_raise_gpu_fallback(
             "_try_nvjpeg_batch_decode", RuntimeError("bogus 1662 strict"))
+
+    assert result is True
+    # No warning should be emitted in strict mode.
+    fallback_warnings = [
+        x for x in w if issubclass(x.category, GeoTIFFFallbackWarning)
+    ]
+    assert fallback_warnings == []
+
+
+def test_warn_or_raise_gpu_fallback_preserves_traceback(set_strict_env):
+    """The call-site pattern preserves the original exception traceback.
+
+    The helper returns True in strict mode; the caller re-raises with a
+    bare ``raise``. The resulting traceback should point at the original
+    failure (``raise RuntimeError(...)`` below), not at the helper.
+    """
+    from xrspatial.geotiff._gpu_decode import _warn_or_raise_gpu_fallback
+
+    def site():
+        try:
+            raise RuntimeError("bogus 1662 traceback")
+        except Exception as e:
+            if _warn_or_raise_gpu_fallback("_dummy_stage", e):
+                raise
+            return None
+
+    with pytest.raises(RuntimeError, match='bogus 1662 traceback') as excinfo:
+        site()
+    # The deepest traceback frame should be ``site``'s ``raise
+    # RuntimeError`` line, not ``_warn_or_raise_gpu_fallback``.
+    tb = excinfo.tb
+    while tb.tb_next is not None:
+        tb = tb.tb_next
+    assert tb.tb_frame.f_code.co_name == 'site'
 
 
 # ---------------------------------------------------------------------------
 # read_geotiff_gpu on_gpu_failure='auto' + env var integration
 # ---------------------------------------------------------------------------
 
-@pytest.mark.skipif(
-    not CUPY_AVAILABLE,
-    reason="cupy required for read_geotiff_gpu fallback test",
-)
-def test_read_geotiff_gpu_env_var_promotes_to_strict(set_strict_env, tmp_path):
-    """With on_gpu_failure='auto' but XRSPATIAL_GEOTIFF_STRICT=1, a GPU
-    decode failure surfaces instead of falling back to CPU."""
-    from xrspatial.geotiff import read_geotiff_gpu
+def _gpu_available() -> bool:
+    if importlib.util.find_spec("cupy") is None:
+        return False
+    try:
+        import cupy
+        return bool(cupy.cuda.is_available())
+    except Exception:
+        return False
 
-    # A non-existent path triggers a failure before any decode runs;
-    # the env var should still bubble it up.
-    bogus = str(tmp_path / 'no_such_file_1662_promote.tif')
-    with pytest.raises(Exception):
-        read_geotiff_gpu(bogus)
+
+_HAS_GPU = _gpu_available()
+
+
+@pytest.mark.skipif(
+    not _HAS_GPU,
+    reason="cupy + CUDA required for read_geotiff_gpu fallback test",
+)
+def test_read_geotiff_gpu_env_var_promotes_to_strict(monkeypatch, tmp_path):
+    """With on_gpu_failure='auto' but XRSPATIAL_GEOTIFF_STRICT=1, a GPU
+    decode failure surfaces instead of falling back to CPU.
+
+    The seam: ``read_geotiff_gpu`` does a local
+    ``from ._gpu_decode import gpu_decode_tiles_from_file`` inside the
+    function body, so rebinding the attribute on the
+    ``xrspatial.geotiff._gpu_decode`` module is picked up on the next
+    call. Stubbing it to raise lets us exercise both branches against
+    a real on-disk TIF without needing a broken GPU stack.
+    """
+    import cupy as cp
+    import numpy as np
+    import xarray as xr
+
+    from xrspatial.geotiff import read_geotiff_gpu, to_geotiff
+    from xrspatial.geotiff import _gpu_decode
+
+    # 1. Write a small valid TIF so the metadata parse succeeds and we
+    # reach the GPU decode stage.
+    h, w = 16, 16
+    arr = np.arange(h * w, dtype=np.float32).reshape(h, w)
+    y = np.arange(h, dtype=np.float64) * -1.0 + 100.0
+    x = np.arange(w, dtype=np.float64) * 1.0 + 0.0
+    da = xr.DataArray(arr, dims=['y', 'x'], coords={'y': y, 'x': x})
+    p = str(tmp_path / 'strict_promote_1662.tif')
+    to_geotiff(da, p, crs=4326)
+
+    sentinel = "bogus 1662 promote"
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError(sentinel)
+
+    monkeypatch.setattr(
+        _gpu_decode, 'gpu_decode_tiles_from_file', _boom)
+    monkeypatch.setattr(
+        _gpu_decode, 'gpu_decode_tiles', _boom)
+
+    # 2. Default mode: XRSPATIAL_GEOTIFF_STRICT unset, the failure
+    # should be absorbed and the CPU fallback should return a
+    # CuPy-backed DataArray.
+    monkeypatch.delenv('XRSPATIAL_GEOTIFF_STRICT', raising=False)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        result = read_geotiff_gpu(p)
+    assert isinstance(result, xr.DataArray)
+    assert isinstance(result.data, cp.ndarray)
+
+    # 3. With XRSPATIAL_GEOTIFF_STRICT=1, the same call should re-raise
+    # the patched RuntimeError instead of falling back.
+    monkeypatch.setenv('XRSPATIAL_GEOTIFF_STRICT', '1')
+    with pytest.raises(RuntimeError, match=sentinel):
+        read_geotiff_gpu(p)


### PR DESCRIPTION
## Summary

Closes #1662.

- Each `except Exception: return None` site flagged in the #1662 audit now emits a `GeoTIFFFallbackWarning` carrying the original exception type and message. Affected helpers: `_wkt_to_epsg`, `_epsg_to_wkt`, the VRT source-skip loop in `_vrt.py`, and eight GPU helpers in `_gpu_decode.py` (GDS, nvCOMP kvikio + ctypes, nvJPEG decode + encode, nvCOMP from-device-bufs, nvCOMP batch compress, nvJPEG2000 decode + encode).
- New `XRSPATIAL_GEOTIFF_STRICT=1` env var (read by `_geotiff_strict_mode()`) re-raises instead of warning. The same env var also promotes `read_geotiff_gpu(on_gpu_failure='auto')` to strict so CI can fail on silent GPU fallbacks without touching every call site.
- 21 new tests in `test_strict_mode_1662.py` pin the warn-vs-raise contract for each entry point.
- Docs reference updated with a "Strict mode" section pointing at the env var.

Out of scope:
- The inner `except Exception: pass` cleanup in `_try_kvikio_read_tiles` (a failed `cupy.cuda.Device().synchronize()` during error recovery) stays broad; there is no useful next step.
- The early `ImportError` guards on optional deps still return `None` quietly. Those are real "feature not available" branches, not silent fast-path failures.

## Test plan

- [x] `pytest xrspatial/geotiff/tests/test_strict_mode_1662.py -v` (21 pass)
- [x] `pytest xrspatial/geotiff/tests/` (1364 pass, 3 skipped; one unrelated matplotlib deepcopy recursion in `test_features.py` excluded)
- [ ] CI matrix
- [ ] Smoke `XRSPATIAL_GEOTIFF_STRICT=1 pytest xrspatial/geotiff/tests/` on a box with GPU + kvikio to confirm no spurious strict-mode failures
