### PR TITLE
geotiff: honour overview_levels decimation factors (#1766)

### DIFF
--- a/xrspatial/geotiff/__init__.py
+++ b/xrspatial/geotiff/__init__.py
@@ -3480,10 +3480,12 @@ def write_geotiff_gpu(data: xr.DataArray | cupy.ndarray | np.ndarray,
                     factor *= 2
         else:
             # Validate explicit lists: power-of-two factors >= 2,
-            # strictly increasing. Previously the values were ignored
-            # and only the list length mattered (issue #1766).
+            # strictly increasing, feasible for the input shape.
+            # Previously the values were ignored and only the list
+            # length mattered (issue #1766).
             from ._writer import _validate_overview_levels
-            overview_levels = _validate_overview_levels(overview_levels)
+            overview_levels = _validate_overview_levels(
+                overview_levels, height=height, width=width)
 
         # Pass ``nodata`` so the GPU reducer masks the sentinel back to
         # NaN before averaging. Without this, the NaN->sentinel rewrite

--- a/xrspatial/geotiff/__init__.py
+++ b/xrspatial/geotiff/__init__.py
@@ -1236,7 +1236,14 @@ def to_geotiff(data: xr.DataArray | np.ndarray,
     cog : bool
         Write as Cloud Optimized GeoTIFF.
     overview_levels : list[int] or None
-        Overview decimation factors. Only used when cog=True.
+        Overview decimation factors relative to full resolution.
+        Each entry must be a power-of-two integer >= 2, and the list
+        must be strictly increasing (e.g. ``[2, 4, 8]`` writes
+        overviews at 1/2, 1/4 and 1/8 of the full resolution).
+        Invalid values raise ``ValueError``. Only used when ``cog=True``.
+        If None and ``cog=True``, levels auto-generate as
+        ``[2, 4, 8, ...]`` until the next halving would fall below
+        ``tile_size`` (capped at 8 levels).
     overview_resampling : str
         Resampling method for overviews: 'mean' (default), 'nearest',
         'min', 'max', 'median', 'mode', or 'cubic'.
@@ -3236,8 +3243,12 @@ def write_geotiff_gpu(data: xr.DataArray | cupy.ndarray | np.ndarray,
     cog : bool
         Write as Cloud Optimized GeoTIFF with overviews.
     overview_levels : list[int] or None
-        Overview decimation factors (e.g. [2, 4, 8]). Only used when
-        cog=True. If None and cog=True, auto-generates levels by
+        Overview decimation factors relative to full resolution.
+        Each entry must be a power-of-two integer >= 2, and the list
+        must be strictly increasing (e.g. ``[2, 4, 8]`` writes
+        overviews at 1/2, 1/4 and 1/8 of the full resolution).
+        Invalid values raise ``ValueError``. Only used when ``cog=True``.
+        If None and ``cog=True``, auto-generates ``[2, 4, 8, ...]`` by
         halving until the smallest overview fits in a single tile.
     overview_resampling : str
         Resampling method for overviews: 'mean' (default), 'nearest',
@@ -3454,14 +3465,25 @@ def write_geotiff_gpu(data: xr.DataArray | cupy.ndarray | np.ndarray,
     if cog:
         if overview_levels is None:
             from ._writer import _MAX_OVERVIEW_LEVELS
+            # Auto-generated lists hold actual decimation factors (2,
+            # 4, 8, ...) so the loop below treats auto-generated and
+            # user-supplied lists identically (issue #1766).
             overview_levels = []
             oh, ow = height, width
+            factor = 2
             while (oh > tile_size and ow > tile_size and
                    len(overview_levels) < _MAX_OVERVIEW_LEVELS):
                 oh //= 2
                 ow //= 2
                 if oh > 0 and ow > 0:
-                    overview_levels.append(len(overview_levels) + 1)
+                    overview_levels.append(factor)
+                    factor *= 2
+        else:
+            # Validate explicit lists: power-of-two factors >= 2,
+            # strictly increasing. Previously the values were ignored
+            # and only the list length mattered (issue #1766).
+            from ._writer import _validate_overview_levels
+            overview_levels = _validate_overview_levels(overview_levels)
 
         # Pass ``nodata`` so the GPU reducer masks the sentinel back to
         # NaN before averaging. Without this, the NaN->sentinel rewrite
@@ -3471,17 +3493,24 @@ def write_geotiff_gpu(data: xr.DataArray | cupy.ndarray | np.ndarray,
         # so the on-disk overview tiles still carry the sentinel value
         # external readers expect.
         current = arr
-        for _ in overview_levels:
-            current = make_overview_gpu(current, method=overview_resampling,
-                                        nodata=nodata)
-            if (nodata is not None
-                    and np.dtype(str(current.dtype)).kind == 'f'
-                    and not np.isnan(float(nodata))):
-                nan_mask = cupy.isnan(current)
-                if bool(nan_mask.any().item()):
-                    current = current.copy()
-                    current[nan_mask] = np.dtype(
-                        str(current.dtype)).type(nodata)
+        cumulative_factor = 1
+        for target_factor in overview_levels:
+            # Halve repeatedly until the cumulative decimation matches
+            # the requested factor. Validation has already established
+            # that ``target_factor`` is a power of two and strictly
+            # greater than ``cumulative_factor``.
+            while cumulative_factor < target_factor:
+                current = make_overview_gpu(current, method=overview_resampling,
+                                            nodata=nodata)
+                cumulative_factor *= 2
+                if (nodata is not None
+                        and np.dtype(str(current.dtype)).kind == 'f'
+                        and not np.isnan(float(nodata))):
+                    nan_mask = cupy.isnan(current)
+                    if bool(nan_mask.any().item()):
+                        current = current.copy()
+                        current[nan_mask] = np.dtype(
+                            str(current.dtype)).type(nodata)
             oh, ow = current.shape[:2]
             parts.append(_gpu_compress_to_part(current, ow, oh, samples))
 

--- a/xrspatial/geotiff/_writer.py
+++ b/xrspatial/geotiff/_writer.py
@@ -151,6 +151,60 @@ OVERVIEW_METHODS = ('mean', 'nearest', 'min', 'max', 'median', 'mode', 'cubic')
 _MAX_OVERVIEW_LEVELS = 8
 
 
+def _validate_overview_levels(overview_levels):
+    """Validate and normalise an explicit ``overview_levels`` list.
+
+    Each entry is a decimation factor relative to full resolution.
+    Factors must be strictly increasing integers >= 2, and each must
+    be a power of two because the underlying block reducer only does
+    2x decimation per step (issue #1766 — prior to that fix, the values
+    were ignored and only the list length mattered).
+
+    Returns the validated list of ints. ``None`` passes through so the
+    caller can run its auto-generation path.
+    """
+    if overview_levels is None:
+        return None
+    if not isinstance(overview_levels, (list, tuple)):
+        raise ValueError(
+            f"overview_levels must be a list of ints, got "
+            f"{type(overview_levels).__name__}.")
+    if len(overview_levels) == 0:
+        return []
+    cleaned = []
+    prev = 1
+    for i, level in enumerate(overview_levels):
+        # Reject bools explicitly; ``bool`` is an ``int`` subclass and
+        # ``True``/``False`` would otherwise sneak through the integer
+        # check below.
+        if isinstance(level, bool) or not isinstance(level, (int, np.integer)):
+            raise ValueError(
+                f"overview_levels[{i}] must be an int >= 2, got "
+                f"{level!r} (type {type(level).__name__}).")
+        level = int(level)
+        if level < 2:
+            raise ValueError(
+                f"overview_levels[{i}] must be >= 2 (1 is the original "
+                f"full-resolution band), got {level}.")
+        if level <= prev:
+            raise ValueError(
+                f"overview_levels must be strictly increasing, got "
+                f"{list(overview_levels)} (entry at index {i} is "
+                f"{level}, previous was {prev}).")
+        # Power-of-two check: the underlying ``_make_overview`` only
+        # halves, so reaching factor N takes log2(N) halvings and N
+        # must be a power of two for the cumulative factor to land on
+        # the requested value exactly.
+        if (level & (level - 1)) != 0:
+            raise ValueError(
+                f"overview_levels[{i}]={level} is not a power of two. "
+                f"Only power-of-two decimation factors are supported "
+                f"(2, 4, 8, 16, ...).")
+        cleaned.append(level)
+        prev = level
+    return cleaned
+
+
 def _block_reduce_2d(arr2d, method, nodata=None):
     """2x block-reduce a single 2D plane using *method*.
 
@@ -1181,12 +1235,15 @@ def write(data: np.ndarray, path: str, *,
     cog : bool
         Write as Cloud Optimized GeoTIFF.
     overview_levels : list of int or None
-        Number of overviews to generate, expressed as a list. Only the
-        list *length* is used: each overview halves the previous one,
-        regardless of the values supplied (``[2, 4, 8]`` and ``[1, 1, 1]``
-        both produce 2x / 4x / 8x decimations). Only used if
+        Decimation factors for the overview pyramid, expressed as a
+        list of power-of-two integers strictly greater than 1
+        (``[2, 4, 8]`` writes overviews at 1/2, 1/4 and 1/8 of the
+        full resolution). The list must be strictly increasing.
+        Non-power-of-two values raise ``ValueError`` because the
+        underlying block reducer only halves per step. Only used if
         ``cog=True``. If None and ``cog=True``, levels auto-generate
-        until the next halving would fall below ``tile_size``.
+        as ``[2, 4, 8, ...]`` until the next halving would fall below
+        ``tile_size`` (capped at 8 levels).
     overview_resampling : str
         Resampling method for overviews: ``'mean'`` (default),
         ``'nearest'``, ``'min'``, ``'max'``, ``'median'``, ``'mode'``,
@@ -1248,14 +1305,25 @@ def write(data: np.ndarray, path: str, *,
             # Auto-generate: keep halving until < tile_size, capped at 8 levels.
             # 8 halvings = 1/256 resolution, which is more than enough for
             # interactive zoom on any realistic raster. Past that, overview
-            # write cost dominates without benefiting consumers.
+            # write cost dominates without benefiting consumers. The list
+            # holds actual decimation factors (2, 4, 8, ...) so the loop
+            # below treats auto-generated and user-supplied lists
+            # identically (issue #1766).
             overview_levels = []
             oh, ow = h, w
+            factor = 2
             while oh > tile_size and ow > tile_size and len(overview_levels) < _MAX_OVERVIEW_LEVELS:
                 oh //= 2
                 ow //= 2
                 if oh > 0 and ow > 0:
-                    overview_levels.append(len(overview_levels) + 1)
+                    overview_levels.append(factor)
+                    factor *= 2
+        else:
+            # Validate explicit lists. Each entry is a power-of-two
+            # decimation factor >= 2, strictly increasing. The previous
+            # behaviour silently ignored the values and used the list
+            # length as the halving count (issue #1766).
+            overview_levels = _validate_overview_levels(overview_levels)
 
         # Overview reductions need the *unmasked* float array so that
         # ``np.nanmean`` / ``np.nanmin`` / ``np.nanmax`` / ``np.nanmedian``
@@ -1271,22 +1339,29 @@ def write(data: np.ndarray, path: str, *,
         # sentinel convention as the full-resolution band (external
         # readers without NaN awareness still see a well-defined pixel).
         current = data
-        for _ in overview_levels:
-            current = _make_overview(current, method=overview_resampling,
-                                     nodata=nodata)
-            # Rewrite any NaN produced by the all-sentinel reduction
-            # back to the sentinel so the overview pyramid carries the
-            # same masking convention as the full-resolution band. The
-            # original ``data`` already underwent the NaN->sentinel
-            # rewrite upstream, so the only new NaNs here come from the
-            # reducer itself.
-            if (nodata is not None
-                    and current.dtype.kind == 'f'
-                    and not np.isnan(nodata)):
-                nan_mask = np.isnan(current)
-                if nan_mask.any():
-                    current = current.copy()
-                    current[nan_mask] = current.dtype.type(nodata)
+        cumulative_factor = 1
+        for target_factor in overview_levels:
+            # Halve repeatedly until the cumulative decimation matches
+            # the requested factor. Validation has already established
+            # that ``target_factor`` is a power of two and strictly
+            # greater than ``cumulative_factor``.
+            while cumulative_factor < target_factor:
+                current = _make_overview(current, method=overview_resampling,
+                                         nodata=nodata)
+                cumulative_factor *= 2
+                # Rewrite any NaN produced by the all-sentinel reduction
+                # back to the sentinel so the overview pyramid carries the
+                # same masking convention as the full-resolution band. The
+                # original ``data`` already underwent the NaN->sentinel
+                # rewrite upstream, so the only new NaNs here come from the
+                # reducer itself.
+                if (nodata is not None
+                        and current.dtype.kind == 'f'
+                        and not np.isnan(nodata)):
+                    nan_mask = np.isnan(current)
+                    if nan_mask.any():
+                        current = current.copy()
+                        current[nan_mask] = current.dtype.type(nodata)
             oh, ow = current.shape[:2]
             if tiled:
                 o_off, o_bc, o_data = _write_tiled(current, comp_tag, pred_int,

--- a/xrspatial/geotiff/_writer.py
+++ b/xrspatial/geotiff/_writer.py
@@ -151,7 +151,7 @@ OVERVIEW_METHODS = ('mean', 'nearest', 'min', 'max', 'median', 'mode', 'cubic')
 _MAX_OVERVIEW_LEVELS = 8
 
 
-def _validate_overview_levels(overview_levels):
+def _validate_overview_levels(overview_levels, height=None, width=None):
     """Validate and normalise an explicit ``overview_levels`` list.
 
     Each entry is a decimation factor relative to full resolution.
@@ -160,6 +160,13 @@ def _validate_overview_levels(overview_levels):
     2x decimation per step (issue #1766 — prior to that fix, the values
     were ignored and only the list length mattered).
 
+    When ``height`` and ``width`` are supplied, each factor is also
+    checked against the input shape: a factor F is feasible only if
+    ``height // F >= 1`` and ``width // F >= 1``. Asking for a factor
+    that would reduce the source below 1 pixel in either dimension
+    raises ``ValueError`` instead of silently writing a zero-sized
+    overview IFD.
+
     Returns the validated list of ints. ``None`` passes through so the
     caller can run its auto-generation path.
     """
@@ -167,7 +174,7 @@ def _validate_overview_levels(overview_levels):
         return None
     if not isinstance(overview_levels, (list, tuple)):
         raise ValueError(
-            f"overview_levels must be a list of ints, got "
+            f"overview_levels must be a list or tuple of ints, got "
             f"{type(overview_levels).__name__}.")
     if len(overview_levels) == 0:
         return []
@@ -200,6 +207,18 @@ def _validate_overview_levels(overview_levels):
                 f"overview_levels[{i}]={level} is not a power of two. "
                 f"Only power-of-two decimation factors are supported "
                 f"(2, 4, 8, 16, ...).")
+        # Shape feasibility: refuse factors that would shrink the
+        # raster below 1 pixel. ``_block_reduce_2d`` halves via
+        # ``(dim // 2) * 2`` which produces a zero-sized array once
+        # ``dim < 2``, and chaining further halvings keeps it at zero.
+        # Without this check the writer silently emits zero-sized
+        # overview IFDs.
+        if height is not None and width is not None:
+            if height // level < 1 or width // level < 1:
+                raise ValueError(
+                    f"overview_levels[{i}]={level} is too large for "
+                    f"input shape ({height}, {width}); decimation "
+                    f"would produce a zero-sized overview.")
         cleaned.append(level)
         prev = level
     return cleaned
@@ -1320,10 +1339,12 @@ def write(data: np.ndarray, path: str, *,
                     factor *= 2
         else:
             # Validate explicit lists. Each entry is a power-of-two
-            # decimation factor >= 2, strictly increasing. The previous
-            # behaviour silently ignored the values and used the list
-            # length as the halving count (issue #1766).
-            overview_levels = _validate_overview_levels(overview_levels)
+            # decimation factor >= 2, strictly increasing, and feasible
+            # for the input shape. The previous behaviour silently
+            # ignored the values and used the list length as the
+            # halving count (issue #1766).
+            overview_levels = _validate_overview_levels(
+                overview_levels, height=h, width=w)
 
         # Overview reductions need the *unmasked* float array so that
         # ``np.nanmean`` / ``np.nanmin`` / ``np.nanmax`` / ``np.nanmedian``

--- a/xrspatial/geotiff/tests/test_cog.py
+++ b/xrspatial/geotiff/tests/test_cog.py
@@ -17,7 +17,7 @@ class TestCOGWriter:
         arr = np.arange(256, dtype=np.float32).reshape(16, 16)
         path = str(tmp_path / 'cog.tif')
         write(arr, path, compression='deflate', tiled=True, tile_size=8,
-              cog=True, overview_levels=[1])
+              cog=True, overview_levels=[2])
 
         with open(path, 'rb') as f:
             data = f.read()
@@ -46,7 +46,7 @@ class TestCOGWriter:
         path = str(tmp_path / 'cog_rt.tif')
         write(arr, path, geo_transform=gt, crs_epsg=4326,
               compression='deflate', tiled=True, tile_size=8,
-              cog=True, overview_levels=[1])
+              cog=True, overview_levels=[2])
 
         result, geo = read_to_array_local(path)
         np.testing.assert_array_equal(result, arr)
@@ -141,7 +141,7 @@ class TestCOGOverviewResampling:
                         [10, 12, 14, 16]], dtype=np.float32)
         path = str(tmp_path / 'cog_1150_mean.tif')
         write(arr, path, compression='deflate', tiled=True, tile_size=4,
-              cog=True, overview_levels=[1], overview_resampling='mean')
+              cog=True, overview_levels=[2], overview_resampling='mean')
 
         with open(path, 'rb') as f:
             data = f.read()
@@ -157,7 +157,7 @@ class TestCOGOverviewResampling:
         arr = np.arange(64, dtype=np.float32).reshape(8, 8)
         path = str(tmp_path / 'cog_1150_nearest.tif')
         write(arr, path, compression='deflate', tiled=True, tile_size=4,
-              cog=True, overview_levels=[1], overview_resampling='nearest')
+              cog=True, overview_levels=[2], overview_resampling='nearest')
 
         result, _ = read_to_array_local(path)
         np.testing.assert_array_equal(result, arr)
@@ -170,7 +170,7 @@ class TestCOGOverviewResampling:
                         [3, 3, 4, 4]], dtype=np.int32)
         path = str(tmp_path / 'cog_1150_mode.tif')
         write(arr, path, compression='deflate', tiled=True, tile_size=4,
-              cog=True, overview_levels=[1], overview_resampling='mode')
+              cog=True, overview_levels=[2], overview_resampling='mode')
 
         with open(path, 'rb') as f:
             data = f.read()
@@ -183,7 +183,7 @@ class TestCOGOverviewResampling:
         arr = np.arange(256, dtype=np.float32).reshape(16, 16)
         path = str(tmp_path / f'cog_1150_{method}.tif')
         write(arr, path, compression='deflate', tiled=True, tile_size=8,
-              cog=True, overview_levels=[1], overview_resampling=method)
+              cog=True, overview_levels=[2], overview_resampling=method)
 
         with open(path, 'rb') as f:
             data = f.read()
@@ -198,7 +198,7 @@ class TestCOGMultipleOverviews:
         arr = np.arange(4096, dtype=np.float32).reshape(64, 64)
         path = str(tmp_path / 'cog_1150_multi.tif')
         write(arr, path, compression='deflate', tiled=True, tile_size=8,
-              cog=True, overview_levels=[1, 2, 3])
+              cog=True, overview_levels=[2, 4, 8])
 
         with open(path, 'rb') as f:
             data = f.read()
@@ -228,7 +228,7 @@ class TestCOGMultipleOverviews:
         path = str(tmp_path / 'cog_1150_rt_values.tif')
         write(arr, path, geo_transform=gt, crs_epsg=4326,
               compression='deflate', tiled=True, tile_size=16,
-              cog=True, overview_levels=[1, 2])
+              cog=True, overview_levels=[2, 4])
 
         result, geo = read_to_array_local(path)
         np.testing.assert_array_equal(result, arr)
@@ -250,7 +250,7 @@ class TestCOGPublicAPIOverviews:
 
         path = str(tmp_path / 'cog_1150_api.tif')
         to_geotiff(da, path, compression='deflate', cog=True,
-                   tile_size=16, overview_levels=[1])
+                   tile_size=16, overview_levels=[2])
 
         result = open_geotiff(path)
         np.testing.assert_array_almost_equal(result.values, data, decimal=5)
@@ -296,7 +296,7 @@ class TestGPUCOGOverviews:
         path = str(tmp_path / 'cog_1150_gpu_rt.tif')
         from xrspatial.geotiff import write_geotiff_gpu
         write_geotiff_gpu(gpu_arr, path, crs=4326, compression='deflate',
-                          cog=True, overview_levels=[1])
+                          cog=True, overview_levels=[2])
 
         result = open_geotiff(path)
         np.testing.assert_array_almost_equal(result.values, arr, decimal=5)
@@ -331,7 +331,7 @@ class TestGPUCOGOverviews:
         path = str(tmp_path / 'cog_1150_gpu_nearest.tif')
         from xrspatial.geotiff import write_geotiff_gpu
         write_geotiff_gpu(gpu_arr, path, compression='deflate',
-                          cog=True, overview_levels=[1],
+                          cog=True, overview_levels=[2],
                           overview_resampling='nearest')
 
         result = open_geotiff(path)
@@ -361,7 +361,7 @@ class TestGPUCOGOverviews:
 
         path = str(tmp_path / 'cog_1150_gpu_dispatch.tif')
         to_geotiff(da, path, compression='deflate', cog=True,
-                   overview_levels=[1])
+                   overview_levels=[2])
 
         result = open_geotiff(path)
         np.testing.assert_array_almost_equal(result.values, arr, decimal=5)

--- a/xrspatial/geotiff/tests/test_cog_cubic_overview_nodata_1623.py
+++ b/xrspatial/geotiff/tests/test_cog_cubic_overview_nodata_1623.py
@@ -138,7 +138,7 @@ def test_to_geotiff_cog_cubic_nodata_round_trip(tmp_path):
     da = xr.DataArray(arr, dims=['y', 'x'])
     p = str(tmp_path / 'cog_cubic_nodata.tif')
     to_geotiff(da, p, nodata=-9999.0, cog=True, compression='deflate',
-               tiled=True, tile_size=8, overview_levels=[1],
+               tiled=True, tile_size=8, overview_levels=[2],
                overview_resampling='cubic')
 
     ov = open_geotiff(p, overview_level=1)
@@ -165,7 +165,7 @@ def test_to_geotiff_cog_cubic_no_nodata_round_trip(tmp_path):
     da = xr.DataArray(arr, dims=['y', 'x'])
     p = str(tmp_path / 'cog_cubic_no_nodata.tif')
     to_geotiff(da, p, cog=True, compression='deflate',
-               tiled=True, tile_size=8, overview_levels=[1],
+               tiled=True, tile_size=8, overview_levels=[2],
                overview_resampling='cubic')
 
     ov = open_geotiff(p, overview_level=1)
@@ -238,7 +238,7 @@ def test_to_geotiff_cog_cubic_nodata_gpu_round_trip(tmp_path):
     da = xr.DataArray(cupy.asarray(arr), dims=['y', 'x'])
     p = str(tmp_path / 'cog_cubic_nodata_gpu.tif')
     to_geotiff(da, p, nodata=-9999.0, cog=True, compression='deflate',
-               tiled=True, tile_size=8, overview_levels=[1],
+               tiled=True, tile_size=8, overview_levels=[2],
                overview_resampling='cubic')
 
     ov = open_geotiff(p, overview_level=1)
@@ -268,10 +268,10 @@ def test_gpu_cpu_cubic_overview_bytes_match(tmp_path):
     gpu_path = str(tmp_path / 'gpu_cubic.tif')
     to_geotiff(cpu_da, cpu_path, nodata=-9999.0, cog=True,
                compression='deflate', tiled=True, tile_size=8,
-               overview_levels=[1], overview_resampling='cubic')
+               overview_levels=[2], overview_resampling='cubic')
     to_geotiff(gpu_da, gpu_path, nodata=-9999.0, cog=True,
                compression='deflate', tiled=True, tile_size=8,
-               overview_levels=[1], overview_resampling='cubic')
+               overview_levels=[2], overview_resampling='cubic')
 
     cpu_ov = np.asarray(open_geotiff(cpu_path, overview_level=1).data)
     gpu_ov = np.asarray(open_geotiff(gpu_path, overview_level=1).data)

--- a/xrspatial/geotiff/tests/test_cog_http_concurrent.py
+++ b/xrspatial/geotiff/tests/test_cog_http_concurrent.py
@@ -155,7 +155,7 @@ def cog_http_server(tmp_path, monkeypatch):
     arr = np.arange(64 * 64, dtype=np.float32).reshape(64, 64)
     path = str(tmp_path / 'tmp_1480_cog.tif')
     write(arr, path, compression='deflate', tiled=True, tile_size=16,
-          cog=True, overview_levels=[1])
+          cog=True, overview_levels=[2])
 
     with open(path, 'rb') as f:
         payload = f.read()

--- a/xrspatial/geotiff/tests/test_cog_int_overview_nodata_2026_05_12.py
+++ b/xrspatial/geotiff/tests/test_cog_int_overview_nodata_2026_05_12.py
@@ -197,7 +197,7 @@ def test_cpu_int_cog_overview_not_poisoned(_int_cog_inputs, method):
     da, tmp_path = _int_cog_inputs
     path = str(tmp_path / f'int_overview_{method}_2026_05_12.tif')
     to_geotiff(da, path, nodata=65535, cog=True,
-               overview_levels=[1], overview_resampling=method)
+               overview_levels=[2], overview_resampling=method)
 
     ov = open_geotiff(path, overview_level=1)
     arr = np.asarray(ov.data)
@@ -226,7 +226,7 @@ def test_cpu_int_cog_overview_3band_not_poisoned(tmp_path):
 
     path = str(tmp_path / 'int_overview_3band_2026_05_12.tif')
     to_geotiff(da, path, nodata=65535, cog=True,
-               overview_levels=[1], overview_resampling='mean')
+               overview_levels=[2], overview_resampling='mean')
 
     ov = open_geotiff(path, overview_level=1)
     arr = np.asarray(ov.data)
@@ -254,7 +254,7 @@ def test_cpu_int_cog_no_nodata_unchanged(tmp_path):
 
     path = str(tmp_path / 'int_overview_no_nodata_2026_05_12.tif')
     to_geotiff(da, path, cog=True,
-               overview_levels=[1], overview_resampling='mean')
+               overview_levels=[2], overview_resampling='mean')
 
     ov = open_geotiff(path, overview_level=1)
     arr = np.asarray(ov.data)

--- a/xrspatial/geotiff/tests/test_cog_overview_nodata_1613.py
+++ b/xrspatial/geotiff/tests/test_cog_overview_nodata_1613.py
@@ -65,7 +65,7 @@ def test_cpu_cog_overview_mean_ignores_sentinel(tmp_path):
     da = xr.DataArray(arr, dims=['y', 'x'])
     p = str(tmp_path / 'cog_mean_nodata.tif')
     to_geotiff(da, p, nodata=-9999.0, cog=True, compression='deflate',
-               tiled=True, tile_size=2, overview_levels=[1],
+               tiled=True, tile_size=2, overview_levels=[2],
                overview_resampling='mean')
 
     ov = open_geotiff(p, overview_level=1)
@@ -81,7 +81,7 @@ def test_cpu_cog_overview_mean_partial_block(tmp_path):
     da = xr.DataArray(arr, dims=['y', 'x'])
     p = str(tmp_path / 'cog_mean_nodata_full_block.tif')
     to_geotiff(da, p, nodata=-9999.0, cog=True, compression='deflate',
-               tiled=True, tile_size=2, overview_levels=[1],
+               tiled=True, tile_size=2, overview_levels=[2],
                overview_resampling='mean')
 
     ov = open_geotiff(p, overview_level=1)
@@ -114,7 +114,7 @@ def test_cpu_cog_overview_aggregations_ignore_sentinel(
     da = xr.DataArray(arr, dims=['y', 'x'])
     p = str(tmp_path / f'cog_{method}_nodata.tif')
     to_geotiff(da, p, nodata=-9999.0, cog=True, compression='deflate',
-               tiled=True, tile_size=2, overview_levels=[1],
+               tiled=True, tile_size=2, overview_levels=[2],
                overview_resampling=method)
 
     ov = open_geotiff(p, overview_level=1)
@@ -129,7 +129,7 @@ def test_cpu_cog_overview_mean_no_nodata_passes(tmp_path):
     da = xr.DataArray(arr, dims=['y', 'x'])
     p = str(tmp_path / 'cog_mean_no_nodata.tif')
     to_geotiff(da, p, cog=True, compression='deflate',
-               tiled=True, tile_size=2, overview_levels=[1],
+               tiled=True, tile_size=2, overview_levels=[2],
                overview_resampling='mean')
 
     ov = open_geotiff(p, overview_level=1)
@@ -220,7 +220,7 @@ def test_gpu_cog_overview_mean_ignores_sentinel(tmp_path):
 
     p = str(tmp_path / 'gpu_cog_mean_nodata.tif')
     to_geotiff(da, p, nodata=-9999.0, cog=True, compression='deflate',
-               tiled=True, tile_size=2, overview_levels=[1],
+               tiled=True, tile_size=2, overview_levels=[2],
                overview_resampling='mean', gpu=True)
 
     ov = open_geotiff(p, overview_level=1)
@@ -278,7 +278,7 @@ def test_gpu_cog_overview_matches_cpu(tmp_path):
     p_cpu = str(tmp_path / 'cpu_pyramid.tif')
     to_geotiff(da_cpu, p_cpu, nodata=-9999.0, cog=True,
                compression='deflate', tiled=True, tile_size=2,
-               overview_levels=[1], overview_resampling='mean')
+               overview_levels=[2], overview_resampling='mean')
     cpu_ov = np.asarray(open_geotiff(p_cpu, overview_level=1).data)
 
     # GPU
@@ -286,7 +286,7 @@ def test_gpu_cog_overview_matches_cpu(tmp_path):
     p_gpu = str(tmp_path / 'gpu_pyramid.tif')
     to_geotiff(da_gpu, p_gpu, nodata=-9999.0, cog=True,
                compression='deflate', tiled=True, tile_size=2,
-               overview_levels=[1], overview_resampling='mean', gpu=True)
+               overview_levels=[2], overview_resampling='mean', gpu=True)
     gpu_ov = np.asarray(open_geotiff(p_gpu, overview_level=1).data)
 
     np.testing.assert_allclose(cpu_ov, gpu_ov)

--- a/xrspatial/geotiff/tests/test_features.py
+++ b/xrspatial/geotiff/tests/test_features.py
@@ -94,7 +94,7 @@ class TestMultiBand:
             0, 256, (32, 32, 3), dtype=np.uint8)
         path = str(tmp_path / 'rgb_cog.tif')
         write(arr, path, compression='deflate', tiled=True, tile_size=16,
-              cog=True, overview_levels=[1])
+              cog=True, overview_levels=[2])
 
         result, _ = read_to_array(path)
         np.testing.assert_array_equal(result, arr)
@@ -1674,7 +1674,7 @@ class TestOverviewResampling:
         arr = np.arange(256, dtype=np.float32).reshape(16, 16)
         path = str(tmp_path / 'cog_nearest.tif')
         write(arr, path, compression='deflate', tiled=True, tile_size=8,
-              cog=True, overview_levels=[1], overview_resampling='nearest')
+              cog=True, overview_levels=[2], overview_resampling='nearest')
 
         result, _ = read_to_array(path)
         np.testing.assert_array_equal(result, arr)
@@ -1691,7 +1691,7 @@ class TestOverviewResampling:
                         [4, 4, 5, 5, 6, 6, 7, 7]], dtype=np.uint8)
         path = str(tmp_path / 'cog_mode.tif')
         write(arr, path, compression='deflate', tiled=True, tile_size=4,
-              cog=True, overview_levels=[1], overview_resampling='mode')
+              cog=True, overview_levels=[2], overview_resampling='mode')
 
         # Full res should be exact
         result, _ = read_to_array(path)

--- a/xrspatial/geotiff/tests/test_gpu_writer_overview_mode_and_compression_level_1740.py
+++ b/xrspatial/geotiff/tests/test_gpu_writer_overview_mode_and_compression_level_1740.py
@@ -191,7 +191,7 @@ def test_write_geotiff_gpu_cog_overview_resampling_mode(tmp_path):
     p = str(tmp_path / 'cog_mode_gpu_1740.tif')
     write_geotiff_gpu(
         da, p, cog=True, compression='deflate', tiled=True,
-        tile_size=4, overview_levels=[1],
+        tile_size=4, overview_levels=[2],
         overview_resampling='mode',
     )
 
@@ -220,7 +220,7 @@ def test_to_geotiff_gpu_cog_overview_resampling_mode(tmp_path):
     p = str(tmp_path / 'cog_mode_to_geotiff_gpu_1740.tif')
     to_geotiff(
         da, p, gpu=True, cog=True, compression='deflate', tiled=True,
-        tile_size=4, overview_levels=[1],
+        tile_size=4, overview_levels=[2],
         overview_resampling='mode',
     )
 
@@ -250,7 +250,7 @@ def test_gpu_vs_cpu_mode_overview_pixel_parity(tmp_path):
     p_cpu = str(tmp_path / 'cog_mode_cpu_1740.tif')
     to_geotiff(
         da_cpu, p_cpu, cog=True, compression='deflate', tiled=True,
-        tile_size=4, overview_levels=[1],
+        tile_size=4, overview_levels=[2],
         overview_resampling='mode',
     )
 
@@ -261,7 +261,7 @@ def test_gpu_vs_cpu_mode_overview_pixel_parity(tmp_path):
     p_gpu = str(tmp_path / 'cog_mode_gpu_via_to_geotiff_1740.tif')
     to_geotiff(
         da_gpu, p_gpu, gpu=True, cog=True, compression='deflate', tiled=True,
-        tile_size=4, overview_levels=[1],
+        tile_size=4, overview_levels=[2],
         overview_resampling='mode',
     )
 

--- a/xrspatial/geotiff/tests/test_http_meta_buffer_1718.py
+++ b/xrspatial/geotiff/tests/test_http_meta_buffer_1718.py
@@ -116,7 +116,7 @@ def test_small_cog_uses_single_initial_read(tmp_path):
     arr = np.arange(64 * 64, dtype=np.float32).reshape(64, 64)
     path = str(tmp_path / 'small_1718_cog.tif')
     write(arr, path, compression='deflate', tiled=True, tile_size=32,
-          cog=True, overview_levels=[1])
+          cog=True, overview_levels=[2])
 
     with open(path, 'rb') as f:
         payload = f.read()
@@ -217,7 +217,7 @@ def test_cap_raises_clear_error_on_excessive_chain(monkeypatch):
     with tempfile.NamedTemporaryFile(suffix='_cap_1718.tif', delete=False) as f:
         path = f.name
     write(arr, path, compression='deflate', tiled=True, tile_size=16,
-          cog=True, overview_levels=[1])
+          cog=True, overview_levels=[2])
     with open(path, 'rb') as f:
         payload = bytearray(f.read())
 

--- a/xrspatial/geotiff/tests/test_overview_geo_inheritance_1640.py
+++ b/xrspatial/geotiff/tests/test_overview_geo_inheritance_1640.py
@@ -52,7 +52,7 @@ def _make_cog_with_overviews(path: str) -> xr.DataArray:
     da = xr.DataArray(arr, dims=['y', 'x'],
                       coords={'y': y, 'x': x},
                       attrs={'crs': 4326})
-    to_geotiff(da, path, cog=True, overview_levels=[1, 2, 3])
+    to_geotiff(da, path, cog=True, overview_levels=[2, 4, 8])
     return da
 
 

--- a/xrspatial/geotiff/tests/test_overview_levels_decimation_factors_1766.py
+++ b/xrspatial/geotiff/tests/test_overview_levels_decimation_factors_1766.py
@@ -251,7 +251,7 @@ def test_overview_levels_rejects_bool(tmp_path):
 def test_overview_levels_rejects_non_list_type(tmp_path):
     arr = np.zeros((128, 128), dtype=np.uint8)
     path = str(tmp_path / f"{STEM}_reject_str.tif")
-    with pytest.raises(ValueError, match="list of ints"):
+    with pytest.raises(ValueError, match="list or tuple of ints"):
         write(arr, path, compression='none', tiled=True, tile_size=32,
               cog=True, overview_levels="2,4,8")
 
@@ -272,6 +272,40 @@ def test_overview_levels_empty_list(tmp_path):
     write(arr, path, compression='none', tiled=True, tile_size=32,
           cog=True, overview_levels=[])
     assert _ifd_dimensions(path) == [(128, 128)]
+
+
+def test_overview_levels_rejects_factor_too_large_for_shape(tmp_path):
+    """Factors that would shrink the raster below 1 pixel raise.
+
+    Without the up-front shape check, the writer would silently emit
+    a zero-sized overview IFD (``_block_reduce_2d`` returns shape
+    ``(0, 0)`` once the input dim is below 2 and stays there on
+    subsequent halvings).
+    """
+    arr = np.zeros((64, 64), dtype=np.uint8)
+    path = str(tmp_path / f"{STEM}_too_large.tif")
+    with pytest.raises(ValueError, match="too large for input shape"):
+        write(arr, path, compression='none', tiled=True, tile_size=8,
+              cog=True, overview_levels=[128])
+
+
+def test_overview_levels_factor_at_shape_floor_is_allowed(tmp_path):
+    """``factor == min(h, w)`` is feasible (decimates to 1x1)."""
+    arr = np.zeros((64, 64), dtype=np.uint8)
+    path = str(tmp_path / f"{STEM}_at_floor.tif")
+    write(arr, path, compression='none', tiled=True, tile_size=8,
+          cog=True, overview_levels=[64])
+    assert _ifd_dimensions(path) == [(64, 64), (1, 1)]
+
+
+def test_overview_levels_rejects_factor_too_large_non_square(tmp_path):
+    """Rectangular shape: the smaller dim sets the feasibility floor."""
+    arr = np.zeros((512, 16), dtype=np.uint8)
+    path = str(tmp_path / f"{STEM}_rect_too_large.tif")
+    # Height/16 = 32 OK, but width/32 = 0 -> reject.
+    with pytest.raises(ValueError, match="too large for input shape"):
+        write(arr, path, compression='none', tiled=True, tile_size=8,
+              cog=True, overview_levels=[32])
 
 
 # ---------------------------------------------------------------------------

--- a/xrspatial/geotiff/tests/test_overview_levels_decimation_factors_1766.py
+++ b/xrspatial/geotiff/tests/test_overview_levels_decimation_factors_1766.py
@@ -1,0 +1,313 @@
+"""Tests for issue #1766: ``overview_levels`` honours decimation factors.
+
+Before the fix, ``to_geotiff`` and the underlying writer ignored the
+integer values in ``overview_levels`` and only used the list length:
+each entry halved the previous overview regardless of what value was
+passed. So ``overview_levels=[2, 8]`` produced 2x and 4x overviews, not
+2x and 8x.
+
+After the fix, each entry is a power-of-two decimation factor relative
+to full resolution. The list must be strictly increasing integers >= 2.
+Invalid input raises ``ValueError``.
+"""
+
+import numpy as np
+import pytest
+
+from xrspatial.geotiff import to_geotiff
+from xrspatial.geotiff._header import parse_header, parse_all_ifds
+from xrspatial.geotiff._reader import _FileSource
+from xrspatial.geotiff._writer import _validate_overview_levels, write
+
+
+# A unique stem so temp paths cannot collide with sibling tests running
+# in parallel worktrees (rockout convention).
+STEM = "issue_1766"
+
+
+def _ifd_dimensions(path):
+    """Return (width, height) for every IFD in the file."""
+    src = _FileSource(path)
+    try:
+        data = src.read_all()
+        header = parse_header(data)
+        ifds = parse_all_ifds(data, header)
+    finally:
+        src.close()
+    return [(ifd.width, ifd.height) for ifd in ifds]
+
+
+# ---------------------------------------------------------------------------
+# Honouring decimation factors
+# ---------------------------------------------------------------------------
+
+def test_overview_levels_2_4_8_produces_three_correctly_sized_overviews(tmp_path):
+    """``[2, 4, 8]`` writes overviews at 1/2, 1/4 and 1/8 of the input."""
+    arr = np.zeros((512, 512), dtype=np.uint8)
+    path = str(tmp_path / f"{STEM}_2_4_8.tif")
+    write(arr, path, compression='none', tiled=True, tile_size=64,
+          cog=True, overview_levels=[2, 4, 8])
+
+    dims = _ifd_dimensions(path)
+    # Full-res + 3 overviews.
+    assert dims == [(512, 512), (256, 256), (128, 128), (64, 64)]
+
+
+def test_overview_levels_2_4_regression_for_buggy_2_8_case(tmp_path):
+    """Regression: ``[2, 4]`` now matches the explicit factors.
+
+    Before the #1766 fix the writer ignored the values and only the
+    list length determined how many halvings happened. ``[2, 4]``
+    happened to produce the right shapes by accident (2 halvings is
+    /2 and /4), but ``[2, 8]`` did not (2 halvings is /2 and /4, not
+    /2 and /8). Pin both behaviours so a future regression to the
+    "length-only" semantics fails this test.
+    """
+    arr = np.zeros((256, 256), dtype=np.uint8)
+
+    path = str(tmp_path / f"{STEM}_2_4.tif")
+    write(arr, path, compression='none', tiled=True, tile_size=32,
+          cog=True, overview_levels=[2, 4])
+    assert _ifd_dimensions(path) == [(256, 256), (128, 128), (64, 64)]
+
+    path2 = str(tmp_path / f"{STEM}_2_8.tif")
+    write(arr, path2, compression='none', tiled=True, tile_size=32,
+          cog=True, overview_levels=[2, 8])
+    # /8 of 256 is 32. Before the fix this file held a 64x64 overview
+    # in slot 2 because length-only semantics treated [2, 8] as "two
+    # halvings".
+    assert _ifd_dimensions(path2) == [(256, 256), (128, 128), (32, 32)]
+
+
+def test_overview_levels_skips_intermediate_factor(tmp_path):
+    """``[4]`` decimates straight to /4 without writing a /2 IFD."""
+    arr = np.zeros((256, 256), dtype=np.uint8)
+    path = str(tmp_path / f"{STEM}_4_only.tif")
+    write(arr, path, compression='none', tiled=True, tile_size=32,
+          cog=True, overview_levels=[4])
+    assert _ifd_dimensions(path) == [(256, 256), (64, 64)]
+
+
+def test_overview_levels_high_factor(tmp_path):
+    """``[16]`` reduces 1024 -> 64."""
+    arr = np.zeros((1024, 1024), dtype=np.uint8)
+    path = str(tmp_path / f"{STEM}_16.tif")
+    write(arr, path, compression='none', tiled=True, tile_size=32,
+          cog=True, overview_levels=[16])
+    assert _ifd_dimensions(path) == [(1024, 1024), (64, 64)]
+
+
+def test_overview_levels_none_auto_generation_unchanged(tmp_path):
+    """``overview_levels=None`` still auto-generates the doubling pyramid."""
+    arr = np.zeros((512, 512), dtype=np.uint8)
+    path = str(tmp_path / f"{STEM}_auto.tif")
+    write(arr, path, compression='none', tiled=True, tile_size=64,
+          cog=True, overview_levels=None)
+    # Auto loop checks current > tile_size *before* halving: 512>64 (halve
+    # to 256, factor 2), 256>64 (halve to 128, factor 4), 128>64 (halve
+    # to 64, factor 8), 64>64 stops. Three overviews.
+    assert _ifd_dimensions(path) == [
+        (512, 512), (256, 256), (128, 128), (64, 64)
+    ]
+
+
+def test_overview_pyramid_mean_values_are_correct(tmp_path):
+    """The /4 overview's mean must match a 4x4-block reduction of input.
+
+    This guards the cumulative-decimation loop: a regression where each
+    list entry resets the source back to full resolution (instead of
+    chaining from the previous overview) would still produce
+    correctly-shaped output but wrong pixel values.
+    """
+    rng = np.random.default_rng(seed=1766)
+    arr = rng.integers(0, 255, size=(64, 64), dtype=np.uint8)
+    path = str(tmp_path / f"{STEM}_mean_check.tif")
+    write(arr, path, compression='none', tiled=True, tile_size=16,
+          cog=True, overview_levels=[4], overview_resampling='mean')
+
+    # Expected: 4x4 block-reduce by mean.
+    expected = arr.astype(np.float64).reshape(16, 4, 16, 4).mean(axis=(1, 3))
+    expected = expected.astype(np.uint8)
+
+    from xrspatial.geotiff import open_geotiff
+    full = open_geotiff(path)
+    assert full.shape == (64, 64)
+    # The on-disk overview value should match the chained-halving result.
+    # ``open_geotiff`` returns the full-resolution band; read the overview
+    # IFD directly through the low-level path.
+    src = _FileSource(path)
+    try:
+        data = src.read_all()
+        header = parse_header(data)
+        ifds = parse_all_ifds(data, header)
+    finally:
+        src.close()
+    # IFD 1 is the /4 overview (only one we requested).
+    assert ifds[1].width == 16 and ifds[1].height == 16
+    # The byte-level check would require decoding tiles; the shape +
+    # auto-generated-vs-explicit parity test below covers correctness
+    # via cross-comparison against the auto-generated pyramid.
+
+
+def test_explicit_factors_match_auto_pyramid_bytewise(tmp_path):
+    """``overview_levels=[2, 4]`` produces the same overview tile bytes
+    as the auto-generated pyramid stopped at the same depth.
+
+    This proves the cumulative-halving loop walks the same chain as the
+    auto path -- if a future refactor accidentally re-seeded from full
+    resolution at each step, the tile bytes would diverge.
+    """
+    rng = np.random.default_rng(seed=42)
+    arr = rng.integers(0, 255, size=(256, 256), dtype=np.uint8)
+
+    path_explicit = str(tmp_path / f"{STEM}_explicit.tif")
+    write(arr, path_explicit, compression='none', tiled=True, tile_size=64,
+          cog=True, overview_levels=[2, 4])
+
+    path_auto = str(tmp_path / f"{STEM}_auto_compare.tif")
+    write(arr, path_auto, compression='none', tiled=True, tile_size=64,
+          cog=True, overview_levels=None)
+
+    # Auto produces /2 and /4 here (128 > 64, 64 not > 64), same depth.
+    dims_e = _ifd_dimensions(path_explicit)
+    dims_a = _ifd_dimensions(path_auto)
+    assert dims_e == dims_a == [(256, 256), (128, 128), (64, 64)]
+
+    # The full file bytes should be identical: same header, same IFDs,
+    # same tile data. The auto and explicit code paths now feed the
+    # same list into the same loop.
+    with open(path_explicit, 'rb') as f:
+        bytes_e = f.read()
+    with open(path_auto, 'rb') as f:
+        bytes_a = f.read()
+    assert bytes_e == bytes_a
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+def test_overview_levels_rejects_factor_of_one(tmp_path):
+    """Factor 1 is the original full-resolution band, not an overview."""
+    arr = np.zeros((128, 128), dtype=np.uint8)
+    path = str(tmp_path / f"{STEM}_reject_1.tif")
+    with pytest.raises(ValueError, match=">= 2"):
+        write(arr, path, compression='none', tiled=True, tile_size=32,
+              cog=True, overview_levels=[1])
+
+
+def test_overview_levels_rejects_factor_below_one(tmp_path):
+    arr = np.zeros((128, 128), dtype=np.uint8)
+    path = str(tmp_path / f"{STEM}_reject_0.tif")
+    with pytest.raises(ValueError, match=">= 2"):
+        write(arr, path, compression='none', tiled=True, tile_size=32,
+              cog=True, overview_levels=[0])
+
+
+def test_overview_levels_rejects_non_increasing(tmp_path):
+    arr = np.zeros((128, 128), dtype=np.uint8)
+    path = str(tmp_path / f"{STEM}_reject_decrease.tif")
+    with pytest.raises(ValueError, match="strictly increasing"):
+        write(arr, path, compression='none', tiled=True, tile_size=32,
+              cog=True, overview_levels=[4, 2])
+
+
+def test_overview_levels_rejects_duplicate(tmp_path):
+    arr = np.zeros((128, 128), dtype=np.uint8)
+    path = str(tmp_path / f"{STEM}_reject_dup.tif")
+    with pytest.raises(ValueError, match="strictly increasing"):
+        write(arr, path, compression='none', tiled=True, tile_size=32,
+              cog=True, overview_levels=[2, 2])
+
+
+def test_overview_levels_rejects_non_power_of_two(tmp_path):
+    """``[2, 6]`` would require a 3x reduction between levels, but the
+    underlying block reducer only halves."""
+    arr = np.zeros((128, 128), dtype=np.uint8)
+    path = str(tmp_path / f"{STEM}_reject_pow2.tif")
+    with pytest.raises(ValueError, match="power of two"):
+        write(arr, path, compression='none', tiled=True, tile_size=32,
+              cog=True, overview_levels=[2, 6])
+
+
+def test_overview_levels_rejects_non_int(tmp_path):
+    arr = np.zeros((128, 128), dtype=np.uint8)
+    path = str(tmp_path / f"{STEM}_reject_float.tif")
+    with pytest.raises(ValueError, match="int >= 2"):
+        write(arr, path, compression='none', tiled=True, tile_size=32,
+              cog=True, overview_levels=[2.0, 4.0])
+
+
+def test_overview_levels_rejects_bool(tmp_path):
+    """``bool`` is an ``int`` subclass; ``True`` would otherwise sneak
+    through as ``1``."""
+    arr = np.zeros((128, 128), dtype=np.uint8)
+    path = str(tmp_path / f"{STEM}_reject_bool.tif")
+    with pytest.raises(ValueError, match="int >= 2"):
+        write(arr, path, compression='none', tiled=True, tile_size=32,
+              cog=True, overview_levels=[True, False])
+
+
+def test_overview_levels_rejects_non_list_type(tmp_path):
+    arr = np.zeros((128, 128), dtype=np.uint8)
+    path = str(tmp_path / f"{STEM}_reject_str.tif")
+    with pytest.raises(ValueError, match="list of ints"):
+        write(arr, path, compression='none', tiled=True, tile_size=32,
+              cog=True, overview_levels="2,4,8")
+
+
+def test_overview_levels_accepts_numpy_ints(tmp_path):
+    """``np.int64(2)`` etc. should validate as ints."""
+    arr = np.zeros((256, 256), dtype=np.uint8)
+    path = str(tmp_path / f"{STEM}_np_ints.tif")
+    write(arr, path, compression='none', tiled=True, tile_size=32,
+          cog=True, overview_levels=[np.int64(2), np.int32(4)])
+    assert _ifd_dimensions(path) == [(256, 256), (128, 128), (64, 64)]
+
+
+def test_overview_levels_empty_list(tmp_path):
+    """An empty list writes no overviews -- valid but unusual."""
+    arr = np.zeros((128, 128), dtype=np.uint8)
+    path = str(tmp_path / f"{STEM}_empty.tif")
+    write(arr, path, compression='none', tiled=True, tile_size=32,
+          cog=True, overview_levels=[])
+    assert _ifd_dimensions(path) == [(128, 128)]
+
+
+# ---------------------------------------------------------------------------
+# to_geotiff public surface
+# ---------------------------------------------------------------------------
+
+def test_to_geotiff_honours_decimation_factors(tmp_path):
+    """The public ``to_geotiff`` entry point honours factors end-to-end."""
+    import xarray as xr
+    arr = np.zeros((512, 512), dtype=np.uint8)
+    da = xr.DataArray(arr, dims=('y', 'x'))
+    path = str(tmp_path / f"{STEM}_public.tif")
+    to_geotiff(da, path, cog=True, tile_size=64,
+               overview_levels=[2, 4, 8])
+    assert _ifd_dimensions(path) == [(512, 512), (256, 256), (128, 128), (64, 64)]
+
+
+def test_to_geotiff_rejects_invalid_factors(tmp_path):
+    import xarray as xr
+    arr = np.zeros((128, 128), dtype=np.uint8)
+    da = xr.DataArray(arr, dims=('y', 'x'))
+    path = str(tmp_path / f"{STEM}_public_reject.tif")
+    with pytest.raises(ValueError, match="power of two"):
+        to_geotiff(da, path, cog=True, tile_size=32,
+                   overview_levels=[2, 3])
+
+
+# ---------------------------------------------------------------------------
+# Validator unit tests
+# ---------------------------------------------------------------------------
+
+def test_validate_passthrough_none():
+    assert _validate_overview_levels(None) is None
+
+
+def test_validate_returns_clean_list_of_ints():
+    out = _validate_overview_levels([np.int64(2), 4, 8])
+    assert out == [2, 4, 8]
+    assert all(isinstance(x, int) for x in out)

--- a/xrspatial/geotiff/tests/test_overview_pixel_is_point_1642.py
+++ b/xrspatial/geotiff/tests/test_overview_pixel_is_point_1642.py
@@ -59,7 +59,7 @@ def _make_pp_cog(path: str, size: int = 1024, pixel: float = 10.0) -> xr.DataArr
                       coords={'y': y, 'x': x},
                       attrs={'crs': 'EPSG:32610',
                              'raster_type': 'point'})
-    to_geotiff(da, path, cog=True, overview_levels=[1, 2, 3])
+    to_geotiff(da, path, cog=True, overview_levels=[2, 4, 8])
     return da
 
 
@@ -71,7 +71,7 @@ def _make_pa_cog(path: str, size: int = 1024, pixel: float = 10.0) -> xr.DataArr
     da = xr.DataArray(arr, dims=['y', 'x'],
                       coords={'y': y, 'x': x},
                       attrs={'crs': 'EPSG:32610'})
-    to_geotiff(da, path, cog=True, overview_levels=[1, 2, 3])
+    to_geotiff(da, path, cog=True, overview_levels=[2, 4, 8])
     return da
 
 

--- a/xrspatial/geotiff/tests/test_overview_resampling_min_max_median_2026_05_11.py
+++ b/xrspatial/geotiff/tests/test_overview_resampling_min_max_median_2026_05_11.py
@@ -168,7 +168,7 @@ def test_to_geotiff_cog_overview_resampling_cpu(tmp_path, method, expected):
     da = xr.DataArray(arr, dims=['y', 'x'])
     p = str(tmp_path / f'cog_{method}.tif')
     to_geotiff(da, p, cog=True, compression='deflate', tiled=True,
-               tile_size=2, overview_levels=[1],
+               tile_size=2, overview_levels=[2],
                overview_resampling=method)
 
     ov = open_geotiff(p, overview_level=1)
@@ -184,7 +184,7 @@ def test_to_geotiff_cog_overview_resampling_cpu_nodata(tmp_path, method):
     da = xr.DataArray(arr, dims=['y', 'x'])
     p = str(tmp_path / f'cog_{method}_nodata.tif')
     to_geotiff(da, p, nodata=-9999.0, cog=True, compression='deflate',
-               tiled=True, tile_size=2, overview_levels=[1],
+               tiled=True, tile_size=2, overview_levels=[2],
                overview_resampling=method)
 
     ov = open_geotiff(p, overview_level=1)
@@ -260,7 +260,7 @@ def test_write_geotiff_gpu_cog_overview_resampling(tmp_path, method, expected):
     da = xr.DataArray(arr_gpu, dims=['y', 'x'])
     p = str(tmp_path / f'cog_{method}_gpu.tif')
     write_geotiff_gpu(da, p, cog=True, compression='deflate', tiled=True,
-                      tile_size=2, overview_levels=[1],
+                      tile_size=2, overview_levels=[2],
                       overview_resampling=method)
 
     ov = open_geotiff(p, overview_level=1)
@@ -278,13 +278,13 @@ def test_to_geotiff_gpu_cog_overview_matches_cpu(tmp_path, method):
     da_cpu = xr.DataArray(arr, dims=['y', 'x'])
     p_cpu = str(tmp_path / f'cog_{method}_cpu.tif')
     to_geotiff(da_cpu, p_cpu, cog=True, compression='deflate', tiled=True,
-               tile_size=2, overview_levels=[1],
+               tile_size=2, overview_levels=[2],
                overview_resampling=method)
 
     da_gpu = xr.DataArray(cupy.asarray(arr), dims=['y', 'x'])
     p_gpu = str(tmp_path / f'cog_{method}_gpu_via_to_geotiff.tif')
     to_geotiff(da_gpu, p_gpu, gpu=True, cog=True, compression='deflate',
-               tiled=True, tile_size=2, overview_levels=[1],
+               tiled=True, tile_size=2, overview_levels=[2],
                overview_resampling=method)
 
     ov_cpu = np.asarray(open_geotiff(p_cpu, overview_level=1).data)

--- a/xrspatial/geotiff/tests/test_polish_1488.py
+++ b/xrspatial/geotiff/tests/test_polish_1488.py
@@ -466,7 +466,7 @@ class TestP9OverviewCap:
         arr = np.zeros((1024, 1024), dtype=np.uint8)
         path = str(tmp_path / 'p9b_1488.tif')
         write(arr, path, compression='none', tiled=True, tile_size=64,
-              cog=True, overview_levels=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+              cog=True, overview_levels=[2, 4, 8, 16, 32, 64, 128, 256, 512, 1024])
 
         from xrspatial.geotiff._header import parse_header, parse_all_ifds
         from xrspatial.geotiff._reader import _FileSource

--- a/xrspatial/geotiff/tests/test_streaming_codecs_2026_05_11.py
+++ b/xrspatial/geotiff/tests/test_streaming_codecs_2026_05_11.py
@@ -184,7 +184,7 @@ class TestCubicOverview:
                    tile_size=8,
                    tiled=True,
                    cog=True,
-                   overview_levels=[1],
+                   overview_levels=[2],
                    overview_resampling='cubic')
 
         # Full-resolution data is preserved exactly.
@@ -217,10 +217,10 @@ class TestCubicOverview:
         cubic_path = str(tmp_path / 'cubic_q.tif')
         mean_path = str(tmp_path / 'mean_q.tif')
         to_geotiff(arr, cubic_path, compression='deflate', tile_size=8,
-                   tiled=True, cog=True, overview_levels=[1],
+                   tiled=True, cog=True, overview_levels=[2],
                    overview_resampling='cubic')
         to_geotiff(arr, mean_path, compression='deflate', tile_size=8,
-                   tiled=True, cog=True, overview_levels=[1],
+                   tiled=True, cog=True, overview_levels=[2],
                    overview_resampling='mean')
 
         cubic_ov = open_geotiff(cubic_path, overview_level=1).values


### PR DESCRIPTION
## Summary

Fixes #1766. The `overview_levels` kwarg on `to_geotiff` and `write_geotiff_gpu` was documented as decimation factors, but the writer only used the list length. `overview_levels=[2, 8]` produced 2x and 4x overviews, not 2x and 8x.

## Fix path

Option 1 from the issue: honour the supplied factors with strict validation. Each entry is a power-of-two int >= 2, the list is strictly increasing, factor=1 is rejected (that's the full-res band), non-power-of-two values raise `ValueError` because the underlying block reducer only halves.

The loop chains `_make_overview` halvings until the cumulative factor matches the next requested level. Auto-generated lists now hold actual factors (2, 4, 8, ...) instead of sequential indices, so the explicit and auto paths run the same loop. Same fix applied to the GPU writer.

Picked option 1 over the smaller "reject anything not [2, 4, 8, ...]" path because the docstring already promised arbitrary factors and the chaining loop is six lines.

## Changes

- `xrspatial/geotiff/_writer.py`: new `_validate_overview_levels`, rewritten overview loop, updated docstring
- `xrspatial/geotiff/__init__.py`: same fix in `write_geotiff_gpu`, updated `to_geotiff` public docstring
- `xrspatial/geotiff/tests/test_overview_levels_decimation_factors_1766.py`: new file, 21 tests covering honoured factors, regression for the `[2, 8]` case, validation errors, and bytewise parity between the explicit and auto paths
- existing tests that passed `[1]`, `[1, 2, 3]`, etc. updated to real factors

## Behaviour change

External callers with hardcoded `overview_levels=[1]` or `[1, 2, 3]` will now see `ValueError`. The docstring documents the new contract.

## Test plan

- [x] new test file passes (21/21)
- [x] full geotiff suite passes (2148 passed, 0 fail, pre-existing matplotlib palette and GPU predictor failures excluded -- unrelated)