### PR TITLE
Add new-contributor issue template with AI tooling checklist (#1858)

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-contributor.md
+++ b/.github/ISSUE_TEMPLATE/new-contributor.md
@@ -1,0 +1,64 @@
+---
+name: New contributor introduction
+about: Introduce yourself as a prospective contributor (AI-assisted contribution welcome)
+title: 'Contributor intro: <your name or handle>'
+labels: help wanted
+assignees: ''
+
+---
+
+Welcome! xarray-spatial actively encourages AI-assisted contribution. See [`AI_POLICY.md`](../../AI_POLICY.md) for the full policy on how we expect AI tools to be used. Fill in what you're comfortable sharing so we can suggest issues that fit your skills and tools. Most fields are optional.
+
+## AI tools you can use
+
+Which AI coding assistants do you have access to? Check all that apply.
+
+- [ ] Claude (Claude Code CLI, claude.ai, Anthropic API)
+- [ ] Codex / ChatGPT (Codex CLI, ChatGPT, OpenAI API)
+- [ ] GitHub Copilot (IDE integration, Copilot CLI, Copilot Workspace)
+- [ ] Gemini (Gemini CLI, Gemini Code Assist)
+- [ ] Cursor
+- [ ] Windsurf
+- [ ] Aider
+- [ ] Continue
+- [ ] Other: _____
+- [ ] None right now
+
+How do you usually work with AI tools? (e.g. pair-programming in an IDE, agentic CLI runs, code review only, test generation, doc writing, or "I haven't really tried them yet")
+
+## Geospatial background
+
+What's your experience with geospatial data and tools? Anything is fine, including "none yet". A few prompts:
+
+- Formats you've worked with (GeoTIFF, NetCDF, Zarr, COG, Shapefile, GeoJSON, ...)
+- Libraries you've used (rasterio, GDAL, xarray, geopandas, rioxarray, ...)
+- Domains you've worked in (remote sensing, hydrology, climate, terrain analysis, agriculture, ...)
+
+## Python background
+
+- Roughly how long you've been writing Python
+- Any packages you've contributed to before (links welcome)
+- Comfort level with NumPy, xarray, Dask, Numba, CuPy
+
+## Areas you'd like to work on
+
+Check anything that interests you. xarray-spatial covers these areas:
+
+- [ ] Focal tools (focal stats, convolution)
+- [ ] Zonal tools
+- [ ] Surface / terrain (slope, aspect, hillshade, curvature, viewshed)
+- [ ] Hydrology (flow direction, accumulation, flood routing)
+- [ ] Proximity tools
+- [ ] Classification
+- [ ] GPU / CuPy backend
+- [ ] Dask scaling
+- [ ] I/O (GeoTIFF, NetCDF)
+- [ ] Documentation, examples, user-guide notebooks
+- [ ] Performance / benchmarking
+- [ ] Testing infrastructure
+- [ ] Not sure yet, point me somewhere
+- [ ] Other: _____
+
+## Anything else
+
+Anything else worth mentioning? Links to prior work, a portfolio, a specific issue you've already spotted, or a question about the project are all welcome.


### PR DESCRIPTION
Closes #1858

## Summary

- Adds `.github/ISSUE_TEMPLATE/new-contributor.md` so prospective contributors can introduce themselves.
- Template asks about AI coding assistants the contributor can use (Claude, Codex/ChatGPT, Copilot, Gemini, Cursor, Windsurf, Aider, Continue, other, none), how they use them, geospatial background, Python background, and which parts of the library they'd like to work on.
- Links to `AI_POLICY.md` so new contributors see our policy up front.

## Test plan

- [ ] Visit "New issue" on GitHub and confirm the "New contributor introduction" template appears alongside the existing bug and feature-proposal templates.
- [ ] Confirm the template renders with checkboxes and the `AI_POLICY.md` link resolves from the rendered issue.