### PR TITLE
ci: limit PR matrix to Python 3.14, keep full matrix on main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python: [3.12, 3.13, 3.14]
+        python: ${{ github.event_name == 'pull_request' && fromJson('["3.14"]') || fromJson('["3.12", "3.13", "3.14"]') }}
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python }}


### PR DESCRIPTION
Closes #1964.

## Summary
- Pull requests now run only Python 3.14 across the three OSes (3 jobs instead of 9).
- Pushes to `main` keep the full 3.12 / 3.13 / 3.14 matrix.

Uses a ternary on `github.event_name` with `fromJson` to swap the matrix array based on event type.

## Test plan
- [ ] This PR itself should show only 3 jobs in the matrix (one per OS, all 3.14).
- [ ] After merge, the post-merge run on `main` should show 9 jobs (3 OS × 3 Python).