### PR TITLE
geotiff: drop decorative post-write header check in writer

### DIFF
--- a/xrspatial/geotiff/_writer.py
+++ b/xrspatial/geotiff/_writer.py
@@ -1693,14 +1693,6 @@ def write(data: np.ndarray, path: str, *,
 
     _write_bytes(file_bytes, path)
 
-    # Post-write validation: verify the header is parseable
-    from ._header import parse_header as _ph
-    try:
-        _ph(file_bytes[:16])
-    except Exception as e:
-        import warnings
-        warnings.warn(f"Written file may be corrupt: {e}", stacklevel=2)
-
 
 def _compress_block(arr, block_w, block_h, samples, dtype, bytes_per_sample,
                     predictor: int, compression, compression_level=None,
@@ -2289,16 +2281,6 @@ def write_streaming(dask_data, path: str, *,
                 patched_tags, overflow_base, bigtiff=use_bigtiff)
             f.write(ifd_bytes)
             f.write(overflow_bytes)
-
-        # Post-write validation
-        from ._header import parse_header as _ph
-        with open(tmp_path, 'rb') as f:
-            try:
-                _ph(f.read(16))
-            except Exception as e:
-                import warnings
-                warnings.warn(
-                    f"Written file may be corrupt: {e}", stacklevel=2)
 
         os.replace(tmp_path, path)
     except BaseException:


### PR DESCRIPTION
Closes #1844.

## Summary

- Removes the "post-write validation" block from `write_geotiff` and the streaming writer in `xrspatial/geotiff/_writer.py`.
- Both copies reparsed the first 16 bytes after the file (or temp file) was already on disk and emitted a `Written file may be corrupt` warning on failure.

## Why

- The check only covered the TIFF / BigTIFF header that our own builder produced, so it said nothing about IFDs, tile or strip offsets and byte counts, geotags, COG layout, or whether any tile decodes.
- It ran after `_write_bytes` (or after the temp file was fully written), so even a real failure would have left a bad file on disk; the warning misled callers into thinking the file had been verified.
- The TIFF assembly is internal and type-checked. A genuine round-trip verifier would duplicate the reader and is better left to callers who can simply call `read_geotiff(path)`.

## What callers gain or lose

- Gain: clearer semantics. The writer no longer claims a verification it does not actually perform.
- Lose: nothing meaningful. No test asserted on this warning, and the parse of 16 self-produced bytes was effectively always succeeding.

## Test plan

- [x] `pytest xrspatial/geotiff/tests/test_writer.py xrspatial/geotiff/tests/test_writer_matrix.py xrspatial/geotiff/tests/test_streaming_write.py xrspatial/geotiff/tests/test_parallel_writer_1800.py` -- 145 passed.
- [x] Full `pytest xrspatial/geotiff/tests/` matches `main`: the remaining failures (`test_features.py::TestPalette`, `test_predictor2_big_endian_gpu_1517.py`, `test_size_param_validation_gpu_vrt_1776.py`) reproduce on `main` and are unrelated to this change.