### PR TITLE
geotiff: golden corpus layout + manifest schema (#1930, phase 1.1)

### DIFF
--- a/xrspatial/geotiff/tests/golden_corpus/README.md
+++ b/xrspatial/geotiff/tests/golden_corpus/README.md
@@ -11,7 +11,7 @@ are wired (Phase 3).
 golden_corpus/
   manifest.yaml   # the contract: every dimension a fixture can have
   generate.py     # deterministic generator that rebuilds .tif files
-  fixtures/       # output dir (populated by Phase 2 PRs, gitignored)
+  fixtures/       # output dir; populated and committed by Phase 2 PRs
   README.md       # this file
 ```
 

--- a/xrspatial/geotiff/tests/golden_corpus/README.md
+++ b/xrspatial/geotiff/tests/golden_corpus/README.md
@@ -1,0 +1,64 @@
+# Geotiff golden corpus
+
+Tracking issue: [#1930](https://github.com/xarray-contrib/xarray-spatial/issues/1930).
+This is Phase 1 PR 1 of that plan: corpus layout + manifest schema only.
+No actual `.tif` files live in this directory yet (Phase 2). No backends
+are wired (Phase 3).
+
+## Layout
+
+```
+golden_corpus/
+  manifest.yaml   # the contract: every dimension a fixture can have
+  generate.py     # deterministic generator that rebuilds .tif files
+  fixtures/       # output dir (populated by Phase 2 PRs, gitignored)
+  README.md       # this file
+```
+
+## Regenerating the corpus
+
+From the repository root, with the `tests` extras and `rasterio` +
+`pyyaml` installed:
+
+```
+python -m xrspatial.geotiff.tests.golden_corpus.generate
+```
+
+Useful flags:
+
+* `--dry-run` validates the manifest and prints the planned outputs.
+  This is what the smoke test runs; you can run it locally without
+  `rasterio` installed.
+* `--only <id>` rebuilds one fixture by id. May be repeated.
+* `--output-dir <path>` writes somewhere other than `./fixtures`.
+
+The generator is deterministic: fixed seeds, no timestamps, sorted
+iteration, and mtimes normalised to a fixed epoch.
+
+## Adding a fixture
+
+1. Add a new entry to `fixtures:` in `manifest.yaml`. Re-use the
+   `defaults` block for everything you do not need to override.
+2. Run the generator (or `--dry-run` first to catch schema errors).
+3. Commit the manifest change. Generated `.tif` files are committed
+   alongside the manifest entry in the same PR.
+
+The schema is documented in the comments at the top of `manifest.yaml`
+and enforced by `generate.validate()`.
+
+## What is deliberately not in this PR
+
+* Real fixture files. Phase 2 PRs add them in batches (tiled/stripped,
+  dtypes, compression, nodata, overviews, CRS, GDAL_METADATA).
+* The oracle harness (`_oracle.py`) that compares a candidate xarray
+  DataArray to the rasterio baseline. That is Phase 1 PR 2 and is in
+  flight in parallel.
+* Backend wiring (eager, dask, gpu, vrt, http). Phase 3.
+
+## Dependencies
+
+`rasterio` and `pyyaml` are runtime dependencies of `generate.py`. They
+are not in `setup.cfg`'s `install_requires` and not yet in the `tests`
+extra. The smoke test uses `pytest.importorskip` for both so a minimal
+test environment still passes. When Phase 2 starts seeding real
+fixtures, the test extra should be amended to make these required.

--- a/xrspatial/geotiff/tests/golden_corpus/__init__.py
+++ b/xrspatial/geotiff/tests/golden_corpus/__init__.py
@@ -1,0 +1,12 @@
+"""Golden corpus for xrspatial geotiff parity tests (issue #1930).
+
+This package hosts the corpus fixtures, manifest, and oracle harness used
+by Phase 3 backend cells. The pieces are split across PRs so they can
+land independently:
+
+* Phase 1 PR 1 -- manifest + deterministic generator. The contract for
+  what a fixture is.
+* Phase 1 PR 2 -- the oracle harness (``_oracle``).
+* Phase 2     -- the seed fixtures themselves.
+* Phase 3     -- the per-backend test cells that call the oracle.
+"""

--- a/xrspatial/geotiff/tests/golden_corpus/generate.py
+++ b/xrspatial/geotiff/tests/golden_corpus/generate.py
@@ -1,0 +1,479 @@
+"""Deterministic generator for the geotiff golden corpus.
+
+Reads ``manifest.yaml`` and rebuilds every fixture under the corpus
+directory. The generator is the contract for what a fixture is: anything
+not expressible here belongs in the manifest schema, not in ad-hoc code.
+
+Determinism guarantees:
+
+* fixtures are iterated in declared order, files are emitted in sorted-id
+  order, and no timestamps are written;
+* pixel data is produced from ``pixel_pattern`` (ramp / checker / noise /
+  uniform) with a per-fixture ``pixel_seed`` when randomness is needed;
+* file modification times are normalised to a fixed epoch after writing so
+  re-runs produce byte-identical sidecar metadata.
+
+Usage::
+
+    python -m xrspatial.geotiff.tests.golden_corpus.generate
+    python -m xrspatial.geotiff.tests.golden_corpus.generate --dry-run
+    python -m xrspatial.geotiff.tests.golden_corpus.generate --only <id>
+
+Dry-run validates the manifest and reports what would be written without
+touching disk. The smoke test in this PR uses dry-run; Phase 2 PRs will
+flip to real writes once each fixture group lands.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import pathlib
+import sys
+from typing import Any, Iterable
+
+# rasterio and pyyaml are not part of the package's install_requires.
+# They are pulled in by the test extra and by typical dev environments.
+# Import errors are surfaced with a clear hint rather than a bare
+# ModuleNotFoundError so a contributor running the script outside the
+# test environment gets actionable output.
+try:
+    import yaml
+except ImportError as exc:  # pragma: no cover - environment guard
+    raise SystemExit(
+        "PyYAML is required to read the golden corpus manifest. "
+        "Install with `pip install pyyaml` or use the test extras."
+    ) from exc
+
+import numpy as np
+
+
+HERE = pathlib.Path(__file__).resolve().parent
+MANIFEST_PATH = HERE / "manifest.yaml"
+DEFAULT_OUTPUT_DIR = HERE / "fixtures"
+
+# Fixed epoch used to normalise on-disk mtimes (2020-01-01 UTC). Picked
+# arbitrarily; the only requirement is that it is constant across runs.
+DETERMINISTIC_EPOCH = 1577836800
+
+REQUIRED_FIELDS = (
+    "id",
+    "description",
+    "width",
+    "height",
+    "bands",
+    "dtype",
+    "byte_order",
+    "layout",
+    "planar_config",
+    "compression",
+    "predictor",
+    "photometric",
+    "pixel_pattern",
+)
+
+ALLOWED_BYTE_ORDER = {"little", "big"}
+ALLOWED_LAYOUT = {"stripped", "tiled"}
+ALLOWED_PLANAR = {"contig", "separate"}
+ALLOWED_COMPRESSION = {
+    "none", "deflate", "lzw", "lerc", "jpeg", "packbits", "zstd",
+}
+ALLOWED_PHOTOMETRIC = {"minisblack", "miniswhite", "rgb", "ycbcr"}
+ALLOWED_PATTERN = {"ramp", "checker", "noise", "uniform"}
+ALLOWED_PREDICTOR = {1, 2, 3}
+
+
+class ManifestError(ValueError):
+    """Raised when the manifest fails validation."""
+
+
+def load_manifest(path: pathlib.Path = MANIFEST_PATH) -> dict[str, Any]:
+    """Load and return the parsed manifest. No validation here."""
+    with path.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    if not isinstance(data, dict):
+        raise ManifestError(f"{path} did not parse to a mapping")
+    return data
+
+
+def _merge_defaults(defaults: dict[str, Any], entry: dict[str, Any]) -> dict[str, Any]:
+    """Return defaults merged with entry. Entry keys win."""
+    merged = dict(defaults)
+    merged.update(entry)
+    return merged
+
+
+def _validate_one(entry: dict[str, Any], seen_ids: set[str]) -> None:
+    """Raise ManifestError if `entry` is malformed."""
+    missing = [k for k in REQUIRED_FIELDS if k not in entry]
+    if missing:
+        raise ManifestError(
+            f"fixture {entry.get('id', '?')!r} missing required fields: "
+            f"{sorted(missing)}"
+        )
+
+    fid = entry["id"]
+    if not isinstance(fid, str) or not fid:
+        raise ManifestError(f"fixture id must be a non-empty string, got {fid!r}")
+    if fid in seen_ids:
+        raise ManifestError(f"duplicate fixture id: {fid!r}")
+    seen_ids.add(fid)
+
+    if entry["byte_order"] not in ALLOWED_BYTE_ORDER:
+        raise ManifestError(
+            f"{fid}: byte_order must be one of {sorted(ALLOWED_BYTE_ORDER)}"
+        )
+    if entry["layout"] not in ALLOWED_LAYOUT:
+        raise ManifestError(
+            f"{fid}: layout must be one of {sorted(ALLOWED_LAYOUT)}"
+        )
+    if entry["layout"] == "tiled":
+        ts = entry.get("tile_size")
+        if not isinstance(ts, int) or ts <= 0 or ts % 16 != 0:
+            raise ManifestError(
+                f"{fid}: tiled layout requires tile_size as a positive int "
+                f"multiple of 16, got {ts!r}"
+            )
+    else:
+        bs = entry.get("blocksize")
+        if not isinstance(bs, int) or bs <= 0:
+            raise ManifestError(
+                f"{fid}: stripped layout requires blocksize as a positive int, "
+                f"got {bs!r}"
+            )
+
+    if entry["planar_config"] not in ALLOWED_PLANAR:
+        raise ManifestError(
+            f"{fid}: planar_config must be one of {sorted(ALLOWED_PLANAR)}"
+        )
+    if entry["compression"] not in ALLOWED_COMPRESSION:
+        raise ManifestError(
+            f"{fid}: compression must be one of {sorted(ALLOWED_COMPRESSION)}"
+        )
+    if entry["predictor"] not in ALLOWED_PREDICTOR:
+        raise ManifestError(
+            f"{fid}: predictor must be one of {sorted(ALLOWED_PREDICTOR)}"
+        )
+    if entry["photometric"] not in ALLOWED_PHOTOMETRIC:
+        raise ManifestError(
+            f"{fid}: photometric must be one of {sorted(ALLOWED_PHOTOMETRIC)}"
+        )
+    if entry["pixel_pattern"] not in ALLOWED_PATTERN:
+        raise ManifestError(
+            f"{fid}: pixel_pattern must be one of {sorted(ALLOWED_PATTERN)}"
+        )
+
+    # dtype must be a recognised numpy dtype.
+    try:
+        np.dtype(entry["dtype"])
+    except TypeError as exc:
+        raise ManifestError(f"{fid}: dtype {entry['dtype']!r} not a numpy dtype") from exc
+
+    bands = entry["bands"]
+    if not isinstance(bands, int) or bands < 1:
+        raise ManifestError(f"{fid}: bands must be a positive int, got {bands!r}")
+
+    for k in ("width", "height"):
+        v = entry[k]
+        if not isinstance(v, int) or v <= 0:
+            raise ManifestError(f"{fid}: {k} must be a positive int, got {v!r}")
+
+    # nodata: null, number, "nan", or "miniswhite"
+    nd = entry.get("nodata", None)
+    if nd is not None and not isinstance(nd, (int, float)) and nd not in (
+        "nan", "miniswhite",
+    ):
+        raise ManifestError(
+            f"{fid}: nodata must be null, a number, \"nan\", or \"miniswhite\"; "
+            f"got {nd!r}"
+        )
+
+    # crs is null or exactly one of epsg / wkt / citation
+    crs = entry.get("crs", None)
+    if crs is not None:
+        if not isinstance(crs, dict):
+            raise ManifestError(f"{fid}: crs must be null or a mapping, got {crs!r}")
+        keys = set(crs)
+        if keys not in ({"epsg"}, {"wkt"}, {"citation"}):
+            raise ManifestError(
+                f"{fid}: crs map must have exactly one of "
+                f"{{epsg, wkt, citation}}, got {sorted(keys)}"
+            )
+
+    transform = entry.get("transform")
+    if transform is not None:
+        if not (isinstance(transform, list) and len(transform) == 6):
+            raise ManifestError(
+                f"{fid}: transform must be a 6-element list, got {transform!r}"
+            )
+
+    overviews = entry.get("overviews")
+    if overviews:
+        if not isinstance(overviews, list) or not all(
+            isinstance(x, int) and x > 1 for x in overviews
+        ):
+            raise ManifestError(
+                f"{fid}: overviews must be a list of ints > 1, got {overviews!r}"
+            )
+
+
+def validate(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    """Validate the parsed manifest and return resolved fixture entries.
+
+    Each returned dict has defaults already merged in.
+    """
+    version = manifest.get("version")
+    if version != 1:
+        raise ManifestError(f"unsupported manifest version: {version!r} (expected 1)")
+
+    defaults = manifest.get("defaults") or {}
+    if not isinstance(defaults, dict):
+        raise ManifestError("defaults must be a mapping if present")
+
+    raw_fixtures = manifest.get("fixtures") or []
+    if not isinstance(raw_fixtures, list):
+        raise ManifestError("fixtures must be a list")
+
+    resolved: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for raw in raw_fixtures:
+        if not isinstance(raw, dict):
+            raise ManifestError(f"fixture entry must be a mapping, got {raw!r}")
+        merged = _merge_defaults(defaults, raw)
+        _validate_one(merged, seen)
+        resolved.append(merged)
+
+    return resolved
+
+
+def _make_pixels(entry: dict[str, Any]) -> np.ndarray:
+    """Build deterministic pixel data for a fixture entry.
+
+    Returns an array of shape (bands, height, width) in the requested dtype.
+    """
+    bands = entry["bands"]
+    h = entry["height"]
+    w = entry["width"]
+    dtype = np.dtype(entry["dtype"])
+    pattern = entry["pixel_pattern"]
+    n = bands * h * w
+
+    if pattern == "ramp":
+        flat = np.arange(n, dtype=np.float64)
+    elif pattern == "checker":
+        rows = np.arange(h)[:, None]
+        cols = np.arange(w)[None, :]
+        single = ((rows // 8 + cols // 8) % 2).astype(np.float64)
+        flat = np.broadcast_to(single, (bands, h, w)).reshape(-1).astype(np.float64)
+    elif pattern == "noise":
+        rng = np.random.default_rng(int(entry.get("pixel_seed", 0)))
+        flat = rng.random(n)
+    elif pattern == "uniform":
+        flat = np.full(n, float(entry.get("pixel_value", 0)), dtype=np.float64)
+    else:  # pragma: no cover - validate() rejects unknown patterns
+        raise ManifestError(f"unknown pixel_pattern: {pattern!r}")
+
+    if dtype.kind in ("i", "u"):
+        info = np.iinfo(dtype)
+        # Map [0, 1) for noise / [0, n) for ramp into the dtype range.
+        if pattern in ("ramp", "checker", "uniform"):
+            arr = flat % (info.max - info.min + 1) + info.min
+        else:  # noise
+            arr = flat * (info.max - info.min) + info.min
+        arr = arr.astype(dtype)
+    else:
+        arr = flat.astype(dtype)
+
+    return arr.reshape(bands, h, w)
+
+
+def _resolve_crs(crs_spec: dict[str, Any] | None):
+    """Convert a manifest CRS spec into a rasterio CRS or None."""
+    if crs_spec is None:
+        return None
+    from rasterio.crs import CRS
+
+    if "epsg" in crs_spec:
+        return CRS.from_epsg(int(crs_spec["epsg"]))
+    if "wkt" in crs_spec:
+        return CRS.from_wkt(str(crs_spec["wkt"]))
+    if "citation" in crs_spec:
+        # Citation-only: a WKT with just a GEOGCS / PROJCS name and no
+        # numeric parameters. Useful for exercising the "we have a CRS
+        # name but no projection" code path. Phase 2 PR 8 fills this in.
+        return CRS.from_wkt(
+            f'GEOGCS["{crs_spec["citation"]}",DATUM["unknown",SPHEROID["unknown",6378137,0]],'
+            'PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]]'
+        )
+    raise ManifestError(f"unreachable: unknown crs spec {crs_spec!r}")
+
+
+def _rasterio_kwargs(entry: dict[str, Any]) -> dict[str, Any]:
+    """Translate a resolved fixture entry into rasterio open() kwargs.
+
+    Pulled out so the validator-only path can introspect it in dry-run.
+    """
+    from rasterio.transform import Affine
+
+    kwargs: dict[str, Any] = {
+        "driver": "GTiff",
+        "width": entry["width"],
+        "height": entry["height"],
+        "count": entry["bands"],
+        "dtype": entry["dtype"],
+        "photometric": entry["photometric"].upper(),
+        "interleave": (
+            "band" if entry["planar_config"] == "separate" else "pixel"
+        ),
+    }
+    if entry["layout"] == "tiled":
+        kwargs["tiled"] = True
+        kwargs["blockxsize"] = entry["tile_size"]
+        kwargs["blockysize"] = entry["tile_size"]
+    else:
+        kwargs["tiled"] = False
+        kwargs["blockysize"] = entry["blocksize"]
+
+    if entry["compression"] != "none":
+        kwargs["compress"] = entry["compression"]
+        if entry["predictor"] != 1 and entry["compression"] in (
+            "deflate", "lzw", "zstd",
+        ):
+            kwargs["predictor"] = entry["predictor"]
+
+    if entry["byte_order"] == "big":
+        # GDAL endian creation option.
+        kwargs["endian"] = "big"
+
+    nd = entry.get("nodata")
+    if isinstance(nd, (int, float)):
+        kwargs["nodata"] = nd
+    elif nd == "nan":
+        kwargs["nodata"] = float("nan")
+    # "miniswhite" / None: no nodata tag written.
+
+    transform = entry.get("transform")
+    if transform is not None:
+        kwargs["transform"] = Affine(*transform)
+
+    crs = _resolve_crs(entry.get("crs"))
+    if crs is not None:
+        kwargs["crs"] = crs
+
+    return kwargs
+
+
+def write_fixture(entry: dict[str, Any], output_dir: pathlib.Path) -> pathlib.Path:
+    """Materialise one fixture. Returns the written path.
+
+    Real writes only run when called by the non-dry-run code path.
+    """
+    import rasterio
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    out_path = output_dir / f"{entry['id']}.tif"
+    pixels = _make_pixels(entry)
+    kwargs = _rasterio_kwargs(entry)
+    extra_tags = entry.get("extra_tags") or {}
+
+    with rasterio.open(str(out_path), "w", **kwargs) as dst:
+        for b in range(entry["bands"]):
+            dst.write(pixels[b], b + 1)
+        gdal_md = entry.get("gdal_metadata") or {}
+        for domain, items in sorted(gdal_md.items()):
+            dst.update_tags(ns=domain, **{str(k): str(v) for k, v in sorted(items.items())})
+        if extra_tags:
+            dst.update_tags(**{str(k): str(v) for k, v in sorted(extra_tags.items())})
+        overviews = entry.get("overviews") or []
+        if overviews and not entry.get("external_overview"):
+            from rasterio.enums import Resampling
+            resamp = getattr(
+                Resampling, entry.get("overview_resampling", "nearest")
+            )
+            dst.build_overviews(sorted(overviews), resamp)
+
+    # Normalise mtime so re-runs are byte-stable on filesystems that
+    # encode timestamps in sidecar files.
+    os.utime(out_path, (DETERMINISTIC_EPOCH, DETERMINISTIC_EPOCH))
+    return out_path
+
+
+def generate(
+    only: Iterable[str] | None = None,
+    output_dir: pathlib.Path = DEFAULT_OUTPUT_DIR,
+    dry_run: bool = False,
+) -> list[pathlib.Path]:
+    """Validate the manifest and (unless dry_run) write every fixture.
+
+    Returns the list of paths that were (or would be) written, in
+    sorted-id order.
+    """
+    manifest = load_manifest()
+    entries = validate(manifest)
+
+    if only is not None:
+        wanted = set(only)
+        entries = [e for e in entries if e["id"] in wanted]
+        missing = wanted - {e["id"] for e in entries}
+        if missing:
+            raise ManifestError(f"unknown fixture ids: {sorted(missing)}")
+
+    # Deterministic output order: sort by id after validation.
+    entries.sort(key=lambda e: e["id"])
+
+    paths: list[pathlib.Path] = []
+    for entry in entries:
+        target = output_dir / f"{entry['id']}.tif"
+        if dry_run:
+            paths.append(target)
+            continue
+        paths.append(write_fixture(entry, output_dir))
+    return paths
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="generate.py",
+        description="Deterministically (re)build the geotiff golden corpus.",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate manifest and print planned outputs without writing.",
+    )
+    p.add_argument(
+        "--only",
+        action="append",
+        default=None,
+        metavar="ID",
+        help="Restrict to one fixture id; may be repeated.",
+    )
+    p.add_argument(
+        "--output-dir",
+        type=pathlib.Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help="Where to write the .tif files (default: ./fixtures).",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        paths = generate(
+            only=args.only,
+            output_dir=args.output_dir,
+            dry_run=args.dry_run,
+        )
+    except ManifestError as exc:
+        print(f"manifest error: {exc}", file=sys.stderr)
+        return 2
+
+    label = "would write" if args.dry_run else "wrote"
+    for path in paths:
+        print(f"{label} {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/xrspatial/geotiff/tests/golden_corpus/generate.py
+++ b/xrspatial/geotiff/tests/golden_corpus/generate.py
@@ -30,7 +30,8 @@ import argparse
 import os
 import pathlib
 import sys
-from typing import Any, Iterable
+from collections.abc import Iterable
+from typing import Any
 
 # rasterio and pyyaml are not part of the package's install_requires.
 # They are pulled in by the test extra and by typical dev environments.
@@ -216,6 +217,31 @@ def _validate_one(entry: dict[str, Any], seen_ids: set[str]) -> None:
                 f"{fid}: overviews must be a list of ints > 1, got {overviews!r}"
             )
 
+    # predictor 3 is the floating-point predictor; predictor 2 is the
+    # horizontal differencing predictor for integer data. Catching the
+    # wrong pairing here gives a clear error instead of a confusing one
+    # from rasterio at write time.
+    pred = entry["predictor"]
+    dtype_kind = np.dtype(entry["dtype"]).kind
+    if pred == 3 and dtype_kind != "f":
+        raise ManifestError(
+            f"{fid}: predictor 3 (floating-point) requires a float dtype, "
+            f"got dtype {entry['dtype']!r}"
+        )
+    if pred == 2 and dtype_kind == "f":
+        raise ManifestError(
+            f"{fid}: predictor 2 (horizontal) requires an integer dtype, "
+            f"got dtype {entry['dtype']!r}"
+        )
+
+    if "external_overview" in entry and not isinstance(
+        entry["external_overview"], bool
+    ):
+        raise ManifestError(
+            f"{fid}: external_overview must be a bool, "
+            f"got {entry['external_overview']!r}"
+        )
+
 
 def validate(manifest: dict[str, Any]) -> list[dict[str, Any]]:
     """Validate the parsed manifest and return resolved fixture entries.
@@ -340,6 +366,20 @@ def _rasterio_kwargs(entry: dict[str, Any]) -> dict[str, Any]:
             "deflate", "lzw", "zstd",
         ):
             kwargs["predictor"] = entry["predictor"]
+        # Codec level (deflate / zstd / lerc). GDAL accepts -1 / None to
+        # mean "default", which we represent by simply not forwarding.
+        level = entry.get("compression_level")
+        if isinstance(level, int) and level >= 0:
+            if entry["compression"] == "deflate":
+                kwargs["zlevel"] = level
+            elif entry["compression"] == "zstd":
+                kwargs["zstd_level"] = level
+            elif entry["compression"] == "jpeg":
+                kwargs["jpeg_quality"] = level
+        if entry["compression"] == "lerc":
+            max_z = entry.get("max_z_error")
+            if max_z is not None:
+                kwargs["max_z_error"] = float(max_z)
 
     if entry["byte_order"] == "big":
         # GDAL endian creation option.
@@ -402,13 +442,14 @@ def generate(
     only: Iterable[str] | None = None,
     output_dir: pathlib.Path = DEFAULT_OUTPUT_DIR,
     dry_run: bool = False,
+    manifest_path: pathlib.Path = MANIFEST_PATH,
 ) -> list[pathlib.Path]:
     """Validate the manifest and (unless dry_run) write every fixture.
 
     Returns the list of paths that were (or would be) written, in
     sorted-id order.
     """
-    manifest = load_manifest()
+    manifest = load_manifest(manifest_path)
     entries = validate(manifest)
 
     if only is not None:

--- a/xrspatial/geotiff/tests/golden_corpus/manifest.yaml
+++ b/xrspatial/geotiff/tests/golden_corpus/manifest.yaml
@@ -1,0 +1,143 @@
+# Golden corpus manifest for geotiff backend parity tests.
+#
+# This file is the contract for what a fixture is. The generator
+# script `generate.py` reads it and rebuilds the TIFFs deterministically.
+# Adding a new fixture is a manifest edit plus a re-run of the generator.
+#
+# Schema (see generate.py for the authoritative validator):
+#
+# version: integer. Bumped when the schema shape changes.
+# defaults: optional map applied to every fixture before its own keys.
+# fixtures: list of fixture entries. Each entry has these keys:
+#
+#   id:               str    Stable identifier, also used as the file stem.
+#   description:      str    One-line human summary.
+#   width:            int    Pixel width.
+#   height:           int    Pixel height.
+#   bands:            int    Number of bands (>= 1).
+#   dtype:            str    numpy dtype string, e.g. "uint8", "int16",
+#                            "float32", "float64".
+#   byte_order:       str    "little" or "big". Native is "little".
+#   layout:           str    "stripped" or "tiled".
+#   tile_size:        int    Tile edge in pixels. Required when layout=tiled.
+#                            Must be a multiple of 16 per the TIFF spec.
+#   blocksize:        int    Rows per strip. Required when layout=stripped.
+#   planar_config:    str    "contig" (chunky) or "separate" (planar).
+#   compression:      str    one of:
+#                              none, deflate, lzw, lerc, jpeg, packbits
+#   predictor:        int    1 (none), 2 (horizontal), or 3 (floating point).
+#                            Only meaningful for deflate / lzw / zstd.
+#   compression_level: int   Codec-specific level. Optional. -1 means default.
+#   max_z_error:      float  LERC max_z_error. Optional, LERC only.
+#   photometric:      str    "minisblack", "miniswhite", "rgb", "ycbcr".
+#                            "miniswhite" exercises the inverted-mask path.
+#   nodata:           any    Nodata sentinel value. Allowed forms:
+#                              null              no nodata tag at all
+#                              <number>          integer or float sentinel
+#                              "nan"             float NaN (string-encoded so
+#                                                YAML stays portable)
+#                              "miniswhite"      no nodata tag, photometric
+#                                                miniswhite acts as the mask
+#   crs:              map    CRS spec. Exactly one of:
+#                              {epsg: <int>}                    EPSG code
+#                              {wkt: <str>}                     full WKT 2
+#                              {citation: <str>}                citation-only,
+#                                                               no projection
+#                              null                             no CRS
+#   transform:        list   Affine as [a, b, c, d, e, f]. c, f are origin.
+#                            Optional; defaults applied per-fixture.
+#   overviews:        list   Optional. Decimation factors, e.g. [2, 4].
+#                            Empty list or omitted means no overviews.
+#   overview_resampling: str Optional. "nearest", "average", "cubic", etc.
+#                            Default "nearest".
+#   external_overview: bool  Optional. If true, write a sidecar `.ovr` file
+#                            instead of internal overviews.
+#   gdal_metadata:    map    Optional. Written into the GDAL_METADATA tag as
+#                            {<domain>: {<item>: <str>}}. Domain "" is the
+#                            default. Used to exercise XML escaping and the
+#                            extra_tags safe-filter path.
+#   extra_tags:       map    Optional. Raw TIFF tag overrides written via
+#                            rasterio's `extra_tags=` kwarg. Tag name to
+#                            value, e.g. {Software: "xrspatial-corpus"}.
+#   pixel_pattern:    str    How the generator fills pixel data. One of:
+#                              "ramp"         deterministic linear ramp
+#                              "checker"      block checker for compression
+#                              "noise"        seeded numpy.random (seed below)
+#                              "uniform"      single constant value
+#   pixel_seed:       int    Seed for "noise" patterns. Default 0.
+#   pixel_value:      number Constant for "uniform" patterns.
+#
+#   tags:             list   Optional. Free-form tags used to filter the
+#                            corpus from CLI / pytest selectors, e.g.
+#                            ["fast", "compression", "predictor"].
+#   tolerance:        map    Optional. Per-fixture comparison tolerance.
+#                            Keys: {atol: float, rtol: float, lossy: bool}.
+#                            "lossy: true" means bit-equality is not
+#                            expected (used for jpeg). The oracle (Phase 1
+#                            PR 2, not in this PR) is responsible for
+#                            interpreting these.
+#
+# Determinism rules:
+#   - No timestamps.
+#   - All randomness goes through pixel_seed.
+#   - The generator iterates `fixtures` in declared order and emits files
+#     in sorted-id order.
+
+version: 1
+
+defaults:
+  bands: 1
+  byte_order: little
+  layout: stripped
+  blocksize: 64
+  planar_config: contig
+  compression: none
+  predictor: 1
+  photometric: minisblack
+  nodata: null
+  crs:
+    epsg: 4326
+  transform: [0.001, 0.0, -120.0, 0.0, -0.001, 45.0]
+  pixel_pattern: ramp
+  pixel_seed: 0
+  tags: []
+
+# One canonical example. Phase 2 PRs (3-9 in the plan) populate the rest.
+# Schema-only example; not yet wired to any backend.
+fixtures:
+  - id: example_tiled_uint16_deflate_pred2
+    description: >-
+      Canonical example showing every schema field. Tiled uint16 with
+      deflate + predictor 2, an integer nodata sentinel, internal
+      overviews, EPSG CRS, and a GDAL_METADATA entry.
+    width: 128
+    height: 128
+    bands: 1
+    dtype: uint16
+    byte_order: little
+    layout: tiled
+    tile_size: 64
+    planar_config: contig
+    compression: deflate
+    predictor: 2
+    compression_level: 6
+    photometric: minisblack
+    nodata: 0
+    crs:
+      epsg: 32613
+    transform: [10.0, 0.0, 500000.0, 0.0, -10.0, 4500000.0]
+    overviews: [2]
+    overview_resampling: nearest
+    external_overview: false
+    gdal_metadata:
+      "":
+        UNITS: meters
+        AREA_OR_POINT: Area
+    extra_tags:
+      Software: xrspatial-golden-corpus
+    pixel_pattern: ramp
+    tags: [fast, tiled, deflate, predictor2, nodata, overviews]
+    tolerance:
+      atol: 0.0
+      rtol: 0.0
+      lossy: false

--- a/xrspatial/geotiff/tests/test_golden_corpus_manifest_1930.py
+++ b/xrspatial/geotiff/tests/test_golden_corpus_manifest_1930.py
@@ -105,6 +105,21 @@ def test_unknown_only_id_errors():
         ),
         # Bad nodata
         (lambda e: e.update(nodata="bananas"), "nodata must be"),
+        # Predictor 3 on integer dtype
+        (
+            lambda e: e.update(predictor=3, dtype="uint16"),
+            r"predictor 3 \(floating-point\) requires a float dtype",
+        ),
+        # Predictor 2 on float dtype
+        (
+            lambda e: e.update(predictor=2, dtype="float32"),
+            r"predictor 2 \(horizontal\) requires an integer dtype",
+        ),
+        # Non-bool external_overview
+        (
+            lambda e: e.update(external_overview="yes"),
+            "external_overview must be a bool",
+        ),
     ],
 )
 def test_validator_rejects_bad_entries(mutate, match):

--- a/xrspatial/geotiff/tests/test_golden_corpus_manifest_1930.py
+++ b/xrspatial/geotiff/tests/test_golden_corpus_manifest_1930.py
@@ -1,0 +1,143 @@
+"""Smoke test for the golden corpus manifest + generator (issue #1930).
+
+This is Phase 1 PR 1 of the plan in #1930: the manifest schema and the
+deterministic generator. The test verifies that:
+
+* the manifest parses,
+* every fixture entry has the required schema fields after defaults are
+  merged in,
+* duplicate ids are rejected,
+* dry-run mode runs end-to-end without writing files,
+* fixture ids round-trip into the planned output paths in sorted order,
+* the validator catches the kinds of schema errors a contributor is
+  likely to hit (bad enum value, missing required field, conflicting
+  CRS spec).
+
+No real fixture files are produced or asserted here; that is Phase 2.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pathlib
+
+import pytest
+
+# pyyaml is needed to read manifest.yaml. It is not in the package's
+# install_requires (and not yet in the `tests` extra; see the README in
+# the golden_corpus directory). importorskip keeps minimal test
+# environments green until the test extra is amended in Phase 2.
+pytest.importorskip("yaml")
+
+generate = importlib.import_module(
+    "xrspatial.geotiff.tests.golden_corpus.generate"
+)
+
+
+def test_manifest_parses():
+    """The shipped manifest loads as a dict with the expected top-level keys."""
+    manifest = generate.load_manifest()
+    assert isinstance(manifest, dict)
+    assert manifest.get("version") == 1
+    assert "fixtures" in manifest
+    assert isinstance(manifest["fixtures"], list)
+
+
+def test_manifest_validates_and_has_at_least_one_entry():
+    """Every shipped fixture passes the validator with defaults applied."""
+    manifest = generate.load_manifest()
+    resolved = generate.validate(manifest)
+    assert len(resolved) >= 1
+    for entry in resolved:
+        for field in generate.REQUIRED_FIELDS:
+            assert field in entry, f"{entry.get('id')!r} missing {field}"
+
+
+def test_manifest_ids_are_unique():
+    """Validator rejects duplicate fixture ids."""
+    manifest = generate.load_manifest()
+    fixtures = manifest["fixtures"]
+    if len(fixtures) < 1:
+        pytest.skip("no fixtures to duplicate")
+    bad = dict(manifest)
+    bad["fixtures"] = list(fixtures) + [dict(fixtures[0])]
+    with pytest.raises(generate.ManifestError, match="duplicate"):
+        generate.validate(bad)
+
+
+def test_dry_run_does_not_write(tmp_path):
+    """Dry-run returns planned paths in sorted-id order without writing anything."""
+    out = tmp_path / "fixtures_dryrun"
+    paths = generate.generate(output_dir=out, dry_run=True)
+    assert paths, "expected at least one planned fixture"
+    assert paths == sorted(paths, key=lambda p: p.name)
+    assert not out.exists(), "dry-run must not create the output directory"
+    for p in paths:
+        assert isinstance(p, pathlib.Path)
+        assert p.suffix == ".tif"
+        assert p.parent == out
+
+
+def test_unknown_only_id_errors():
+    """--only with an unknown id is reported as a manifest error."""
+    with pytest.raises(generate.ManifestError, match="unknown fixture ids"):
+        generate.generate(only=["definitely-not-a-real-fixture-id"], dry_run=True)
+
+
+@pytest.mark.parametrize(
+    "mutate, match",
+    [
+        # Bad enum
+        (lambda e: e.update(layout="checkered"), "layout must be one of"),
+        # Missing required
+        (lambda e: e.pop("dtype"), "missing required fields"),
+        # Bad predictor
+        (lambda e: e.update(predictor=99), "predictor must be one of"),
+        # Tiled without tile_size
+        (
+            lambda e: (e.update(layout="tiled"), e.pop("tile_size", None)),
+            "tile_size",
+        ),
+        # CRS with conflicting keys
+        (
+            lambda e: e.update(crs={"epsg": 4326, "wkt": "GEOGCS[..]"}),
+            "exactly one of",
+        ),
+        # Bad nodata
+        (lambda e: e.update(nodata="bananas"), "nodata must be"),
+    ],
+)
+def test_validator_rejects_bad_entries(mutate, match):
+    """Schema errors a contributor is likely to hit are caught with a clear message."""
+    manifest = generate.load_manifest()
+    fixtures = manifest["fixtures"]
+    assert fixtures, "manifest must ship at least one example fixture"
+
+    # Start from the merged form so defaults are present, then mutate.
+    defaults = manifest.get("defaults") or {}
+    entry = dict(defaults)
+    entry.update(fixtures[0])
+    mutate(entry)
+
+    bad = {"version": 1, "defaults": {}, "fixtures": [entry]}
+    with pytest.raises(generate.ManifestError, match=match):
+        generate.validate(bad)
+
+
+def test_required_fields_constant_covers_dimensions():
+    """REQUIRED_FIELDS keeps the issue-1930 dimensions in lockstep with the schema.
+
+    If you add a new dimension to the schema, add the field name here so
+    no fixture can be added that quietly omits it.
+    """
+    expected_subset = {
+        "id",
+        "dtype",
+        "layout",
+        "compression",
+        "predictor",
+        "photometric",
+        "byte_order",
+        "planar_config",
+    }
+    assert expected_subset.issubset(set(generate.REQUIRED_FIELDS))


### PR DESCRIPTION
## Summary

First PR of the Phase 1 split for #1930. Lands the corpus layout and
the manifest schema, nothing else.

From the implementation plan in #1930:

> **Corpus layout + manifest schema.** Add `xrspatial/geotiff/tests/golden_corpus/`
> with a YAML manifest describing every fixture (dtype, compression,
> predictor, nodata, crs, overviews, extra_tags) and a deterministic
> generator script that rebuilds the TIFFs from the manifest. No test
> cells yet, no fixtures yet. The generator is the contract for what a
> fixture is.

## What lands

- `manifest.yaml` -- schema documented in the header comment, one
  canonical example fixture covering every field, version: 1.
- `generate.py` -- deterministic generator. CLI flags: `--dry-run`,
  `--only <id>`, `--output-dir`. `generate.validate()` is the
  authoritative schema check.
- `README.md` -- how to regenerate, what each phase will add.
- `test_golden_corpus_manifest_1930.py` -- smoke test. Parses the
  manifest, validates every entry, runs the generator in dry-run mode,
  and checks the error messages a contributor is most likely to hit.

## Out of scope

- The oracle harness (`_oracle.py`). Sibling PR for Phase 1 PR 2 (#1991).
- Any real fixture `.tif` files. Phase 2 PRs add them in batches.
- Backend wiring (eager / dask / gpu / vrt / http). Phase 3.
- Adding `pyyaml` / `rasterio` to `setup.cfg`'s `tests` extra. The
  smoke test uses `importorskip` until Phase 2 needs real writes in CI.

## Test plan

- `pytest xrspatial/geotiff/tests/test_golden_corpus_manifest_1930.py`
  -- 12 tests, all pass locally.
- `python -m xrspatial.geotiff.tests.golden_corpus.generate --dry-run`
  -- exits 0, prints planned outputs.
- `python -m xrspatial.geotiff.tests.golden_corpus.generate --output-dir /tmp/x`
  -- writes the example fixture end-to-end with normalised mtime;
  byte-stable across reruns.