### PR TITLE
geotiff: honour window and max_pixels for stripped HTTP reads (#1842)

### DIFF
--- a/xrspatial/geotiff/_reader.py
+++ b/xrspatial/geotiff/_reader.py
@@ -2029,27 +2029,21 @@ def _fetch_decode_cog_http_strips(
     if rps is None or rps <= 0:
         raise ValueError(f"Invalid RowsPerStrip: {rps!r}")
 
-    # Per-strip compressed-byte cap (#1664). Mirrors the local strip path
-    # and the tiled HTTP path: a crafted ``StripByteCounts`` entry can
-    # request an unbounded HTTP Range GET or decompress a few KiB into
-    # gigabytes. Apply the cap before any fetch list is built.
+    # Per-strip compressed-byte cap (#1664). A crafted ``StripByteCounts``
+    # entry can request an unbounded HTTP Range GET or decompress a few
+    # KiB into gigabytes. The cap applies to strips we actually fetch:
+    # - Full-image path: validated inside ``_read_strips`` over every
+    #   strip (full file is materialised regardless).
+    # - Windowed path: validated inside the fetch-range loop below so a
+    #   small window only fails on strips it intersects -- mirrors the
+    #   tiled HTTP path's per-tile check (#1851).
     max_tile_bytes = _max_tile_bytes_from_env()
-    for _strip_idx, _bc in enumerate(byte_counts):
-        if _bc > max_tile_bytes:
-            raise ValueError(
-                f"TIFF strip {_strip_idx} declares "
-                f"StripByteCount={_bc:,} bytes, which exceeds the "
-                f"per-strip safety cap of {max_tile_bytes:,} bytes. "
-                f"The file is malformed or attempting denial-of-service. "
-                f"Override via XRSPATIAL_COG_MAX_TILE_BYTES if this file "
-                f"is legitimate."
-            )
 
     # Full-image read: keep the legacy ``read_all`` + ``_read_strips``
     # path so anything _read_strips already validates (sparse strips,
-    # strip-table truncation, LERC masked_fill, etc.) stays in one
-    # place. Just thread the caller's ``max_pixels`` through so the
-    # dim check uses their cap instead of the default 1B.
+    # strip-table truncation, LERC masked_fill, per-strip byte cap, etc.)
+    # stays in one place. Just thread the caller's ``max_pixels`` through
+    # so the dim check uses their cap instead of the default 1B.
     if window is None:
         _check_dimensions(width, height, samples, max_pixels)
         all_data = source.read_all()
@@ -2121,6 +2115,20 @@ def _fetch_decode_cog_http_strips(
             if bc == 0:
                 # Sparse strip: result is already pre-filled above.
                 continue
+            # Per-strip byte cap, scoped to strips the window actually
+            # fetches (#1851). Mirrors the per-tile check in
+            # ``_fetch_decode_cog_http_tiles`` so a window over a benign
+            # strip is not rejected because some unrelated strip in the
+            # file exceeds the cap.
+            if bc > max_tile_bytes:
+                raise ValueError(
+                    f"TIFF strip {global_idx} declares "
+                    f"StripByteCount={bc:,} bytes, which exceeds the "
+                    f"per-strip safety cap of {max_tile_bytes:,} bytes. "
+                    f"The file is malformed or attempting denial-of-service. "
+                    f"Override via XRSPATIAL_COG_MAX_TILE_BYTES if this file "
+                    f"is legitimate."
+                )
             fetch_ranges.append((offsets[global_idx], bc))
             placements.append((band_idx, strip_idx))
 
@@ -2149,6 +2157,17 @@ def _fetch_decode_cog_http_strips(
         strip_rows = min(rps, height - strip_row)
         if strip_rows <= 0:
             continue
+
+        # Per-strip decoded-dimension cap (#1851). Mirrors the per-tile
+        # ``_check_dimensions(tw, th, samples, MAX_PIXELS_DEFAULT)`` in
+        # the tiled HTTP path: a tiny window intersecting an oversized
+        # strip would otherwise force ``_decode_strip_or_tile`` to
+        # allocate ``width * strip_rows * strip_samples`` bytes before
+        # the window clip. Use ``MAX_PIXELS_DEFAULT`` rather than the
+        # caller's ``max_pixels`` so a small output-window budget does
+        # not reject normal strip sizes.
+        _check_dimensions(width, strip_rows, strip_samples,
+                          MAX_PIXELS_DEFAULT)
 
         strip_pixels = _decode_strip_or_tile(
             strip_data, compression, width, strip_rows, strip_samples,

--- a/xrspatial/geotiff/_reader.py
+++ b/xrspatial/geotiff/_reader.py
@@ -1981,6 +1981,199 @@ def _read_cog_http(url: str, overview_level: int | None = None,
     return arr, geo_info
 
 
+def _fetch_decode_cog_http_strips(
+    source: _HTTPSource,
+    header: TIFFHeader,
+    ifd: IFD,
+    dtype: np.dtype,
+    bps: int,
+    *,
+    max_pixels: int = MAX_PIXELS_DEFAULT,
+    window: tuple[int, int, int, int] | None = None,
+) -> np.ndarray:
+    """Fetch and decode the strips of a stripped TIFF over HTTP.
+
+    Stripped HTTP companion to :func:`_fetch_decode_cog_http_tiles`. When
+    *window* is given, only the strip byte-ranges that intersect the
+    window are fetched + decoded; the result is sized to the (clamped)
+    window rather than the full image, so a small window read of a
+    multi-billion-pixel stripped file does not download the whole
+    raster. Adjacent strip ranges are coalesced via
+    :meth:`_HTTPSource.read_ranges_coalesced` the same way the tiled
+    path does. ``max_pixels`` is applied to the *materialised* pixel
+    count (window for windowed reads, full image otherwise) so a small
+    caller cap on a tiny window passes a large source the same way the
+    tiled branch does (#1823). When *window* is None, the function
+    falls back to ``source.read_all()`` and dispatches to
+    :func:`_read_strips`; the caller's ``max_pixels`` is threaded
+    through so the full-image dim check honours the user's cap.
+    See issues #1664 and #1823 for the safety contract this restores.
+    """
+    width = ifd.width
+    height = ifd.height
+    samples = ifd.samples_per_pixel
+    compression = ifd.compression
+    rps = ifd.rows_per_strip
+    offsets = ifd.strip_offsets
+    byte_counts = ifd.strip_byte_counts
+    pred = ifd.predictor
+    bytes_per_sample = bps // 8
+    is_sub_byte = bps in SUB_BYTE_BPS
+    jpeg_tables = ifd.jpeg_tables
+    masked_fill = (_resolve_masked_fill(ifd.nodata_str, dtype)
+                   if compression == COMPRESSION_LERC else None)
+    planar = ifd.planar_config
+
+    if offsets is None or byte_counts is None:
+        raise ValueError("Missing strip offsets or byte counts")
+    if rps is None or rps <= 0:
+        raise ValueError(f"Invalid RowsPerStrip: {rps!r}")
+
+    # Per-strip compressed-byte cap (#1664). Mirrors the local strip path
+    # and the tiled HTTP path: a crafted ``StripByteCounts`` entry can
+    # request an unbounded HTTP Range GET or decompress a few KiB into
+    # gigabytes. Apply the cap before any fetch list is built.
+    max_tile_bytes = _max_tile_bytes_from_env()
+    for _strip_idx, _bc in enumerate(byte_counts):
+        if _bc > max_tile_bytes:
+            raise ValueError(
+                f"TIFF strip {_strip_idx} declares "
+                f"StripByteCount={_bc:,} bytes, which exceeds the "
+                f"per-strip safety cap of {max_tile_bytes:,} bytes. "
+                f"The file is malformed or attempting denial-of-service. "
+                f"Override via XRSPATIAL_COG_MAX_TILE_BYTES if this file "
+                f"is legitimate."
+            )
+
+    # Full-image read: keep the legacy ``read_all`` + ``_read_strips``
+    # path so anything _read_strips already validates (sparse strips,
+    # strip-table truncation, LERC masked_fill, etc.) stays in one
+    # place. Just thread the caller's ``max_pixels`` through so the
+    # dim check uses their cap instead of the default 1B.
+    if window is None:
+        _check_dimensions(width, height, samples, max_pixels)
+        all_data = source.read_all()
+        return _read_strips(all_data, ifd, header, dtype,
+                            max_pixels=max_pixels)
+
+    # Windowed read: fetch only the strips that intersect the window.
+    r0, c0, r1, c1 = window
+    r0 = max(0, r0)
+    c0 = max(0, c0)
+    r1 = min(height, r1)
+    c1 = min(width, c1)
+    out_h = r1 - r0
+    out_w = c1 - c0
+    _check_dimensions(out_w, out_h, samples, max_pixels)
+
+    strips_per_band = (height + rps - 1) // rps
+    if planar == 2 and samples > 1:
+        n_strips_expected = strips_per_band * samples
+        if (len(offsets) < n_strips_expected
+                or len(byte_counts) < n_strips_expected):
+            raise ValueError(
+                f"Strip table truncated for planar layout "
+                f"(PlanarConfiguration=2): expected "
+                f"{n_strips_expected} entries "
+                f"({strips_per_band} strips x {samples} samples), got "
+                f"offsets={len(offsets)}, byte_counts={len(byte_counts)}")
+    else:
+        n_strips_expected = strips_per_band
+        if (len(offsets) < n_strips_expected
+                or len(byte_counts) < n_strips_expected):
+            raise ValueError(
+                f"Strip table truncated: expected "
+                f"{n_strips_expected} entries, got "
+                f"offsets={len(offsets)}, byte_counts={len(byte_counts)}")
+
+    first_strip = r0 // rps
+    last_strip = min((r1 - 1) // rps, strips_per_band - 1)
+
+    # Sparse strips (StripByteCounts == 0) must materialise as nodata or 0,
+    # mirroring the local strip path. Detect sparsity over the *whole*
+    # strip table so an empty strip outside the window does not change
+    # the windowed allocation contract.
+    sparse = _has_sparse(byte_counts)
+    if sparse:
+        fill = _sparse_fill_value(ifd, dtype)
+        if samples > 1:
+            result = np.full((out_h, out_w, samples), fill, dtype=dtype)
+        else:
+            result = np.full((out_h, out_w), fill, dtype=dtype)
+    elif samples > 1:
+        result = np.empty((out_h, out_w, samples), dtype=dtype)
+    else:
+        result = np.empty((out_h, out_w), dtype=dtype)
+
+    # Pass 1: build the list of byte ranges + placements. Skip sparse
+    # strips and any strips whose intersected row range is empty.
+    band_count = samples if (planar == 2 and samples > 1) else 1
+    strip_samples = 1 if band_count > 1 else samples
+    fetch_ranges: list[tuple[int, int]] = []
+    placements: list[tuple[int, int]] = []
+    for band_idx in range(band_count):
+        band_offset = band_idx * strips_per_band if band_count > 1 else 0
+        for strip_idx in range(first_strip, last_strip + 1):
+            global_idx = band_offset + strip_idx
+            if global_idx >= len(offsets):
+                continue
+            bc = byte_counts[global_idx]
+            if bc == 0:
+                # Sparse strip: result is already pre-filled above.
+                continue
+            fetch_ranges.append((offsets[global_idx], bc))
+            placements.append((band_idx, strip_idx))
+
+    # Pass 2: fetch the strip bytes, coalescing adjacent ranges (mirrors
+    # the tiled HTTP path; see #1823 / coalescing rationale on line ~2145).
+    try:
+        workers = max(1, int(
+            _os_module.environ.get('XRSPATIAL_COG_HTTP_WORKERS', '8')))
+    except ValueError:
+        workers = 8
+    try:
+        gap = int(_os_module.environ.get(
+            'XRSPATIAL_COG_COALESCE_GAP',
+            str(COALESCE_GAP_THRESHOLD_DEFAULT)))
+    except ValueError:
+        gap = COALESCE_GAP_THRESHOLD_DEFAULT
+    if fetch_ranges:
+        strip_bytes_list = source.read_ranges_coalesced(
+            fetch_ranges, max_workers=workers, gap_threshold=gap)
+    else:
+        strip_bytes_list = []
+
+    # Pass 3: decode each strip and place its intersection with the window.
+    for (band_idx, strip_idx), strip_data in zip(placements, strip_bytes_list):
+        strip_row = strip_idx * rps
+        strip_rows = min(rps, height - strip_row)
+        if strip_rows <= 0:
+            continue
+
+        strip_pixels = _decode_strip_or_tile(
+            strip_data, compression, width, strip_rows, strip_samples,
+            bps, bytes_per_sample, is_sub_byte, dtype, pred,
+            byte_order=header.byte_order,
+            jpeg_tables=jpeg_tables,
+            masked_fill=masked_fill)
+
+        src_r0 = max(r0 - strip_row, 0)
+        src_r1 = min(r1 - strip_row, strip_rows)
+        dst_r0 = max(strip_row - r0, 0)
+        dst_r1 = dst_r0 + (src_r1 - src_r0)
+        if dst_r1 <= dst_r0:
+            continue
+
+        if band_count > 1:
+            # Planar=2 strip holds one band; place into the per-band slot.
+            result[dst_r0:dst_r1, :, band_idx] = (
+                strip_pixels[src_r0:src_r1, c0:c1])
+        else:
+            result[dst_r0:dst_r1] = strip_pixels[src_r0:src_r1, c0:c1]
+
+    return result
+
+
 def _fetch_decode_cog_http_tiles(
     source: _HTTPSource,
     header: TIFFHeader,
@@ -2001,14 +2194,10 @@ def _fetch_decode_cog_http_tiles(
     bps = resolve_bits_per_sample(ifd.bits_per_sample)
     dtype = tiff_dtype_to_numpy(bps, ifd.sample_format)
     if not ifd.is_tiled:
-        # Stripped HTTP COG: fall back to a full read. Window is honoured
-        # by slicing the decoded array.
-        all_data = source.read_all()
-        arr = _read_strips(all_data, ifd, header, dtype)
-        if window is not None:
-            r0, c0, r1, c1 = window
-            return arr[r0:r1, c0:c1]
-        return arr
+        return _fetch_decode_cog_http_strips(
+            source, header, ifd, dtype, bps,
+            max_pixels=max_pixels, window=window,
+        )
 
     width = ifd.width
     height = ifd.height

--- a/xrspatial/geotiff/tests/test_http_stripped_window_max_pixels_issue_A_1842.py
+++ b/xrspatial/geotiff/tests/test_http_stripped_window_max_pixels_issue_A_1842.py
@@ -218,3 +218,129 @@ def test_windowed_stripped_http_matches_full_read(
     arr, _ = _read_cog_http('http://mock/stripped.tif', window=window)
     r0, c0, r1, c1 = window
     np.testing.assert_array_equal(arr, expected[r0:r1, c0:c1])
+
+
+# ---------------------------------------------------------------------------
+# Test 5: per-strip byte cap applies only to strips inside the window (#1851)
+# ---------------------------------------------------------------------------
+#
+# Before #1851 the windowed stripped HTTP path validated every strip's
+# StripByteCount before deciding which strips intersected the window. A
+# window that only touched a small benign strip would still fail if some
+# unrelated strip elsewhere in the file exceeded the per-strip cap. The
+# tiled HTTP path already applied the cap only when adding intersecting
+# tiles; the fix mirrors that.
+
+def _poison_strip_byte_count(ifd, strip_idx, value):
+    """Replace StripByteCounts[strip_idx] in the parsed IFD.
+
+    Mutates the IFD entry in place so downstream ``ifd.strip_byte_counts``
+    reads see ``value`` for that strip. Returns the original tuple so the
+    test can confirm only one entry changed.
+    """
+    from xrspatial.geotiff._header import TAG_STRIP_BYTE_COUNTS
+    entry = ifd.entries[TAG_STRIP_BYTE_COUNTS]
+    original = entry.value
+    if not isinstance(original, tuple):
+        original = (original,)
+    poisoned = list(original)
+    poisoned[strip_idx] = value
+    entry.value = tuple(poisoned)
+    entry.count = len(poisoned)
+    return original
+
+
+def test_windowed_strip_byte_cap_skips_unrelated_oversized_strip(
+        tmp_path, monkeypatch):
+    """Window touching only strip 1 must succeed even if strip 3 is over-cap."""
+    buf, expected, _ = _make_stripped_cog(tmp_path)
+
+    # Patch ``_parse_cog_http_meta`` so the returned IFD reports an
+    # over-cap byte count for a strip the window does not intersect.
+    from xrspatial.geotiff import _reader as _r
+    real_meta = _r._parse_cog_http_meta
+    max_tile_bytes = _r._max_tile_bytes_from_env()
+    poison_target = {'idx': None, 'cap': max_tile_bytes}
+
+    def fake_meta(source, *args, **kwargs):
+        header, ifd, geo_info, header_bytes = real_meta(
+            source, *args, **kwargs)
+        n_strips = len(ifd.strip_offsets)
+        assert n_strips >= 3, "test needs >=3 strips"
+        # Poison the *last* strip with a count larger than the cap. The
+        # actual on-disk bytes are untouched; the windowed path never
+        # reads them, so the test only exercises the metadata guard.
+        poison_idx = n_strips - 1
+        _poison_strip_byte_count(ifd, poison_idx, max_tile_bytes * 4)
+        poison_target['idx'] = poison_idx
+        return header, ifd, geo_info, header_bytes
+
+    monkeypatch.setattr(_r, '_parse_cog_http_meta', fake_meta)
+    src = _RecordingHTTPSource(buf)
+    monkeypatch.setattr(reader_mod, '_HTTPSource', lambda url: src)
+
+    # Aim at strip 1 only.
+    peek_src = _RecordingHTTPSource(buf)
+    _, peek_ifd, _, _ = real_meta(peek_src)
+    rps = peek_ifd.rows_per_strip
+    r0 = 1 * rps
+    r1 = r0 + 1
+    arr, _ = _read_cog_http(
+        'http://mock/stripped.tif', window=(r0, 0, r1, peek_ifd.width))
+    np.testing.assert_array_equal(arr, expected[r0:r1, :])
+
+    # And confirm we still raise when the window *does* touch the
+    # poisoned strip, so the cap has not been disabled outright.
+    poison_idx = poison_target['idx']
+    bad_r0 = poison_idx * rps
+    bad_r1 = bad_r0 + 1
+    with pytest.raises(ValueError, match='exceeds the per-strip safety cap'):
+        _read_cog_http(
+            'http://mock/stripped.tif',
+            window=(bad_r0, 0, bad_r1, peek_ifd.width),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 6: per-strip decoded-dimension guard (#1851)
+# ---------------------------------------------------------------------------
+#
+# A tiny window intersecting a strip whose decoded geometry
+# (width * strip_rows * strip_samples) would blow past the absolute
+# safety budget must be rejected before ``_decode_strip_or_tile`` is
+# invoked, even if the caller's ``max_pixels`` is generous. Mirrors the
+# per-tile ``_check_dimensions(tw, th, samples, MAX_PIXELS_DEFAULT)``
+# guard in the tiled HTTP path.
+
+def test_windowed_strip_decoded_dim_guard_rejects_oversized_strip(
+        tmp_path, monkeypatch):
+    """Tiny window into a strip with absurd decoded dims must raise."""
+    buf, _expected, _ = _make_stripped_cog(tmp_path)
+
+    from xrspatial.geotiff import _reader as _r
+    from xrspatial.geotiff._header import TAG_IMAGE_WIDTH
+    real_meta = _r._parse_cog_http_meta
+
+    def fake_meta(source, *args, **kwargs):
+        header, ifd, geo_info, header_bytes = real_meta(
+            source, *args, **kwargs)
+        # Claim a width that, multiplied by rows-per-strip and samples,
+        # blows past ``MAX_PIXELS_DEFAULT`` (1e9). 1024x1024 sample TIFF
+        # with 256 rps -> set width to 5_000_000 so each strip would
+        # decode 5_000_000 * 256 = 1.28e9 pixels, above the cap.
+        ifd.entries[TAG_IMAGE_WIDTH].value = 5_000_000
+        return header, ifd, geo_info, header_bytes
+
+    monkeypatch.setattr(_r, '_parse_cog_http_meta', fake_meta)
+    src = _RecordingHTTPSource(buf)
+    monkeypatch.setattr(reader_mod, '_HTTPSource', lambda url: src)
+
+    # Tiny window inside the (fake) huge image. Caller's max_pixels is
+    # comfortably large so the output-budget check passes; only the
+    # per-strip absolute guard should reject this.
+    with pytest.raises(PixelSafetyLimitError):
+        _read_cog_http(
+            'http://mock/stripped.tif',
+            max_pixels=10_000,
+            window=(0, 0, 50, 50),
+        )

--- a/xrspatial/geotiff/tests/test_http_stripped_window_max_pixels_issue_A_1842.py
+++ b/xrspatial/geotiff/tests/test_http_stripped_window_max_pixels_issue_A_1842.py
@@ -1,0 +1,220 @@
+"""Regression tests for issue #1842.
+
+The stripped branch of ``_fetch_decode_cog_http_tiles`` used to call
+``source.read_all()`` and slice the decoded array. That violated two
+contracts the tiled branch upholds (#1664, #1823):
+
+1. A windowed HTTP read should fetch only the byte ranges of the strips
+   that intersect the window, not the whole file.
+2. The caller's ``max_pixels`` should bound the *materialised* pixel
+   count (the window for windowed reads, the full image otherwise),
+   not be silently swapped for ``MAX_PIXELS_DEFAULT``.
+
+These tests pin both behaviours.
+"""
+from __future__ import annotations
+
+import threading
+
+import numpy as np
+import pytest
+
+from xrspatial.geotiff import _reader as reader_mod
+from xrspatial.geotiff._reader import (
+    PixelSafetyLimitError,
+    _HTTPSource,
+    _read_cog_http,
+)
+from xrspatial.geotiff._writer import write
+
+
+class _RecordingHTTPSource(_HTTPSource):
+    """In-memory ``_HTTPSource`` that records every range fetch.
+
+    Tests assert how many strip GETs (and which offsets) the reader
+    issues, so they can tell apart a windowed strip fetch from a
+    ``read_all`` of the entire file.
+    """
+
+    def __init__(self, buf: bytes):
+        self._url = 'mock://'
+        self._size = len(buf)
+        self._pool = None
+        self._buf = buf
+        self.calls: list[tuple[int, int]] = []
+        self.read_all_called = False
+        self._lock = threading.Lock()
+
+    def read_range(self, start: int, length: int) -> bytes:
+        with self._lock:
+            self.calls.append((start, length))
+        return self._buf[start:start + length]
+
+    def read_all(self) -> bytes:
+        with self._lock:
+            self.read_all_called = True
+        return self._buf
+
+
+def _make_stripped_cog(tmp_path, *, height=1024, width=64):
+    """Write a stripped (non-tiled) TIFF and return its raw bytes.
+
+    Sized so the writer's default 256 rows-per-strip produces at least
+    four strips, which is what the byte-range coverage test needs to be
+    meaningful.
+    """
+    arr = np.arange(height * width, dtype=np.float32).reshape(height, width)
+    path = str(tmp_path / 'stripped_issue_A_1842.tif')
+    write(arr, path, compression='none', tiled=False)
+    with open(path, 'rb') as f:
+        return f.read(), arr, path
+
+
+# ---------------------------------------------------------------------------
+# Test 1: a windowed read fetches only the strips it needs
+# ---------------------------------------------------------------------------
+
+def test_windowed_stripped_http_fetches_only_intersecting_strips(
+        tmp_path, monkeypatch):
+    """A window covering one strip must only fetch that strip's bytes."""
+    buf, expected, _ = _make_stripped_cog(tmp_path)
+    src = _RecordingHTTPSource(buf)
+
+    monkeypatch.setattr(reader_mod, '_HTTPSource', lambda url: src)
+
+    # Pick a window that covers exactly one row range. We don't know the
+    # writer-picked rows_per_strip until we open the file once, so peek
+    # at the IFD via a second mock source (the recording source's calls
+    # for the peek pass are not asserted on).
+    from xrspatial.geotiff._reader import _parse_cog_http_meta
+    peek = _RecordingHTTPSource(buf)
+    _, ifd, _, _ = _parse_cog_http_meta(peek)
+    rps = ifd.rows_per_strip
+    n_strips = len(ifd.strip_offsets)
+    assert n_strips >= 2, "test needs at least 2 strips to be meaningful"
+
+    # Aim the window at strip 1 only (rows [rps : 2*rps)). Use a sub-row
+    # column range to confirm the column-slice still works.
+    target_strip = 1
+    r0 = target_strip * rps
+    r1 = r0 + 1
+    window = (r0, 0, r1, ifd.width)
+
+    arr, _ = _read_cog_http('http://mock/stripped.tif', window=window)
+    np.testing.assert_array_equal(arr, expected[r0:r1, :])
+
+    # The recording source must NOT have fetched the whole file.
+    assert not src.read_all_called, (
+        "windowed stripped HTTP read fell back to read_all; the fix is "
+        "supposed to fetch only the intersecting strip's byte range")
+
+    # Strip-fetch ranges are everything past the header probe(s). The
+    # header probe is exactly (0, 16384) or (0, 65536); a fetch starting
+    # at the target strip's offset is the strip GET we expect.
+    target_offset = ifd.strip_offsets[target_strip]
+    target_bc = ifd.strip_byte_counts[target_strip]
+    strip_calls = [
+        (s, le) for (s, le) in src.calls
+        if not (s == 0 and le in (16384, 65536))
+    ]
+    # Exactly one strip GET, covering the target strip's range. Either a
+    # coalesced GET starting at the target offset, or a single-range GET
+    # of (offset, byte_count).
+    assert len(strip_calls) == 1, (
+        f"expected one strip GET for a single-strip window, got "
+        f"{len(strip_calls)}: {strip_calls}")
+    got_start, got_len = strip_calls[0]
+    assert got_start == target_offset, (
+        f"strip GET start={got_start} does not match strip {target_strip}'s "
+        f"offset {target_offset}")
+    assert got_len >= target_bc, (
+        f"strip GET length={got_len} is shorter than strip {target_strip}'s "
+        f"declared byte count {target_bc}")
+
+
+# ---------------------------------------------------------------------------
+# Test 2: max_pixels applies to the WINDOW, not the full image
+# ---------------------------------------------------------------------------
+#
+# The 1024x64 = 65,536-pixel test file makes this distinction sharp:
+# - ``max_pixels=2500`` on a (50, 50) window must succeed (window is
+#   2,500 px), even though 2500 < 65,536. Pre-fix, ``_read_strips``
+#   was always called with ``MAX_PIXELS_DEFAULT`` (1 billion) so the
+#   caller's cap was simply dropped on the floor; post-fix the windowed
+#   path checks ``max_pixels`` against the WINDOW size.
+# - ``max_pixels=2499`` on the same window must raise because
+#   ``50 * 50 = 2500`` exceeds 2499.
+
+def test_windowed_max_pixels_honoured_for_stripped_http_read(
+        tmp_path, monkeypatch):
+    """A 50x50 window with ``max_pixels=2500`` reads cleanly even though the
+    full image is 65,536 pixels (well above the caller's cap)."""
+    buf, expected, _ = _make_stripped_cog(tmp_path)
+    src = _RecordingHTTPSource(buf)
+    monkeypatch.setattr(reader_mod, '_HTTPSource', lambda url: src)
+
+    arr, _ = _read_cog_http(
+        'http://mock/stripped.tif',
+        max_pixels=2500,
+        window=(0, 0, 50, 50),
+    )
+    np.testing.assert_array_equal(arr, expected[0:50, 0:50])
+
+
+def test_windowed_max_pixels_too_small_raises(tmp_path, monkeypatch):
+    """``max_pixels`` below the window size must raise even on the windowed path."""
+    buf, _expected, _ = _make_stripped_cog(tmp_path)
+    src = _RecordingHTTPSource(buf)
+    monkeypatch.setattr(reader_mod, '_HTTPSource', lambda url: src)
+
+    with pytest.raises(PixelSafetyLimitError):
+        _read_cog_http(
+            'http://mock/stripped.tif',
+            max_pixels=2499,
+            window=(0, 0, 50, 50),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: full-image read still capped by max_pixels
+# ---------------------------------------------------------------------------
+
+def test_full_stripped_http_read_honours_caller_max_pixels(
+        tmp_path, monkeypatch):
+    """``window=None`` must apply ``max_pixels`` to the full image, not 1B."""
+    buf, _, _ = _make_stripped_cog(tmp_path)
+    src = _RecordingHTTPSource(buf)
+    monkeypatch.setattr(reader_mod, '_HTTPSource', lambda url: src)
+
+    # File is 1024x64 = 65,536 pixels; cap at 100 must reject.
+    with pytest.raises(PixelSafetyLimitError):
+        _read_cog_http(
+            'http://mock/stripped.tif',
+            max_pixels=100,
+            window=None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: round-trip parity - windowed strip read matches a slice of the
+# full-image read. This pins the placement math so the byte-range
+# optimisation does not silently return a misaligned region.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('window', [
+    (0, 0, 16, 16),
+    (8, 8, 40, 40),
+    (200, 0, 400, 64),   # spans strip boundary at row 256
+    (255, 0, 260, 64),   # tiny window straddling two strips
+    (768, 0, 1024, 64),  # last strip only
+    (0, 0, 1024, 64),    # full image
+])
+def test_windowed_stripped_http_matches_full_read(
+        tmp_path, monkeypatch, window):
+    buf, expected, _ = _make_stripped_cog(tmp_path)
+    src = _RecordingHTTPSource(buf)
+    monkeypatch.setattr(reader_mod, '_HTTPSource', lambda url: src)
+
+    arr, _ = _read_cog_http('http://mock/stripped.tif', window=window)
+    r0, c0, r1, c1 = window
+    np.testing.assert_array_equal(arr, expected[r0:r1, c0:c1])


### PR DESCRIPTION
## Summary

Fixes #1842.

- `_fetch_decode_cog_http_tiles` had a `not ifd.is_tiled` branch that called `source.read_all()` and sliced the result. That dropped two safety contracts the tiled branch had from #1664 and #1823: (1) the comment a few lines below promises windowed HTTP reads "only allocate the window", but stripped COGs were downloading the whole raster anyway; (2) the caller's `max_pixels` was silently swapped for `MAX_PIXELS_DEFAULT` (1B), so a 50x50 window read with `max_pixels=2500` against a huge stripped file went through unchecked.
- Move the work into a new `_fetch_decode_cog_http_strips` helper. For windowed reads it computes which strips intersect `[r0:r1]`, fetches only those byte ranges via `read_ranges_coalesced` (same coalescing logic as the tiled path), decodes each via `_decode_strip_or_tile`, and places each strip's intersection with the window into the output. Per-strip byte cap (#1664), chunky vs planar layouts, and sparse strips all follow `_read_strips`. For full-image reads the path stays on `read_all` + `_read_strips`, but `max_pixels` is now threaded through.

## Test plan

- [x] new regression tests in `xrspatial/geotiff/tests/test_http_stripped_window_max_pixels_issue_A_1842.py`:
  - byte-range coverage: a window covering one strip issues exactly one strip GET at that strip's offset, and `read_all` is never called.
  - windowed `max_pixels` honoured: a 50x50 window with `max_pixels=2500` succeeds against a 65,536-pixel source; the same window with `max_pixels=2499` raises `PixelSafetyLimitError`.
  - full-image read still capped: `window=None` with `max_pixels=100` against a 65,536-pixel source raises `PixelSafetyLimitError`.
  - parametrised round-trip parity across six window shapes (strip-boundary spans, tiny straddling windows, last strip, full image).
- [x] full `xrspatial/geotiff/tests/` suite passes apart from 11 pre-existing failures on main (matplotlib + Python 3.14 deepcopy recursion, GPU tests without a GPU, an unrelated tile-size validation test); none of them touch the HTTP path.
- [x] HTTP-adjacent suites (`test_http_*`, `test_cog_http_*`, `test_reader.py`, `test_local_tile_byte_cap_1664.py`, `test_ssrf_hardening_1664.py`) all pass: 106/106.