### PR TITLE
accessor: use constrained layout in plot() to avoid tight_layout recursion

### DIFF
--- a/xrspatial/accessor.py
+++ b/xrspatial/accessor.py
@@ -60,10 +60,16 @@ class XrsSpatialDataArrayAccessor:
             kwargs.setdefault('norm', BoundaryNorm(boundaries, n_colors))
             kwargs.setdefault('add_colorbar', True)
 
-        # Create a figure with sensible size if none provided.
+        # Create a figure with sensible size if none provided. Use
+        # ``constrained`` layout so palette colorbars and titles get sized
+        # correctly without calling ``tight_layout``; the tight-layout
+        # solver triggers a deepcopy of internal MarkerStyle objects on
+        # matplotlib 3.10 that recurses past Python's stack limit when a
+        # BoundaryNorm colorbar is attached (issue #1874).
         if 'ax' not in kwargs:
             fig, ax = plt.subplots(
                 figsize=kwargs.get('figsize', (8, 6)),
+                layout='constrained',
             )
             kwargs.pop('figsize', None)
             kwargs['ax'] = ax
@@ -71,7 +77,6 @@ class XrsSpatialDataArrayAccessor:
         result = da.plot(**kwargs)
 
         kwargs['ax'].set_aspect('equal')
-        plt.tight_layout()
         return result
 
     # ---- Surface ----


### PR DESCRIPTION
Closes #1874.

## Summary

`da.xrs.plot()` raised `RecursionError` on matplotlib 3.10 when the DataArray carried an embedded GeoTIFF palette. The trailing `plt.tight_layout()` deep-copies internal `MarkerStyle` objects inside the `BoundaryNorm` colorbar and the recursion hits Python's stack limit.

Build the figure with `layout='constrained'` and drop the `plt.tight_layout()` call. Constrained layout sizes the colorbar and title without the deepcopy path.

## Test plan

- [x] `tests/geotiff/test_features.py::TestPalette` (7 tests) all pass.
- [x] Spot-check: `da.xrs.plot()` returns a `QuadMesh` artist with palette data, with no recursion.