### PR TITLE
geotiff: fix CI regression where int-coord no-georef writes hit fail-closed guard

### DIFF
--- a/xrspatial/geotiff/_coords.py
+++ b/xrspatial/geotiff/_coords.py
@@ -262,6 +262,17 @@ def require_transform_for_georeferenced(
         ydim = da.dims[-2]
         xdim = da.dims[-1]
     if xdim in da.coords and ydim in da.coords:
+        # Integer-dtype coords are the read-side no-georef sentinel
+        # (see #1949 + ``coords_to_transform``): the reader emits
+        # ``np.arange(N, dtype=np.int64)`` for files without GeoTIFF
+        # tags. Those callers are explicitly *not* requesting a
+        # georeferenced output, so the fail-closed guard must not fire
+        # on them. Mirrors the same short-circuit in
+        # ``coords_to_transform``.
+        x = da.coords[xdim].values
+        y = da.coords[ydim].values
+        if x.dtype.kind in ('i', 'u') or y.dtype.kind in ('i', 'u'):
+            return
         raise ValueError(
             f"Cannot infer GeoTIFF transform from a "
             f"{tuple(da.sizes.values())} array with spatial coords on "


### PR DESCRIPTION
## Summary

CI on main has been red since the back-to-back merges of #1953 (preserve transform on 1xN / Nx1 georeferenced writes) and #1954 (keep no-georef int coords through to_geotiff round-trip).

- #1953 added `require_transform_for_georeferenced`, which raises when a DataArray carries spatial coords but no transform was derived.
- #1954 made `coords_to_transform` return `None` for integer-dtype coords, because those are the read-side no-georef sentinel the eager reader emits for files without GeoTIFF tags.

The interaction breaks any read -> write round-trip of a non-georef TIFF: `coords_to_transform` correctly returns `None` on the int coords, then the fail-closed guard sees coords present + no transform and raises `ValueError("Cannot infer GeoTIFF transform...")`.

Eleven previously-passing tests started failing on the merge of #1959:

- `test_features.py::TestExtraTags::test_extra_tags_round_trip`
- `test_georef_edges.py::TestNonGeoreferencedRead::test_round_trip_preserves_pixels`
- `test_metadata_round_trip_1484.py` (3 tests)
- `test_vrt_int_nodata_1564.py` (6 tests)

The fix mirrors the int-dtype short-circuit from `coords_to_transform` inside `require_transform_for_georeferenced`: when both spatial coord arrays are integer-dtype, treat that as the no-georef sentinel and return without raising. Float-coord 1x1 inputs still trip the guard, which is what #1945 was actually targeting.

## Test plan

- [x] All 11 CI failures pass locally after the fix
- [x] #1945 fail-closed contract still holds (`test_degenerate_georef_1945.py`)
- [x] #1949 no-georef sentinel contract still holds (`test_no_georef_writer_round_trip_1949.py`)
- [x] Full `xrspatial/geotiff/` suite: 3177 passed (8 unrelated pre-existing GPU failures local to my environment, not in CI)