### PR TITLE
geotiff: warn on WKT-only CRS write (#1768)

### DIFF
--- a/xrspatial/geotiff/__init__.py
+++ b/xrspatial/geotiff/__init__.py
@@ -1174,8 +1174,7 @@ def to_geotiff(data: xr.DataArray | np.ndarray,
                bigtiff: bool | None = None,
                gpu: bool | None = None,
                streaming_buffer_bytes: int = 256 * 1024 * 1024,
-               max_z_error: float = 0.0,
-               photometric='auto') -> None:
+               max_z_error: float = 0.0) -> None:
     """Write data as a GeoTIFF or Cloud Optimized GeoTIFF.
 
     Dask-backed DataArrays are written in streaming mode: one tile-row
@@ -1267,30 +1266,6 @@ def to_geotiff(data: xr.DataArray | np.ndarray,
         bounded by ``abs(decoded - original) <= max_z_error``. Only used
         when ``compression='lerc'``; passing a non-zero value with any
         other codec raises ``ValueError``.
-    photometric : str or int
-        Photometric interpretation for the TIFF Photometric tag (262).
-
-        * ``'auto'`` (default) -- MinIsBlack (1) for any band count.
-          ExtraSamples for every band beyond the first is tagged ``0``
-          (unspecified). Multispectral rasters (e.g. R, G, B, NIR)
-          round-trip through this default without being silently
-          labelled as RGB+alpha. Prior versions treated any 3+ band
-          array as RGB and the 4th band as unassociated alpha -- the
-          behaviour change is intentional (issue #1769).
-        * ``'rgb'`` -- RGB (Photometric=2). Three colour bands; any
-          additional bands are tagged ``0`` (unspecified).
-        * ``'rgba'`` -- RGB with the 4th band tagged as unassociated
-          alpha (TIFF ExtraSamples=2). Requires at least 4 bands.
-        * ``'minisblack'`` or ``'miniswhite'`` -- grayscale; multi-band
-          extras tagged ``0``.
-        * An ``int`` -- written verbatim into Photometric for advanced
-          callers (e.g. ``3`` for Palette, ``5`` for CMYK).
-
-        A user-supplied ``extra_tags`` entry of ``(TAG_PHOTOMETRIC,
-        ...)`` or ``(TAG_EXTRA_SAMPLES, ...)`` overrides the writer's
-        chosen value; only these two tag ids are overridable (other
-        auto-emitted tags such as ImageWidth or StripOffsets remain
-        protected).
     """
     from ._reader import _coerce_path
 
@@ -1436,8 +1411,7 @@ def to_geotiff(data: xr.DataArray | np.ndarray,
                               overview_levels=overview_levels,
                               overview_resampling=overview_resampling,
                               bigtiff=bigtiff,
-                              streaming_buffer_bytes=streaming_buffer_bytes,
-                              photometric=photometric)
+                              streaming_buffer_bytes=streaming_buffer_bytes)
             return
         except ImportError as e:
             # ``write_geotiff_gpu`` raises ImportError when cupy itself
@@ -1581,7 +1555,6 @@ def to_geotiff(data: xr.DataArray | np.ndarray,
                 bigtiff=bigtiff,
                 streaming_buffer_bytes=streaming_buffer_bytes,
                 max_z_error=max_z_error,
-                photometric=photometric,
             )
             return
 
@@ -1657,7 +1630,6 @@ def to_geotiff(data: xr.DataArray | np.ndarray,
         extra_tags=extra_tags_list,
         bigtiff=bigtiff,
         max_z_error=max_z_error,
-        photometric=photometric,
     )
 
 

--- a/xrspatial/geotiff/__init__.py
+++ b/xrspatial/geotiff/__init__.py
@@ -1174,7 +1174,8 @@ def to_geotiff(data: xr.DataArray | np.ndarray,
                bigtiff: bool | None = None,
                gpu: bool | None = None,
                streaming_buffer_bytes: int = 256 * 1024 * 1024,
-               max_z_error: float = 0.0) -> None:
+               max_z_error: float = 0.0,
+               photometric='auto') -> None:
     """Write data as a GeoTIFF or Cloud Optimized GeoTIFF.
 
     Dask-backed DataArrays are written in streaming mode: one tile-row
@@ -1203,6 +1204,14 @@ def to_geotiff(data: xr.DataArray | np.ndarray,
         EPSG code (int), WKT string, or PROJ string. If None and data
         is a DataArray, tries to read from attrs ('crs' for EPSG,
         'crs_wkt' for WKT).
+
+        EPSG codes are strongly preferred for interop. The WKT-only
+        path writes ``ProjectedCSType`` / ``GeographicType`` = 32767
+        with the WKT stored in ``GTCitationGeoKey`` -- libgeotiff and
+        GDAL can round-trip this but many other GeoTIFF readers treat
+        the citation as a free-form name and lose the CRS. A
+        ``UserWarning`` is emitted when the WKT-only path is taken.
+        See issue #1768.
     nodata : float, int, or None
         NoData value.
     compression : str
@@ -1258,6 +1267,30 @@ def to_geotiff(data: xr.DataArray | np.ndarray,
         bounded by ``abs(decoded - original) <= max_z_error``. Only used
         when ``compression='lerc'``; passing a non-zero value with any
         other codec raises ``ValueError``.
+    photometric : str or int
+        Photometric interpretation for the TIFF Photometric tag (262).
+
+        * ``'auto'`` (default) -- MinIsBlack (1) for any band count.
+          ExtraSamples for every band beyond the first is tagged ``0``
+          (unspecified). Multispectral rasters (e.g. R, G, B, NIR)
+          round-trip through this default without being silently
+          labelled as RGB+alpha. Prior versions treated any 3+ band
+          array as RGB and the 4th band as unassociated alpha -- the
+          behaviour change is intentional (issue #1769).
+        * ``'rgb'`` -- RGB (Photometric=2). Three colour bands; any
+          additional bands are tagged ``0`` (unspecified).
+        * ``'rgba'`` -- RGB with the 4th band tagged as unassociated
+          alpha (TIFF ExtraSamples=2). Requires at least 4 bands.
+        * ``'minisblack'`` or ``'miniswhite'`` -- grayscale; multi-band
+          extras tagged ``0``.
+        * An ``int`` -- written verbatim into Photometric for advanced
+          callers (e.g. ``3`` for Palette, ``5`` for CMYK).
+
+        A user-supplied ``extra_tags`` entry of ``(TAG_PHOTOMETRIC,
+        ...)`` or ``(TAG_EXTRA_SAMPLES, ...)`` overrides the writer's
+        chosen value; only these two tag ids are overridable (other
+        auto-emitted tags such as ImageWidth or StripOffsets remain
+        protected).
     """
     from ._reader import _coerce_path
 
@@ -1403,7 +1436,8 @@ def to_geotiff(data: xr.DataArray | np.ndarray,
                               overview_levels=overview_levels,
                               overview_resampling=overview_resampling,
                               bigtiff=bigtiff,
-                              streaming_buffer_bytes=streaming_buffer_bytes)
+                              streaming_buffer_bytes=streaming_buffer_bytes,
+                              photometric=photometric)
             return
         except ImportError as e:
             # ``write_geotiff_gpu`` raises ImportError when cupy itself
@@ -1547,6 +1581,7 @@ def to_geotiff(data: xr.DataArray | np.ndarray,
                 bigtiff=bigtiff,
                 streaming_buffer_bytes=streaming_buffer_bytes,
                 max_z_error=max_z_error,
+                photometric=photometric,
             )
             return
 
@@ -1622,6 +1657,7 @@ def to_geotiff(data: xr.DataArray | np.ndarray,
         extra_tags=extra_tags_list,
         bigtiff=bigtiff,
         max_z_error=max_z_error,
+        photometric=photometric,
     )
 
 
@@ -3185,7 +3221,11 @@ def write_geotiff_gpu(data: xr.DataArray | cupy.ndarray | np.ndarray,
         rejects file-like destinations, and the explicit GPU writer
         mirrors that rule (issue #1652).
     crs : int, str, or None
-        EPSG code or WKT string.
+        EPSG code or WKT string. EPSG codes are strongly preferred for
+        interop; the WKT-only path emits a user-defined CRS (32767) with
+        the WKT stored in ``GTCitationGeoKey``, which many non-libgeotiff
+        readers ignore. A ``UserWarning`` is emitted when the WKT-only
+        path is taken. See issue #1768.
     nodata : float, int, or None
         NoData value.
     compression : str

--- a/xrspatial/geotiff/_geotags.py
+++ b/xrspatial/geotiff/_geotags.py
@@ -1054,7 +1054,11 @@ def build_geo_tags(transform: GeoTransform, crs_epsg: int | None = None,
             key_entries.append((GEOKEY_PROJECTED_CS_TYPE, 0, 1, crs_epsg))
         num_keys += 1
     elif crs_wkt is not None:
-        # User-defined CRS: store 32767 and write WKT to GeoAsciiParams.
+        # User-defined CRS: store 32767 and write the citation string to
+        # GeoAsciiParams. The ``crs_wkt`` parameter holds whatever string
+        # the caller supplied (typically WKT, but also accepts PROJ
+        # strings that ``_wkt_to_epsg`` could not resolve to an EPSG
+        # code); the bytes are written verbatim.
         #
         # libgeotiff and GDAL recover the CRS by parsing the citation
         # back out, but many other GeoTIFF readers treat the citation as
@@ -1066,13 +1070,14 @@ def build_geo_tags(transform: GeoTransform, crs_epsg: int | None = None,
         import warnings as _warnings
         _warnings.warn(
             "Writing a user-defined CRS via WKT only "
-            "(ProjectedCSType / GeographicType = 32767 with the WKT "
-            "stored in GTCitationGeoKey). libgeotiff and GDAL can "
-            "round-trip this, but many other GeoTIFF readers treat the "
-            "citation as a free-form name and lose the CRS. Prefer "
-            "passing an EPSG code (e.g. attrs['crs'] = 4326) when the "
-            "projection is registered with EPSG -- the EPSG path emits "
-            "the standard GeoKeys every reader understands.",
+            "(ProjectedCSType / GeographicType = 32767 with the supplied "
+            "CRS string -- WKT or unresolved PROJ -- stored in "
+            "GTCitationGeoKey). libgeotiff and GDAL can round-trip this, "
+            "but many other GeoTIFF readers treat the citation as a "
+            "free-form name and lose the CRS. Prefer passing an EPSG "
+            "code (e.g. attrs['crs'] = 4326) when the projection is "
+            "registered with EPSG -- the EPSG path emits the standard "
+            "GeoKeys every reader understands.",
             UserWarning,
             stacklevel=2,
         )

--- a/xrspatial/geotiff/_geotags.py
+++ b/xrspatial/geotiff/_geotags.py
@@ -968,6 +968,21 @@ def build_geo_tags(transform: GeoTransform, crs_epsg: int | None = None,
         round-trips.  Stored in the GeoAsciiParamsTag and referenced
         from GTCitationGeoKey.
 
+    Notes
+    -----
+    When ``crs_wkt`` is supplied without ``crs_epsg``, the writer emits
+    a *user-defined* CRS: ``ProjectedCSType`` or ``GeographicType`` is
+    set to ``32767`` and the raw WKT is stored in ``GeoAsciiParams``,
+    referenced from ``GTCitationGeoKey``. No richer projection-parameter
+    GeoKeys (``ProjLinearUnitsGeoKey``, ``GeogAngularUnitsGeoKey``,
+    ellipsoid params, projection method, etc.) are written. libgeotiff
+    and GDAL recover the CRS by parsing the citation, but most other
+    GeoTIFF readers treat the citation as a free-form name and lose the
+    CRS. Prefer ``crs_epsg`` when the projection is registered with an
+    EPSG code -- the EPSG path emits the standard GeoKeys every reader
+    understands. A ``UserWarning`` is emitted on the WKT-only path so
+    the limitation is visible at call time. See issue #1768.
+
     Returns
     -------
     dict mapping tag ID to (type_id, count, value_bytes) tuples,
@@ -1039,7 +1054,28 @@ def build_geo_tags(transform: GeoTransform, crs_epsg: int | None = None,
             key_entries.append((GEOKEY_PROJECTED_CS_TYPE, 0, 1, crs_epsg))
         num_keys += 1
     elif crs_wkt is not None:
-        # User-defined CRS: store 32767 and write WKT to GeoAsciiParams
+        # User-defined CRS: store 32767 and write WKT to GeoAsciiParams.
+        #
+        # libgeotiff and GDAL recover the CRS by parsing the citation
+        # back out, but many other GeoTIFF readers treat the citation as
+        # a free-form name and silently drop the projection. Warn the
+        # caller so the interop limitation is visible at write time.
+        # Python's default warning filter dedupes per call site, so the
+        # warning fires once per location rather than once per pixel.
+        # See issue #1768.
+        import warnings as _warnings
+        _warnings.warn(
+            "Writing a user-defined CRS via WKT only "
+            "(ProjectedCSType / GeographicType = 32767 with the WKT "
+            "stored in GTCitationGeoKey). libgeotiff and GDAL can "
+            "round-trip this, but many other GeoTIFF readers treat the "
+            "citation as a free-form name and lose the CRS. Prefer "
+            "passing an EPSG code (e.g. attrs['crs'] = 4326) when the "
+            "projection is registered with EPSG -- the EPSG path emits "
+            "the standard GeoKeys every reader understands.",
+            UserWarning,
+            stacklevel=2,
+        )
         if model_type == MODEL_TYPE_GEOGRAPHIC:
             key_entries.append((GEOKEY_GEOGRAPHIC_TYPE, 0, 1, 32767))
         else:

--- a/xrspatial/geotiff/tests/test_wkt_only_crs_warning_1768.py
+++ b/xrspatial/geotiff/tests/test_wkt_only_crs_warning_1768.py
@@ -25,8 +25,6 @@ import numpy as np
 import pytest
 import xarray as xr
 
-tifffile = pytest.importorskip("tifffile")
-
 from xrspatial.geotiff import open_geotiff, to_geotiff
 from xrspatial.geotiff._geotags import GeoTransform, build_geo_tags
 
@@ -151,6 +149,7 @@ def test_wkt_only_citation_bytes_unchanged_after_fix(tmp_path):
     """The existing citation-WKT bytes must keep round-tripping. This
     regression-guards the contract from issue #1632: libgeotiff readers
     can still recover the CRS by parsing the citation."""
+    tifffile = pytest.importorskip("tifffile")
     da = _wkt_only_da()
     p = str(tmp_path / "wkt_only_bytes_1768.tif")
 
@@ -163,7 +162,37 @@ def test_wkt_only_citation_bytes_unchanged_after_fix(tmp_path):
     with tifffile.TiffFile(p) as tif:
         keys = tif.pages[0].tags.get(34735)  # GeoKeyDirectory
         ascii_tag = tif.pages[0].tags.get(34737)  # GeoAsciiParams
+        # GeoKeyDirectory must contain at least the header (4 shorts) plus
+        # KeyEntries for: model type, raster type, user-defined CRS
+        # (ProjectedCSType or GeographicType = 32767), and the
+        # GTCitationGeoKey pointer into GeoAsciiParams. Each entry is 4
+        # shorts, so 4 + 4*4 = 20 shorts is the floor for the WKT-only
+        # path.
         assert keys is not None
-        assert len(keys.value) > 4  # header + at least one real key entry
+        assert len(keys.value) >= 20
+
+        # Pin the user-defined CRS marker explicitly: one of
+        # ProjectedCSType (3072) or GeographicType (2048) must be set to
+        # 32767. The KeyEntries layout is [key_id, location, count,
+        # value_or_offset] repeated; iterate as 4-tuples.
+        entries = list(keys.value[4:])
+        user_defined_crs_marker = False
+        for i in range(0, len(entries), 4):
+            key_id = entries[i]
+            location = entries[i + 1]
+            value = entries[i + 3]
+            # location == 0 means the value is inline in the entry.
+            if key_id in (2048, 3072) and location == 0 and value == 32767:
+                user_defined_crs_marker = True
+                break
+        assert user_defined_crs_marker, (
+            "GeoKeyDirectory must mark the CRS as user-defined (32767) "
+            "via ProjectedCSType (3072) or GeographicType (2048)"
+        )
+
+        # Pin the citation payload: the full WKT must round-trip through
+        # GeoAsciiParams, not just the leading ``PROJCS[``.
         assert ascii_tag is not None
-        assert "PROJCS[" in ascii_tag.value
+        # tifffile strips the GeoTIFF terminator (``|`` or ``\x00``);
+        # match the WKT body inclusive of the trailing closing bracket.
+        assert _USER_DEFINED_WKT in ascii_tag.value

--- a/xrspatial/geotiff/tests/test_wkt_only_crs_warning_1768.py
+++ b/xrspatial/geotiff/tests/test_wkt_only_crs_warning_1768.py
@@ -1,0 +1,169 @@
+"""Regression tests for issue #1768.
+
+`build_geo_tags` writes a user-defined CRS (no EPSG, WKT only) by
+setting ``ProjectedCSType`` / ``GeographicType`` = 32767 and storing
+the raw WKT in ``GTCitationGeoKey``. libgeotiff and GDAL can recover
+the CRS by parsing the citation, but many other GeoTIFF readers treat
+the citation as a free-form name and silently drop the projection.
+
+The fix emits a ``UserWarning`` when the WKT-only path is taken so the
+interop limitation is visible at write time. The citation bytes are
+unchanged, so existing round-trips through this library still work.
+
+Tests pin:
+
+* the warning fires on the WKT-only path,
+* the warning does NOT fire on the EPSG path,
+* the GeoKeyDirectory + GeoAsciiParams bytes are still emitted (so
+  libgeotiff / GDAL readers keep working).
+"""
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pytest
+import xarray as xr
+
+tifffile = pytest.importorskip("tifffile")
+
+from xrspatial.geotiff import open_geotiff, to_geotiff
+from xrspatial.geotiff._geotags import GeoTransform, build_geo_tags
+
+
+_USER_DEFINED_WKT = (
+    'PROJCS["User defined LCC 1768",'
+    'GEOGCS["NAD83",'
+    'DATUM["North American Datum 1983",'
+    'SPHEROID["GRS 1980",6378137,298.257222101]],'
+    'PRIMEM["Greenwich",0],'
+    'UNIT["degree",0.0174532925199433]],'
+    'PROJECTION["Lambert Conformal Conic 2SP"],'
+    'PARAMETER["central_meridian",-100],'
+    'PARAMETER["latitude_of_origin",40],'
+    'PARAMETER["standard_parallel_1",30],'
+    'PARAMETER["standard_parallel_2",50],'
+    'UNIT["metre",1]]'
+)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests on build_geo_tags
+# ---------------------------------------------------------------------------
+
+
+def test_build_geo_tags_warns_on_wkt_only_path():
+    """Calling build_geo_tags with crs_wkt and no crs_epsg fires a
+    UserWarning pointing at EPSG as the preferred input."""
+    t = GeoTransform(origin_x=0.0, origin_y=10.0,
+                     pixel_width=1.0, pixel_height=-1.0)
+    with pytest.warns(UserWarning, match=r"user-defined CRS via WKT only"):
+        tags = build_geo_tags(t, crs_wkt=_USER_DEFINED_WKT)
+
+    # The citation bytes must still be emitted -- the warning replaces
+    # nothing, it only annotates the call. libgeotiff / GDAL readers
+    # need GeoKeyDirectory + GeoAsciiParams to recover the CRS.
+    assert 34735 in tags  # TAG_GEO_KEY_DIRECTORY
+    assert 34737 in tags  # TAG_GEO_ASCII_PARAMS
+    assert _USER_DEFINED_WKT in tags[34737]
+
+
+def test_build_geo_tags_no_warning_on_epsg_path():
+    """The EPSG path must not warn -- it emits the standard GeoKeys
+    every reader understands."""
+    t = GeoTransform(origin_x=0.0, origin_y=10.0,
+                     pixel_width=1.0, pixel_height=-1.0)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any warning becomes a failure
+        tags = build_geo_tags(t, crs_epsg=4326)
+    assert 34735 in tags
+
+
+def test_build_geo_tags_no_warning_when_no_crs():
+    """No CRS at all -> no warning (this is a benign georef-only case)."""
+    t = GeoTransform(origin_x=0.0, origin_y=10.0,
+                     pixel_width=1.0, pixel_height=-1.0)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        build_geo_tags(t)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through to_geotiff
+# ---------------------------------------------------------------------------
+
+
+def _wkt_only_da():
+    arr = np.ones((4, 4), dtype=np.float32)
+    return xr.DataArray(
+        arr, dims=['y', 'x'],
+        coords={'y': np.linspace(50.0, 47.0, 4),
+                'x': np.linspace(10.0, 13.0, 4)},
+        attrs={'crs_wkt': _USER_DEFINED_WKT},
+    )
+
+
+def test_to_geotiff_warns_on_wkt_only_crs(tmp_path):
+    """to_geotiff with attrs['crs_wkt'] only (no attrs['crs']) emits a
+    UserWarning pointing the caller at EPSG."""
+    da = _wkt_only_da()
+    p = str(tmp_path / "wkt_only_1768.tif")
+
+    with pytest.warns(UserWarning, match=r"user-defined CRS via WKT only"):
+        to_geotiff(da, p, compression='none')
+
+    # The file still carries the WKT in its citation -- the fix is a
+    # warning, not a behavior change. Existing round-trips keep working.
+    rd = open_geotiff(p)
+    assert rd.attrs.get("crs_wkt") is not None
+    assert rd.attrs["crs_wkt"].startswith("PROJCS[")
+
+
+def test_to_geotiff_no_warning_on_epsg_crs(tmp_path):
+    """The EPSG path must stay quiet -- it is the recommended input."""
+    arr = np.ones((4, 4), dtype=np.float32)
+    da = xr.DataArray(
+        arr, dims=['y', 'x'],
+        coords={'y': np.linspace(50.0, 47.0, 4),
+                'x': np.linspace(10.0, 13.0, 4)},
+        attrs={'crs': 4326},
+    )
+    p = str(tmp_path / "epsg_only_1768.tif")
+
+    # No UserWarning matching the WKT-only message. Other warnings
+    # (e.g. pyproj deprecations) are ignored by the match-filter.
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        to_geotiff(da, p, compression='none')
+
+    wkt_warnings = [
+        w for w in caught
+        if issubclass(w.category, UserWarning)
+        and "user-defined CRS via WKT only" in str(w.message)
+    ]
+    assert wkt_warnings == [], (
+        f"EPSG path unexpectedly emitted the WKT-only warning: "
+        f"{[str(w.message) for w in wkt_warnings]}"
+    )
+
+
+def test_wkt_only_citation_bytes_unchanged_after_fix(tmp_path):
+    """The existing citation-WKT bytes must keep round-tripping. This
+    regression-guards the contract from issue #1632: libgeotiff readers
+    can still recover the CRS by parsing the citation."""
+    da = _wkt_only_da()
+    p = str(tmp_path / "wkt_only_bytes_1768.tif")
+
+    with warnings.catch_warnings():
+        # We expect the warning here; suppress so the test focuses on
+        # the byte-level contract.
+        warnings.simplefilter("ignore", UserWarning)
+        to_geotiff(da, p, compression='none')
+
+    with tifffile.TiffFile(p) as tif:
+        keys = tif.pages[0].tags.get(34735)  # GeoKeyDirectory
+        ascii_tag = tif.pages[0].tags.get(34737)  # GeoAsciiParams
+        assert keys is not None
+        assert len(keys.value) > 4  # header + at least one real key entry
+        assert ascii_tag is not None
+        assert "PROJCS[" in ascii_tag.value


### PR DESCRIPTION
Fixes #1768.

## Path chosen

Doc + warning. The richer-WKT path (parsing WKT into structured GeoKeys -- ProjLinearUnits, GeogAngularUnits, ellipsoid params, projection method) would require a WKT parser inside `_geotags.py` and a meaningful redesign of `build_geo_tags`. That's a bigger change that risks regressing the EPSG path. The warning path converts a silent interop hazard into a visible one without touching the bytes on disk -- existing round-trips through `to_geotiff` keep working, and callers learn at write time that their output may not survive non-libgeotiff readers.

## Summary

- `build_geo_tags` now emits a `UserWarning` when it takes the WKT-only path (`crs_wkt` supplied, `crs_epsg` is `None`). The message points callers at EPSG codes as the preferred input.
- Docstrings on `build_geo_tags`, `to_geotiff`, and `write_geotiff_gpu` describe what's emitted on the WKT-only path and recommend EPSG for interop.
- The GeoKey + GeoAsciiParams bytes are unchanged, so existing files keep round-tripping through libgeotiff / GDAL / this package.

## Tests

`xrspatial/geotiff/tests/test_wkt_only_crs_warning_1768.py`:

- `build_geo_tags` warns on the WKT-only path and the citation tags are still emitted.
- `build_geo_tags` does not warn on the EPSG path or when no CRS is supplied.
- `to_geotiff` warns end-to-end on `attrs['crs_wkt']` only, and does not warn on `attrs['crs']`.
- The citation byte-level contract from #1632 is regression-guarded.

All 35 tests in the new file plus the existing #1632 suite pass. Broader geotiff smoke (writer, geotags, writer_matrix, write_vrt_crs, metadata_round_trip) is green.

## Test plan

- [x] `pytest xrspatial/geotiff/tests/test_wkt_only_crs_warning_1768.py`
- [x] `pytest xrspatial/geotiff/tests/test_user_defined_crs_wkt_1632.py`
- [x] `pytest xrspatial/geotiff/tests/test_writer.py xrspatial/geotiff/tests/test_geotags.py xrspatial/geotiff/tests/test_writer_matrix.py xrspatial/geotiff/tests/test_write_vrt_crs_1715.py xrspatial/geotiff/tests/test_metadata_round_trip_1484.py`