### PR TITLE
geotiff: reject non-int band kwarg in non-VRT read paths (#1910)

### DIFF
--- a/xrspatial/geotiff/_backends/dask.py
+++ b/xrspatial/geotiff/_backends/dask.py
@@ -250,6 +250,14 @@ def read_geotiff_dask(source: str, *,
         if isinstance(band, (bool, np.bool_)):
             raise ValueError(
                 f"band must be a non-negative int, got {band!r}")
+        # Reject non-integer numeric types and anything else that would
+        # slip past the bool guard. ``band=0.0`` passes the range check
+        # below and either silently reads band 0 (single-band) or fails
+        # with a raw numpy ``IndexError`` (multi-band). The VRT paths
+        # already enforce this; mirror them here. See #1910.
+        if not isinstance(band, (int, np.integer)):
+            raise TypeError(
+                f"band must be a non-negative int, got {band!r}")
         if n_bands == 0:
             if band != 0:
                 raise IndexError(

--- a/xrspatial/geotiff/_backends/gpu.py
+++ b/xrspatial/geotiff/_backends/gpu.py
@@ -319,6 +319,14 @@ def read_geotiff_gpu(source: str, *,
             if isinstance(band, (bool, np.bool_)):
                 raise ValueError(
                     f"band must be a non-negative int, got {band!r}")
+            # Reject non-integer numeric types and anything else that
+            # slips past the bool guard. ``band=0.0`` passes the range
+            # check below and either silently reads band 0 or fails with
+            # a raw numpy/cupy ``IndexError`` on multi-band files. The
+            # VRT paths already enforce this. See #1910.
+            if not isinstance(band, (int, np.integer)):
+                raise TypeError(
+                    f"band must be a non-negative int, got {band!r}")
             if ifd_samples <= 1:
                 if band != 0:
                     raise IndexError(
@@ -1005,6 +1013,13 @@ def _read_geotiff_gpu_chunked_gds(source, ifd, geo_info, header, *,
         # (#1896).
         if isinstance(band, (bool, np.bool_)):
             raise ValueError(
+                f"band must be a non-negative int, got {band!r}")
+        # Reject non-integer numeric types and anything else that slips
+        # past the bool guard. ``band=0.0`` passes the range check below
+        # and either silently reads band 0 or fails with a raw IndexError
+        # from deep in the GDS read path on multi-band files. See #1910.
+        if not isinstance(band, (int, np.integer)):
+            raise TypeError(
                 f"band must be a non-negative int, got {band!r}")
         if n_bands_out == 0:
             if band != 0:

--- a/xrspatial/geotiff/_reader.py
+++ b/xrspatial/geotiff/_reader.py
@@ -2230,6 +2230,17 @@ def _read_cog_http(url: str, overview_level: int | None = None,
                 source.close()
                 raise ValueError(
                     f"band must be a non-negative int, got {band!r}")
+            # Reject non-integer numeric types and anything else that
+            # would slip past the bool guard. ``band=0.0`` passes
+            # ``0 <= 0.0 < n_bands`` and silently selects band 0 on a
+            # single-band file or raises a raw numpy ``IndexError`` from
+            # deep in the read path on multi-band files; ``band="0"``
+            # fails the comparison with an opaque ``TypeError``. The VRT
+            # paths already enforce this; mirror them here. See #1910.
+            if not isinstance(band, (int, np.integer)):
+                source.close()
+                raise TypeError(
+                    f"band must be a non-negative int, got {band!r}")
             if ifd.samples_per_pixel <= 1:
                 if band != 0:
                     source.close()
@@ -2996,6 +3007,15 @@ def read_to_array(source, *, window=None, overview_level: int | None = None,
             # rejection. See #1786.
             if isinstance(band, (bool, np.bool_)):
                 raise ValueError(
+                    f"band must be a non-negative int, got {band!r}")
+            # Reject non-integer numeric types and anything else that
+            # would slip past the bool guard. ``band=0.0`` passes
+            # ``0 <= 0.0 < n_bands`` and silently selects band 0 on a
+            # single-band file or raises a raw numpy ``IndexError`` from
+            # deep in the read path on multi-band files. The VRT paths
+            # already enforce this; mirror them here. See #1910.
+            if not isinstance(band, (int, np.integer)):
+                raise TypeError(
                     f"band must be a non-negative int, got {band!r}")
             if ifd_samples <= 1:
                 if band != 0:

--- a/xrspatial/geotiff/tests/test_geotiff_band_type_rejection_1910.py
+++ b/xrspatial/geotiff/tests/test_geotiff_band_type_rejection_1910.py
@@ -1,0 +1,199 @@
+"""Regression tests for issue #1910.
+
+The non-VRT read paths reject ``bool`` / ``np.bool_`` (#1786) but they
+do not reject non-integer numeric types like ``float`` or strings. A
+caller passing ``band=0.0`` slips past the type guard, the range check
+evaluates ``0 <= 0.0 < n_bands`` as True, and the read either silently
+succeeds on a single-band file or fails with a raw numpy ``IndexError``
+on multi-band files. The VRT paths in ``_vrt.py`` and
+``_backends/vrt.py`` already use the stricter
+``isinstance(band, (int, np.integer))`` form, so the contract differed
+across backends.
+
+These tests pin each non-VRT read entry point -- ``read_to_array``,
+``open_geotiff``, ``read_geotiff_dask``, ``read_geotiff_gpu`` (when
+cupy is available) -- to raise ``TypeError`` for non-int ``band``
+values. They also confirm the existing bool rejection from #1786 still
+fires (and still raises ``ValueError`` for back-compat).
+"""
+from __future__ import annotations
+
+import importlib.util
+
+import numpy as np
+import pytest
+import xarray as xr
+
+
+def _gpu_available() -> bool:
+    if importlib.util.find_spec("cupy") is None:
+        return False
+    try:
+        import cupy
+        return bool(cupy.cuda.is_available())
+    except Exception:
+        return False
+
+
+_HAS_GPU = _gpu_available()
+_gpu_only = pytest.mark.skipif(not _HAS_GPU, reason="cupy + CUDA required")
+
+
+@pytest.fixture
+def multiband_tiff_path_1910(tmp_path):
+    """4x6 three-band tiled tiff for the band-type rejection tests."""
+    from xrspatial.geotiff import to_geotiff
+
+    arr = np.arange(72, dtype=np.float32).reshape(4, 6, 3)
+    da = xr.DataArray(
+        arr,
+        dims=['y', 'x', 'band'],
+        coords={
+            'y': np.array([0.5, 1.5, 2.5, 3.5]),
+            'x': np.array([0.5, 1.5, 2.5, 3.5, 4.5, 5.5]),
+            'band': [0, 1, 2],
+        },
+        attrs={'crs': 4326},
+    )
+    p = tmp_path / 'tmp_1910_band_type.tif'
+    to_geotiff(da, str(p), tile_size=16)
+    return str(p), arr
+
+
+# ---------------------------------------------------------------------------
+# read_to_array (local eager path)
+# ---------------------------------------------------------------------------
+
+
+def test_read_to_array_band_float_rejected(multiband_tiff_path_1910):
+    """``band=0.0`` no longer silently reads band 0."""
+    from xrspatial.geotiff._reader import read_to_array
+
+    path, _ = multiband_tiff_path_1910
+    with pytest.raises(TypeError, match="band must be a non-negative int"):
+        read_to_array(path, band=0.0)
+
+
+def test_read_to_array_band_np_float_rejected(multiband_tiff_path_1910):
+    """``band=np.float32(0)`` is rejected as well."""
+    from xrspatial.geotiff._reader import read_to_array
+
+    path, _ = multiband_tiff_path_1910
+    with pytest.raises(TypeError, match="band must be a non-negative int"):
+        read_to_array(path, band=np.float32(0))
+
+
+def test_read_to_array_band_str_rejected(multiband_tiff_path_1910):
+    """Strings are rejected too."""
+    from xrspatial.geotiff._reader import read_to_array
+
+    path, _ = multiband_tiff_path_1910
+    with pytest.raises(TypeError, match="band must be a non-negative int"):
+        read_to_array(path, band="0")
+
+
+def test_read_to_array_band_int_still_works(multiband_tiff_path_1910):
+    """``band=1`` is a plain int and still selects band 1."""
+    from xrspatial.geotiff._reader import read_to_array
+
+    path, arr = multiband_tiff_path_1910
+    out, _ = read_to_array(path, band=1)
+    np.testing.assert_array_equal(out, arr[:, :, 1])
+
+
+def test_read_to_array_band_np_integer_still_works(multiband_tiff_path_1910):
+    """``np.int64(1)`` is accepted because it is an ``np.integer``."""
+    from xrspatial.geotiff._reader import read_to_array
+
+    path, arr = multiband_tiff_path_1910
+    out, _ = read_to_array(path, band=np.int64(1))
+    np.testing.assert_array_equal(out, arr[:, :, 1])
+
+
+def test_read_to_array_band_bool_still_rejected(multiband_tiff_path_1910):
+    """The #1786 bool guard fires first and keeps the ValueError."""
+    from xrspatial.geotiff._reader import read_to_array
+
+    path, _ = multiband_tiff_path_1910
+    with pytest.raises(ValueError, match="band must be a non-negative int"):
+        read_to_array(path, band=True)
+
+
+# ---------------------------------------------------------------------------
+# open_geotiff (public dispatcher)
+# ---------------------------------------------------------------------------
+
+
+def test_open_geotiff_band_float_rejected(multiband_tiff_path_1910):
+    """``open_geotiff(..., band=0.0)`` raises ``TypeError``."""
+    from xrspatial.geotiff import open_geotiff
+
+    path, _ = multiband_tiff_path_1910
+    with pytest.raises(TypeError, match="band must be a non-negative int"):
+        open_geotiff(path, band=0.0)
+
+
+def test_open_geotiff_band_str_rejected(multiband_tiff_path_1910):
+    """``open_geotiff(..., band='0')`` raises ``TypeError``."""
+    from xrspatial.geotiff import open_geotiff
+
+    path, _ = multiband_tiff_path_1910
+    with pytest.raises(TypeError, match="band must be a non-negative int"):
+        open_geotiff(path, band="0")
+
+
+# ---------------------------------------------------------------------------
+# read_geotiff_dask (dask CPU path)
+# ---------------------------------------------------------------------------
+
+
+def test_read_geotiff_dask_band_float_rejected(multiband_tiff_path_1910):
+    """``read_geotiff_dask(..., band=0.0)`` is rejected before scheduling."""
+    from xrspatial.geotiff import read_geotiff_dask
+
+    path, _ = multiband_tiff_path_1910
+    with pytest.raises(TypeError, match="band must be a non-negative int"):
+        read_geotiff_dask(path, chunks=4, band=0.0)
+
+
+def test_read_geotiff_dask_band_str_rejected(multiband_tiff_path_1910):
+    """``read_geotiff_dask(..., band='0')`` raises ``TypeError``."""
+    from xrspatial.geotiff import read_geotiff_dask
+
+    path, _ = multiband_tiff_path_1910
+    with pytest.raises(TypeError, match="band must be a non-negative int"):
+        read_geotiff_dask(path, chunks=4, band="0")
+
+
+def test_read_geotiff_dask_band_int_still_works(multiband_tiff_path_1910):
+    """``band=1`` still routes through and reads band 1."""
+    from xrspatial.geotiff import read_geotiff_dask
+
+    path, arr = multiband_tiff_path_1910
+    out = read_geotiff_dask(path, chunks=4, band=1)
+    np.testing.assert_array_equal(out.values, arr[:, :, 1])
+
+
+# ---------------------------------------------------------------------------
+# read_geotiff_gpu (GPU path)
+# ---------------------------------------------------------------------------
+
+
+@_gpu_only
+def test_read_geotiff_gpu_band_float_rejected(multiband_tiff_path_1910):
+    """``read_geotiff_gpu(..., band=0.0)`` raises ``TypeError``."""
+    from xrspatial.geotiff import read_geotiff_gpu
+
+    path, _ = multiband_tiff_path_1910
+    with pytest.raises(TypeError, match="band must be a non-negative int"):
+        read_geotiff_gpu(path, band=0.0)
+
+
+@_gpu_only
+def test_read_geotiff_gpu_band_str_rejected(multiband_tiff_path_1910):
+    """``read_geotiff_gpu(..., band='0')`` raises ``TypeError``."""
+    from xrspatial.geotiff import read_geotiff_gpu
+
+    path, _ = multiband_tiff_path_1910
+    with pytest.raises(TypeError, match="band must be a non-negative int"):
+        read_geotiff_gpu(path, band="0")


### PR DESCRIPTION
Closes #1910.

## Summary

- The five non-VRT band validators rejected `bool` / `np.bool_` (#1786) but let `float`, `str`, and other non-int types slip past to the range check, so `band=0.0` silently selected band 0 or raised a raw numpy `IndexError`.
- Added a `TypeError` after the existing bool guard in `_read_cog_http`, `read_to_array`, `read_geotiff_dask`, and both GPU paths. The bool guard stays first because `bool` is a subclass of `int`, and it keeps its `ValueError` for back-compat with the tests added in #1786.
- The VRT paths already enforced this; the four backends now agree on the `band` contract.

## Test plan

- [x] `python -m pytest xrspatial/geotiff/tests/test_geotiff_band_type_rejection_1910.py -x -q` (13 passed; GPU tests skipped on this box)
- [x] `python -m pytest xrspatial/geotiff/tests/test_geotiff_band_bool_rejection_1786.py -x -q` (17 passed; existing bool guard still fires first with `ValueError`)
- [x] `python -m pytest xrspatial/geotiff/tests/test_band_validation_1673.py xrspatial/geotiff/tests/test_gds_chunked_gpu_parity_1896.py -x -q` (13 passed)
- [ ] GPU smoke run on a CUDA box (the GPU paths in this PR are covered by `_gpu_only` tests in the new file)
