### PR TITLE
rasterize: vectorize _polys_to_wkb with shapely.to_wkb (#2059)

### DIFF
--- a/xrspatial/rasterize.py
+++ b/xrspatial/rasterize.py
@@ -1607,6 +1607,11 @@ def _slice_props_for_tile(geom_idx, props):
 
 def _polys_to_wkb(geoms):
     """Pre-serialize polygon geometries to WKB for cheap pickling."""
+    if not geoms:
+        return []
+    if _HAS_SHAPELY2:
+        import shapely
+        return shapely.to_wkb(np.asarray(geoms, dtype=object)).tolist()
     return [g.wkb for g in geoms]
 
 

--- a/xrspatial/rasterize.py
+++ b/xrspatial/rasterize.py
@@ -1694,7 +1694,7 @@ def _run_dask_numpy(geometries, props_array, bounds, height, width, fill,
     # Store as object array for single-pass boolean indexing per tile.
     if poly_geoms:
         poly_bboxes = _geometry_bboxes(poly_geoms)
-        poly_wkb_arr = np.array([g.wkb for g in poly_geoms], dtype=object)
+        poly_wkb_arr = np.array(_polys_to_wkb(poly_geoms), dtype=object)
     else:
         poly_bboxes = np.empty((0, 4), dtype=np.float64)
         poly_wkb_arr = np.empty(0, dtype=object)
@@ -1854,7 +1854,7 @@ def _run_dask_cupy(geometries, props_array, bounds, height, width, fill,
     # Pre-serialize polygons to WKB (20x cheaper to pickle than shapely).
     if poly_geoms:
         poly_bboxes = _geometry_bboxes(poly_geoms)
-        poly_wkb_arr = np.array([g.wkb for g in poly_geoms], dtype=object)
+        poly_wkb_arr = np.array(_polys_to_wkb(poly_geoms), dtype=object)
     else:
         poly_bboxes = np.empty((0, 4), dtype=np.float64)
         poly_wkb_arr = np.empty(0, dtype=object)

--- a/xrspatial/tests/test_rasterize.py
+++ b/xrspatial/tests/test_rasterize.py
@@ -1811,3 +1811,44 @@ class TestMetadataPropagation:
                   or read_back.attrs.get('_FillValue'))
         assert nodata is not None
         assert float(nodata) == -9999.0
+
+
+class TestPolysToWkb:
+    """Tests for the _polys_to_wkb helper (issue #2059)."""
+
+    def test_empty_input_returns_empty_list(self):
+        from xrspatial.rasterize import _polys_to_wkb
+        result = _polys_to_wkb([])
+        assert result == []
+        assert isinstance(result, list)
+
+    def test_output_matches_per_geometry_wkb(self):
+        """Vectorized output is byte-identical to the per-geometry path."""
+        from xrspatial.rasterize import _polys_to_wkb
+        rng = np.random.default_rng(2059)
+        geoms = []
+        for _ in range(100):
+            cx, cy = rng.uniform(-100, 100, 2)
+            r = rng.uniform(0.1, 5.0)
+            geoms.append(box(cx - r, cy - r, cx + r, cy + r))
+
+        result = _polys_to_wkb(geoms)
+        expected = [g.wkb for g in geoms]
+
+        assert isinstance(result, list)
+        assert len(result) == len(expected)
+        assert all(isinstance(b, (bytes, bytearray)) for b in result)
+        assert result == expected
+
+    def test_roundtrip_through_from_wkb(self):
+        """Output round-trips through _polys_from_wkb to equal geometries."""
+        from xrspatial.rasterize import _polys_to_wkb, _polys_from_wkb
+        geoms = [
+            Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]),
+            Polygon([(5, 5), (6, 5), (6, 6), (5, 6)]),
+            Polygon([(-2, -2), (2, -2), (2, 2), (-2, 2)]),
+        ]
+        restored = _polys_from_wkb(_polys_to_wkb(geoms))
+        assert len(restored) == len(geoms)
+        for original, copy in zip(geoms, restored):
+            assert original.equals(copy)


### PR DESCRIPTION
Closes #2059.

## Summary
- Replace the per-geometry `.wkb` list comprehension in `_polys_to_wkb` with a single `shapely.to_wkb` call on the shapely 2.0+ path.
- Route both inline `[g.wkb for g in poly_geoms]` call sites inside `_run_dask_numpy` (numpy and cupy variants) through `_polys_to_wkb`, so the vectorized path actually fires for dask backends.
- The shapely<2 fallback is preserved (issue #2060 handles dropping it separately).
- Output remains a Python list of `bytes`, byte-identical to the prior implementation. `_polys_from_wkb` and downstream pickling are unaffected.

## Bench
On 100k random box polygons (single process, shapely 2.x):

```
old (list comp):   248.9 ms
new (vectorized):   31.5 ms
speedup:            7.90x
byte-identical:     True
```

## Test plan
- [x] `pytest xrspatial/tests/test_rasterize.py::TestPolysToWkb -x` (new tests: empty input, byte-identical to per-geometry path on 100 polygons, round-trip through `_polys_from_wkb`)
- [x] `pytest xrspatial/tests/test_rasterize*.py -q` -> 244 passed, 2 skipped
- [x] Inline call sites in `_run_dask_numpy` (numpy + cupy) wired through `_polys_to_wkb` so the dask backend gets the speedup