### PR TITLE
Skip urllib3 SSRF redirect tests when urllib3 is not installed

### DIFF
--- a/xrspatial/geotiff/tests/test_ssrf_hardening_1664.py
+++ b/xrspatial/geotiff/tests/test_ssrf_hardening_1664.py
@@ -267,18 +267,17 @@ class _MockPool:
 
 
 class TestRedirectRevalidation:
-    # The tests in this class exercise the urllib3 transport path: they mock
+    # The test_urllib3_* tests exercise the urllib3 transport path: they mock
     # urllib3.PoolManager and call read_range(), which internally builds a
     # urllib3.Timeout via _urllib3_timeout(). urllib3 is an optional runtime
     # dependency (_HTTPSource falls back to stdlib urllib.request when it's
-    # missing -- see _reader.py:615-617). Skip rather than fail when the
-    # package isn't installed; the stdlib fallback path is covered elsewhere.
-    @pytest.fixture(autouse=True)
-    def _require_urllib3(self):
-        pytest.importorskip("urllib3")
+    # missing -- see _reader.py:615-617), so each urllib3-using test starts
+    # with pytest.importorskip("urllib3"). The test_stdlib_* tests below
+    # exercise the stdlib redirect handler directly and run regardless.
 
     def test_urllib3_redirect_to_private_rejected(self, monkeypatch):
         """Public host that 302-redirects to loopback must be rejected."""
+        pytest.importorskip("urllib3")
         # Initial validator pass: example.com resolves to a public IP.
         monkeypatch.setattr(
             socket, 'getaddrinfo', _fake_getaddrinfo('93.184.216.34'))
@@ -300,6 +299,7 @@ class TestRedirectRevalidation:
 
     def test_urllib3_redirect_to_public_followed(self, monkeypatch):
         """Public -> public redirect is followed; validator passes each hop."""
+        pytest.importorskip("urllib3")
         monkeypatch.setattr(
             socket, 'getaddrinfo', _fake_getaddrinfo('93.184.216.34'))
         src = _reader_mod._HTTPSource('https://example.com/cog.tif')
@@ -315,6 +315,7 @@ class TestRedirectRevalidation:
 
     def test_urllib3_redirect_chain_capped(self, monkeypatch):
         """More than _HTTP_MAX_REDIRECTS hops raises rather than looping."""
+        pytest.importorskip("urllib3")
         monkeypatch.setattr(
             socket, 'getaddrinfo', _fake_getaddrinfo('93.184.216.34'))
         src = _reader_mod._HTTPSource('https://example.com/cog.tif')
@@ -332,6 +333,7 @@ class TestRedirectRevalidation:
 
     def test_urllib3_relative_location_resolved(self, monkeypatch):
         """Relative Location like ``/other.tif`` resolves against the source."""
+        pytest.importorskip("urllib3")
         monkeypatch.setattr(
             socket, 'getaddrinfo', _fake_getaddrinfo('93.184.216.34'))
         src = _reader_mod._HTTPSource('https://example.com/dir/cog.tif')

--- a/xrspatial/geotiff/tests/test_ssrf_hardening_1664.py
+++ b/xrspatial/geotiff/tests/test_ssrf_hardening_1664.py
@@ -267,6 +267,16 @@ class _MockPool:
 
 
 class TestRedirectRevalidation:
+    # The tests in this class exercise the urllib3 transport path: they mock
+    # urllib3.PoolManager and call read_range(), which internally builds a
+    # urllib3.Timeout via _urllib3_timeout(). urllib3 is an optional runtime
+    # dependency (_HTTPSource falls back to stdlib urllib.request when it's
+    # missing -- see _reader.py:615-617). Skip rather than fail when the
+    # package isn't installed; the stdlib fallback path is covered elsewhere.
+    @pytest.fixture(autouse=True)
+    def _require_urllib3(self):
+        pytest.importorskip("urllib3")
+
     def test_urllib3_redirect_to_private_rejected(self, monkeypatch):
         """Public host that 302-redirects to loopback must be rejected."""
         # Initial validator pass: example.com resolves to a public IP.


### PR DESCRIPTION
Closes #1681.

## Summary

`TestRedirectRevalidation` in `xrspatial/geotiff/tests/test_ssrf_hardening_1664.py` exercises the urllib3 transport path: each test mocks `urllib3.PoolManager` and calls `src.read_range(...)`, which internally builds a `urllib3.Timeout` via `_urllib3_timeout()` (a lazy `import urllib3`). `urllib3` is an optional runtime dep (`_HTTPSource` falls back to stdlib `urllib.request` when it's missing), but the test class did not gate on its presence.

In CI environments without `urllib3`, the four `test_urllib3_*` tests fail with `ModuleNotFoundError`. Main has been red on this since commit 919d827 (#1668); every PR branched from main hits the same wall (PRs #1675-#1680).

This adds an autouse `pytest.importorskip("urllib3")` fixture to the class so urllib3-specific tests skip cleanly when the package is absent. The three `test_stdlib_*` tests in the same class are unaffected.

## Test plan

- [x] Local run with urllib3 installed: 7 passed (4 urllib3 + 3 stdlib).
- [ ] CI run without urllib3: 4 skipped, 3 passed.
- [ ] No other tests touched.