### PR TITLE
geotiff: cap pixel-array IFD tag counts against IFD geometry

### DIFF
--- a/xrspatial/geotiff/_header.py
+++ b/xrspatial/geotiff/_header.py
@@ -34,6 +34,15 @@ from ._dtypes import (
 MAX_IFD_ENTRY_COUNT = 100_000
 MAX_IFD_ENTRY_BYTES = 1 << 18  # 256 KiB
 
+# Absolute ceiling for pixel-array tag (StripOffsets, StripByteCounts,
+# TileOffsets, TileByteCounts, ColorMap) `count` values. These tags scale
+# with image size and aren't subject to MAX_IFD_ENTRY_COUNT, but `count`
+# still drives a Python tuple allocation of `count` PyLong objects in
+# `_read_value`. Each PyLong is ~28 bytes, so 100M elements is ~3 GiB of
+# heap before any layout validation runs. Real-world COGs sit well below
+# this: a 1M x 1M image at 256-pixel tiles has ~16M tile entries.
+MAX_PIXEL_ARRAY_COUNT = 100_000_000
+
 # Maximum number of IFDs we walk in `parse_all_ifds` before giving up.
 # Real-world COGs carry the full-resolution IFD plus a handful of overview
 # levels and (optionally) per-band masks, so they sit comfortably below 64
@@ -466,6 +475,86 @@ def _read_value(data: bytes | memoryview, offset: int, type_id: int,
     return struct.unpack_from(f'{bo}{count}{fmt_char}', data, offset)
 
 
+# Tags that pre-scan reads so pixel-array counts can be validated against
+# the IFD's declared geometry. Keep this in sync with
+# _expected_pixel_array_count below.
+_DIMENSION_TAGS = frozenset({
+    TAG_IMAGE_WIDTH,
+    TAG_IMAGE_LENGTH,
+    TAG_TILE_WIDTH,
+    TAG_TILE_LENGTH,
+    TAG_ROWS_PER_STRIP,
+    TAG_SAMPLES_PER_PIXEL,
+    TAG_PLANAR_CONFIG,
+    TAG_BITS_PER_SAMPLE,
+})
+
+# Pixel-array tags exempt from MAX_IFD_ENTRY_COUNT; each gets its own
+# count cap derived from the IFD's dimensions.
+_PIXEL_ARRAY_TAGS = frozenset({
+    TAG_STRIP_OFFSETS,
+    TAG_STRIP_BYTE_COUNTS,
+    TAG_TILE_OFFSETS,
+    TAG_TILE_BYTE_COUNTS,
+    TAG_COLORMAP,
+})
+
+
+def _scalar(v: Any) -> Any:
+    """Unwrap a single-element tuple, leave everything else alone."""
+    if isinstance(v, tuple):
+        return v[0] if v else None
+    return v
+
+
+def _expected_pixel_array_count(tag: int, dims: dict[int, Any]) -> int | None:
+    """Maximum legitimate count for a pixel-array tag given the IFD's
+    declared dimensions. Returns None when the geometry tags needed for
+    the calculation are missing or unusable; callers must still apply
+    the absolute MAX_PIXEL_ARRAY_COUNT cap in that case."""
+    width = _scalar(dims.get(TAG_IMAGE_WIDTH))
+    height = _scalar(dims.get(TAG_IMAGE_LENGTH))
+    samples = _scalar(dims.get(TAG_SAMPLES_PER_PIXEL)) or 1
+    planar = _scalar(dims.get(TAG_PLANAR_CONFIG)) or 1
+    if not isinstance(samples, int) or samples < 1:
+        samples = 1
+    if planar not in (1, 2):
+        planar = 1
+
+    if tag == TAG_COLORMAP:
+        bps = _scalar(dims.get(TAG_BITS_PER_SAMPLE))
+        if not isinstance(bps, int) or bps <= 0 or bps > 16:
+            # TIFF 6.0 caps palette BitsPerSample at 8 (officially); 16
+            # is the widest reasonable upper bound we'll accept.
+            bps = 16
+        return 3 * (1 << bps)
+
+    if tag in (TAG_TILE_OFFSETS, TAG_TILE_BYTE_COUNTS):
+        tw = _scalar(dims.get(TAG_TILE_WIDTH))
+        th = _scalar(dims.get(TAG_TILE_LENGTH))
+        if not (isinstance(tw, int) and isinstance(th, int)
+                and isinstance(width, int) and isinstance(height, int)
+                and tw > 0 and th > 0 and width > 0 and height > 0):
+            return None
+        tiles = math.ceil(width / tw) * math.ceil(height / th)
+        if planar == 2:
+            tiles *= samples
+        return tiles
+
+    if tag in (TAG_STRIP_OFFSETS, TAG_STRIP_BYTE_COUNTS):
+        if not (isinstance(height, int) and height > 0):
+            return None
+        rps = _scalar(dims.get(TAG_ROWS_PER_STRIP))
+        if not isinstance(rps, int) or rps <= 0:
+            rps = height
+        strips = math.ceil(height / rps)
+        if planar == 2:
+            strips *= samples
+        return strips
+
+    return None
+
+
 def parse_ifd(data: bytes | memoryview, offset: int,
               header: TIFFHeader) -> IFD:
     """Parse a single IFD at the given offset.
@@ -523,15 +612,37 @@ def parse_ifd(data: bytes | memoryview, offset: int,
     inline_max = 8 if is_big else 4
     entries = {}
 
-    # Tags whose `count` legitimately scales with image size (one entry per
-    # strip / tile / colormap slot). These are exempt from MAX_IFD_ENTRY_COUNT.
-    pixel_array_tags = {
-        TAG_STRIP_OFFSETS,
-        TAG_STRIP_BYTE_COUNTS,
-        TAG_TILE_OFFSETS,
-        TAG_TILE_BYTE_COUNTS,
-        TAG_COLORMAP,
-    }
+    # Pre-scan: walk the entry table and read inline values for the
+    # geometry tags we need to validate pixel-array counts. This pass
+    # only touches the fixed-size entry table; no pointer follows. A
+    # malformed file with a huge `count` on a pixel-array tag is caught
+    # by _expected_pixel_array_count below before the main loop reaches
+    # the actual unpack.
+    dims: dict[int, Any] = {}
+    for i in range(num_entries):
+        eo = entry_offset + i * entry_size
+        if is_big:
+            tag = struct.unpack_from(f'{bo}H', data, eo)[0]
+            type_id = struct.unpack_from(f'{bo}H', data, eo + 2)[0]
+            count = struct.unpack_from(f'{bo}Q', data, eo + 4)[0]
+            value_area_offset = eo + 12
+        else:
+            tag = struct.unpack_from(f'{bo}H', data, eo)[0]
+            type_id = struct.unpack_from(f'{bo}H', data, eo + 2)[0]
+            count = struct.unpack_from(f'{bo}I', data, eo + 4)[0]
+            value_area_offset = eo + 8
+        if tag not in _DIMENSION_TAGS:
+            continue
+        type_size = TIFF_TYPE_SIZES.get(type_id, 1)
+        if count == 0 or count * type_size > inline_max:
+            # Out-of-line dimension values would require following a
+            # pointer we haven't validated. Skip; the absolute pixel
+            # cap still fires.
+            continue
+        try:
+            dims[tag] = _read_value(data, value_area_offset, type_id, count, bo)
+        except (struct.error, ValueError):
+            continue
 
     for i in range(num_entries):
         eo = entry_offset + i * entry_size
@@ -551,10 +662,23 @@ def parse_ifd(data: bytes | memoryview, offset: int,
         total_size = count * type_size
 
         # Reject absurd counts/sizes on non-pixel tags before any
-        # allocation. Pixel-data offset/byte-count arrays may legitimately
-        # be very large for high-resolution tiled images, so they're
-        # exempt. Both element-count and byte-range caps fire here.
-        if tag not in pixel_array_tags:
+        # allocation. Pixel-data offset/byte-count and colormap arrays
+        # are bounded separately against the IFD's geometry below.
+        if tag in _PIXEL_ARRAY_TAGS:
+            if count > MAX_PIXEL_ARRAY_COUNT:
+                raise ValueError(
+                    f"IFD entry tag={tag} count={count} exceeds "
+                    f"MAX_PIXEL_ARRAY_COUNT={MAX_PIXEL_ARRAY_COUNT}; refusing "
+                    f"to parse possibly malformed TIFF"
+                )
+            expected = _expected_pixel_array_count(tag, dims)
+            if expected is not None and count > expected:
+                raise ValueError(
+                    f"IFD entry tag={tag} count={count} exceeds expected "
+                    f"value {expected} derived from IFD dimensions; refusing "
+                    f"to parse possibly malformed TIFF"
+                )
+        else:
             if count > MAX_IFD_ENTRY_COUNT:
                 raise ValueError(
                     f"IFD entry tag={tag} count={count} exceeds "

--- a/xrspatial/geotiff/tests/test_pixel_array_count_cap_1901.py
+++ b/xrspatial/geotiff/tests/test_pixel_array_count_cap_1901.py
@@ -1,0 +1,321 @@
+"""Pixel-array IFD tag count must be bounded against IFD dimensions.
+
+Regression for issue #1901. `StripOffsets`, `StripByteCounts`,
+`TileOffsets`, `TileByteCounts`, and `ColorMap` were exempt from the
+generic `MAX_IFD_ENTRY_COUNT` cap because their `count` legitimately
+scales with image size. The exemption made it possible to craft a
+TIFF whose value pointer falls inside the file but whose `count` is
+astronomically large; `parse_ifd` would then allocate a Python tuple
+of `count` PyLong objects before any layout validation ran.
+
+The fix:
+
+* `MAX_PIXEL_ARRAY_COUNT` (100M) caps any pixel-array tag absolutely.
+* `_expected_pixel_array_count` derives a tighter cap from the IFD's
+  ImageWidth / ImageLength / TileWidth / TileLength / RowsPerStrip /
+  SamplesPerPixel / PlanarConfiguration / BitsPerSample tags. The
+  parser pre-scans those (inline only) before the main entry loop.
+"""
+from __future__ import annotations
+
+import struct
+
+import pytest
+
+from xrspatial.geotiff import _header
+from xrspatial.geotiff._dtypes import LONG, SHORT
+from xrspatial.geotiff._header import (
+    MAX_PIXEL_ARRAY_COUNT,
+    TAG_BITS_PER_SAMPLE,
+    TAG_COLORMAP,
+    TAG_IMAGE_LENGTH,
+    TAG_IMAGE_WIDTH,
+    TAG_PLANAR_CONFIG,
+    TAG_ROWS_PER_STRIP,
+    TAG_SAMPLES_PER_PIXEL,
+    TAG_STRIP_BYTE_COUNTS,
+    TAG_STRIP_OFFSETS,
+    TAG_TILE_BYTE_COUNTS,
+    TAG_TILE_LENGTH,
+    TAG_TILE_OFFSETS,
+    TAG_TILE_WIDTH,
+    parse_header,
+    parse_ifd,
+)
+
+
+def _short_bytes(v: int) -> bytes:
+    return struct.pack('<H', v) + b'\x00\x00'
+
+
+def _long_bytes(v: int) -> bytes:
+    return struct.pack('<I', v)
+
+
+def _build_classic_tiff(
+    entries: list[tuple[int, int, int, bytes]],
+    tail_padding: int = 0,
+    external_payloads: list[tuple[int, bytes]] | None = None,
+) -> bytes:
+    bo = '<'
+    n = len(entries)
+    ifd_offset = 8
+    ifd_size = 2 + n * 12 + 4
+    end_of_ifd = ifd_offset + ifd_size
+    file_size = end_of_ifd + tail_padding
+    if external_payloads:
+        for off, payload in external_payloads:
+            file_size = max(file_size, off + len(payload))
+
+    buf = bytearray(file_size)
+    buf[0:2] = b'II'
+    struct.pack_into(f'{bo}H', buf, 2, 42)
+    struct.pack_into(f'{bo}I', buf, 4, ifd_offset)
+    struct.pack_into(f'{bo}H', buf, ifd_offset, n)
+    for i, (tag, type_id, count, value_bytes) in enumerate(entries):
+        eo = ifd_offset + 2 + i * 12
+        struct.pack_into(f'{bo}H', buf, eo, tag)
+        struct.pack_into(f'{bo}H', buf, eo + 2, type_id)
+        struct.pack_into(f'{bo}I', buf, eo + 4, count)
+        assert len(value_bytes) == 4
+        buf[eo + 8:eo + 12] = value_bytes
+    struct.pack_into(f'{bo}I', buf, ifd_offset + 2 + n * 12, 0)
+    if external_payloads:
+        for off, payload in external_payloads:
+            buf[off:off + len(payload)] = payload
+    return bytes(buf)
+
+
+def test_tile_offsets_count_exceeds_geometry_rejected():
+    """TileOffsets `count` larger than tiles_across * tiles_down raises.
+
+    1024x1024 image, 256x256 tiles -> 16 tiles. count=100 must raise.
+    """
+    payload_offset = 8 + 2 + 12 * 5 + 4
+    bad_count = 100
+    payload = b'\x00' * (bad_count * 4)
+    entries = [
+        (TAG_IMAGE_WIDTH, LONG, 1, _long_bytes(1024)),
+        (TAG_IMAGE_LENGTH, LONG, 1, _long_bytes(1024)),
+        (TAG_TILE_WIDTH, LONG, 1, _long_bytes(256)),
+        (TAG_TILE_LENGTH, LONG, 1, _long_bytes(256)),
+        (TAG_TILE_OFFSETS, LONG, bad_count, _long_bytes(payload_offset)),
+    ]
+    data = _build_classic_tiff(
+        entries, external_payloads=[(payload_offset, payload)],
+    )
+    header = parse_header(data)
+    with pytest.raises(ValueError, match="exceeds expected value 16"):
+        parse_ifd(data, header.first_ifd_offset, header)
+
+
+def test_tile_offsets_count_matching_geometry_passes():
+    """16 tiles in a 1024x1024 image with 256x256 tiles must parse."""
+    payload_offset = 8 + 2 + 12 * 5 + 4
+    good_count = 16
+    payload = b'\x00' * (good_count * 4)
+    entries = [
+        (TAG_IMAGE_WIDTH, LONG, 1, _long_bytes(1024)),
+        (TAG_IMAGE_LENGTH, LONG, 1, _long_bytes(1024)),
+        (TAG_TILE_WIDTH, LONG, 1, _long_bytes(256)),
+        (TAG_TILE_LENGTH, LONG, 1, _long_bytes(256)),
+        (TAG_TILE_OFFSETS, LONG, good_count, _long_bytes(payload_offset)),
+    ]
+    data = _build_classic_tiff(
+        entries, external_payloads=[(payload_offset, payload)],
+    )
+    header = parse_header(data)
+    ifd = parse_ifd(data, header.first_ifd_offset, header)
+    assert ifd.entries[TAG_TILE_OFFSETS].count == good_count
+
+
+def test_strip_offsets_count_exceeds_geometry_rejected():
+    """StripOffsets count larger than ceil(height / rows_per_strip) raises.
+
+    256x256 with RowsPerStrip=64 -> 4 strips. count=200 must raise.
+    """
+    payload_offset = 8 + 2 + 12 * 4 + 4
+    bad_count = 200
+    payload = b'\x00' * (bad_count * 4)
+    entries = [
+        (TAG_IMAGE_WIDTH, LONG, 1, _long_bytes(256)),
+        (TAG_IMAGE_LENGTH, LONG, 1, _long_bytes(256)),
+        (TAG_ROWS_PER_STRIP, LONG, 1, _long_bytes(64)),
+        (TAG_STRIP_OFFSETS, LONG, bad_count, _long_bytes(payload_offset)),
+    ]
+    data = _build_classic_tiff(
+        entries, external_payloads=[(payload_offset, payload)],
+    )
+    header = parse_header(data)
+    with pytest.raises(ValueError, match="exceeds expected value 4"):
+        parse_ifd(data, header.first_ifd_offset, header)
+
+
+def test_strip_byte_counts_planar_multiplies_by_samples():
+    """PlanarConfig=2 multiplies expected strip count by samples_per_pixel.
+
+    256x256 with RowsPerStrip=64 and 3 samples planar -> 12 entries.
+    count=12 passes; count=13 raises.
+    """
+    payload_offset = 8 + 2 + 12 * 6 + 4
+    payload = b'\x00' * (12 * 4)
+    base_entries = [
+        (TAG_IMAGE_WIDTH, LONG, 1, _long_bytes(256)),
+        (TAG_IMAGE_LENGTH, LONG, 1, _long_bytes(256)),
+        (TAG_ROWS_PER_STRIP, LONG, 1, _long_bytes(64)),
+        (TAG_SAMPLES_PER_PIXEL, SHORT, 1, _short_bytes(3)),
+        (TAG_PLANAR_CONFIG, SHORT, 1, _short_bytes(2)),
+    ]
+    good = base_entries + [
+        (TAG_STRIP_BYTE_COUNTS, LONG, 12, _long_bytes(payload_offset)),
+    ]
+    data = _build_classic_tiff(
+        good, external_payloads=[(payload_offset, payload)],
+    )
+    header = parse_header(data)
+    ifd = parse_ifd(data, header.first_ifd_offset, header)
+    assert ifd.entries[TAG_STRIP_BYTE_COUNTS].count == 12
+
+    bad = base_entries + [
+        (TAG_STRIP_BYTE_COUNTS, LONG, 13, _long_bytes(payload_offset)),
+    ]
+    data = _build_classic_tiff(
+        bad, external_payloads=[(payload_offset, b'\x00' * (13 * 4))],
+    )
+    header = parse_header(data)
+    with pytest.raises(ValueError, match="exceeds expected value 12"):
+        parse_ifd(data, header.first_ifd_offset, header)
+
+
+def test_colormap_count_exceeds_bits_per_sample_rejected():
+    """ColorMap count > 3 * 2^bits_per_sample raises.
+
+    BitsPerSample=8 -> expected 3 * 256 = 768. count=2000 must raise.
+    """
+    payload_offset = 8 + 2 + 12 * 2 + 4
+    bad_count = 2000
+    payload = b'\x00' * (bad_count * 2)
+    entries = [
+        (TAG_BITS_PER_SAMPLE, SHORT, 1, _short_bytes(8)),
+        (TAG_COLORMAP, SHORT, bad_count, _long_bytes(payload_offset)),
+    ]
+    data = _build_classic_tiff(
+        entries, external_payloads=[(payload_offset, payload)],
+    )
+    header = parse_header(data)
+    with pytest.raises(ValueError, match="exceeds expected value 768"):
+        parse_ifd(data, header.first_ifd_offset, header)
+
+
+def test_colormap_count_at_expected_passes():
+    """ColorMap with the exact expected count for BPS=8 must parse."""
+    payload_offset = 8 + 2 + 12 * 2 + 4
+    good_count = 3 * 256
+    payload = b'\x00' * (good_count * 2)
+    entries = [
+        (TAG_BITS_PER_SAMPLE, SHORT, 1, _short_bytes(8)),
+        (TAG_COLORMAP, SHORT, good_count, _long_bytes(payload_offset)),
+    ]
+    data = _build_classic_tiff(
+        entries, external_payloads=[(payload_offset, payload)],
+    )
+    header = parse_header(data)
+    ifd = parse_ifd(data, header.first_ifd_offset, header)
+    assert ifd.entries[TAG_COLORMAP].count == good_count
+
+
+def test_absolute_cap_fires_when_dimensions_missing():
+    """With no geometry tags in the IFD, MAX_PIXEL_ARRAY_COUNT alone caps.
+
+    Monkeypatched down to keep the test cheap.
+    """
+    cap = 100
+    monkey_value = cap
+    orig = _header.MAX_PIXEL_ARRAY_COUNT
+    _header.MAX_PIXEL_ARRAY_COUNT = monkey_value
+    try:
+        bad_count = cap + 1
+        entries = [
+            (TAG_TILE_OFFSETS, LONG, bad_count, _long_bytes(0)),
+        ]
+        data = _build_classic_tiff(entries, tail_padding=512)
+        header = parse_header(data)
+        with pytest.raises(
+            ValueError, match=r"exceeds MAX_PIXEL_ARRAY_COUNT=100"
+        ):
+            parse_ifd(data, header.first_ifd_offset, header)
+    finally:
+        _header.MAX_PIXEL_ARRAY_COUNT = orig
+
+
+def test_absolute_cap_constant_is_reasonable():
+    """Sanity check: 100M elements is enough for any realistic image but
+    far below the count required to drive a multi-GiB allocation."""
+    # 1M x 1M image at 256-pixel tiles is ~16M tiles.
+    assert MAX_PIXEL_ARRAY_COUNT >= 16_000_000
+    # 100M PyLongs is roughly 3 GiB; refuse to allocate more than that.
+    assert MAX_PIXEL_ARRAY_COUNT <= 1_000_000_000
+
+
+def test_dimensions_listed_after_pixel_array_tag_still_validate():
+    """Pre-scan must collect dimensions even when the pixel-array tag
+    appears earlier in tag-numeric order than they do.
+
+    A malicious file could reorder entries; the parser pre-scan walks
+    the whole entry table before validating counts.
+    """
+    payload_offset = 8 + 2 + 12 * 5 + 4
+    bad_count = 100
+    payload = b'\x00' * (bad_count * 4)
+    # Same 1024x1024, 256x256 case (16 tiles), but TileOffsets first.
+    entries = [
+        (TAG_TILE_OFFSETS, LONG, bad_count, _long_bytes(payload_offset)),
+        (TAG_IMAGE_WIDTH, LONG, 1, _long_bytes(1024)),
+        (TAG_IMAGE_LENGTH, LONG, 1, _long_bytes(1024)),
+        (TAG_TILE_WIDTH, LONG, 1, _long_bytes(256)),
+        (TAG_TILE_LENGTH, LONG, 1, _long_bytes(256)),
+    ]
+    # Note: TIFF spec says entries should be tag-sorted, but the parser
+    # doesn't enforce that. We test that out-of-order entries still get
+    # validated against the geometry.
+    data = _build_classic_tiff(
+        entries, external_payloads=[(payload_offset, payload)],
+    )
+    header = parse_header(data)
+    with pytest.raises(ValueError, match="exceeds expected value 16"):
+        parse_ifd(data, header.first_ifd_offset, header)
+
+
+def test_strip_byte_counts_chunky_uses_image_length_only():
+    """PlanarConfig=1 (chunky) does NOT multiply expected strip count.
+
+    256x256 with RowsPerStrip=64 and 3 samples chunky -> 4 entries.
+    """
+    payload_offset = 8 + 2 + 12 * 6 + 4
+    good_count = 4
+    payload = b'\x00' * (good_count * 4)
+    entries = [
+        (TAG_IMAGE_WIDTH, LONG, 1, _long_bytes(256)),
+        (TAG_IMAGE_LENGTH, LONG, 1, _long_bytes(256)),
+        (TAG_ROWS_PER_STRIP, LONG, 1, _long_bytes(64)),
+        (TAG_SAMPLES_PER_PIXEL, SHORT, 1, _short_bytes(3)),
+        (TAG_PLANAR_CONFIG, SHORT, 1, _short_bytes(1)),
+        (TAG_STRIP_OFFSETS, LONG, good_count, _long_bytes(payload_offset)),
+    ]
+    data = _build_classic_tiff(
+        entries, external_payloads=[(payload_offset, payload)],
+    )
+    header = parse_header(data)
+    ifd = parse_ifd(data, header.first_ifd_offset, header)
+    assert ifd.entries[TAG_STRIP_OFFSETS].count == good_count
+
+    # And chunky with count=5 raises.
+    bad = entries[:-1] + [
+        (TAG_STRIP_OFFSETS, LONG, 5, _long_bytes(payload_offset)),
+    ]
+    data = _build_classic_tiff(
+        bad, external_payloads=[(payload_offset, b'\x00' * (5 * 4))],
+    )
+    header = parse_header(data)
+    with pytest.raises(ValueError, match="exceeds expected value 4"):
+        parse_ifd(data, header.first_ifd_offset, header)

--- a/xrspatial/geotiff/tests/test_security.py
+++ b/xrspatial/geotiff/tests/test_security.py
@@ -238,7 +238,14 @@ class TestTileDimensionGuard:
         with open(forged_path, 'wb') as f:
             f.write(bytes(patched))
 
-        with pytest.raises(ValueError, match="exceed the safety limit"):
+        # Two valid rejection points: parse_ifd catches the mismatch
+        # between forged tile dims and the actual TileOffsets count
+        # (issue #1901), or validate_tile_layout's safety-limit check
+        # fires later if pre-IFD validation is ever relaxed.
+        with pytest.raises(
+            ValueError,
+            match=r"exceed the safety limit|exceeds expected value",
+        ):
             open_geotiff(forged_path, max_pixels=1_000_000)
 
 


### PR DESCRIPTION
## Summary

- Cap pixel-array IFD tag counts (`StripOffsets`, `StripByteCounts`, `TileOffsets`, `TileByteCounts`, `ColorMap`) against expected counts derived from the IFD's own dimension tags.
- Pre-scan inline values for `ImageWidth`, `ImageLength`, `TileWidth`, `TileLength`, `RowsPerStrip`, `SamplesPerPixel`, `PlanarConfiguration`, and `BitsPerSample` before validating pixel-array counts. Entries can be in any order; the pre-scan walks the entry table once with no pointer follows.
- Add `MAX_PIXEL_ARRAY_COUNT = 100_000_000` as an absolute ceiling for the case where dimensions are missing or unusable. 100M PyLong tuple entries is roughly 3 GiB — well above any realistic image (1M x 1M at 256-pixel tiles is ~16M tiles) but bounded enough to block multi-GB allocation from a tampered IFD.

Before this, the file-length bound stopped out-of-range reads, but `struct.unpack_from(f'{bo}{count}{fmt_char}', ...)` still allocated a tuple of `count` PyLong objects. With a multi-GiB sparse or legitimately large file plus a tampered IFD, that drove a large heap allocation before `max_pixels` or `validate_tile_layout` ran.

The existing forged-tile-dims security test now hits the new check at IFD parse time rather than at `validate_tile_layout`; the regex accepts both messages.

Closes #1901.

## Test plan

- [x] `pytest xrspatial/geotiff/tests/test_pixel_array_count_cap_1901.py` — new regression tests pass
- [x] `pytest xrspatial/geotiff/tests/test_parse_ifd_bounds.py xrspatial/geotiff/tests/test_ifd_entry_table_bounds_1672.py` — existing IFD-bounds tests pass
- [x] Full `xrspatial/geotiff/tests/` suite passes (2872 tests; 2 pre-existing failures on main are unrelated)
