### PR TITLE
fix(test): avoid 4 GB list allocation in BigTIFF threshold test

### DIFF
--- a/xrspatial/tests/test_geotiff_streaming_bigtiff_threshold_1785.py
+++ b/xrspatial/tests/test_geotiff_streaming_bigtiff_threshold_1785.py
@@ -141,17 +141,18 @@ class TestShouldUseBigTIFFStreaming:
     def test_large_strip_table_alone_can_promote(self):
         """Even a small pixel payload can need BigTIFF if n_entries is huge.
 
-        This documents the strip-table contribution: ~536 M entries puts
-        the table itself near 4 GiB. Not realistic in practice, but it
-        proves the overhead is wired through.
+        Documents the strip-table contribution: ~536 M entries puts the
+        table itself near 4 GiB and forces BigTIFF with no pixel data.
+        Driven through the ``n_entries`` parameter (8 bytes per entry)
+        to avoid allocating a 536 M-element Python list at test time;
+        the ``ifd_overhead_bytes`` path is exercised by
+        ``test_overhead_pushes_just_under_threshold_over``.
         """
         n_entries = (UINT32_MAX // 8) + 1
-        tags = _minimal_tag_list(n_entries=n_entries)
-        overhead = _compute_classic_ifd_overhead(tags)
         assert _should_use_bigtiff_streaming(
             uncompressed_bytes=0,
-            n_entries=0,
-            ifd_overhead_bytes=overhead,
+            n_entries=n_entries,
+            ifd_overhead_bytes=0,
         ) is True
 
     def test_overhead_pushes_just_under_threshold_over(self):


### PR DESCRIPTION
## Summary

CI on `main` has been failing since PR #1787 merged. The newly added
`test_large_strip_table_alone_can_promote` allocated a Python list of
`(UINT32_MAX // 8) + 1` (~536 M) zeros before `_compute_classic_ifd_overhead`
was even called. On GitHub-hosted ubuntu runners (~7 GB RAM) this
OOM-killed the pytest worker with exit code 143, and fail-fast cancelled
every other matrix job.

## Fix

Drive the same "huge strip table alone forces BigTIFF" assertion through
the `n_entries` parameter of `_should_use_bigtiff_streaming` (8 bytes per
entry, no list allocation). The `_compute_classic_ifd_overhead` wiring
is already covered by `test_overhead_pushes_just_under_threshold_over`
and `test_large_gdal_metadata_flips_decision`.

## Evidence

Before: `xrspatial/tests/test_geotiff_streaming_bigtiff_threshold_1785.py ....`
then `##[error]Process completed with exit code 143.` ([run 25807252057](https://github.com/xarray-contrib/xarray-spatial/actions/runs/25807252057)).

After (local):
```
10 passed in 0.23s
```

## Test plan
- [x] Whole file runs in 0.23s locally
- [ ] Full pytest matrix on this branch passes in CI