### PR TITLE
geotiff: golden corpus oracle harness (#1930, phase 1.2)

### DIFF
--- a/xrspatial/geotiff/tests/golden_corpus/__init__.py
+++ b/xrspatial/geotiff/tests/golden_corpus/__init__.py
@@ -1,0 +1,12 @@
+"""Golden corpus for xrspatial geotiff parity tests (issue #1930).
+
+This package hosts the corpus fixtures, manifest, and oracle harness used
+by Phase 3 backend cells. The pieces are split across PRs so they can
+land independently:
+
+* Phase 1 PR 1 -- manifest + deterministic generator. The contract for
+  what a fixture is.
+* Phase 1 PR 2 -- the oracle harness (``_oracle``).
+* Phase 2     -- the seed fixtures themselves.
+* Phase 3     -- the per-backend test cells that call the oracle.
+"""

--- a/xrspatial/geotiff/tests/golden_corpus/_oracle.py
+++ b/xrspatial/geotiff/tests/golden_corpus/_oracle.py
@@ -1,0 +1,399 @@
+"""Oracle harness for the geotiff golden corpus (issue #1930, Phase 1.2).
+
+``compare_to_oracle(fixture_path, candidate_da)`` reads ``fixture_path`` with
+rasterio (the reference implementation) and asserts that an xrspatial-produced
+``xarray.DataArray`` agrees on every observable property: pixel values,
+dtype, transform, CRS, nodata sentinel, and a small set of canonical attrs.
+
+The Phase 3 backend cells (numpy, dask+numpy, cupy, dask+cupy, HTTP, VRT)
+each call this single function with the DataArray they produced; the oracle
+encapsulates "what parity means" so every backend agrees on it.
+
+Scope notes:
+
+* The full canonical-attrs contract is tracked in issue #1984 and is not
+  settled yet. Until it lands, the oracle asserts only the obvious subset
+  (``crs``, ``transform``, ``nodata``, ``dtype``) and leaves a hook
+  (``_assert_canonical_attrs``) that later PRs can fill in. See the TODO
+  in that function.
+* ``lossy=True`` skips bit-exact pixel comparison (for JPEG cells in
+  Phase 2) and instead verifies only shape, dtype, transform, and CRS.
+* The oracle does not import the corpus manifest from Phase 1 PR 1; it
+  takes a raw filesystem path so the two PRs stay decoupled.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import xarray as xr
+
+
+# ---------------------------------------------------------------------------
+# Rasterio lazy import
+# ---------------------------------------------------------------------------
+
+def _require_rasterio():
+    """Import rasterio lazily so the module is importable in environments
+    without it; tests using the oracle call ``pytest.importorskip('rasterio')``
+    at module load time.
+    """
+    try:
+        import rasterio  # noqa: F401
+        import rasterio.crs  # noqa: F401
+        import rasterio.transform  # noqa: F401
+        return rasterio
+    except ImportError as exc:  # pragma: no cover - exercised via importorskip
+        raise ImportError(
+            'rasterio is required for the golden-corpus oracle. '
+            'Install it with `pip install rasterio`.'
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Transform helpers
+# ---------------------------------------------------------------------------
+
+# xrspatial stores its transform under ``attrs['transform']`` as
+# ``(pixel_width, 0.0, origin_x, 0.0, pixel_height, origin_y)`` -- the same
+# 6-tuple order as ``rasterio.Affine(a, b, c, d, e, f)``. See
+# ``xrspatial.geotiff._coords.transform_tuple_from_pixel_geometry``.
+_TRANSFORM_ATOL = 1e-9
+
+
+def _candidate_transform(candidate_da: xr.DataArray):
+    """Derive a rasterio ``Affine`` from the candidate.
+
+    Preference order:
+
+    1. ``attrs['transform']`` -- the canonical xrspatial 6-tuple. Byte-exact
+       round-trips depend on this attr (see ``_coords.transform_tuple``).
+    2. ``rio.transform()`` -- if rioxarray decorated the DataArray.
+    3. Derived from the y/x coords, treating them as pixel centres.
+
+    Returns ``None`` when no transform can be recovered (a no-georef raster).
+    """
+    rasterio = _require_rasterio()
+    Affine = rasterio.transform.Affine
+
+    t = candidate_da.attrs.get('transform')
+    if t is not None:
+        if len(t) != 6:
+            raise AssertionError(
+                f"candidate attrs['transform'] must be a 6-tuple, got {t!r}")
+        return Affine(*[float(v) for v in t])
+
+    rio = getattr(candidate_da, 'rio', None)
+    if rio is not None:
+        try:
+            return rio.transform()
+        except Exception:
+            pass
+
+    if 'y' in candidate_da.coords and 'x' in candidate_da.coords:
+        y = np.asarray(candidate_da.coords['y'].values, dtype=float)
+        x = np.asarray(candidate_da.coords['x'].values, dtype=float)
+        if y.size >= 2 and x.size >= 2:
+            pw = float(x[1] - x[0])
+            ph = float(y[1] - y[0])
+            ox = float(x[0]) - 0.5 * pw
+            oy = float(y[0]) - 0.5 * ph
+            return Affine(pw, 0.0, ox, 0.0, ph, oy)
+    return None
+
+
+def _affine_close(a, b, *, atol: float = _TRANSFORM_ATOL) -> bool:
+    return all(
+        abs(float(x) - float(y)) <= atol
+        for x, y in zip(tuple(a)[:6], tuple(b)[:6])
+    )
+
+
+# ---------------------------------------------------------------------------
+# CRS helpers
+# ---------------------------------------------------------------------------
+
+def _candidate_crs(candidate_da: xr.DataArray):
+    """Best-effort CRS extraction from a candidate DataArray.
+
+    Tries, in order:
+
+    1. ``attrs['crs']`` -- xrspatial stores an EPSG int here when known.
+    2. ``attrs['crs_wkt']`` -- WKT fallback.
+    3. ``rio.crs`` -- rioxarray decoration (mostly for sibling tools).
+
+    The return value is whatever ``rasterio.crs.CRS.from_user_input`` accepts,
+    or ``None`` when no CRS is recorded.
+    """
+    rasterio = _require_rasterio()
+    attrs = candidate_da.attrs
+
+    crs_val = attrs.get('crs')
+    if crs_val is not None:
+        return rasterio.crs.CRS.from_user_input(crs_val)
+
+    wkt = attrs.get('crs_wkt')
+    if wkt:
+        return rasterio.crs.CRS.from_user_input(wkt)
+
+    rio = getattr(candidate_da, 'rio', None)
+    if rio is not None:
+        crs = getattr(rio, 'crs', None)
+        if crs is not None:
+            return rasterio.crs.CRS.from_user_input(crs)
+    return None
+
+
+def _crs_equal(ref, cand) -> bool:
+    """EPSG-aware CRS equality.
+
+    rasterio's ``CRS.__eq__`` compares WKT structurally, which makes
+    EPSG-equivalent WKTs (one from PROJ, one from libgeotiff) compare
+    unequal even when they describe the same coordinate system. Fall back
+    to EPSG-code comparison when both sides resolve to an EPSG code.
+    """
+    if ref is None and cand is None:
+        return True
+    if ref is None or cand is None:
+        return False
+    if ref == cand:
+        return True
+    try:
+        ref_epsg = ref.to_epsg()
+        cand_epsg = cand.to_epsg()
+    except Exception:
+        ref_epsg = None
+        cand_epsg = None
+    if ref_epsg is not None and cand_epsg is not None:
+        return ref_epsg == cand_epsg
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Pixel / nodata helpers
+# ---------------------------------------------------------------------------
+
+def _candidate_pixels(candidate_da: xr.DataArray) -> np.ndarray:
+    """Return a 2-D or 3-D numpy view regardless of backend (dask/cupy)."""
+    raw = candidate_da.data
+    if hasattr(raw, 'compute'):
+        raw = raw.compute()
+    if hasattr(raw, 'get'):
+        raw = raw.get()
+    return np.asarray(raw)
+
+
+def _nodata_equal(ref, cand) -> bool:
+    """NaN-aware nodata comparison.
+
+    Treats two NaN sentinels as equal (``float('nan') != float('nan')`` in
+    Python's default semantics, but they are the same nodata for our
+    purposes). ``None`` on both sides also counts as equal.
+    """
+    if ref is None and cand is None:
+        return True
+    if ref is None or cand is None:
+        return False
+    try:
+        ref_f = float(ref)
+        cand_f = float(cand)
+    except (TypeError, ValueError):
+        return ref == cand
+    if np.isnan(ref_f) and np.isnan(cand_f):
+        return True
+    return ref_f == cand_f
+
+
+def _pixels_equal(ref: np.ndarray, cand: np.ndarray) -> bool:
+    """Bit-exact pixel comparison, NaN-aware for floats."""
+    if ref.shape != cand.shape:
+        return False
+    if ref.dtype.kind == 'f' or cand.dtype.kind == 'f':
+        return np.array_equal(ref, cand, equal_nan=True)
+    return np.array_equal(ref, cand)
+
+
+# ---------------------------------------------------------------------------
+# Canonical-attrs hook (issue #1984)
+# ---------------------------------------------------------------------------
+
+# Attrs the oracle currently asserts. Kept intentionally small until
+# issue #1984 (canonical attrs contract) settles which keys are canonical,
+# which are aliases, and which are pass-through metadata that may legally
+# diverge between rasterio and xrspatial reads.
+_CANONICAL_ATTR_KEYS_PROVISIONAL: tuple[str, ...] = (
+    'crs',
+    'transform',
+    'nodata',
+    'dtype',
+)
+
+
+def _assert_canonical_attrs(
+    ref_attrs: dict[str, Any],
+    candidate_da: xr.DataArray,
+) -> None:
+    """Assert the canonical-attrs subset.
+
+    TODO(#1984): Expand this to the full canonical attrs contract once it
+    settles. Today it only covers the obvious subset (crs/transform/nodata/
+    dtype). Those four are already checked structurally by the dedicated
+    helpers in this module; this hook exists so a later PR can layer on
+    canonical-tier checks (e.g. ``raster_type``, resolution keys, GDAL
+    metadata canonicalisation) without touching the call sites.
+    """
+    # No-op today on purpose. The four checks below
+    # (_assert_dtype/_assert_transform/_assert_crs/_assert_nodata)
+    # implement the provisional contract. Keep this function so test code
+    # references stay stable when #1984 lands.
+    _ = _CANONICAL_ATTR_KEYS_PROVISIONAL  # silence unused warning
+    _ = ref_attrs
+    _ = candidate_da
+
+
+# ---------------------------------------------------------------------------
+# Per-property assertions
+# ---------------------------------------------------------------------------
+
+def _assert_dtype(ref_dtype: np.dtype, candidate_da: xr.DataArray) -> None:
+    cand_dtype = np.dtype(candidate_da.dtype)
+    ref_dtype = np.dtype(ref_dtype)
+    assert cand_dtype == ref_dtype, (
+        f'dtype mismatch: rasterio={ref_dtype}, xrspatial={cand_dtype}')
+
+
+def _assert_transform(ref_transform, candidate_da: xr.DataArray) -> None:
+    cand_t = _candidate_transform(candidate_da)
+    if ref_transform is None or _is_default_transform(ref_transform):
+        # The fixture has no real georef. xrspatial may legitimately
+        # carry no transform attr at all (#1710); skip the comparison.
+        if cand_t is None:
+            return
+        if _is_default_transform(cand_t):
+            return
+        raise AssertionError(
+            'fixture has no georef but candidate carries a non-identity '
+            f'transform: {tuple(cand_t)}')
+    assert cand_t is not None, (
+        'rasterio transform is non-default but candidate has no transform '
+        f'attr/coords. ref={tuple(ref_transform)}')
+    assert _affine_close(ref_transform, cand_t), (
+        f'transform mismatch:\n  rasterio:  {tuple(ref_transform)[:6]}\n'
+        f'  xrspatial: {tuple(cand_t)[:6]}')
+
+
+def _is_default_transform(t) -> bool:
+    rasterio = _require_rasterio()
+    return tuple(t)[:6] == tuple(rasterio.transform.Affine.identity())[:6]
+
+
+def _assert_crs(ref_crs, candidate_da: xr.DataArray) -> None:
+    cand_crs = _candidate_crs(candidate_da)
+    assert _crs_equal(ref_crs, cand_crs), (
+        f'CRS mismatch:\n  rasterio:  {ref_crs!r}\n  xrspatial: {cand_crs!r}')
+
+
+def _assert_nodata(ref_nodata, candidate_da: xr.DataArray) -> None:
+    cand_nodata = candidate_da.attrs.get('nodata')
+    assert _nodata_equal(ref_nodata, cand_nodata), (
+        f'nodata mismatch: rasterio={ref_nodata!r}, '
+        f'xrspatial={cand_nodata!r}')
+
+
+def _assert_pixels(ref_pixels: np.ndarray, candidate_da: xr.DataArray) -> None:
+    cand_pixels = _candidate_pixels(candidate_da)
+    # Single-band rasterio reads come back as (1, H, W); xrspatial may drop
+    # the band axis. Squeeze a leading length-1 axis on either side so the
+    # comparison is band-agnostic for the single-band case.
+    if ref_pixels.ndim == 3 and ref_pixels.shape[0] == 1 and cand_pixels.ndim == 2:
+        ref_pixels = ref_pixels[0]
+    elif cand_pixels.ndim == 3 and cand_pixels.shape[0] == 1 and ref_pixels.ndim == 2:
+        cand_pixels = cand_pixels[0]
+    assert _pixels_equal(ref_pixels, cand_pixels), (
+        'pixel arrays differ (bit-exact / NaN-aware comparison failed). '
+        f'ref shape={ref_pixels.shape} dtype={ref_pixels.dtype}, '
+        f'cand shape={cand_pixels.shape} dtype={cand_pixels.dtype}')
+
+
+def _assert_shape_only(ref_pixels: np.ndarray, candidate_da: xr.DataArray) -> None:
+    cand_pixels = _candidate_pixels(candidate_da)
+    if ref_pixels.ndim == 3 and ref_pixels.shape[0] == 1 and cand_pixels.ndim == 2:
+        ref_shape = ref_pixels.shape[1:]
+    elif cand_pixels.ndim == 3 and cand_pixels.shape[0] == 1 and ref_pixels.ndim == 2:
+        ref_shape = ref_pixels.shape
+        cand_pixels = cand_pixels[0]
+    else:
+        ref_shape = ref_pixels.shape
+    assert ref_shape == cand_pixels.shape, (
+        f'shape mismatch: rasterio={ref_shape}, xrspatial={cand_pixels.shape}')
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def compare_to_oracle(
+    fixture_path: str | Path,
+    candidate_da: xr.DataArray,
+    *,
+    lossy: bool = False,
+) -> None:
+    """Assert that ``candidate_da`` matches the rasterio read of ``fixture_path``.
+
+    Parameters
+    ----------
+    fixture_path
+        Path to a TIFF on disk. The oracle does not consult the corpus
+        manifest; callers (Phase 3 test cells) pass a raw path.
+    candidate_da
+        The xarray DataArray produced by an xrspatial read backend.
+    lossy
+        When ``True``, skip bit-exact pixel comparison and assert only
+        shape, dtype, transform, and CRS. Use this for JPEG cells where
+        the codec is intrinsically lossy (Phase 2 PR 5).
+
+    Raises
+    ------
+    AssertionError
+        On the first property that disagrees. The message identifies the
+        property and prints both sides.
+
+    Notes
+    -----
+    The canonical-attrs contract is tracked in issue #1984. Until it
+    settles, only the four obvious keys (crs/transform/nodata/dtype) are
+    checked; ``_assert_canonical_attrs`` is the hook later PRs will fill
+    in. Pass-through GeoTIFF metadata (gdal_metadata, extra_tags, etc.)
+    is intentionally not asserted here.
+    """
+    rasterio = _require_rasterio()
+    fixture_path = Path(fixture_path)
+    if not fixture_path.exists():
+        raise FileNotFoundError(f'oracle fixture not found: {fixture_path}')
+
+    with rasterio.open(fixture_path) as src:
+        ref_pixels = src.read()  # shape (bands, H, W)
+        ref_dtype = np.dtype(src.dtypes[0]) if src.dtypes else ref_pixels.dtype
+        ref_transform = src.transform
+        ref_crs = src.crs
+        ref_nodata = src.nodata
+        ref_attrs = {
+            'crs': ref_crs,
+            'transform': ref_transform,
+            'nodata': ref_nodata,
+            'dtype': ref_dtype,
+        }
+
+    _assert_dtype(ref_dtype, candidate_da)
+    _assert_transform(ref_transform, candidate_da)
+    _assert_crs(ref_crs, candidate_da)
+    _assert_nodata(ref_nodata, candidate_da)
+    if lossy:
+        _assert_shape_only(ref_pixels, candidate_da)
+    else:
+        _assert_pixels(ref_pixels, candidate_da)
+    _assert_canonical_attrs(ref_attrs, candidate_da)
+
+
+__all__ = ['compare_to_oracle']

--- a/xrspatial/geotiff/tests/golden_corpus/_oracle.py
+++ b/xrspatial/geotiff/tests/golden_corpus/_oracle.py
@@ -231,25 +231,26 @@ _CANONICAL_ATTR_KEYS_PROVISIONAL: tuple[str, ...] = (
 
 
 def _assert_canonical_attrs(
-    ref_attrs: dict[str, Any],
-    candidate_da: xr.DataArray,
+    _ref_attrs: dict[str, Any],
+    _candidate_da: xr.DataArray,
 ) -> None:
     """Assert the canonical-attrs subset.
 
-    TODO(#1984): Expand this to the full canonical attrs contract once it
-    settles. Today it only covers the obvious subset (crs/transform/nodata/
-    dtype). Those four are already checked structurally by the dedicated
-    helpers in this module; this hook exists so a later PR can layer on
-    canonical-tier checks (e.g. ``raster_type``, resolution keys, GDAL
-    metadata canonicalisation) without touching the call sites.
+    No-op today on purpose. The four sibling helpers
+    (``_assert_dtype`` / ``_assert_transform`` / ``_assert_crs`` /
+    ``_assert_nodata``) cover the provisional contract; this stub exists
+    so test code references stay stable when issue #1984 lands.
+
+    TODO(#1984): Expand to the full canonical-attrs contract once it
+    settles. The provisional key set is in
+    ``_CANONICAL_ATTR_KEYS_PROVISIONAL``. Likely additions when #1984
+    lands: ``raster_type`` (PixelIsArea vs PixelIsPoint), resolution
+    keys, and a canonicalised view of GDAL metadata. Pass-through tags
+    (``gdal_metadata``, ``extra_tags``) stay out of scope.
+
+    Parameters are prefixed with ``_`` because they are deliberately
+    unused today; rename them when this function gains a body.
     """
-    # No-op today on purpose. The four checks below
-    # (_assert_dtype/_assert_transform/_assert_crs/_assert_nodata)
-    # implement the provisional contract. Keep this function so test code
-    # references stay stable when #1984 lands.
-    _ = _CANONICAL_ATTR_KEYS_PROVISIONAL  # silence unused warning
-    _ = ref_attrs
-    _ = candidate_da
 
 
 # ---------------------------------------------------------------------------
@@ -263,20 +264,47 @@ def _assert_dtype(ref_dtype: np.dtype, candidate_da: xr.DataArray) -> None:
         f'dtype mismatch: rasterio={ref_dtype}, xrspatial={cand_dtype}')
 
 
-def _assert_transform(ref_transform, candidate_da: xr.DataArray) -> None:
+def _assert_transform(
+    ref_transform,
+    candidate_da: xr.DataArray,
+    *,
+    ref_has_georef: bool,
+) -> None:
+    """Compare transforms.
+
+    ``ref_has_georef`` is True when the rasterio source carried real
+    GeoTIFF tags (i.e. a CRS *or* a non-identity transform). When it is
+    False the file is bare -- rasterio returns ``Affine.identity()`` for
+    such files regardless of pixel size -- and xrspatial may legitimately
+    drop the transform attr (#1710). Identity-equal transforms alone are
+    NOT enough to declare "no georef": a real raster written at origin
+    (0, 0) with 1.0 pixel size also matches identity.
+    """
     cand_t = _candidate_transform(candidate_da)
-    if ref_transform is None or _is_default_transform(ref_transform):
-        # The fixture has no real georef. xrspatial may legitimately
-        # carry no transform attr at all (#1710); skip the comparison.
+    if not ref_has_georef:
+        # Bare file. The candidate may legitimately:
+        # * carry no transform attr at all (xrspatial's no-georef path,
+        #   #1710),
+        # * carry an identity transform attr,
+        # * carry a transform derived from integer-pixel-center coords
+        #   (origin -0.5, pixel size 1.0 -- what xrspatial's
+        #   ``coords_from_pixel_geometry`` emits with ``has_georef=False``).
+        # We require only that the candidate also disclaims a real georef
+        # via one of those routes; we do not compare the transform tuple
+        # itself, because rasterio synthesises ``Affine.identity()`` here
+        # while xrspatial may produce any of the three forms above.
         if cand_t is None:
+            return
+        if candidate_da.attrs.get('transform') is None:
+            # Came from coord derivation only -- treat as no transform.
             return
         if _is_default_transform(cand_t):
             return
         raise AssertionError(
             'fixture has no georef but candidate carries a non-identity '
-            f'transform: {tuple(cand_t)}')
+            f'transform attr: {tuple(cand_t)}')
     assert cand_t is not None, (
-        'rasterio transform is non-default but candidate has no transform '
+        'rasterio transform is set but candidate has no transform '
         f'attr/coords. ref={tuple(ref_transform)}')
     assert _affine_close(ref_transform, cand_t), (
         f'transform mismatch:\n  rasterio:  {tuple(ref_transform)[:6]}\n'
@@ -286,6 +314,20 @@ def _assert_transform(ref_transform, candidate_da: xr.DataArray) -> None:
 def _is_default_transform(t) -> bool:
     rasterio = _require_rasterio()
     return tuple(t)[:6] == tuple(rasterio.transform.Affine.identity())[:6]
+
+
+def _ref_has_georef(src) -> bool:
+    """Has the rasterio source got any georef at all?
+
+    True if it has a CRS *or* a non-identity transform. rasterio returns
+    ``Affine.identity()`` for files with no georef, but a fully-real
+    raster can also have an identity transform (origin 0, 1.0 pixels),
+    so identity alone is not a "no georef" signal -- pair it with the
+    absence of a CRS.
+    """
+    has_crs = src.crs is not None
+    has_non_id_transform = not _is_default_transform(src.transform)
+    return has_crs or has_non_id_transform
 
 
 def _assert_crs(ref_crs, candidate_da: xr.DataArray) -> None:
@@ -378,6 +420,7 @@ def compare_to_oracle(
         ref_transform = src.transform
         ref_crs = src.crs
         ref_nodata = src.nodata
+        ref_has_georef = _ref_has_georef(src)
         ref_attrs = {
             'crs': ref_crs,
             'transform': ref_transform,
@@ -386,7 +429,7 @@ def compare_to_oracle(
         }
 
     _assert_dtype(ref_dtype, candidate_da)
-    _assert_transform(ref_transform, candidate_da)
+    _assert_transform(ref_transform, candidate_da, ref_has_georef=ref_has_georef)
     _assert_crs(ref_crs, candidate_da)
     _assert_nodata(ref_nodata, candidate_da)
     if lossy:

--- a/xrspatial/geotiff/tests/golden_corpus/test_oracle.py
+++ b/xrspatial/geotiff/tests/golden_corpus/test_oracle.py
@@ -282,7 +282,12 @@ def test_lossy_still_rejects_transform_mismatch(tmp_path: Path) -> None:
 
 
 def test_lossy_rejects_shape_mismatch(tmp_path: Path) -> None:
-    """In lossy mode, the shape check still trips when sizes disagree."""
+    """In lossy mode, the shape check still trips when sizes disagree.
+
+    This is the only test that exercises ``_assert_shape_only``; strict
+    mode goes through ``_assert_pixels`` instead, which catches shape
+    mismatches as part of the bit-exact comparison.
+    """
     # Same pixel size + CRS + origin on both sides, but the fixture is 4x4
     # while the candidate is 5x5 -- only shape disagrees.
     transform = from_origin(0.0, 4.0, 1.0, 1.0)
@@ -300,6 +305,57 @@ def test_lossy_rejects_shape_mismatch(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 # Missing-file handling
 # ---------------------------------------------------------------------------
+
+def test_identity_transform_with_crs_still_compared(tmp_path: Path) -> None:
+    """Regression: an identity-shaped transform on a real raster (CRS set)
+    must still go through the transform comparison.
+
+    Earlier the oracle treated any identity-equal ref transform as
+    "no georef" and short-circuited. That hid bugs where the candidate
+    drifted from the fixture's identity transform on real rasters
+    written at origin (0, 0) with pixel size 1.0. The fix keys "no
+    georef" off ``src.crs is None and src.transform.is_identity``
+    together, not transform alone.
+    """
+    from rasterio.transform import Affine
+    data = np.arange(4, dtype=np.int16).reshape(2, 2)
+    fixture = _write_tiff(
+        tmp_path / 'id_with_crs.tif',
+        data,
+        transform=Affine.identity(),
+        crs='EPSG:4326',
+    )
+    # Candidate carries a SHIFTED transform; oracle must catch it.
+    shifted = from_origin(99.0, 2.0, 1.0, 1.0)
+    cand = _build_candidate(data, transform=shifted)
+    with pytest.raises(AssertionError, match='transform mismatch'):
+        compare_to_oracle(fixture, cand)
+
+
+def test_no_georef_fixture_tolerates_missing_candidate_transform(
+    tmp_path: Path,
+) -> None:
+    """A fixture with no CRS *and* identity transform may match a candidate
+    that drops the transform attr entirely (xrspatial #1710 behaviour).
+    """
+    from rasterio.transform import Affine
+    data = np.zeros((2, 2), dtype=np.int16)
+    fixture = _write_tiff(
+        tmp_path / 'no_georef.tif',
+        data,
+        transform=Affine.identity(),
+        crs=None,
+    )
+    # Build a candidate by hand with no transform attr, no CRS attr,
+    # integer-pixel coords.
+    cand = xr.DataArray(
+        data,
+        dims=('y', 'x'),
+        coords={'y': np.arange(2), 'x': np.arange(2)},
+        attrs={},
+    )
+    compare_to_oracle(fixture, cand)
+
 
 def test_missing_fixture_raises_filenotfounderror(tmp_path: Path) -> None:
     cand = _build_candidate(

--- a/xrspatial/geotiff/tests/golden_corpus/test_oracle.py
+++ b/xrspatial/geotiff/tests/golden_corpus/test_oracle.py
@@ -1,0 +1,310 @@
+"""Unit tests for the golden-corpus oracle harness (issue #1930, Phase 1.2).
+
+These tests exercise the oracle in isolation: they synthesise a tiny TIFF
+in a tmp_path with rasterio, build an ``xarray.DataArray`` by hand that
+mirrors what an xrspatial reader would emit, and verify the oracle accepts
+the matching case and rejects each property mismatch individually.
+
+The tests do NOT depend on the Phase 1 PR 1 manifest or generator; the
+oracle takes raw filesystem paths, so unit tests for the oracle only need
+a writable temp directory.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import xarray as xr
+
+rasterio = pytest.importorskip('rasterio')
+
+from rasterio.transform import Affine, from_origin  # noqa: E402
+
+from xrspatial.geotiff.tests.golden_corpus._oracle import (  # noqa: E402
+    compare_to_oracle,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+def _write_tiff(
+    path: Path,
+    data: np.ndarray,
+    *,
+    transform: Affine | None = None,
+    crs: str | int | None = 'EPSG:4326',
+    nodata: float | int | None = None,
+) -> Path:
+    """Write a single-band TIFF to ``path`` using rasterio."""
+    if transform is None:
+        transform = from_origin(0.0, data.shape[0], 1.0, 1.0)
+    profile = {
+        'driver': 'GTiff',
+        'height': data.shape[0],
+        'width': data.shape[1],
+        'count': 1,
+        'dtype': data.dtype,
+        'transform': transform,
+    }
+    if crs is not None:
+        profile['crs'] = rasterio.crs.CRS.from_user_input(crs)
+    if nodata is not None:
+        profile['nodata'] = nodata
+    with rasterio.open(path, 'w', **profile) as dst:
+        dst.write(data, 1)
+    return path
+
+
+def _build_candidate(
+    data: np.ndarray,
+    *,
+    transform: Affine,
+    crs: int | None = 4326,
+    crs_wkt: str | None = None,
+    nodata: float | int | None = None,
+    drop_band_axis: bool = True,
+) -> xr.DataArray:
+    """Build an xrspatial-shaped DataArray from in-memory data."""
+    if drop_band_axis and data.ndim == 3 and data.shape[0] == 1:
+        data = data[0]
+    height = data.shape[-2]
+    width = data.shape[-1]
+    # pixel-centre coords matching xrspatial's coords_from_pixel_geometry
+    pw = float(transform.a)
+    ph = float(transform.e)
+    ox = float(transform.c)
+    oy = float(transform.f)
+    x = ox + (np.arange(width) + 0.5) * pw
+    y = oy + (np.arange(height) + 0.5) * ph
+    attrs: dict = {
+        'transform': (pw, 0.0, ox, 0.0, ph, oy),
+    }
+    if crs is not None:
+        attrs['crs'] = crs
+    if crs_wkt is not None:
+        attrs['crs_wkt'] = crs_wkt
+    if nodata is not None:
+        attrs['nodata'] = nodata
+    return xr.DataArray(
+        data,
+        dims=('y', 'x') if data.ndim == 2 else ('band', 'y', 'x'),
+        coords={'y': y, 'x': x},
+        attrs=attrs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Success path
+# ---------------------------------------------------------------------------
+
+def test_compare_to_oracle_success_int(tmp_path: Path) -> None:
+    """Matching int raster: oracle accepts."""
+    data = np.arange(16, dtype=np.int16).reshape(4, 4)
+    transform = from_origin(100.0, 200.0, 1.0, 1.0)
+    fixture = _write_tiff(tmp_path / 'ok_int.tif', data, transform=transform)
+    cand = _build_candidate(data, transform=transform, nodata=None)
+    compare_to_oracle(fixture, cand)
+
+
+def test_compare_to_oracle_success_float_with_nan(tmp_path: Path) -> None:
+    """Float raster with NaN sentinels: oracle treats NaN as equal."""
+    data = np.array([[1.0, np.nan], [np.nan, 4.0]], dtype=np.float32)
+    transform = from_origin(0.0, 2.0, 1.0, 1.0)
+    fixture = _write_tiff(
+        tmp_path / 'ok_nan.tif', data, transform=transform,
+        nodata=float('nan'),
+    )
+    cand = _build_candidate(
+        data.copy(), transform=transform, nodata=float('nan'),
+    )
+    compare_to_oracle(fixture, cand)
+
+
+def test_compare_to_oracle_success_via_crs_wkt(tmp_path: Path) -> None:
+    """A candidate carrying crs_wkt (no EPSG int) still compares equal."""
+    data = np.zeros((3, 3), dtype=np.uint8)
+    transform = from_origin(0.0, 3.0, 1.0, 1.0)
+    fixture = _write_tiff(tmp_path / 'crs_wkt.tif', data, transform=transform)
+    wkt = rasterio.crs.CRS.from_epsg(4326).to_wkt()
+    cand = _build_candidate(
+        data, transform=transform, crs=None, crs_wkt=wkt,
+    )
+    compare_to_oracle(fixture, cand)
+
+
+def test_compare_to_oracle_lossy_skips_pixel_check(tmp_path: Path) -> None:
+    """``lossy=True`` skips bit-exact pixel comparison."""
+    data = np.arange(16, dtype=np.uint8).reshape(4, 4)
+    transform = from_origin(0.0, 4.0, 1.0, 1.0)
+    fixture = _write_tiff(tmp_path / 'lossy.tif', data, transform=transform)
+    # Different pixel values, same shape/dtype/transform/CRS:
+    perturbed = data + 5
+    cand = _build_candidate(perturbed.astype(np.uint8), transform=transform)
+    # Strict mode rejects:
+    with pytest.raises(AssertionError, match='pixel arrays differ'):
+        compare_to_oracle(fixture, cand)
+    # Lossy mode accepts:
+    compare_to_oracle(fixture, cand, lossy=True)
+
+
+# ---------------------------------------------------------------------------
+# Mismatched-property failures
+# ---------------------------------------------------------------------------
+
+def test_dtype_mismatch_fails(tmp_path: Path) -> None:
+    data = np.ones((4, 4), dtype=np.int16)
+    transform = from_origin(0.0, 4.0, 1.0, 1.0)
+    fixture = _write_tiff(tmp_path / 'dtype.tif', data, transform=transform)
+    cand = _build_candidate(data.astype(np.int32), transform=transform)
+    with pytest.raises(AssertionError, match='dtype mismatch'):
+        compare_to_oracle(fixture, cand)
+
+
+def test_transform_mismatch_fails(tmp_path: Path) -> None:
+    data = np.zeros((4, 4), dtype=np.int16)
+    fixture_transform = from_origin(0.0, 4.0, 1.0, 1.0)
+    candidate_transform = from_origin(99.0, 4.0, 1.0, 1.0)  # shifted origin
+    fixture = _write_tiff(
+        tmp_path / 'tx.tif', data, transform=fixture_transform,
+    )
+    cand = _build_candidate(data, transform=candidate_transform)
+    with pytest.raises(AssertionError, match='transform mismatch'):
+        compare_to_oracle(fixture, cand)
+
+
+def test_crs_mismatch_fails(tmp_path: Path) -> None:
+    data = np.zeros((3, 3), dtype=np.int16)
+    transform = from_origin(0.0, 3.0, 1.0, 1.0)
+    fixture = _write_tiff(
+        tmp_path / 'crs.tif', data, transform=transform, crs='EPSG:4326',
+    )
+    cand = _build_candidate(data, transform=transform, crs=3857)
+    with pytest.raises(AssertionError, match='CRS mismatch'):
+        compare_to_oracle(fixture, cand)
+
+
+def test_nodata_nan_vs_zero_fails(tmp_path: Path) -> None:
+    """A float fixture with NaN nodata must not pass when candidate uses 0."""
+    data = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
+    transform = from_origin(0.0, 2.0, 1.0, 1.0)
+    fixture = _write_tiff(
+        tmp_path / 'nodata.tif', data, transform=transform,
+        nodata=float('nan'),
+    )
+    cand = _build_candidate(data, transform=transform, nodata=0.0)
+    with pytest.raises(AssertionError, match='nodata mismatch'):
+        compare_to_oracle(fixture, cand)
+
+
+def test_nodata_missing_on_candidate_fails(tmp_path: Path) -> None:
+    """rasterio reports an int nodata, candidate forgets to set it."""
+    data = np.full((3, 3), 7, dtype=np.int16)
+    transform = from_origin(0.0, 3.0, 1.0, 1.0)
+    fixture = _write_tiff(
+        tmp_path / 'nodata_none.tif', data, transform=transform, nodata=-1,
+    )
+    cand = _build_candidate(data, transform=transform, nodata=None)
+    with pytest.raises(AssertionError, match='nodata mismatch'):
+        compare_to_oracle(fixture, cand)
+
+
+def test_pixel_mismatch_fails(tmp_path: Path) -> None:
+    data = np.arange(9, dtype=np.int16).reshape(3, 3)
+    transform = from_origin(0.0, 3.0, 1.0, 1.0)
+    fixture = _write_tiff(tmp_path / 'pix.tif', data, transform=transform)
+    bad = data.copy()
+    bad[1, 1] = 999
+    cand = _build_candidate(bad, transform=transform)
+    with pytest.raises(AssertionError, match='pixel arrays differ'):
+        compare_to_oracle(fixture, cand)
+
+
+def test_pixel_nan_vs_zero_fails(tmp_path: Path) -> None:
+    """A NaN in the fixture must not silently match a 0 in the candidate."""
+    data = np.array([[1.0, np.nan], [3.0, 4.0]], dtype=np.float32)
+    transform = from_origin(0.0, 2.0, 1.0, 1.0)
+    fixture = _write_tiff(
+        tmp_path / 'pix_nan.tif', data, transform=transform,
+        nodata=float('nan'),
+    )
+    bad = data.copy()
+    bad[0, 1] = 0.0
+    cand = _build_candidate(
+        bad, transform=transform, nodata=float('nan'),
+    )
+    with pytest.raises(AssertionError, match='pixel arrays differ'):
+        compare_to_oracle(fixture, cand)
+
+
+# ---------------------------------------------------------------------------
+# EPSG-equivalent-WKT handling
+# ---------------------------------------------------------------------------
+
+def test_crs_epsg_equivalent_wkt_compares_equal(tmp_path: Path) -> None:
+    """rasterio EPSG:4326 vs a WKT for the same CRS must compare equal."""
+    data = np.zeros((3, 3), dtype=np.int16)
+    transform = from_origin(0.0, 3.0, 1.0, 1.0)
+    fixture = _write_tiff(
+        tmp_path / 'crs_eq.tif', data, transform=transform, crs='EPSG:4326',
+    )
+    # Candidate uses a hand-written WGS84 WKT instead of the EPSG int.
+    wkt = rasterio.crs.CRS.from_epsg(4326).to_wkt()
+    cand = _build_candidate(data, transform=transform, crs=None, crs_wkt=wkt)
+    compare_to_oracle(fixture, cand)
+
+
+# ---------------------------------------------------------------------------
+# Lossy-mode failure modes
+# ---------------------------------------------------------------------------
+
+def test_lossy_still_rejects_dtype_mismatch(tmp_path: Path) -> None:
+    data = np.ones((4, 4), dtype=np.uint8)
+    transform = from_origin(0.0, 4.0, 1.0, 1.0)
+    fixture = _write_tiff(tmp_path / 'lossy_dtype.tif', data, transform=transform)
+    cand = _build_candidate(data.astype(np.uint16), transform=transform)
+    with pytest.raises(AssertionError, match='dtype mismatch'):
+        compare_to_oracle(fixture, cand, lossy=True)
+
+
+def test_lossy_still_rejects_transform_mismatch(tmp_path: Path) -> None:
+    data = np.zeros((4, 4), dtype=np.uint8)
+    fixture_transform = from_origin(0.0, 4.0, 1.0, 1.0)
+    candidate_transform = from_origin(0.0, 4.0, 2.0, 2.0)  # wrong pixel size
+    fixture = _write_tiff(
+        tmp_path / 'lossy_tx.tif', data, transform=fixture_transform,
+    )
+    cand = _build_candidate(data, transform=candidate_transform)
+    with pytest.raises(AssertionError, match='transform mismatch'):
+        compare_to_oracle(fixture, cand, lossy=True)
+
+
+def test_lossy_rejects_shape_mismatch(tmp_path: Path) -> None:
+    """In lossy mode, the shape check still trips when sizes disagree."""
+    # Same pixel size + CRS + origin on both sides, but the fixture is 4x4
+    # while the candidate is 5x5 -- only shape disagrees.
+    transform = from_origin(0.0, 4.0, 1.0, 1.0)
+    fixture = _write_tiff(
+        tmp_path / 'lossy_shape_only.tif',
+        np.zeros((4, 4), dtype=np.uint8),
+        transform=transform,
+    )
+    bigger = np.zeros((5, 5), dtype=np.uint8)
+    cand = _build_candidate(bigger, transform=transform)
+    with pytest.raises(AssertionError, match='shape mismatch'):
+        compare_to_oracle(fixture, cand, lossy=True)
+
+
+# ---------------------------------------------------------------------------
+# Missing-file handling
+# ---------------------------------------------------------------------------
+
+def test_missing_fixture_raises_filenotfounderror(tmp_path: Path) -> None:
+    cand = _build_candidate(
+        np.zeros((2, 2), dtype=np.int16),
+        transform=from_origin(0.0, 2.0, 1.0, 1.0),
+    )
+    with pytest.raises(FileNotFoundError):
+        compare_to_oracle(tmp_path / 'does_not_exist.tif', cand)


### PR DESCRIPTION
## Summary

Phase 1 PR 2 of #1930 (golden corpus for geotiff parity).

From the plan:

> **PR 2 -- Oracle harness.** `tests/golden_corpus/_oracle.py` with
> `compare_to_oracle(fixture, candidate_da)` that opens the fixture with
> rasterio and asserts pixel / transform / CRS / nodata / dtype /
> canonical-attrs match the candidate. NaN-aware float comparison.
> No backends wired yet.

One public function:

```python
def compare_to_oracle(fixture_path, candidate_da, *, lossy=False) -> None
```

Reads the fixture with rasterio and asserts, in order:

1. dtype (exact)
2. transform (rasterio `Affine` vs xrspatial `attrs['transform']`, 1e-9 tol)
3. CRS (falls back to EPSG-code equality when two WKTs describe the same
   coordinate system)
4. nodata (NaN-aware)
5. pixel values (bit-exact for ints, `array_equal(..., equal_nan=True)` for floats)

`lossy=True` skips step 5 and checks shape only. That path is for the
JPEG cells in Phase 2 PR 5.

## Canonical-attrs hook (#1984)

The plan asks the oracle to assert "canonical-attrs match the candidate".
The canonical-attrs contract is tracked in #1984 and is not settled, so
this PR:

- asserts only the obvious subset (crs / transform / nodata / dtype)
  via the helpers listed above,
- adds a `_assert_canonical_attrs(ref_attrs, candidate_da)` hook so a
  later PR can extend the contract without touching call sites,
- leaves a `TODO(#1984)` in that function.

## Out of scope

- Manifest schema / generator (Phase 1 PR 1, sibling PR).
- Fixture `.tif` files (Phase 2 PRs 3-9).
- Wiring the oracle into per-backend test cells (Phase 3 PRs 10-15).
- Pass-through GeoTIFF metadata (`gdal_metadata`, `extra_tags`, etc.) --
  those wait on #1984.

The oracle takes a raw filesystem path, not a manifest entry, so it
does not import anything from the sibling Phase 1 PR 1 work.

## Test plan

- [x] `pytest xrspatial/geotiff/tests/golden_corpus/test_oracle.py` -- 16 tests, all green
- [x] Success: int, float-with-NaN, CRS-via-WKT, lossy
- [x] Failure: mismatched dtype / transform / CRS / nodata-NaN-vs-zero /
      missing nodata / pixel / pixel-NaN-vs-zero / lossy-dtype /
      lossy-transform / lossy-shape / missing-file
- [x] flake8 clean on the new files