### PR TITLE
geotiff: add max_cloud_bytes to canonical reader kwarg order (#1957)

### DIFF
--- a/xrspatial/geotiff/tests/test_reader_kwarg_order_1935.py
+++ b/xrspatial/geotiff/tests/test_reader_kwarg_order_1935.py
@@ -39,6 +39,7 @@ _CANONICAL_ORDER = (
     "chunks",
     "gpu",
     "max_pixels",
+    "max_cloud_bytes",
     "on_gpu_failure",
     "missing_sources",
 )


### PR DESCRIPTION
## Summary

Closes #1957. Unblocks CI on `main` and on every open PR.

PR #1932 added the `max_cloud_bytes` kw-only param to `open_geotiff` but did not update `_CANONICAL_ORDER` in `test_reader_kwarg_order_1935.py`. The signature-parity test has been failing on `main` on every Python version since that commit landed, which in turn makes every other open PR's CI fail (with the rest of the matrix CANCELLED via fail-fast).

Insert `"max_cloud_bytes"` between `"max_pixels"` and `"on_gpu_failure"` to match the real signature. The other readers (`read_geotiff_dask`, `read_geotiff_gpu`, `read_vrt`) don't expose this kwarg yet; `_assert_canonical` intersects with the canonical tuple, so they keep passing without any change.

## Test plan

- [x] `pytest xrspatial/geotiff/tests/test_reader_kwarg_order_1935.py` — all 5 tests pass locally.
