### PR TITLE
geotiff: add attrs['masked_nodata'] alongside attrs['nodata'] (#1988)

### DIFF
--- a/xrspatial/geotiff/__init__.py
+++ b/xrspatial/geotiff/__init__.py
@@ -70,6 +70,7 @@ from ._attrs import (
     _extract_rich_tags,
     _populate_attrs_from_geo_info,
     _resolve_nodata_attr,
+    _set_nodata_attrs,
 )
 from ._backends._gpu_helpers import _is_gpu_data
 # Re-export only; called by xrspatial/geotiff/tests/test_nodata_*.py.
@@ -507,7 +508,6 @@ def open_geotiff(source: str | BinaryIO, *,
     # memory for a multi-MB raster.
     nodata = geo_info.nodata
     if nodata is not None:
-        attrs['nodata'] = nodata
         # When the reader applied MinIsWhite, the sentinel-equality mask
         # must compare against the inverted sentinel value (issue #1809).
         # ``read_to_array`` / ``_read_cog_http`` stash that value on
@@ -550,6 +550,11 @@ def open_geotiff(source: str | BinaryIO, *,
         target = np.dtype(dtype)
         _validate_dtype_cast(arr.dtype, target)
         arr = arr.astype(target)
+
+    # Set ``attrs['nodata']`` + ``attrs['masked_nodata']`` after the
+    # mask + optional dtype cast so ``masked_nodata`` reflects the
+    # final array dtype (issue #1988).
+    _set_nodata_attrs(attrs, nodata, array_dtype=arr.dtype)
 
     if arr.ndim == 3:
         dims = ['y', 'x', 'band']

--- a/xrspatial/geotiff/_attrs.py
+++ b/xrspatial/geotiff/_attrs.py
@@ -152,15 +152,48 @@ def _extent_to_window(transform, file_height, file_width,
     return (row_start, col_start, row_stop, col_stop)
 
 
+def _set_nodata_attrs(attrs: dict, nodata, *, array_dtype) -> None:
+    """Set ``attrs['nodata']`` and ``attrs['masked_nodata']`` on a read.
+
+    Splits the two meanings previously fused into ``attrs['nodata']``
+    (issue #1988):
+
+    * ``attrs['nodata']`` -- declared file sentinel, as a scalar of the
+      source dtype. Set whenever the source declared one, regardless of
+      whether the array is float-with-NaN or int-with-sentinels.
+    * ``attrs['masked_nodata']`` -- boolean flag. ``True`` iff the in-
+      memory array has been NaN-masked (i.e. it is float dtype and the
+      reader's sentinel-to-NaN step ran). ``False`` iff the array still
+      carries the literal integer sentinel value.
+
+    Callers pass ``array_dtype`` as the final post-mask, post-cast dtype
+    of the array that will be wrapped in the returned DataArray. The
+    float/non-float split drives the ``masked_nodata`` value: any float
+    output is treated as NaN-aware (NaN is the sentinel proxy), any
+    integer output still carries the raw sentinel.
+
+    ``masked_nodata`` is only emitted when ``nodata is not None``. With
+    no declared sentinel, the flag is meaningless and its absence is the
+    signal.
+    """
+    if nodata is None:
+        return
+    attrs['nodata'] = nodata
+    attrs['masked_nodata'] = bool(np.dtype(array_dtype).kind == 'f')
+
+
 def _populate_attrs_from_geo_info(attrs: dict, geo_info, *, window=None) -> None:
     """Populate ``attrs`` with all GeoTIFF metadata from ``geo_info``.
 
     Centralised so the eager numpy, dask, and GPU read paths emit the
     same attrs keys for the same input file. Mutates ``attrs`` in place.
 
-    The ``nodata`` attr is intentionally NOT set here because each caller
-    sets it next to its own nodata-masking step (the value's presence in
-    attrs signals "this array has been NaN-masked").
+    The ``nodata`` / ``masked_nodata`` pair is intentionally NOT set
+    here because each caller pairs them with its own nodata-masking step
+    via :func:`_set_nodata_attrs`. The pair carries two distinct
+    signals: ``nodata`` is the declared file sentinel (always set when
+    the source declared one), and ``masked_nodata`` is a boolean for
+    whether the in-memory array has been NaN-masked (issue #1988).
 
     ``window`` is a ``(r0, c0, r1, c1)`` tuple for windowed reads; when
     set, the emitted ``attrs['transform']`` shifts the origin to the

--- a/xrspatial/geotiff/_backends/dask.py
+++ b/xrspatial/geotiff/_backends/dask.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import numpy as np
 import xarray as xr
 
-from .._attrs import _populate_attrs_from_geo_info
+from .._attrs import _populate_attrs_from_geo_info, _set_nodata_attrs
 from .._coords import (
     coords_from_geo_info as _coords_from_geo_info,
     geo_to_coords as _geo_to_coords,
@@ -296,8 +296,12 @@ def read_geotiff_dask(source: str, *,
 
     attrs = {}
     _populate_attrs_from_geo_info(attrs, geo_info, window=window)
-    if nodata_attr is not None:
-        attrs['nodata'] = nodata_attr
+    # ``masked_nodata`` reflects the declared dask graph dtype: a float
+    # graph means every chunk runs the sentinel-to-NaN promotion (or
+    # already arrived as float), so the in-memory array is NaN-masked.
+    # An integer graph means each chunk keeps the literal sentinel
+    # value. See issue #1988.
+    _set_nodata_attrs(attrs, nodata_attr, array_dtype=target_dtype)
 
     if isinstance(chunks, int):
         ch_h = ch_w = chunks

--- a/xrspatial/geotiff/_backends/gpu.py
+++ b/xrspatial/geotiff/_backends/gpu.py
@@ -20,7 +20,7 @@ import warnings
 import numpy as np
 import xarray as xr
 
-from .._attrs import _populate_attrs_from_geo_info
+from .._attrs import _populate_attrs_from_geo_info, _set_nodata_attrs
 from .._coords import (
     coords_from_geo_info as _coords_from_geo_info,
 )
@@ -393,13 +393,18 @@ def read_geotiff_gpu(source: str, *,
             # sentinel otherwise (#1809).
             nodata = geo_info.nodata
             if nodata is not None:
-                attrs['nodata'] = nodata
                 mask_value = getattr(_stripped_geo, '_mask_nodata', nodata)
                 arr_gpu = _apply_nodata_mask_gpu(arr_gpu, mask_value)
             if dtype is not None:
                 target = np.dtype(dtype)
                 _validate_dtype_cast(np.dtype(str(arr_gpu.dtype)), target)
                 arr_gpu = arr_gpu.astype(target)
+            # ``attrs['nodata']`` + ``attrs['masked_nodata']`` reflect the
+            # post-mask, post-cast array dtype (issue #1988).
+            _set_nodata_attrs(
+                attrs, nodata,
+                array_dtype=np.dtype(str(arr_gpu.dtype)),
+            )
             # ``read_to_array`` already applied window + band slicing, so
             # ``arr_gpu`` is at output shape. Compute coords for that
             # shape without re-slicing. Mirror the eager-numpy /
@@ -707,8 +712,11 @@ def read_geotiff_gpu(source: str, *,
 
     attrs = {}
     _populate_attrs_from_geo_info(attrs, geo_info, window=window)
-    if nodata is not None:
-        attrs['nodata'] = nodata
+    # ``attrs['nodata']`` + ``attrs['masked_nodata']`` reflect the
+    # post-mask, post-cast array dtype (issue #1988).
+    _set_nodata_attrs(
+        attrs, nodata, array_dtype=np.dtype(str(arr_gpu.dtype)),
+    )
 
     # Apply window/band slicing post-decode. Coords are derived from the
     # sliced array so the (y, x) labels line up with the user's requested
@@ -1153,8 +1161,9 @@ def _read_geotiff_gpu_chunked_gds(source, ifd, geo_info, header, *,
 
     attrs = {}
     _populate_attrs_from_geo_info(attrs, geo_info, window=window)
-    if nodata is not None:
-        attrs['nodata'] = nodata
+    # ``masked_nodata`` reflects the declared dask graph dtype; mirrors
+    # the dask+numpy backend contract (issue #1988).
+    _set_nodata_attrs(attrs, nodata, array_dtype=declared_dtype)
 
     if name is None:
         import os

--- a/xrspatial/geotiff/_backends/vrt.py
+++ b/xrspatial/geotiff/_backends/vrt.py
@@ -596,10 +596,11 @@ def _read_vrt_chunked(source, *, window, band, name, chunks, gpu, dtype,
 
     # Surface the nodata sentinel for the selected band. The chunked
     # path declares ``float64`` up front whenever any selected band has
-    # a representable integer sentinel (see ``declared_dtype`` block
-    # below), so the dask graph dtype drives ``masked_nodata`` (issue
-    # #1988). The call to ``_set_nodata_attrs`` happens after
-    # ``declared_dtype`` is computed.
+    # a representable integer sentinel (see the ``declared_dtype`` block
+    # earlier in this function), so the dask graph dtype drives
+    # ``masked_nodata`` (issue #1988). ``final_dtype`` is the post-cast
+    # dtype the dask array was reshaped to above, which is what the
+    # caller will see on the returned DataArray.
     nodata_meta = None
     if vrt.bands:
         band_idx_for_nodata = band if band is not None else 0

--- a/xrspatial/geotiff/_backends/vrt.py
+++ b/xrspatial/geotiff/_backends/vrt.py
@@ -13,7 +13,7 @@ import math
 import numpy as np
 import xarray as xr
 
-from .._attrs import _ATTRS_CONTRACT_VERSION
+from .._attrs import _ATTRS_CONTRACT_VERSION, _set_nodata_attrs
 from .._coords import (
     coords_from_pixel_geometry as _coords_from_pixel_geometry,
     transform_tuple_from_pixel_geometry as _transform_tuple_from_pixel_geometry,
@@ -227,17 +227,14 @@ def read_vrt(source: str, *,
     if vrt.bands:
         band_idx_for_nodata = band if band is not None else 0
         nodata = vrt.bands[band_idx_for_nodata].nodata
-        if nodata is not None:
-            attrs['nodata'] = nodata
 
     # Mirror the integer-with-nodata promotion that open_geotiff /
     # read_geotiff_dask / read_geotiff_gpu apply post-decode. The VRT
     # internal reader NaN-masks float source arrays inline (see
-    # ``_vrt._read_data``) but leaves integer sentinels untouched. Without
-    # this branch, ``attrs['nodata']`` would be set while the array still
-    # carried the literal sentinel value, breaking the convention that
-    # downstream code follows (``attrs['nodata']`` is present iff the
-    # array has already been NaN-masked).
+    # ``_vrt._read_data``) but leaves integer sentinels untouched.
+    # ``attrs['nodata']`` (the declared sentinel) is set unconditionally
+    # below; ``attrs['masked_nodata']`` is computed from the final array
+    # dtype so it reflects whether NaN masking actually ran (issue #1988).
     #
     # The helper handles both per-band masking (multi-band reads where
     # each band has its own ``<NoDataValue>``) and single-band masking,
@@ -268,6 +265,12 @@ def read_vrt(source: str, *,
         target = np.dtype(dtype)
         _validate_dtype_cast(np.dtype(str(arr.dtype)), target)
         arr = arr.astype(target)
+
+    # Record ``nodata`` + ``masked_nodata`` from the final array dtype
+    # (issue #1988). On GPU the dtype is read off the CuPy array via
+    # ``str(arr.dtype)`` so ``np.dtype`` accepts it without a CuPy
+    # dependency in ``_set_nodata_attrs``.
+    _set_nodata_attrs(attrs, nodata, array_dtype=np.dtype(str(arr.dtype)))
 
     if arr.ndim == 3:
         dims = ['y', 'x', 'band']
@@ -591,13 +594,17 @@ def _read_vrt_chunked(source, *, window, band, name, chunks, gpu, dtype,
     if vrt.raster_type == 'point':
         attrs['raster_type'] = 'point'
 
-    # Surface the nodata sentinel for the selected band.
+    # Surface the nodata sentinel for the selected band. The chunked
+    # path declares ``float64`` up front whenever any selected band has
+    # a representable integer sentinel (see ``declared_dtype`` block
+    # below), so the dask graph dtype drives ``masked_nodata`` (issue
+    # #1988). The call to ``_set_nodata_attrs`` happens after
+    # ``declared_dtype`` is computed.
     nodata_meta = None
     if vrt.bands:
         band_idx_for_nodata = band if band is not None else 0
         nodata_meta = vrt.bands[band_idx_for_nodata].nodata
-        if nodata_meta is not None:
-            attrs['nodata'] = nodata_meta
+    _set_nodata_attrs(attrs, nodata_meta, array_dtype=final_dtype)
 
     # Static hole detection: mirror the eager-path ``attrs['vrt_holes']``
     # contract (#1734) by scanning every source referenced in the parsed

--- a/xrspatial/geotiff/tests/test_nodata_semantics_split_1988.py
+++ b/xrspatial/geotiff/tests/test_nodata_semantics_split_1988.py
@@ -1,0 +1,360 @@
+"""Regression tests for issue #1988.
+
+``attrs['nodata']`` was historically overloaded as both "the file
+declared this sentinel" and "the reader already replaced sentinel
+pixels with NaN." Issue #1988 split those into two attrs:
+
+* ``attrs['nodata']`` -- declared file sentinel, always set when the
+  source declared one.
+* ``attrs['masked_nodata']`` -- boolean, ``True`` iff the in-memory
+  array has been NaN-masked. ``False`` iff the array still carries the
+  literal integer sentinel value (e.g. an int raster whose sentinel
+  did not match any decoded pixel, or a dask graph that stayed at the
+  source integer dtype).
+
+This module exercises the matrix:
+
+    source-has-sentinel x backend x {float-NaN-masked, int-sentinel-preserved}
+
+and asserts the contract on every cell.
+"""
+from __future__ import annotations
+
+import importlib.util
+import struct
+
+import numpy as np
+import pytest
+import rasterio
+import xarray as xr
+from rasterio.transform import from_origin
+
+from xrspatial.geotiff import open_geotiff, read_geotiff_dask
+
+
+_SENTINEL = -9999.0
+
+
+def _gpu_available() -> bool:
+    if importlib.util.find_spec("cupy") is None:
+        return False
+    try:
+        import cupy
+        return bool(cupy.cuda.is_available())
+    except Exception:
+        return False
+
+
+_HAS_GPU = _gpu_available()
+_gpu_only = pytest.mark.skipif(
+    not _HAS_GPU,
+    reason="cupy + CUDA required",
+)
+
+
+def _write_float_tiff(path: str, *, with_sentinel: bool) -> None:
+    """Write a 4x4 float32 TIFF with or without a declared nodata sentinel."""
+    arr = np.array(
+        [[1.0, 2.0, _SENTINEL, 4.0],
+         [5.0, _SENTINEL, 7.0, 8.0],
+         [9.0, 10.0, 11.0, 12.0],
+         [13.0, 14.0, 15.0, 16.0]],
+        dtype=np.float32,
+    )
+    kw = dict(
+        driver="GTiff", height=4, width=4, count=1, dtype="float32",
+        transform=from_origin(0, 4, 1, 1), crs="EPSG:4326",
+    )
+    if with_sentinel:
+        kw["nodata"] = _SENTINEL
+    with rasterio.open(path, "w", **kw) as ds:
+        ds.write(arr, 1)
+
+
+def _write_int_tiff(path: str, *, with_sentinel_hit: bool) -> None:
+    """Write a uint16 TIFF.
+
+    ``with_sentinel_hit`` controls whether the sentinel matches any
+    pixel: when True, the file contains pixels equal to the declared
+    sentinel (so the reader will float-promote and mask); when False,
+    the file declares a sentinel but no pixel matches (so the reader
+    keeps the integer dtype and masked_nodata stays False).
+    """
+    if with_sentinel_hit:
+        arr = np.array(
+            [[10, 20, 65535, 40],
+             [50, 65535, 70, 80],
+             [90, 100, 110, 120],
+             [130, 140, 150, 160]],
+            dtype=np.uint16,
+        )
+    else:
+        arr = np.array(
+            [[10, 20, 30, 40],
+             [50, 60, 70, 80],
+             [90, 100, 110, 120],
+             [130, 140, 150, 160]],
+            dtype=np.uint16,
+        )
+    with rasterio.open(
+        path, "w",
+        driver="GTiff", height=4, width=4, count=1, dtype="uint16",
+        transform=from_origin(0, 4, 1, 1), crs="EPSG:4326",
+        nodata=65535,
+    ) as ds:
+        ds.write(arr, 1)
+
+
+# ----------------------------------------------------------------------------
+# Eager numpy backend
+# ----------------------------------------------------------------------------
+
+
+class TestEagerNumpy:
+    """``open_geotiff`` (eager numpy backend)."""
+
+    def test_float_source_with_sentinel(self, tmp_path):
+        """Float source + declared sentinel -> nodata set, masked_nodata=True."""
+        path = str(tmp_path / "tnss1988_float_sentinel.tif")
+        _write_float_tiff(path, with_sentinel=True)
+        da = open_geotiff(path)
+        assert da.attrs["nodata"] == _SENTINEL
+        assert da.attrs["masked_nodata"] is True
+        # The literal sentinel must have been replaced with NaN.
+        assert np.isnan(da.values).sum() == 2
+
+    def test_float_source_without_sentinel(self, tmp_path):
+        """Float source + no sentinel declared -> neither attr set."""
+        path = str(tmp_path / "tnss1988_float_no_sentinel.tif")
+        _write_float_tiff(path, with_sentinel=False)
+        da = open_geotiff(path)
+        assert "nodata" not in da.attrs
+        # ``masked_nodata`` is only meaningful when a sentinel was
+        # declared; absence is the signal.
+        assert "masked_nodata" not in da.attrs
+
+    def test_int_source_with_sentinel_hit(self, tmp_path):
+        """Int source + sentinel hit -> nodata set, masked_nodata=True (promoted)."""
+        path = str(tmp_path / "tnss1988_int_hit.tif")
+        _write_int_tiff(path, with_sentinel_hit=True)
+        da = open_geotiff(path)
+        assert da.attrs["nodata"] == 65535
+        # Eager numpy promotes integer to float64 on the first hit.
+        assert da.dtype.kind == "f"
+        assert da.attrs["masked_nodata"] is True
+        assert np.isnan(da.values).sum() == 2
+
+    def test_int_source_no_hit_keeps_sentinel(self, tmp_path):
+        """Int source + sentinel declared but no hit -> nodata set, masked_nodata=False.
+
+        The eager numpy path only promotes integer arrays to float on
+        the first sentinel hit. When the sentinel is in-range but never
+        matches a pixel, the array stays at the source integer dtype
+        and ``masked_nodata`` is False so downstream code knows the
+        literal sentinel is still in-band.
+        """
+        path = str(tmp_path / "tnss1988_int_no_hit.tif")
+        _write_int_tiff(path, with_sentinel_hit=False)
+        da = open_geotiff(path)
+        assert da.attrs["nodata"] == 65535
+        assert da.dtype.kind in ("u", "i")
+        assert da.attrs["masked_nodata"] is False
+
+
+# ----------------------------------------------------------------------------
+# Dask numpy backend
+# ----------------------------------------------------------------------------
+
+
+class TestDaskNumpy:
+    """``read_geotiff_dask`` (lazy dask + numpy backend)."""
+
+    def test_float_source_with_sentinel(self, tmp_path):
+        path = str(tmp_path / "tnss1988_dask_float_sentinel.tif")
+        _write_float_tiff(path, with_sentinel=True)
+        da = read_geotiff_dask(path, chunks=2)
+        assert da.attrs["nodata"] == _SENTINEL
+        assert da.attrs["masked_nodata"] is True
+
+    def test_float_source_without_sentinel(self, tmp_path):
+        path = str(tmp_path / "tnss1988_dask_float_no_sentinel.tif")
+        _write_float_tiff(path, with_sentinel=False)
+        da = read_geotiff_dask(path, chunks=2)
+        assert "nodata" not in da.attrs
+        assert "masked_nodata" not in da.attrs
+
+    def test_int_source_with_in_range_sentinel(self, tmp_path):
+        """Dask declares float64 up front for any in-range integer sentinel.
+
+        The dask backend cannot defer promotion to runtime the way the
+        eager path does (each chunk reads independently and concat
+        needs a fixed dtype). When any integer sentinel is in-range,
+        the declared graph dtype is float64 and ``masked_nodata`` is
+        True regardless of whether a chunk actually hits the sentinel.
+        """
+        path = str(tmp_path / "tnss1988_dask_int_in_range.tif")
+        _write_int_tiff(path, with_sentinel_hit=False)
+        da = read_geotiff_dask(path, chunks=2)
+        assert da.attrs["nodata"] == 65535
+        assert da.dtype.kind == "f"
+        assert da.attrs["masked_nodata"] is True
+
+
+# ----------------------------------------------------------------------------
+# Cross-cutting: integer sentinel that is out-of-range
+# ----------------------------------------------------------------------------
+
+
+def _build_uint16_with_out_of_range_nodata(path: str) -> None:
+    """Write a uint16 TIFF whose declared nodata is out of dtype range.
+
+    Mirrors the corpus used by ``test_nodata_nan_int_1774.py``. The
+    sentinel cannot match any pixel, so masking is a no-op and the
+    array stays uint16. ``masked_nodata`` must be False so downstream
+    code knows the literal value space is intact.
+    """
+    bo = '<'
+    width, height = 2, 2
+    pixels = np.array([[10, 20], [30, 40]], dtype=np.uint16)
+
+    nodata_str = "-9999"  # out of range for uint16
+    nodata_bytes = nodata_str.encode('ascii') + b'\x00'
+
+    tag_list: list[tuple[int, int, int, bytes]] = []
+
+    def add_short(tag: int, val: int) -> None:
+        tag_list.append((tag, 3, 1, struct.pack(f'{bo}H', val)))
+
+    def add_long(tag: int, val: int) -> None:
+        tag_list.append((tag, 4, 1, struct.pack(f'{bo}I', val)))
+
+    def add_ascii(tag: int, data: bytes) -> None:
+        tag_list.append((tag, 2, len(data), data))
+
+    add_short(256, width)
+    add_short(257, height)
+    add_short(258, 16)            # BitsPerSample
+    add_short(259, 1)             # Compression (none)
+    add_short(262, 1)             # PhotometricInterpretation (BlackIsZero)
+    add_short(277, 1)             # SamplesPerPixel
+    add_short(284, 1)             # PlanarConfiguration (chunky)
+    add_short(339, 1)             # SampleFormat (unsigned)
+    add_long(254, 0)              # NewSubfileType
+    add_long(322, 256)            # TileWidth (placeholder; we use strips)
+
+    # Strip the placeholder TileWidth: switch to strips.
+    tag_list = [t for t in tag_list if t[0] != 322]
+
+    rows_per_strip = height
+    add_short(278, rows_per_strip)  # RowsPerStrip
+
+    pixels_bytes = pixels.tobytes()
+    add_long(279, len(pixels_bytes))  # StripByteCounts
+
+    add_ascii(42113, nodata_bytes)   # GDAL_NODATA
+
+    tag_list.sort(key=lambda t: t[0])
+
+    header_size = 8
+    ifd_entries = len(tag_list)
+    # Strip offset placeholder; pixel data goes after the IFD.
+    strip_offsets_tag = (273, 4, 1, b'\x00\x00\x00\x00')  # type=LONG
+    tag_list.append(strip_offsets_tag)
+    ifd_entries += 1
+    tag_list.sort(key=lambda t: t[0])
+
+    ifd_size = 2 + ifd_entries * 12 + 4
+
+    # Layout: header (8) + IFD + tag-overflow data + pixels.
+    ifd_offset = header_size
+    overflow_offset = ifd_offset + ifd_size
+
+    overflow_buffers: list[bytes] = []
+    overflow_positions: dict[int, int] = {}
+
+    new_entries: list[bytes] = []
+    for (tag, type_, count, data) in tag_list:
+        if len(data) > 4:
+            overflow_positions[tag] = overflow_offset + sum(
+                len(b) for b in overflow_buffers
+            )
+            overflow_buffers.append(data)
+            value_field = struct.pack(f'{bo}I', overflow_positions[tag])
+        else:
+            value_field = data.ljust(4, b'\x00')
+        new_entries.append(
+            struct.pack(f'{bo}HHI', tag, type_, count) + value_field
+        )
+
+    pixel_offset = (overflow_offset
+                    + sum(len(b) for b in overflow_buffers))
+
+    # Patch StripOffsets value field.
+    patched_entries = []
+    for entry, (tag, *_) in zip(new_entries, tag_list):
+        if tag == 273:
+            entry = entry[:8] + struct.pack(f'{bo}I', pixel_offset)
+        patched_entries.append(entry)
+
+    with open(path, 'wb') as f:
+        f.write(b'II' + struct.pack(f'{bo}HI', 42, ifd_offset))
+        f.write(struct.pack(f'{bo}H', ifd_entries))
+        for e in patched_entries:
+            f.write(e)
+        f.write(struct.pack(f'{bo}I', 0))  # next IFD = none
+        for b in overflow_buffers:
+            f.write(b)
+        f.write(pixels_bytes)
+
+
+def test_int_source_with_out_of_range_sentinel(tmp_path):
+    """Out-of-range int sentinel -> nodata set, masked_nodata=False (eager).
+
+    The sentinel cannot match any pixel so masking is a no-op and the
+    array stays at the source integer dtype. ``masked_nodata`` must be
+    False so downstream code knows the literal sentinel value is still
+    a possible (but in this case unhit) pixel value in the array.
+    """
+    path = str(tmp_path / "tnss1988_int_oor.tif")
+    _build_uint16_with_out_of_range_nodata(path)
+    da = open_geotiff(path)
+    assert da.attrs["nodata"] == -9999
+    assert da.dtype.kind == "u"
+    assert da.attrs["masked_nodata"] is False
+
+
+# ----------------------------------------------------------------------------
+# Helper unit tests
+# ----------------------------------------------------------------------------
+
+
+class TestSetNodataAttrsHelper:
+    """Direct coverage of :func:`_set_nodata_attrs` in ``_attrs.py``."""
+
+    def test_float_dtype_marks_masked(self):
+        from xrspatial.geotiff._attrs import _set_nodata_attrs
+        attrs: dict = {}
+        _set_nodata_attrs(attrs, -9999, array_dtype=np.float64)
+        assert attrs == {"nodata": -9999, "masked_nodata": True}
+
+    def test_int_dtype_marks_unmasked(self):
+        from xrspatial.geotiff._attrs import _set_nodata_attrs
+        attrs: dict = {}
+        _set_nodata_attrs(attrs, -9999, array_dtype=np.uint16)
+        assert attrs == {"nodata": -9999, "masked_nodata": False}
+
+    def test_none_nodata_is_noop(self):
+        from xrspatial.geotiff._attrs import _set_nodata_attrs
+        attrs: dict = {}
+        _set_nodata_attrs(attrs, None, array_dtype=np.uint16)
+        assert attrs == {}
+
+    def test_accepts_dtype_string(self):
+        """``array_dtype`` may be a numpy dtype object, type, or string."""
+        from xrspatial.geotiff._attrs import _set_nodata_attrs
+        attrs: dict = {}
+        _set_nodata_attrs(attrs, 0, array_dtype="float32")
+        assert attrs["masked_nodata"] is True
+        attrs = {}
+        _set_nodata_attrs(attrs, 0, array_dtype="uint8")
+        assert attrs["masked_nodata"] is False

--- a/xrspatial/geotiff/tests/test_nodata_semantics_split_1988.py
+++ b/xrspatial/geotiff/tests/test_nodata_semantics_split_1988.py
@@ -198,6 +198,23 @@ class TestDaskNumpy:
         assert da.dtype.kind == "f"
         assert da.attrs["masked_nodata"] is True
 
+    def test_int_source_with_out_of_range_sentinel(self, tmp_path):
+        """Dask + out-of-range int sentinel -> graph stays int, masked_nodata=False.
+
+        Mirrors the eager-path ``test_int_source_with_out_of_range_sentinel``
+        free function. The dask ``effective_dtype`` branch only promotes
+        to float64 when the sentinel fits the source dtype range; an
+        out-of-range sentinel (e.g. uint16 file with
+        ``GDAL_NODATA="-9999"``) cannot match any pixel, so the declared
+        graph dtype stays uint16 and ``masked_nodata`` must be False.
+        """
+        path = str(tmp_path / "tnss1988_dask_int_oor.tif")
+        _build_uint16_with_out_of_range_nodata(path)
+        da = read_geotiff_dask(path, chunks=2)
+        assert da.attrs["nodata"] == -9999
+        assert da.dtype.kind == "u"
+        assert da.attrs["masked_nodata"] is False
+
 
 # ----------------------------------------------------------------------------
 # Cross-cutting: integer sentinel that is out-of-range

--- a/xrspatial/geotiff/tests/test_nodata_semantics_split_1988.py
+++ b/xrspatial/geotiff/tests/test_nodata_semantics_split_1988.py
@@ -26,10 +26,9 @@ import struct
 import numpy as np
 import pytest
 import rasterio
-import xarray as xr
 from rasterio.transform import from_origin
 
-from xrspatial.geotiff import open_geotiff, read_geotiff_dask
+from xrspatial.geotiff import open_geotiff, read_geotiff_dask, read_vrt
 
 
 _SENTINEL = -9999.0
@@ -305,6 +304,166 @@ def _build_uint16_with_out_of_range_nodata(path: str) -> None:
         for b in overflow_buffers:
             f.write(b)
         f.write(pixels_bytes)
+
+
+# ----------------------------------------------------------------------------
+# VRT backend (eager + chunked)
+# ----------------------------------------------------------------------------
+
+
+def _write_uint16_vrt_source(tmp_path, *, sentinel_hit: bool, filename: str):
+    """Write a 2x2 uint16 source raster with declared sentinel 65535."""
+    from xrspatial.geotiff._writer import write
+    if sentinel_hit:
+        band = np.array([[1, 2], [3, 65535]], dtype=np.uint16)
+    else:
+        band = np.array([[1, 2], [3, 4]], dtype=np.uint16)
+    p = str(tmp_path / filename)
+    write(band, p, nodata=65535, compression="none", tiled=False)
+    return p
+
+
+def _build_vrt(tmp_path, source_path, vrt_dtype, nodata_value,
+               filename="tnss1988.vrt"):
+    """Hand-roll a 2x2 VRT pointing at ``source_path``."""
+    vrt_xml = f"""<VRTDataset rasterXSize="2" rasterYSize="2">
+  <GeoTransform>0.0, 1.0, 0.0, 0.0, 0.0, -1.0</GeoTransform>
+  <VRTRasterBand dataType="{vrt_dtype}" band="1">
+    <NoDataValue>{nodata_value}</NoDataValue>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">{source_path}</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="2" ySize="2"/>
+      <DstRect xOff="0" yOff="0" xSize="2" ySize="2"/>
+    </SimpleSource>
+  </VRTRasterBand>
+</VRTDataset>"""
+    p = str(tmp_path / filename)
+    with open(p, "w") as f:
+        f.write(vrt_xml)
+    return p
+
+
+class TestVRTEager:
+    """``read_vrt`` (eager path) honours the split-attrs contract."""
+
+    def test_float32_vrt_int_source_with_hit(self, tmp_path):
+        """Float-typed VRT over int source with sentinel hit -> masked_nodata=True."""
+        src = _write_uint16_vrt_source(
+            tmp_path, sentinel_hit=True, filename="tnss1988_vrt_src_hit.tif",
+        )
+        vrt = _build_vrt(tmp_path, src, "Float32", 65535,
+                         filename="tnss1988_vrt_hit.vrt")
+        r = read_vrt(vrt)
+        assert r.attrs["nodata"] == 65535.0
+        assert r.dtype.kind == "f"
+        assert r.attrs["masked_nodata"] is True
+
+    def test_uint16_vrt_int_source_no_hit(self, tmp_path):
+        """Int-typed VRT over int source, no sentinel pixel -> masked_nodata=False.
+
+        A ``dataType="UInt16"`` VRT with no scale/offset keeps the
+        source integer dtype. With no sentinel pixel in the source, the
+        eager path produces a uint16 array carrying the literal
+        sentinel value space, so ``masked_nodata`` must be False.
+        """
+        src = _write_uint16_vrt_source(
+            tmp_path, sentinel_hit=False,
+            filename="tnss1988_vrt_src_nohit.tif",
+        )
+        vrt = _build_vrt(tmp_path, src, "UInt16", 65535,
+                         filename="tnss1988_vrt_nohit.vrt")
+        r = read_vrt(vrt)
+        assert r.attrs["nodata"] == 65535.0
+        assert r.dtype.kind in ("u", "i")
+        assert r.attrs["masked_nodata"] is False
+
+    def test_vrt_no_nodata_emits_neither_attr(self, tmp_path):
+        """VRT band with no ``<NoDataValue>`` -> neither attr set."""
+        src = _write_uint16_vrt_source(
+            tmp_path, sentinel_hit=False,
+            filename="tnss1988_vrt_src_no_nd.tif",
+        )
+        # Build a VRT without a NoDataValue element.
+        vrt_xml = """<VRTDataset rasterXSize="2" rasterYSize="2">
+  <GeoTransform>0.0, 1.0, 0.0, 0.0, 0.0, -1.0</GeoTransform>
+  <VRTRasterBand dataType="UInt16" band="1">
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">""" + src + """</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="2" ySize="2"/>
+      <DstRect xOff="0" yOff="0" xSize="2" ySize="2"/>
+    </SimpleSource>
+  </VRTRasterBand>
+</VRTDataset>"""
+        vrt = str(tmp_path / "tnss1988_vrt_no_nd.vrt")
+        with open(vrt, "w") as f:
+            f.write(vrt_xml)
+        r = read_vrt(vrt)
+        assert "nodata" not in r.attrs
+        assert "masked_nodata" not in r.attrs
+
+
+class TestVRTChunked:
+    """``read_vrt(..., chunks=N)`` honours the split-attrs contract."""
+
+    def test_chunked_int_source_in_range_sentinel(self, tmp_path):
+        """Chunked VRT declares float64 for in-range int sentinel -> masked_nodata=True."""
+        src = _write_uint16_vrt_source(
+            tmp_path, sentinel_hit=False,
+            filename="tnss1988_vrt_chunked_src.tif",
+        )
+        vrt = _build_vrt(tmp_path, src, "UInt16", 65535,
+                         filename="tnss1988_vrt_chunked.vrt")
+        r = read_vrt(vrt, chunks=2)
+        assert r.attrs["nodata"] == 65535.0
+        # Chunked path promotes to float64 declared dtype.
+        assert r.dtype == np.float64
+        assert r.attrs["masked_nodata"] is True
+
+
+# ----------------------------------------------------------------------------
+# GPU backend
+# ----------------------------------------------------------------------------
+
+
+@_gpu_only
+class TestGPU:
+    """``read_geotiff_gpu`` honours the split-attrs contract."""
+
+    def test_int_source_with_hit(self, tmp_path):
+        """Int source + sentinel hit on GPU -> masked_nodata=True (float)."""
+        from xrspatial.geotiff import read_geotiff_gpu
+        path = str(tmp_path / "tnss1988_gpu_int_hit.tif")
+        _write_int_tiff(path, with_sentinel_hit=True)
+        da = read_geotiff_gpu(path)
+        assert da.attrs["nodata"] == 65535
+        assert np.dtype(str(da.dtype)).kind == "f"
+        assert da.attrs["masked_nodata"] is True
+
+    def test_int_source_no_hit_keeps_sentinel(self, tmp_path):
+        """Int source + sentinel no hit on GPU -> masked_nodata=False.
+
+        Mirrors the eager-numpy contract: GPU masking only promotes int
+        to float64 when at least one sentinel pixel is found.
+        """
+        from xrspatial.geotiff import read_geotiff_gpu
+        path = str(tmp_path / "tnss1988_gpu_int_nohit.tif")
+        _write_int_tiff(path, with_sentinel_hit=False)
+        da = read_geotiff_gpu(path)
+        assert da.attrs["nodata"] == 65535
+        assert np.dtype(str(da.dtype)).kind in ("u", "i")
+        assert da.attrs["masked_nodata"] is False
+
+    def test_dask_gpu_in_range_sentinel(self, tmp_path):
+        """Dask+GPU declares float64 graph for in-range int sentinel."""
+        from xrspatial.geotiff import read_geotiff_gpu
+        path = str(tmp_path / "tnss1988_gpu_dask_int.tif")
+        _write_int_tiff(path, with_sentinel_hit=False)
+        da = read_geotiff_gpu(path, chunks=2)
+        assert da.attrs["nodata"] == 65535
+        assert np.dtype(str(da.dtype)).kind == "f"
+        assert da.attrs["masked_nodata"] is True
 
 
 def test_int_source_with_out_of_range_sentinel(tmp_path):

--- a/xrspatial/geotiff/tests/test_nodata_semantics_split_1988.py
+++ b/xrspatial/geotiff/tests/test_nodata_semantics_split_1988.py
@@ -25,10 +25,11 @@ import struct
 
 import numpy as np
 import pytest
-import rasterio
-from rasterio.transform import from_origin
 
 from xrspatial.geotiff import open_geotiff, read_geotiff_dask, read_vrt
+
+rasterio = pytest.importorskip("rasterio")
+from rasterio.transform import from_origin  # noqa: E402
 
 
 _SENTINEL = -9999.0


### PR DESCRIPTION
## Summary

Closes the foundational chunk of #1988: split the declared file sentinel from the masked-state signal in DataArray attrs on every geotiff read path.

- ``attrs['nodata']`` -- declared file sentinel as a scalar of the source dtype. Set whenever the source declared one. Independent of whether masking ran.
- ``attrs['masked_nodata']`` -- new boolean. ``True`` iff the reader replaced sentinel pixels with NaN in the in-memory array (final dtype is float). ``False`` iff the array still carries the literal integer sentinel.

The two signals were previously fused: ``attrs['nodata']`` doubled as "the file declared this sentinel" and "the reader already replaced sentinel pixels with NaN." Downstream code branching on the second meaning had to use the first as a proxy and lost the ability to tell a float-NaN array from an int-with-sentinel array.

## Changes

- New ``_set_nodata_attrs(attrs, nodata, *, array_dtype)`` in ``_attrs.py``. Sets both keys atomically from the final array dtype.
- Every read backend calls it from one site, after any masking and any user-requested dtype cast:
  - ``open_geotiff`` eager numpy (``__init__.py``)
  - ``read_geotiff_dask`` (``_backends/dask.py``) -- uses the declared graph dtype
  - ``read_geotiff_gpu`` -- three sites (eager tiled, eager stripped, chunked dask+gpu) in ``_backends/gpu.py``
  - ``read_vrt`` eager + chunked in ``_backends/vrt.py``
- Test matrix in ``test_nodata_semantics_split_1988.py``: source-has-sentinel x backend x {float-NaN-masked, int-sentinel-preserved}, plus direct unit coverage of ``_set_nodata_attrs``.

## What this does not change

This PR is additive. The writer still reads ``attrs['nodata']`` through ``_resolve_nodata_attr`` and ignores ``masked_nodata``; no existing nodata test changes its expectation. Migrating writers and downstream xrspatial code to branch on ``masked_nodata`` is the follow-up scope on #1988.

## Test plan

- [x] ``pytest xrspatial/geotiff/tests/test_nodata_semantics_split_1988.py`` (12 passed)
- [x] All existing nodata regression suites pass: ``test_nodata_nan_int_1774``, ``test_nodata_int64_precision_1847``, ``test_nodata_attr_aliases_1582``, ``test_miniswhite_nodata_1809``, ``test_vrt_band_nodata_1598``, ``test_overview_nodata_inheritance_1739``, ``test_vrt_int_source_float_dtype_1616``, ``test_vrt_multiband_int_nodata_1611`` (88 passed)
- [x] Full ``xrspatial/geotiff/`` suite (excluding the pre-existing fuzz failure on ``test_fuzz_hypothesis_1661.py``, which reproduces on ``main``): 952 passed