### PR TITLE
Fix Windows-only test failure: VRT path error uses non-repr format

### DIFF
--- a/xrspatial/geotiff/_vrt.py
+++ b/xrspatial/geotiff/_vrt.py
@@ -300,9 +300,15 @@ def parse_vrt(xml_str: str, vrt_dir: str = '.') -> VRTDataset:
             else:
                 trusted = [vrt_root, *allowed_roots]
             if not any(_path_is_under(filename, r) for r in trusted):
+                # Use direct interpolation (not !r) for ``filename`` and
+                # ``vrt_root`` so Windows paths render with single
+                # backslashes rather than the doubled escapes repr emits.
+                # The explicit quotes keep the boundary readable when the
+                # path has embedded spaces. ``allowed_roots`` stays as !r
+                # for its list-of-strings render.
                 raise ValueError(
-                    f"VRT SourceFilename {filename!r} resolves outside "
-                    f"the VRT directory ({vrt_root!r}) and is not "
+                    f"VRT SourceFilename '{filename}' resolves outside "
+                    f"the VRT directory ('{vrt_root}') and is not "
                     f"covered by any {_ALLOWED_ROOTS_ENV} entry "
                     f"({allowed_roots!r}). Refusing to read; see issue "
                     f"#1671."


### PR DESCRIPTION
Closes #1702.

## Summary

`test_error_message_names_rejected_path` is failing on `windows-latest, 3.12` (the rest of the Windows/macOS matrix is being cancelled via fail-fast). Main has been red since #1679 merged.

The ValueError emitted by `parse_vrt` for paths outside the VRT directory used `{filename!r}` and `{vrt_root!r}`, which renders Windows paths with doubled backslashes (\`C:\\\\Users\\\\...\`). The test compares against the raw \`os.path.realpath\` output (single backslashes), so the substring match fails. The doubled output is also user-hostile on Windows.

This switches to explicit single-quote interpolation for `filename` and `vrt_root`. \`allowed_roots\` stays as `!r` since it is a list and the list-of-strings repr is fine cross-platform.

## Test plan

- [x] All 10 tests in `test_vrt_path_containment_1671.py` pass on POSIX with the fix.
- [ ] CI on `windows-latest` goes green.
- [ ] User-facing error message reads cleanly on Windows.