### PR TITLE
docs: add AI policy and 1.0.0 feature freeze callout to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<!-- markdownlint-disable MD033 MD041 -->
+> [!IMPORTANT]
+> **xarray-spatial uses AI assistance more aggressively than most open-source projects.** Before opening a PR, read the [AI-Assisted Contribution Policy](AI_POLICY.md) and run your changes through the project's approved AI review workflow (see the slash-command suite in [`.claude/commands/`](.claude/commands)). PRs that ignore the workflow are likely to be rejected.
+>
+> **Feature freeze in effect.** The project is working toward its first major release (1.0.0). Until 1.0.0 ships, only bug fixes, test coverage, performance work, and documentation PRs will be considered. New feature proposals will be triaged but not implemented until after the release.
+
 <img src="img/Xarray-Spatial-logo.svg"/>
 
 <table>


### PR DESCRIPTION
## Summary

- Replaces the bare logo at the top of `README.md` with a GitHub-style `IMPORTANT` callout.
- Links to [`AI_POLICY.md`](AI_POLICY.md) and the slash-command suite under [`.claude/commands/`](.claude/commands), and notes that PRs ignoring the AI review workflow are likely to be rejected.
- Calls out the feature freeze in effect until the 1.0.0 release. New feature PRs will be triaged but not implemented until after 1.0.0 ships.
- The logo moves below the callout, ahead of the badges table.

Closes #1855.

## Test plan

- [ ] Verify the README renders the `> [!IMPORTANT]` callout correctly on GitHub.
- [ ] Confirm both links resolve: `AI_POLICY.md` and `.claude/commands/`.
- [ ] Confirm the logo still shows below the callout.