### PR TITLE
geotiff: reject invalid PlanarConfiguration values

### DIFF
--- a/xrspatial/geotiff/_header.py
+++ b/xrspatial/geotiff/_header.py
@@ -236,7 +236,19 @@ class IFD:
 
     @property
     def planar_config(self) -> int:
-        return self.get_value(TAG_PLANAR_CONFIG, 1)
+        # TIFF 6.0 defines only 1 (Chunky) and 2 (Planar). Treating any
+        # other value as chunky would silently decode a malformed file
+        # under an assumed layout. Missing tag defaults to 1 per spec.
+        v = self.get_value(TAG_PLANAR_CONFIG, 1)
+        if isinstance(v, tuple):
+            v = v[0] if v else 1
+        v = int(v)
+        if v not in (1, 2):
+            raise ValueError(
+                f"Invalid PlanarConfiguration: {v}. TIFF 6.0 allows only "
+                f"1 (Chunky) or 2 (Planar)."
+            )
+        return v
 
     @property
     def jpeg_tables(self) -> bytes | None:

--- a/xrspatial/geotiff/_header.py
+++ b/xrspatial/geotiff/_header.py
@@ -239,14 +239,17 @@ class IFD:
         # TIFF 6.0 defines only 1 (Chunky) and 2 (Planar). Treating any
         # other value as chunky would silently decode a malformed file
         # under an assumed layout. Missing tag defaults to 1 per spec.
+        # PlanarConfiguration is type SHORT (uint16) in well-formed
+        # TIFFs; rejecting non-integer values up front catches malformed
+        # files that declare it as FLOAT/RATIONAL, where a naive int()
+        # cast would round (e.g. 1.5 -> 1) and accept the file as chunky.
         v = self.get_value(TAG_PLANAR_CONFIG, 1)
         if isinstance(v, tuple):
             v = v[0] if v else 1
-        v = int(v)
-        if v not in (1, 2):
+        if isinstance(v, bool) or not isinstance(v, int) or v not in (1, 2):
             raise ValueError(
-                f"Invalid PlanarConfiguration: {v}. TIFF 6.0 allows only "
-                f"1 (Chunky) or 2 (Planar)."
+                f"Invalid PlanarConfiguration: {v!r}. TIFF 6.0 allows "
+                f"only 1 (Chunky) or 2 (Planar)."
             )
         return v
 

--- a/xrspatial/geotiff/tests/test_header.py
+++ b/xrspatial/geotiff/tests/test_header.py
@@ -125,6 +125,53 @@ class TestIFDProperties:
         assert not ifd.is_tiled
 
 
+class TestPlanarConfigValidation:
+    """PlanarConfiguration must be 1 (Chunky) or 2 (Planar) per TIFF 6.0.
+
+    Issue #1870: ``planar_config`` previously returned the raw tag value
+    unchecked, so a malformed file with e.g. ``PlanarConfiguration=0``
+    decoded under an assumed chunky layout instead of being rejected.
+    """
+
+    def _ifd_with_planar(self, value) -> IFD:
+        from xrspatial.geotiff._header import IFDEntry, TAG_PLANAR_CONFIG
+        ifd = IFD()
+        ifd.entries[TAG_PLANAR_CONFIG] = IFDEntry(
+            tag=TAG_PLANAR_CONFIG, type_id=3, count=1, value=value,
+        )
+        return ifd
+
+    def test_chunky_accepted(self):
+        assert self._ifd_with_planar(1).planar_config == 1
+
+    def test_planar_accepted(self):
+        assert self._ifd_with_planar(2).planar_config == 2
+
+    def test_zero_rejected(self):
+        with pytest.raises(ValueError, match=r"Invalid PlanarConfiguration"):
+            _ = self._ifd_with_planar(0).planar_config
+
+    def test_three_rejected(self):
+        with pytest.raises(ValueError, match=r"Invalid PlanarConfiguration"):
+            _ = self._ifd_with_planar(3).planar_config
+
+    def test_large_value_rejected(self):
+        with pytest.raises(ValueError, match=r"Invalid PlanarConfiguration"):
+            _ = self._ifd_with_planar(255).planar_config
+
+    def test_missing_tag_defaults_to_one(self):
+        # No TAG_PLANAR_CONFIG entry => default 1 (chunky) per spec.
+        assert IFD().planar_config == 1
+
+    def test_tuple_value_uniform_one_accepted(self):
+        # Some encoders write count>1 even though the tag is scalar.
+        assert self._ifd_with_planar((1,)).planar_config == 1
+
+    def test_tuple_value_invalid_rejected(self):
+        with pytest.raises(ValueError, match=r"Invalid PlanarConfiguration"):
+            _ = self._ifd_with_planar((7,)).planar_config
+
+
 class TestIFDChainLoop:
     """Verify parse_all_ifds bails out on a malicious IFD chain cycle.
 

--- a/xrspatial/geotiff/tests/test_header.py
+++ b/xrspatial/geotiff/tests/test_header.py
@@ -171,6 +171,19 @@ class TestPlanarConfigValidation:
         with pytest.raises(ValueError, match=r"Invalid PlanarConfiguration"):
             _ = self._ifd_with_planar((7,)).planar_config
 
+    def test_float_value_rejected(self):
+        # A malformed TIFF declaring tag 284 as FLOAT/DOUBLE would resolve
+        # to a Python float. A naive int() cast would round 1.5 down to 1
+        # and silently accept the file as Chunky.
+        with pytest.raises(ValueError, match=r"Invalid PlanarConfiguration"):
+            _ = self._ifd_with_planar(1.5).planar_config
+
+    def test_bool_value_rejected(self):
+        # Bools are int subclasses but a TIFF tag is never legitimately
+        # a bool; rejecting them keeps the predicate honest.
+        with pytest.raises(ValueError, match=r"Invalid PlanarConfiguration"):
+            _ = self._ifd_with_planar(True).planar_config
+
 
 class TestIFDChainLoop:
     """Verify parse_all_ifds bails out on a malicious IFD chain cycle.


### PR DESCRIPTION
Closes #1870.

## Summary

`IFD.planar_config` returned the raw tag value with a default of 1, so a malformed file with `PlanarConfiguration=0`, `3`, or `255` silently decoded under the default chunky layout. TIFF 6.0 defines only `1` (Chunky) and `2` (Planar).

Validate in the property: missing tag still defaults to `1` per spec; any explicit value outside `{1, 2}` raises `ValueError`. Also handle the length-1 tuple wrapping that the orientation property already accounts for.

## Test plan

- [x] New `TestPlanarConfigValidation` covers chunky, planar, zero, three, large value, missing tag, uniform tuple, invalid tuple.
- [x] `test_reader.py`, `test_mixed_bps.py`, `test_dask_planar_multiband.py`, `test_geotiff_planar_strip_truncation_1782.py`, `test_predictor_multisample.py`, `test_features.py` (192 tests) pass. The one pre-existing failure in `test_features.py::TestPalette::test_xrs_plot_with_palette` is the unrelated tight_layout recursion tracked separately.