### PR TITLE
README: link awesome-spectral-indices and spyndex from multispectral section

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,8 @@ Same-CRS tiles skip reprojection entirely and are placed by direct coordinate al
 | [Structure Insensitive Pigment Index (SIPI)](xrspatial/multispectral.py) | Estimates carotenoid-to-chlorophyll ratio for plant stress detection | Penuelas et al. 1995 | ✅️ |✅️ | ✅️ |✅️ |
 | [True Color](xrspatial/multispectral.py) | Composites red, green, and blue bands into a natural color image | Standard | ✅️ | ✅️ | ✅️ | ✅️ |
 
+For a broader catalog of spectral indices and sensor-specific band combinations, see [awesome-spectral-indices](https://github.com/awesome-spectral-indices/awesome-spectral-indices) and its companion xarray library [spyndex](https://github.com/awesome-spectral-indices/spyndex).
+
 -------
 
 


### PR DESCRIPTION
## Summary
- Adds a one-line pointer below the Multispectral feature matrix to [awesome-spectral-indices](https://github.com/awesome-spectral-indices/awesome-spectral-indices) and its xarray companion [spyndex](https://github.com/awesome-spectral-indices/spyndex) for users wanting a broader catalog of indices and sensor-specific band combinations.

## Test plan
- [x] Visual check that the new line renders correctly after the multispectral table and before the divider.

fixes #1828 