### PR TITLE
geotiff: default missing_sources to 'raise' in public read_vrt (#1860)

### DIFF
--- a/xrspatial/geotiff/__init__.py
+++ b/xrspatial/geotiff/__init__.py
@@ -611,14 +611,16 @@ def open_geotiff(source: str | BinaryIO, *,
         Passing this kwarg with ``gpu=False`` raises ``ValueError``
         because the policy only applies to the GPU pipeline. See
         ``read_geotiff_gpu`` for the full description.
-    missing_sources : {'warn', 'raise'}, optional
+    missing_sources : {'raise', 'warn'}, optional
         Forwarded to ``read_vrt`` when the source is a ``.vrt`` file.
-        ``'warn'`` preserves the historical behavior: emit
+        When the caller does not pass this kwarg, the public
+        ``read_vrt`` default applies (``'raise'`` since #1860).
+        ``'raise'`` fails immediately on an unreadable backing source.
+        ``'warn'`` is the opt-in lenient mode: emit
         ``GeoTIFFFallbackWarning``, record ``attrs['vrt_holes']``, and
-        return a partial mosaic. ``'raise'`` fails immediately. Passing
-        this kwarg with a non-VRT source raises ``ValueError`` because
-        the policy only applies to the VRT pipeline. See ``read_vrt``
-        for the full description.
+        return a partial mosaic. Passing this kwarg with a non-VRT
+        source raises ``ValueError`` because the policy only applies to
+        the VRT pipeline. See ``read_vrt`` for the full description.
 
     Returns
     -------
@@ -3795,7 +3797,7 @@ def read_vrt(source: str, *,
              chunks: int | tuple | None = None,
              gpu: bool = False,
              max_pixels: int | None = None,
-             missing_sources: str = 'warn') -> xr.DataArray:
+             missing_sources: str = 'raise') -> xr.DataArray:
     """Read a GDAL Virtual Raster Table (.vrt) into an xarray.DataArray.
 
     The VRT's source GeoTIFFs are read via windowed reads and assembled
@@ -3824,12 +3826,21 @@ def read_vrt(source: str, *,
         assembled VRT region. None uses the reader default (~1 billion).
         Matches ``open_geotiff`` / ``read_geotiff_dask`` /
         ``read_geotiff_gpu``.
-    missing_sources : {'warn', 'raise'}, default 'warn'
-        Policy for unreadable source files referenced by the VRT. ``'warn'``
-        preserves the historical behavior: emit ``GeoTIFFFallbackWarning``,
-        record ``attrs['vrt_holes']``, and return a partial mosaic.
-        ``'raise'`` fails immediately. ``XRSPATIAL_GEOTIFF_STRICT=1`` also
-        raises, even when ``missing_sources='warn'``.
+    missing_sources : {'raise', 'warn'}, default 'raise'
+        Policy for unreadable source files referenced by the VRT.
+        ``'raise'`` (the default since #1860) fails immediately on an
+        unreadable backing source so a partial mosaic never surfaces
+        silently. This matches the internal ``_vrt.read_vrt`` default
+        and the rest of the geotiff module's up-front rejection of
+        malformed input. Prior to #1860 the public default was
+        ``'warn'``; callers that relied on the lenient behaviour pass
+        ``missing_sources='warn'`` explicitly.
+        ``'warn'`` is the opt-in escape hatch for partial mosaics: it
+        emits ``GeoTIFFFallbackWarning``, records ``attrs['vrt_holes']``,
+        and returns the mosaic with holes left as the band's nodata
+        sentinel (or zero on integer bands without a sentinel).
+        ``XRSPATIAL_GEOTIFF_STRICT=1`` forces a raise across the whole
+        module regardless of this kwarg.
 
     Returns
     -------

--- a/xrspatial/geotiff/tests/test_read_vrt_default_missing_sources_1860.py
+++ b/xrspatial/geotiff/tests/test_read_vrt_default_missing_sources_1860.py
@@ -1,0 +1,99 @@
+"""Regression test for #1860: the public ``read_vrt`` and
+``open_geotiff(.vrt)`` default ``missing_sources`` to ``'raise'``, matching
+the internal ``_vrt.read_vrt`` default set in #1843.
+
+Before #1860 the public wrapper defaulted to ``'warn'``, which silently
+overrode the internal ``'raise'`` default and let unreadable backing
+sources produce zero-fill holes on integer rasters with no exception.
+Callers that want the lenient partial-mosaic behaviour pass
+``missing_sources='warn'`` explicitly.
+"""
+from __future__ import annotations
+
+import pytest
+
+from xrspatial.geotiff import open_geotiff, read_vrt
+from xrspatial.geotiff import GeoTIFFFallbackWarning
+
+
+def _write_missing_source_vrt(path):
+    path.write_text(
+        '<VRTDataset rasterXSize="2" rasterYSize="2">\n'
+        '  <VRTRasterBand dataType="Byte" band="1">\n'
+        '    <SimpleSource>\n'
+        '      <SourceFilename relativeToVRT="1">missing_1860.tif'
+        '</SourceFilename>\n'
+        '      <SourceBand>1</SourceBand>\n'
+        '      <SrcRect xOff="0" yOff="0" xSize="2" ySize="2"/>\n'
+        '      <DstRect xOff="0" yOff="0" xSize="2" ySize="2"/>\n'
+        '    </SimpleSource>\n'
+        '  </VRTRasterBand>\n'
+        '</VRTDataset>\n'
+    )
+
+
+def test_public_read_vrt_default_raises_on_unreadable_source(tmp_path):
+    """Public ``read_vrt`` with no ``missing_sources`` kwarg must raise.
+
+    Before #1860 the default was ``'warn'`` and the call returned a
+    partial mosaic with ``attrs['vrt_holes']`` instead of raising. With
+    the default aligned to the internal ``_vrt.read_vrt`` default of
+    ``'raise'``, the unreadable source must now halt the call.
+    """
+    vrt = tmp_path / "tmp_1860_public_default_raise.vrt"
+    _write_missing_source_vrt(vrt)
+
+    with pytest.raises((OSError, ValueError)):
+        read_vrt(str(vrt))
+
+
+def test_open_geotiff_vrt_default_raises_on_unreadable_source(tmp_path):
+    """``open_geotiff(vrt_path)`` with no ``missing_sources`` kwarg must
+    raise on an unreadable backing source.
+
+    ``open_geotiff`` forwards ``missing_sources`` to ``read_vrt`` only
+    when the caller passed it explicitly; otherwise the public
+    ``read_vrt`` default applies. With that default now ``'raise'``, the
+    silent-degradation path is closed for ``open_geotiff`` callers too.
+    """
+    vrt = tmp_path / "tmp_1860_open_geotiff_default_raise.vrt"
+    _write_missing_source_vrt(vrt)
+
+    with pytest.raises((OSError, ValueError)):
+        open_geotiff(str(vrt))
+
+
+def test_public_read_vrt_explicit_warn_preserves_lenient_behaviour(tmp_path):
+    """``missing_sources='warn'`` is still the escape hatch for partial
+    mosaics on the public ``read_vrt`` API.
+
+    The warning fires, the call returns, and ``attrs['vrt_holes']`` is
+    populated with the skipped source record. Pinning this keeps the
+    historical contract available to callers that opt in.
+    """
+    vrt = tmp_path / "tmp_1860_public_explicit_warn.vrt"
+    _write_missing_source_vrt(vrt)
+
+    with pytest.warns(GeoTIFFFallbackWarning, match="could not be read"):
+        da = read_vrt(str(vrt), missing_sources='warn')
+
+    assert 'vrt_holes' in da.attrs
+    assert da.attrs['vrt_holes'][0]['source'].endswith('missing_1860.tif')
+
+
+def test_open_geotiff_vrt_explicit_warn_preserves_lenient_behaviour(tmp_path):
+    """``open_geotiff(vrt_path, missing_sources='warn')`` still produces
+    a partial mosaic with the hole record on the DataArray attrs.
+
+    The forwarding branch in ``open_geotiff`` only runs when the caller
+    explicitly passes ``missing_sources``; this test pins that branch
+    against regressions.
+    """
+    vrt = tmp_path / "tmp_1860_open_geotiff_explicit_warn.vrt"
+    _write_missing_source_vrt(vrt)
+
+    with pytest.warns(GeoTIFFFallbackWarning, match="could not be read"):
+        da = open_geotiff(str(vrt), missing_sources='warn')
+
+    assert 'vrt_holes' in da.attrs
+    assert da.attrs['vrt_holes'][0]['source'].endswith('missing_1860.tif')

--- a/xrspatial/geotiff/tests/test_strict_mode_1662.py
+++ b/xrspatial/geotiff/tests/test_strict_mode_1662.py
@@ -160,7 +160,10 @@ def test_vrt_missing_source_default_warns_then_continues(
 
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
-        da = read_vrt(str(vrt_path))
+        # Public ``read_vrt`` defaults to ``missing_sources='raise'``
+        # since #1860. Opt back into the lenient warn-then-continue
+        # behaviour to keep exercising the warning path.
+        da = read_vrt(str(vrt_path), missing_sources='warn')
 
     # The mosaic should still load (with a hole) and one warning should
     # describe the skipped source.

--- a/xrspatial/geotiff/tests/test_vrt_holes_attr_1734.py
+++ b/xrspatial/geotiff/tests/test_vrt_holes_attr_1734.py
@@ -76,7 +76,10 @@ def test_skipped_source_records_vrt_holes_attr(
 
     with warnings.catch_warnings():
         warnings.simplefilter('ignore', GeoTIFFFallbackWarning)
-        da = read_vrt(str(vrt_path))
+        # Public ``read_vrt`` defaults to ``missing_sources='raise'``
+        # since #1860; the lenient path that populates ``vrt_holes`` is
+        # now an explicit opt-in.
+        da = read_vrt(str(vrt_path), missing_sources='warn')
 
     # Confirm the integer-specific failure mode is in play: the hole is
     # filled with zeros (not NaN), indistinguishable from real data
@@ -168,7 +171,10 @@ def test_warning_mentions_how_to_detect_holes(clear_strict_env, tmp_path):
 
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
-        read_vrt(str(vrt_path))
+        # The lenient path is now an explicit opt-in (#1860); the
+        # warning content this test pins is still emitted under
+        # ``missing_sources='warn'``.
+        read_vrt(str(vrt_path), missing_sources='warn')
 
     fallback = [
         x for x in w if issubclass(x.category, GeoTIFFFallbackWarning)

--- a/xrspatial/geotiff/tests/test_vrt_narrow_except_1670.py
+++ b/xrspatial/geotiff/tests/test_vrt_narrow_except_1670.py
@@ -129,7 +129,10 @@ def test_file_not_found_warns_and_continues(
 
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
-        da = read_vrt(str(vrt_path))
+        # The public ``read_vrt`` defaults to ``missing_sources='raise'``
+        # since #1860; this test pins the warn-and-continue path, which
+        # is now an explicit opt-in.
+        da = read_vrt(str(vrt_path), missing_sources='warn')
 
     # Mosaic still loads (with a hole) and the skipped source is reported.
     assert da.shape == (4, 4)
@@ -176,7 +179,9 @@ def test_value_error_warns_and_continues(
 
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
-        da = read_vrt(str(vrt_path))
+        # Opt into the lenient path: the public default is now
+        # ``missing_sources='raise'`` since #1860.
+        da = read_vrt(str(vrt_path), missing_sources='warn')
 
     assert da.shape == (4, 4)
     fallback_warnings = [
@@ -227,7 +232,9 @@ def test_struct_error_warns_and_continues(
 
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
-        da = read_vrt(str(vrt_path))
+        # Opt into the lenient path: the public default is now
+        # ``missing_sources='raise'`` since #1860.
+        da = read_vrt(str(vrt_path), missing_sources='warn')
 
     assert da.shape == (4, 4)
     fallback_warnings = [
@@ -255,7 +262,9 @@ def test_permission_error_warns_and_continues(
 
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
-        da = read_vrt(str(vrt_path))
+        # Opt into the lenient path: the public default is now
+        # ``missing_sources='raise'`` since #1860.
+        da = read_vrt(str(vrt_path), missing_sources='warn')
 
     assert da.shape == (4, 4)
     fallback_warnings = [
@@ -303,7 +312,9 @@ def test_zlib_error_warns_and_continues(
 
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
-        da = read_vrt(str(vrt_path))
+        # Opt into the lenient path: the public default is now
+        # ``missing_sources='raise'`` since #1860.
+        da = read_vrt(str(vrt_path), missing_sources='warn')
 
     assert da.shape == (4, 4)
     fallback_warnings = [
@@ -355,7 +366,9 @@ def test_zstd_error_warns_and_continues_if_available(
 
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')
-        da = read_vrt(str(vrt_path))
+        # Opt into the lenient path: the public default is now
+        # ``missing_sources='raise'`` since #1860.
+        da = read_vrt(str(vrt_path), missing_sources='warn')
 
     assert da.shape == (4, 4)
     fallback_warnings = [


### PR DESCRIPTION
## Summary
- Public `read_vrt` and `open_geotiff(.vrt)` now default to `missing_sources='raise'`, matching the internal `_vrt.read_vrt` default. Callers who want the older lenient behavior pass `missing_sources='warn'` explicitly.
- Closes #1860.

## Test plan
- [x] New test reproduces the silent-degradation bug before the fix and passes after.
- [x] Existing VRT tests still pass (any that depended on the lenient default were updated to opt in explicitly).