### PR TITLE
geotiff: skip degenerate streaming tests when tifffile is unavailable

### DIFF
--- a/xrspatial/geotiff/tests/test_dask_streaming_write_degenerate_2026_05_15.py
+++ b/xrspatial/geotiff/tests/test_dask_streaming_write_degenerate_2026_05_15.py
@@ -59,7 +59,7 @@ def _read_raw_pixels(path: str) -> np.ndarray:
     correctly. ``tifffile`` decodes the pixels but does not consult
     ``GDAL_NODATA``, so a raw read surfaces what is actually on disk.
     """
-    import tifffile
+    tifffile = pytest.importorskip("tifffile")
 
     with tifffile.TiffFile(path) as tif:
         return tif.asarray()


### PR DESCRIPTION
## Summary

CI on main has been failing since #1912 (commit 15882e6) landed. The new file `test_dask_streaming_write_degenerate_2026_05_15.py` uses a `_read_raw_pixels` helper that does a bare `import tifffile`. `tifffile` is an optional dependency that is not installed in the CI environment, so three tests that call the helper error out with `ModuleNotFoundError` instead of skipping:

- `TestStreamingWriteAllNan::test_all_nan_with_sentinel`
- `TestStreamingWriteAllNan::test_all_nan_default_nodata`
- `TestStreamingWriteMixedNanInf::test_mixed_nan_plus_minus_inf`

Other tests in the repo handle the same situation with `pytest.importorskip("tifffile")` (e.g. `test_dask_max_pixels_default_guard_1838.py`, `test_backend_pixel_parity_matrix_1813.py`, `test_predictor2_int8.py`). This change applies the same pattern in the helper so the three tests skip when tifffile is missing and still run when it is installed.

Failed run: https://github.com/xarray-contrib/xarray-spatial/actions/runs/25921856318

## Test plan

- [x] Run the file locally with tifffile installed: all 16 tests pass.
- [x] Run the file locally with tifffile blocked via a meta_path shim: 13 pass, 3 skip (previously 3 errored).
- [ ] CI pytest job goes green on this PR.