### PR TITLE
geotiff: fail closed on unparseable CRS strings by default

### DIFF
--- a/xrspatial/geotiff/_crs.py
+++ b/xrspatial/geotiff/_crs.py
@@ -17,6 +17,33 @@ import warnings
 from ._runtime import GeoTIFFFallbackWarning, _geotiff_strict_mode
 
 
+#: WKT root keywords. A string that starts with one of these (after
+#: stripping leading whitespace) is structurally a WKT and is allowed
+#: to land in ``GTCitationGeoKey`` even when pyproj is not available
+#: to validate it. Anything else (``"EPSG:4326"`` minus pyproj,
+#: ``"+proj=..."`` minus pyproj, free-form garbage) is rejected by
+#: :func:`_validate_crs_fallback` unless the caller opts in. See
+#: issue #1929.
+_WKT_ROOT_KEYWORDS = (
+    'PROJCS', 'GEOGCS', 'PROJCRS', 'GEOGCRS',
+    'COMPD_CS', 'COMPOUNDCRS', 'BOUNDCRS', 'LOCAL_CS', 'ENGCRS',
+    'VERT_CS', 'VERTCRS', 'PARAMETRICCRS', 'TIMECRS', 'DERIVEDPROJCRS',
+)
+
+
+def _looks_like_wkt(s: str) -> bool:
+    """Cheap structural check: does ``s`` start with a WKT root keyword?
+
+    Used by :func:`_validate_crs_fallback` to decide whether a string
+    that pyproj could not (or was not asked to) validate is at least
+    *shaped* like WKT. WKT-shaped strings land in ``GTCitationGeoKey``
+    verbatim; everything else is refused by default.
+    """
+    if not isinstance(s, str):
+        return False
+    return s.lstrip().upper().startswith(_WKT_ROOT_KEYWORDS)
+
+
 def _wkt_to_epsg(wkt_or_proj: str) -> int | None:
     """Try to extract an EPSG code from a WKT or PROJ string.
 
@@ -41,6 +68,49 @@ def _wkt_to_epsg(wkt_or_proj: str) -> int | None:
             stacklevel=2,
         )
         return None
+
+
+def _validate_crs_fallback(
+    wkt_fallback: str | None,
+    allow_unparseable_crs: bool,
+) -> None:
+    """Refuse to land an unvalidatable string in ``GTCitationGeoKey``.
+
+    Issue #1929: when ``_wkt_to_epsg`` cannot resolve the caller's CRS
+    to an EPSG code, the writer stores the original string as
+    ``wkt_fallback`` and emits it into ``GTCitationGeoKey``. If the
+    string is a malformed PROJ / EPSG token (e.g. ``"EPSG:4326"`` on a
+    host without pyproj, or a typo'd PROJ string), the file ends up
+    with garbage in the citation field. For a foundational I/O module
+    the default has to be fail-closed.
+
+    Raises ``ValueError`` when ``wkt_fallback`` is non-None, the string
+    does not structurally look like WKT (:func:`_looks_like_wkt`), and
+    the caller has not opted in via ``allow_unparseable_crs=True``.
+
+    Pyproj-validatable strings never reach the fallback because
+    ``_wkt_to_epsg`` returns an EPSG (or, under
+    ``XRSPATIAL_GEOTIFF_STRICT=1``, raises). The remaining failure
+    modes -- pyproj missing, or pyproj installed and parse-fails --
+    both leave a non-None ``wkt_fallback``, and this helper is what
+    closes the gap.
+    """
+    if wkt_fallback is None:
+        return
+    if _looks_like_wkt(wkt_fallback):
+        return
+    if allow_unparseable_crs:
+        return
+    raise ValueError(
+        "crs is not an EPSG code, is not a WKT string "
+        "(no PROJCS / GEOGCS / PROJCRS / GEOGCRS root), and could not "
+        f"be parsed: got {wkt_fallback!r}. Writing it verbatim to "
+        "GTCitationGeoKey would produce a file most GeoTIFF readers "
+        "cannot interpret. Pass an EPSG int (recommended), a real "
+        "WKT string, install pyproj so EPSG / PROJ tokens can be "
+        "resolved, or pass allow_unparseable_crs=True to keep the "
+        "pre-#1929 citation-only behaviour."
+    )
 
 
 def _resolve_crs_to_wkt(crs) -> str | None:

--- a/xrspatial/geotiff/_writers/eager.py
+++ b/xrspatial/geotiff/_writers/eager.py
@@ -32,7 +32,7 @@ from .._coords import (
     coords_to_transform as _coords_to_transform,
     transform_from_attr as _transform_from_attr,
 )
-from .._crs import _wkt_to_epsg
+from .._crs import _validate_crs_fallback, _wkt_to_epsg
 from .._geotags import GeoTransform, RASTER_PIXEL_IS_AREA
 from .._runtime import (
     GeoTIFFFallbackWarning,
@@ -64,7 +64,8 @@ def to_geotiff(data: xr.DataArray | np.ndarray,
                streaming_buffer_bytes: int = 256 * 1024 * 1024,
                max_z_error: float = 0.0,
                photometric: str | int = 'auto',
-               allow_internal_only_jpeg: bool = False) -> None:
+               allow_internal_only_jpeg: bool = False,
+               allow_unparseable_crs: bool = False) -> None:
     """Write data as a GeoTIFF or Cloud Optimized GeoTIFF.
 
     Dask-backed DataArrays are written in streaming mode: one tile-row
@@ -203,6 +204,18 @@ def to_geotiff(data: xr.DataArray | np.ndarray,
         kwarg is forwarded unchanged to ``write_geotiff_gpu`` on the
         GPU dispatch path so callers can reach the same experimental
         encode via ``to_geotiff(..., gpu=True)``. See issue #1845.
+    allow_unparseable_crs : bool
+        Opt in to writing an unvalidatable CRS string into
+        ``GTCitationGeoKey`` (default ``False``). When ``False`` (the
+        default since #1929), a ``crs=`` value that is neither an EPSG
+        int nor a string that pyproj can resolve and is not
+        structurally WKT (no ``PROJCS`` / ``GEOGCS`` / ``PROJCRS`` /
+        ``GEOGCRS`` root) raises ``ValueError`` instead of landing
+        verbatim in the citation field. Set to ``True`` to keep the
+        pre-#1929 permissive behaviour. The fail-closed default
+        protects against files where a typo'd PROJ string or an
+        ``"EPSG:4326"`` token on a host without pyproj produces a
+        citation that most readers cannot interpret. See issue #1929.
 
     Raises
     ------
@@ -375,7 +388,8 @@ def to_geotiff(data: xr.DataArray | np.ndarray,
                          predictor=predictor,
                          bigtiff=bigtiff,
                          max_z_error=max_z_error,
-                         photometric=photometric)
+                         photometric=photometric,
+                         allow_unparseable_crs=allow_unparseable_crs)
         return
 
     # Dispatch to write_geotiff_gpu when GPU was selected (explicit
@@ -420,6 +434,7 @@ def to_geotiff(data: xr.DataArray | np.ndarray,
                 streaming_buffer_bytes=streaming_buffer_bytes,
                 photometric=photometric,
                 allow_internal_only_jpeg=allow_internal_only_jpeg,
+                allow_unparseable_crs=allow_unparseable_crs,
             )
             return
         except ImportError as e:
@@ -550,6 +565,12 @@ def to_geotiff(data: xr.DataArray | np.ndarray,
                             f"compression_level={compression_level} out of "
                             f"range for {compression} (valid: {lo}-{hi})")
             from .._writer import write_streaming
+            # Issue #1929: refuse to write an unvalidatable CRS string
+            # into GTCitationGeoKey unless the caller opts in. ``epsg``
+            # is set when ``_wkt_to_epsg`` succeeded; only the fallback
+            # branch needs the guard.
+            if epsg is None:
+                _validate_crs_fallback(wkt_fallback, allow_unparseable_crs)
             write_streaming(
                 dask_arr, path,
                 geo_transform=geo_transform,
@@ -630,6 +651,10 @@ def to_geotiff(data: xr.DataArray | np.ndarray,
                     f"compression_level={compression_level} out of range "
                     f"for {compression} (valid: {lo}-{hi})")
 
+    # Issue #1929: refuse to write an unvalidatable CRS string into
+    # GTCitationGeoKey unless the caller opts in.
+    if epsg is None:
+        _validate_crs_fallback(wkt_fallback, allow_unparseable_crs)
     write(
         arr, path,
         geo_transform=geo_transform,
@@ -726,7 +751,8 @@ def _write_vrt_tiled(data, vrt_path, *, crs=None, nodata=None,
                      compression='zstd', compression_level=None,
                      tile_size=256, predictor: bool | int = False,
                      bigtiff=None, max_z_error: float = 0.0,
-                     photometric: str | int = 'auto'):
+                     photometric: str | int = 'auto',
+                     allow_unparseable_crs: bool = False):
     """Write a DataArray as a directory of tiled GeoTIFFs with a VRT index.
 
     This enables streaming dask arrays to disk without materializing the
@@ -811,6 +837,14 @@ def _write_vrt_tiled(data, vrt_path, *, crs=None, nodata=None,
         res_unit = _rich['resolution_unit']
     else:
         raw = data
+
+    # Issue #1929: refuse to write an unvalidatable CRS string into the
+    # per-tile GTCitationGeoKey fields unless the caller opts in.
+    # ``_write_single_tile`` forwards ``wkt_fallback`` to the geokey
+    # builder once per tile, so validate once up front rather than
+    # per-tile.
+    if epsg is None:
+        _validate_crs_fallback(wkt_fallback, allow_unparseable_crs)
 
     # Check for dask backing
     is_dask = hasattr(raw, 'dask')

--- a/xrspatial/geotiff/_writers/gpu.py
+++ b/xrspatial/geotiff/_writers/gpu.py
@@ -22,7 +22,7 @@ from .._coords import (
     coords_to_transform as _coords_to_transform,
     transform_from_attr as _transform_from_attr,
 )
-from .._crs import _wkt_to_epsg
+from .._crs import _validate_crs_fallback, _wkt_to_epsg
 from .._runtime import GeoTIFFFallbackWarning
 from .._validation import (
     _validate_3d_writer_dims,
@@ -46,7 +46,8 @@ def write_geotiff_gpu(data: xr.DataArray | cupy.ndarray | np.ndarray,
                       max_z_error: float = 0.0,
                       streaming_buffer_bytes: int = 256 * 1024 * 1024,
                       photometric: str | int = 'auto',
-                      allow_internal_only_jpeg: bool = False) -> None:
+                      allow_internal_only_jpeg: bool = False,
+                      allow_unparseable_crs: bool = False) -> None:
     """Write a CuPy-backed DataArray as a GeoTIFF with GPU compression.
 
     Tiles are extracted and compressed on the GPU via nvCOMP, then
@@ -172,6 +173,11 @@ def write_geotiff_gpu(data: xr.DataArray | cupy.ndarray | np.ndarray,
         ``GeoTIFFFallbackWarning`` is emitted at call time. Without
         the flag, ``compression='jpeg'`` raises ``ValueError`` for
         parity with ``to_geotiff``. See issue #1845.
+    allow_unparseable_crs : bool
+        Opt in to writing an unvalidatable CRS string into
+        ``GTCitationGeoKey`` (default ``False``). See
+        :func:`to_geotiff` for the full description; the GPU writer
+        applies the same fail-closed default. See issue #1929.
 
     Raises
     ------
@@ -486,6 +492,10 @@ def write_geotiff_gpu(data: xr.DataArray | cupy.ndarray | np.ndarray,
             oh, ow = current.shape[:2]
             parts.append(_gpu_compress_to_part(current, ow, oh, samples))
 
+    # Issue #1929: refuse to write an unvalidatable CRS string into
+    # GTCitationGeoKey unless the caller opts in.
+    if epsg is None:
+        _validate_crs_fallback(wkt_fallback, allow_unparseable_crs)
     file_bytes = _assemble_tiff(
         width, height, np_dtype, comp_tag, pred_val, True, tile_size,
         parts, geo_transform, epsg, nodata,

--- a/xrspatial/geotiff/tests/test_crs_fail_closed_1929.py
+++ b/xrspatial/geotiff/tests/test_crs_fail_closed_1929.py
@@ -1,0 +1,191 @@
+"""Regression tests for issue #1929.
+
+The CRS resolution path used to swallow ``pyproj`` parse failures with
+only a warning, then write the original unvalidatable string verbatim
+into ``GTCitationGeoKey``. A caller who passed
+``to_geotiff(crs="EPSG:4326")`` on a host without pyproj ended up with
+the literal string ``"EPSG:4326"`` in the citation field; non-libgeotiff
+readers drop the projection in that case. The same hole existed for
+typo'd PROJ strings and free-form garbage even with pyproj installed.
+
+The fix:
+
+* Adds ``_validate_crs_fallback`` in ``_crs.py``. It refuses to land any
+  non-WKT-shaped string in the citation when the caller has not opted
+  in via ``allow_unparseable_crs=True``.
+* Adds ``allow_unparseable_crs`` to ``to_geotiff``, ``write_geotiff_gpu``,
+  and the dispatch through to ``_write_vrt_tiled``.
+
+The validator is intentionally cheap (a ``str.startswith`` over the WKT
+root keywords) so it stays in the hot write path.
+"""
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from xrspatial.geotiff import to_geotiff
+from xrspatial.geotiff._crs import (
+    _looks_like_wkt,
+    _validate_crs_fallback,
+    _WKT_ROOT_KEYWORDS,
+)
+
+
+def _make_da() -> xr.DataArray:
+    """Plain numpy-backed DataArray with no CRS attrs."""
+    arr = np.arange(16, dtype=np.float32).reshape(4, 4)
+    return xr.DataArray(
+        arr,
+        dims=("y", "x"),
+        coords={"y": np.arange(4.0, 0, -1), "x": np.arange(4.0)},
+    )
+
+
+class TestLooksLikeWkt:
+    """Structural WKT recognition. Cheap and pyproj-free."""
+
+    @pytest.mark.parametrize("root", _WKT_ROOT_KEYWORDS)
+    def test_each_root_keyword_recognised(self, root):
+        assert _looks_like_wkt(f'{root}["WGS 84", ...]')
+
+    def test_leading_whitespace_tolerated(self):
+        assert _looks_like_wkt('   PROJCS["UTM"]')
+
+    def test_case_insensitive(self):
+        assert _looks_like_wkt('projcs["UTM"]')
+        assert _looks_like_wkt('GeOgCs["WGS 84"]')
+
+    def test_epsg_token_rejected(self):
+        assert not _looks_like_wkt("EPSG:4326")
+
+    def test_proj_string_rejected(self):
+        assert not _looks_like_wkt("+proj=utm +zone=10")
+
+    def test_garbage_rejected(self):
+        assert not _looks_like_wkt("not a CRS at all")
+
+    def test_empty_string_rejected(self):
+        assert not _looks_like_wkt("")
+
+    def test_non_string_rejected(self):
+        assert not _looks_like_wkt(None)
+        assert not _looks_like_wkt(4326)
+
+
+class TestValidateCrsFallback:
+    """Direct unit tests on the validator helper."""
+
+    def test_none_fallback_returns(self):
+        _validate_crs_fallback(None, allow_unparseable_crs=False)
+
+    def test_wkt_shaped_returns(self):
+        _validate_crs_fallback(
+            'PROJCS["test", ...]', allow_unparseable_crs=False
+        )
+
+    def test_non_wkt_raises(self):
+        with pytest.raises(ValueError, match="GTCitationGeoKey"):
+            _validate_crs_fallback("EPSG:4326", allow_unparseable_crs=False)
+
+    def test_opt_in_allows_non_wkt(self):
+        _validate_crs_fallback("EPSG:4326", allow_unparseable_crs=True)
+
+    def test_message_names_the_offending_string(self):
+        with pytest.raises(ValueError) as exc:
+            _validate_crs_fallback("frobnicate", allow_unparseable_crs=False)
+        assert "frobnicate" in str(exc.value)
+        assert "allow_unparseable_crs" in str(exc.value)
+
+
+class TestToGeotiffCrsFailClosed:
+    """End-to-end through the public ``to_geotiff`` entry point.
+
+    Default behaviour now raises on unvalidatable CRS strings, and the
+    opt-in restores the pre-#1929 citation-only write.
+    """
+
+    def test_epsg_int_unchanged(self, tmp_path):
+        """An int EPSG kwarg never lands in the fallback path."""
+        out = str(tmp_path / "epsg_int_1929.tif")
+        to_geotiff(_make_da(), out, crs=4326)
+        assert os.path.exists(out)
+
+    def test_valid_wkt_unchanged(self, tmp_path):
+        """A WKT-shaped string is accepted by the structural check
+        even without pyproj-driven validation."""
+        out = str(tmp_path / "wkt_shaped_1929.tif")
+        wkt = (
+            'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",'
+            '6378137,298.257223563]],PRIMEM["Greenwich",0],'
+            'UNIT["degree",0.0174532925199433]]'
+        )
+        to_geotiff(_make_da(), out, crs=wkt)
+        assert os.path.exists(out)
+
+    def test_epsg_token_string_via_kwarg(self, tmp_path):
+        """``crs="EPSG:4326"`` resolves to int 4326 when pyproj is
+        installed (so ``wkt_fallback`` stays None). Without pyproj the
+        validator would refuse. We assert the success path here; the
+        no-pyproj path is exercised by the validator unit tests."""
+        out = str(tmp_path / "epsg_token_1929.tif")
+        pytest.importorskip("pyproj")
+        to_geotiff(_make_da(), out, crs="EPSG:4326")
+        assert os.path.exists(out)
+
+    def test_garbage_string_kwarg_raises(self, tmp_path):
+        """A free-form non-WKT, non-PROJ string raises by default."""
+        out = str(tmp_path / "garbage_kwarg_1929.tif")
+        # Even with pyproj installed, ``"absolute-garbage"`` fails to
+        # parse, ``_wkt_to_epsg`` returns None with a warning, the
+        # writer lands it as ``wkt_fallback``, and the validator
+        # refuses it. Filter the warning so it does not pollute the
+        # test report.
+        with pytest.warns(Warning):
+            with pytest.raises(ValueError, match="GTCitationGeoKey"):
+                to_geotiff(_make_da(), out, crs="absolute-garbage")
+
+    def test_opt_in_allows_garbage(self, tmp_path):
+        """``allow_unparseable_crs=True`` restores the citation-only
+        write. The file still emits a ``UserWarning`` from the geokey
+        builder, mirroring the pre-#1929 behaviour."""
+        out = str(tmp_path / "opt_in_1929.tif")
+        with pytest.warns(Warning):
+            to_geotiff(
+                _make_da(), out,
+                crs="absolute-garbage",
+                allow_unparseable_crs=True,
+            )
+        assert os.path.exists(out)
+
+    def test_garbage_string_attr_raises(self, tmp_path):
+        """The same guard fires when the bad string arrives via
+        ``attrs['crs']`` instead of the ``crs=`` kwarg."""
+        out = str(tmp_path / "garbage_attr_1929.tif")
+        da = _make_da()
+        da.attrs["crs"] = "still-garbage"
+        with pytest.warns(Warning):
+            with pytest.raises(ValueError, match="GTCitationGeoKey"):
+                to_geotiff(da, out)
+
+    def test_no_crs_at_all_unchanged(self, tmp_path):
+        """No CRS supplied means no GTCitationGeoKey is written; the
+        validator is a no-op."""
+        out = str(tmp_path / "no_crs_1929.tif")
+        to_geotiff(_make_da(), out)
+        assert os.path.exists(out)
+
+    def test_message_recommends_alternatives(self, tmp_path):
+        """The error message points users at the four options:
+        EPSG int, real WKT, install pyproj, or opt in."""
+        out = str(tmp_path / "msg_check_1929.tif")
+        with pytest.warns(Warning):
+            with pytest.raises(ValueError) as exc:
+                to_geotiff(_make_da(), out, crs="bogus")
+        msg = str(exc.value)
+        assert "EPSG" in msg
+        assert "WKT" in msg
+        assert "allow_unparseable_crs" in msg


### PR DESCRIPTION
Closes #1929.

## Summary
- New ``_validate_crs_fallback`` in ``_crs.py``. Refuses to land any non-WKT-shaped string (no ``PROJCS`` / ``GEOGCS`` / ``PROJCRS`` / ``GEOGCRS`` root) in ``GTCitationGeoKey`` unless the caller opts in.
- New ``allow_unparseable_crs`` kwarg (default ``False``) on ``to_geotiff``, ``write_geotiff_gpu``, and the forwarded ``_write_vrt_tiled`` path.
- The pre-#1929 permissive citation-only write is reachable with ``allow_unparseable_crs=True``.
- Existing ``XRSPATIAL_GEOTIFF_STRICT=1`` path keeps working: it re-raises the pyproj parse exception before the fallback ever fires, so strict mode is strictly stronger than the new default.
- ``write_vrt`` is unaffected: ``_resolve_crs_to_wkt`` already raised on parse failure, so the public VRT writer was already fail-closed.

## Test plan
- [x] 34 new tests in ``test_crs_fail_closed_1929.py`` cover the structural WKT recogniser, the validator helper, and the public ``to_geotiff`` surface for int EPSG, valid WKT, ``"EPSG:..."`` tokens with pyproj, garbage strings (kwarg and attrs paths), the opt-in, and the error message contents.
- [x] Existing CRS-WKT tests in ``test_user_defined_crs_wkt_1632.py`` and ``test_write_vrt_crs_1715.py`` still pass (41 tests).
- [x] Full ``xrspatial/geotiff/tests`` suite: 3024 passed, 7 skipped. 8 pre-existing failures (stale monkeypatch in ``test_predictor2_big_endian_gpu_1517.py`` and stale ``tile_size`` validation in ``test_size_param_validation_gpu_vrt_1776.py``) are unrelated to this PR.

## Migration
Callers who relied on the old permissive behaviour (passing ``"EPSG:NNNN"`` strings or PROJ strings to writers on a host without pyproj, or relying on citation-only output for malformed strings) need to either:
- Install pyproj (recommended).
- Pass an int EPSG code via ``crs=4326`` or ``attrs['crs'] = 4326``.
- Pass a real WKT string.
- Add ``allow_unparseable_crs=True`` per call.