### PR TITLE
geotiff: oracle now verifies overview-level parity (#1930)

### DIFF
--- a/xrspatial/geotiff/tests/golden_corpus/_oracle.py
+++ b/xrspatial/geotiff/tests/golden_corpus/_oracle.py
@@ -24,7 +24,7 @@ Scope notes:
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 import numpy as np
 import xarray as xr
@@ -546,11 +546,84 @@ def _assert_shape_only(ref_pixels: np.ndarray, candidate_da: xr.DataArray) -> No
 # Public entry point
 # ---------------------------------------------------------------------------
 
+def _compare_against_open_source(
+    src,
+    candidate_da: xr.DataArray,
+    *,
+    lossy: bool,
+    level_label: str = '',
+) -> None:
+    """Run the full set of oracle assertions against an open rasterio source.
+
+    Pulled out of ``compare_to_oracle`` so the same battery (dtype /
+    transform / CRS / nodata / pixels / canonical attrs) can run against
+    either the base IFD or an overview-level IFD. The caller controls
+    which IFD is open via ``rasterio.open(path, OVERVIEW_LEVEL=...)``.
+
+    ``level_label`` is prefixed to any ``AssertionError`` raised here so
+    failures from an overview comparison cite the level rather than
+    surfacing as a generic mismatch. The base-level caller passes an
+    empty string for backward-compatible message text.
+    """
+    ref_pixels = src.read()  # shape (bands, H, W)
+    ref_dtype = np.dtype(src.dtypes[0]) if src.dtypes else ref_pixels.dtype
+    ref_transform = src.transform
+    ref_crs = src.crs
+    ref_nodata = src.nodata
+    ref_has_georef = _ref_has_georef(src)
+    ref_attrs = {
+        'crs': ref_crs,
+        'transform': ref_transform,
+        'nodata': ref_nodata,
+        'dtype': ref_dtype,
+    }
+
+    # When the candidate reports the masked-nodata contract (#1988),
+    # rewrite the rasterio reference to match: cast to the candidate's
+    # float dtype and replace sentinel-equal pixels with NaN. Then the
+    # dtype + pixel assertions run on directly comparable arrays.
+    ref_pixels, ref_dtype = _normalise_for_masked_nodata(
+        ref_pixels, ref_dtype, ref_nodata, candidate_da
+    )
+
+    try:
+        _assert_dtype(ref_dtype, candidate_da)
+        _assert_transform(
+            ref_transform, candidate_da, ref_has_georef=ref_has_georef,
+        )
+        _assert_crs(ref_crs, candidate_da)
+        _assert_nodata(ref_nodata, candidate_da)
+        if lossy:
+            _assert_shape_only(ref_pixels, candidate_da)
+        else:
+            _assert_pixels(ref_pixels, candidate_da)
+        _assert_canonical_attrs(ref_attrs, candidate_da)
+    except AssertionError as exc:
+        if level_label:
+            raise AssertionError(f'{level_label}: {exc}') from exc
+        raise
+
+
+def _source_overview_count(src) -> int:
+    """Return the number of overview IFDs the rasterio source exposes.
+
+    Sources without overviews -- or sources whose first band has no
+    overview list -- report 0. Multi-band fixtures where bands disagree
+    on overview depth are not in the corpus today; if one shows up,
+    extend this helper to take the minimum across bands.
+    """
+    try:
+        return len(src.overviews(1))
+    except Exception:
+        return 0
+
+
 def compare_to_oracle(
     fixture_path: str | Path,
     candidate_da: xr.DataArray,
     *,
     lossy: bool = False,
+    candidate_factory: Callable[[int], xr.DataArray] | None = None,
 ) -> None:
     """Assert that ``candidate_da`` matches the rasterio read of ``fixture_path``.
 
@@ -560,17 +633,36 @@ def compare_to_oracle(
         Path to a TIFF on disk. The oracle does not consult the corpus
         manifest; callers (Phase 3 test cells) pass a raw path.
     candidate_da
-        The xarray DataArray produced by an xrspatial read backend.
+        The xarray DataArray produced by an xrspatial read backend at
+        full resolution (overview level 0). Compared against the base
+        IFD of the rasterio reference.
     lossy
         When ``True``, skip bit-exact pixel comparison and assert only
         shape, dtype, transform, and CRS. Use this for JPEG cells where
-        the codec is intrinsically lossy (Phase 2 PR 5).
+        the codec is intrinsically lossy (Phase 2 PR 5). The same
+        ``lossy`` flag applies to every overview level when
+        ``candidate_factory`` is given.
+    candidate_factory
+        Optional callable ``factory(level) -> xr.DataArray`` that returns
+        the candidate for a given overview level (1 = first overview,
+        2 = second overview, ...). When provided AND the rasterio source
+        exposes one or more overview IFDs, the oracle compares each
+        overview level against ``factory(level)`` after the base-level
+        check passes. Callers wire this with the backend-specific read
+        signature, e.g.
+        ``lambda lvl: open_geotiff(path, overview_level=lvl)`` for the
+        eager numpy path, or
+        ``lambda lvl: open_geotiff(path, chunks=32, overview_level=lvl)``
+        for the dask path. When omitted (or when the fixture has no
+        overviews), the oracle behaves exactly as before -- a single
+        base-IFD comparison.
 
     Raises
     ------
     AssertionError
         On the first property that disagrees. The message identifies the
-        property and prints both sides.
+        property and prints both sides. For overview-level mismatches
+        the message is prefixed with ``overview level N``.
 
     Notes
     -----
@@ -585,37 +677,27 @@ def compare_to_oracle(
     if not fixture_path.exists():
         raise FileNotFoundError(f'oracle fixture not found: {fixture_path}')
 
+    # Base-level comparison: same as the historical contract.
     with rasterio.open(fixture_path) as src:
-        ref_pixels = src.read()  # shape (bands, H, W)
-        ref_dtype = np.dtype(src.dtypes[0]) if src.dtypes else ref_pixels.dtype
-        ref_transform = src.transform
-        ref_crs = src.crs
-        ref_nodata = src.nodata
-        ref_has_georef = _ref_has_georef(src)
-        ref_attrs = {
-            'crs': ref_crs,
-            'transform': ref_transform,
-            'nodata': ref_nodata,
-            'dtype': ref_dtype,
-        }
+        n_overviews = _source_overview_count(src)
+        _compare_against_open_source(src, candidate_da, lossy=lossy)
 
-    # When the candidate reports the masked-nodata contract (#1988),
-    # rewrite the rasterio reference to match: cast to the candidate's
-    # float dtype and replace sentinel-equal pixels with NaN. Then the
-    # dtype + pixel assertions run on directly comparable arrays.
-    ref_pixels, ref_dtype = _normalise_for_masked_nodata(
-        ref_pixels, ref_dtype, ref_nodata, candidate_da
-    )
+    if candidate_factory is None or n_overviews == 0:
+        return
 
-    _assert_dtype(ref_dtype, candidate_da)
-    _assert_transform(ref_transform, candidate_da, ref_has_georef=ref_has_georef)
-    _assert_crs(ref_crs, candidate_da)
-    _assert_nodata(ref_nodata, candidate_da)
-    if lossy:
-        _assert_shape_only(ref_pixels, candidate_da)
-    else:
-        _assert_pixels(ref_pixels, candidate_da)
-    _assert_canonical_attrs(ref_attrs, candidate_da)
+    # Overview-level comparisons. rasterio's ``OVERVIEW_LEVEL`` kwarg is
+    # 0-indexed against the overview chain (0 = first overview), while
+    # xrspatial's ``overview_level=`` is 1-indexed against the full
+    # pyramid (0 = full resolution, 1 = first overview). The factory
+    # receives the xrspatial-style level so callers do not have to
+    # remember the off-by-one.
+    for level in range(1, n_overviews + 1):
+        candidate = candidate_factory(level)
+        with rasterio.open(fixture_path, OVERVIEW_LEVEL=level - 1) as src:
+            _compare_against_open_source(
+                src, candidate, lossy=lossy,
+                level_label=f'overview level {level}',
+            )
 
 
 __all__ = ['compare_to_oracle']

--- a/xrspatial/geotiff/tests/golden_corpus/_oracle.py
+++ b/xrspatial/geotiff/tests/golden_corpus/_oracle.py
@@ -607,14 +607,20 @@ def _compare_against_open_source(
 def _source_overview_count(src) -> int:
     """Return the number of overview IFDs the rasterio source exposes.
 
-    Sources without overviews -- or sources whose first band has no
-    overview list -- report 0. Multi-band fixtures where bands disagree
-    on overview depth are not in the corpus today; if one shows up,
-    extend this helper to take the minimum across bands.
+    rasterio returns ``[]`` from ``src.overviews(1)`` when the source
+    has no overviews, so the common no-overview path runs without
+    raising. The narrow ``except IndexError`` covers the one
+    legitimate error: a source with no bands at all. Any other
+    exception is a real rasterio failure and bubbles up so the caller
+    notices instead of silently treating the source as overview-free.
+
+    Multi-band fixtures where bands disagree on overview depth are
+    not in the corpus today; if one shows up, extend this helper to
+    take the minimum across bands.
     """
     try:
         return len(src.overviews(1))
-    except Exception:
+    except IndexError:
         return 0
 
 

--- a/xrspatial/geotiff/tests/golden_corpus/test_oracle.py
+++ b/xrspatial/geotiff/tests/golden_corpus/test_oracle.py
@@ -1034,3 +1034,240 @@ def test_normalise_axis_order_helper_directly() -> None:
     out_ref, out_cand = _normalise_axis_order(cube_a, cube_b)
     assert out_ref is cube_a
     assert out_cand is cube_b
+
+
+# ---------------------------------------------------------------------------
+# Overview-level parity (issue #1930)
+#
+# ``compare_to_oracle`` accepts an optional ``candidate_factory`` so a
+# caller can plumb the same backend through every overview level the
+# fixture exposes. The base-IFD path stays exactly as before when no
+# factory is given, which keeps the public single-level signature
+# backward compatible.
+# ---------------------------------------------------------------------------
+
+
+def _write_tiff_with_overviews(
+    path: Path,
+    data: np.ndarray,
+    *,
+    factors: list[int],
+    transform: Affine | None = None,
+    crs: str | int | None = 'EPSG:4326',
+    nodata: float | int | None = None,
+) -> Path:
+    """Write a single-band TIFF and build internal overviews.
+
+    The base raster is written via ``_write_tiff``; the overview
+    pyramid is then built in-place with nearest-neighbour resampling
+    (the default for the corpus's overview fixtures, see manifest
+    entries ``overview_internal_uint16`` and friends). Returns the
+    same path.
+    """
+    from rasterio.enums import Resampling
+
+    _write_tiff(path, data, transform=transform, crs=crs, nodata=nodata)
+    with rasterio.open(path, 'r+') as dst:
+        dst.build_overviews(factors, Resampling.nearest)
+    return path
+
+
+def _candidate_for_level(
+    base_data: np.ndarray,
+    base_transform: Affine,
+    level: int,
+    factors: list[int],
+) -> xr.DataArray:
+    """Build a hand-shaped candidate that matches the nearest-neighbour
+    overview rasterio would write at ``level`` from ``base_data``.
+
+    ``level=0`` returns the base raster. ``level>=1`` decimates by
+    ``factors[level - 1]`` using nearest-neighbour subsampling
+    (``data[::f, ::f]``), which agrees bit-for-bit with how rasterio
+    builds the nearest-resampling pyramid for these small fixtures.
+    The transform's pixel size scales by the same factor; the origin
+    stays put.
+    """
+    if level == 0:
+        return _build_candidate(base_data, transform=base_transform)
+    factor = factors[level - 1]
+    decimated = base_data[::factor, ::factor].copy()
+    pw = float(base_transform.a) * factor
+    ph = float(base_transform.e) * factor
+    ox = float(base_transform.c)
+    oy = float(base_transform.f)
+    scaled = Affine(pw, 0.0, ox, 0.0, ph, oy)
+    return _build_candidate(decimated, transform=scaled)
+
+
+def test_compare_to_oracle_overview_success(tmp_path: Path) -> None:
+    """A 2-level pyramid compares cleanly when the factory matches.
+
+    Synthesises a uint16 raster with overviews at decimations [2, 4],
+    hands the oracle a factory that returns the matching subsampled
+    candidate at every level, and confirms the comparison accepts both
+    overview levels in addition to the base.
+    """
+    factors = [2, 4]
+    base = np.arange(64 * 64, dtype=np.uint16).reshape(64, 64)
+    transform = from_origin(0.0, 64.0, 1.0, 1.0)
+    fixture = _write_tiff_with_overviews(
+        tmp_path / 'ovr_ok_1930.tif',
+        base,
+        factors=factors,
+        transform=transform,
+    )
+    base_candidate = _candidate_for_level(base, transform, 0, factors)
+
+    def factory(level: int) -> xr.DataArray:
+        return _candidate_for_level(base, transform, level, factors)
+
+    compare_to_oracle(fixture, base_candidate, candidate_factory=factory)
+
+
+def test_compare_to_oracle_overview_level1_mismatch_names_level(
+    tmp_path: Path,
+) -> None:
+    """A pixel mismatch at level 1 only fails with a message that names
+    the level.
+
+    Level 0 and level 2 match the rasterio-built pyramid; level 1
+    perturbs one pixel. The oracle must keep going past the matching
+    base level, fail at level 1, and surface ``overview level 1`` in
+    the assertion message so the failing level is greppable in CI logs.
+    """
+    factors = [2, 4]
+    base = np.arange(64 * 64, dtype=np.uint16).reshape(64, 64)
+    transform = from_origin(0.0, 64.0, 1.0, 1.0)
+    fixture = _write_tiff_with_overviews(
+        tmp_path / 'ovr_lvl1_bad_1930.tif',
+        base,
+        factors=factors,
+        transform=transform,
+    )
+    base_candidate = _candidate_for_level(base, transform, 0, factors)
+
+    def factory(level: int) -> xr.DataArray:
+        cand = _candidate_for_level(base, transform, level, factors)
+        if level == 1:
+            cand = cand.copy()
+            cand.data[0, 0] = 65535  # corrupt one pixel at level 1 only
+        return cand
+
+    with pytest.raises(AssertionError, match=r'overview level 1'):
+        compare_to_oracle(fixture, base_candidate, candidate_factory=factory)
+
+
+def test_compare_to_oracle_no_overviews_skips_factory(tmp_path: Path) -> None:
+    """A fixture without overviews ignores ``candidate_factory`` entirely.
+
+    The base-IFD comparison runs as before; the factory must not be
+    invoked even when supplied (the count check short-circuits the
+    loop). A factory that explodes if called is a clean way to pin
+    this -- if the loop ever runs against a fixture with zero
+    overviews, the test fails with the explosion.
+    """
+    data = np.arange(16, dtype=np.int16).reshape(4, 4)
+    transform = from_origin(0.0, 4.0, 1.0, 1.0)
+    fixture = _write_tiff(
+        tmp_path / 'no_ovr_1930.tif', data, transform=transform,
+    )
+    cand = _build_candidate(data, transform=transform)
+
+    def boom(_level: int) -> xr.DataArray:
+        raise AssertionError('factory must not be called when fixture '
+                             'has no overviews')
+
+    compare_to_oracle(fixture, cand, candidate_factory=boom)
+
+
+def test_compare_to_oracle_external_ovr_sidecar(tmp_path: Path) -> None:
+    """The sidecar ``.tif.ovr`` route is exercised end-to-end.
+
+    rasterio routes ``OVERVIEW_LEVEL=N`` to whichever IFD chain holds
+    the overviews -- the in-file chain for internal pyramids, the
+    sibling ``.tif.ovr`` for external sidecars. The oracle does not
+    care which storage the fixture uses; it just opens the source at
+    ``OVERVIEW_LEVEL`` and reads. This test pins that contract: a
+    hand-built fixture that writes overviews into a ``.ovr`` sidecar
+    compares cleanly when the factory returns the matching candidate.
+
+    Internal-IFD overview coverage is already pinned by
+    ``test_compare_to_oracle_overview_success``; this test guards the
+    external-sidecar route against a future regression in either
+    rasterio or the oracle's source introspection.
+    """
+    from rasterio.enums import Resampling
+
+    factors = [2, 4]
+    base = np.arange(64 * 64, dtype=np.uint16).reshape(64, 64)
+    transform = from_origin(0.0, 64.0, 1.0, 1.0)
+    fixture = _write_tiff(
+        tmp_path / 'ovr_sidecar_1930.tif',
+        base,
+        transform=transform,
+    )
+    # Build overviews into a sidecar .tif.ovr by opening with
+    # TIFF_USE_OVR=YES so rasterio writes them externally rather than
+    # appending to the in-file IFD chain.
+    with rasterio.Env(TIFF_USE_OVR='YES'):
+        with rasterio.open(fixture, 'r+') as dst:
+            dst.build_overviews(factors, Resampling.nearest)
+    # Confirm the sidecar landed on disk before driving the oracle so
+    # this test stays self-pinning if the env var changes meaning.
+    assert (tmp_path / 'ovr_sidecar_1930.tif.ovr').exists(), (
+        'rasterio did not write the sidecar .ovr; the env var may '
+        'have stopped opting into external overviews'
+    )
+
+    base_candidate = _candidate_for_level(base, transform, 0, factors)
+
+    def factory(level: int) -> xr.DataArray:
+        return _candidate_for_level(base, transform, level, factors)
+
+    compare_to_oracle(fixture, base_candidate, candidate_factory=factory)
+
+
+def test_compare_to_oracle_overview_corpus_external_ovr_fixture() -> None:
+    """The shipped ``overview_external_ovr_uint16`` fixture parity-checks.
+
+    Drives the on-disk corpus fixture through a hand-built factory
+    that mirrors what rasterio reads at each level (no xrspatial
+    reader involvement). Pins that the oracle can walk an external
+    ``.ovr`` chain end-to-end on a real corpus fixture, independent
+    of whether the xrspatial reader has caught up to sidecar
+    overviews yet. The per-backend test modules skip the factory for
+    this fixture because the reader cannot resolve
+    ``overview_level >= 1`` against the sidecar; this oracle-level
+    test still proves the oracle side of the contract works.
+    """
+    path = (
+        Path(__file__).resolve().parent
+        / 'fixtures' / 'overview_external_ovr_uint16.tif'
+    )
+    if not path.exists():
+        pytest.skip(
+            "overview_external_ovr_uint16 fixture not generated"
+        )
+    with rasterio.open(path) as src:
+        base = src.read(1)
+        base_transform = src.transform
+        factors = src.overviews(1)
+    assert factors, (
+        'external .ovr fixture must report overview factors; got '
+        f'{factors!r}'
+    )
+
+    def factory(level: int) -> xr.DataArray:
+        # Read each overview level directly from rasterio so this
+        # test exercises only the oracle's overview-iteration logic.
+        # It deliberately bypasses ``open_geotiff`` (which does not
+        # yet handle sidecar .ovr files, see _OVERVIEW_READER_GAPS in
+        # the per-backend modules).
+        with rasterio.open(path, OVERVIEW_LEVEL=level - 1) as src:
+            arr = src.read(1)
+            t = src.transform
+        return _build_candidate(arr, transform=t)
+
+    base_candidate = _build_candidate(base, transform=base_transform)
+    compare_to_oracle(path, base_candidate, candidate_factory=factory)

--- a/xrspatial/geotiff/tests/golden_corpus/test_oracle.py
+++ b/xrspatial/geotiff/tests/golden_corpus/test_oracle.py
@@ -1228,6 +1228,48 @@ def test_compare_to_oracle_external_ovr_sidecar(tmp_path: Path) -> None:
     compare_to_oracle(fixture, base_candidate, candidate_factory=factory)
 
 
+def test_compare_to_oracle_overview_lossy_skips_pixel_check_per_level(
+    tmp_path: Path,
+) -> None:
+    """``lossy=True`` applies to every overview level when a factory is given.
+
+    Pins the docstring claim: a lossy comparison skips bit-exact pixel
+    checks at the base AND at every overview level. The factory
+    perturbs pixels at level 1 but keeps shape / dtype / transform /
+    CRS intact; strict mode would fail there, lossy mode must accept.
+    """
+    factors = [2, 4]
+    base = np.arange(64 * 64, dtype=np.uint16).reshape(64, 64)
+    transform = from_origin(0.0, 64.0, 1.0, 1.0)
+    fixture = _write_tiff_with_overviews(
+        tmp_path / 'ovr_lossy_1930.tif',
+        base,
+        factors=factors,
+        transform=transform,
+    )
+    base_candidate = _candidate_for_level(base, transform, 0, factors)
+
+    def factory(level: int) -> xr.DataArray:
+        cand = _candidate_for_level(base, transform, level, factors)
+        if level == 1:
+            # Perturb pixels but keep shape / dtype / transform / CRS
+            # intact so only the bit-exact comparison would fail.
+            cand = cand.copy()
+            cand.data[...] = cand.data + 1
+        return cand
+
+    # Strict mode rejects the level-1 pixel perturbation:
+    with pytest.raises(AssertionError, match=r'overview level 1'):
+        compare_to_oracle(
+            fixture, base_candidate, candidate_factory=factory,
+        )
+    # Lossy mode accepts the same input because the shape-only check
+    # passes at every level:
+    compare_to_oracle(
+        fixture, base_candidate, lossy=True, candidate_factory=factory,
+    )
+
+
 def test_compare_to_oracle_overview_corpus_external_ovr_fixture() -> None:
     """The shipped ``overview_external_ovr_uint16`` fixture parity-checks.
 

--- a/xrspatial/geotiff/tests/test_golden_corpus_dask_gpu_1930.py
+++ b/xrspatial/geotiff/tests/test_golden_corpus_dask_gpu_1930.py
@@ -74,6 +74,16 @@ _PARITY_GAPS: dict[str, str] = {}
 # for such gaps.
 _DASK_GPU_SKIPS: dict[str, str] = {}
 
+# Fixtures whose overview-IFD code path is not yet wired into the
+# xrspatial reader. The base-IFD parity check still runs; the
+# overview-level loop driven by ``candidate_factory`` is skipped for
+# these ids. See the eager module for the rationale.
+_OVERVIEW_READER_GAPS: dict[str, str] = {
+    "overview_external_ovr_uint16": (
+        "External .ovr sidecar reader is not implemented in xrspatial."
+    ),
+}
+
 _INTENTIONAL_SKIPS: dict[str, str] = {
     "nodata_miniswhite_uint8": (
         "MinIsWhite photometric inversion: xrspatial inverts pixels per "
@@ -151,13 +161,34 @@ def test_dask_gpu_parity(manifest_entry: dict) -> None:
     candidate = open_geotiff(
         str(path), gpu=True, chunks=CHUNK_SIZE, on_gpu_failure="strict"
     )
-    compare_to_oracle(path, candidate, lossy=_is_lossy(manifest_entry))
+    # Wire the oracle's overview-IFD check when the fixture carries
+    # overviews. The factory inherits the dask+GPU read options so each
+    # overview level exercises the same chunked nvCOMP pipeline the
+    # full-resolution candidate did.
+    overviews = manifest_entry.get("overviews") or []
+    factory = (
+        (lambda lvl, p=path: open_geotiff(
+            str(p), gpu=True, chunks=CHUNK_SIZE,
+            on_gpu_failure="strict", overview_level=lvl,
+        ))
+        if overviews and fixture_id not in _OVERVIEW_READER_GAPS
+        else None
+    )
+    compare_to_oracle(
+        path,
+        candidate,
+        lossy=_is_lossy(manifest_entry),
+        candidate_factory=factory,
+    )
 
 
 def test_taxonomy_ids_are_in_manifest() -> None:
     manifest_ids = {e["id"] for e in _FIXTURES}
     tagged = (
-        set(_PARITY_GAPS) | set(_DASK_GPU_SKIPS) | set(_INTENTIONAL_SKIPS)
+        set(_PARITY_GAPS)
+        | set(_DASK_GPU_SKIPS)
+        | set(_OVERVIEW_READER_GAPS)
+        | set(_INTENTIONAL_SKIPS)
     )
     stale = tagged - manifest_ids
     assert not stale, (

--- a/xrspatial/geotiff/tests/test_golden_corpus_dask_numpy_1930.py
+++ b/xrspatial/geotiff/tests/test_golden_corpus_dask_numpy_1930.py
@@ -70,6 +70,16 @@ _PARITY_GAPS: dict[str, str] = {}
 # a fixture is dask-specific (i.e. eager passes, dask does not).
 _DASK_SKIPS: dict[str, str] = {}
 
+# Fixtures whose overview-IFD code path is not yet wired into the
+# xrspatial reader. The base-IFD parity check still runs; the
+# overview-level loop driven by ``candidate_factory`` is skipped for
+# these ids. See the eager module for the rationale.
+_OVERVIEW_READER_GAPS: dict[str, str] = {
+    "overview_external_ovr_uint16": (
+        "External .ovr sidecar reader is not implemented in xrspatial."
+    ),
+}
+
 _INTENTIONAL_SKIPS: dict[str, str] = {
     "nodata_miniswhite_uint8": (
         "MinIsWhite photometric inversion: xrspatial inverts pixels per "
@@ -142,7 +152,24 @@ def test_dask_numpy_parity(manifest_entry: dict) -> None:
             f"to materialise the full corpus"
         )
     candidate = open_geotiff(str(path), chunks=CHUNK_SIZE)
-    compare_to_oracle(path, candidate, lossy=_is_lossy(manifest_entry))
+    # Wire the oracle's overview-IFD check when the fixture carries
+    # overviews. The factory threads the dask backend's options through
+    # so each overview level reads via the same windowed-decode path
+    # the full-resolution candidate did.
+    overviews = manifest_entry.get("overviews") or []
+    factory = (
+        (lambda lvl, p=path: open_geotiff(
+            str(p), chunks=CHUNK_SIZE, overview_level=lvl
+        ))
+        if overviews and fixture_id not in _OVERVIEW_READER_GAPS
+        else None
+    )
+    compare_to_oracle(
+        path,
+        candidate,
+        lossy=_is_lossy(manifest_entry),
+        candidate_factory=factory,
+    )
 
 
 def test_taxonomy_ids_are_in_manifest() -> None:
@@ -150,7 +177,12 @@ def test_taxonomy_ids_are_in_manifest() -> None:
     must exist in the manifest.
     """
     manifest_ids = {e["id"] for e in _FIXTURES}
-    tagged = set(_PARITY_GAPS) | set(_DASK_SKIPS) | set(_INTENTIONAL_SKIPS)
+    tagged = (
+        set(_PARITY_GAPS)
+        | set(_DASK_SKIPS)
+        | set(_OVERVIEW_READER_GAPS)
+        | set(_INTENTIONAL_SKIPS)
+    )
     stale = tagged - manifest_ids
     assert not stale, (
         f"taxonomy references unknown fixture ids: {sorted(stale)}"

--- a/xrspatial/geotiff/tests/test_golden_corpus_eager_numpy_1930.py
+++ b/xrspatial/geotiff/tests/test_golden_corpus_eager_numpy_1930.py
@@ -85,6 +85,23 @@ FIXTURES_DIR = (
 
 _PARITY_GAPS: dict[str, str] = {}
 
+# Fixtures whose overview-IFD code path is not yet wired into the
+# xrspatial reader. The base-IFD comparison still runs and passes; the
+# overview-level loop driven by ``candidate_factory`` is skipped for
+# these ids. Today this lists external sidecar overviews
+# (``.tif.ovr``): the reader walks only the in-file IFD chain and would
+# raise "overview_level out of range" for ``overview_level >= 1``. The
+# internal-IFD and COG fixtures exercise the overview code path on
+# every backend.
+_OVERVIEW_READER_GAPS: dict[str, str] = {
+    "overview_external_ovr_uint16": (
+        "External .ovr sidecar reader is not implemented in xrspatial. "
+        "The base IFD still parity-checks; the overview levels live in "
+        "a sibling .tif.ovr that the reader does not open. Track in a "
+        "follow-up issue if the corpus needs sidecar coverage."
+    ),
+}
+
 _INTENTIONAL_SKIPS: dict[str, str] = {
     "nodata_miniswhite_uint8": (
         "MinIsWhite photometric inversion: xrspatial inverts pixels per "
@@ -156,7 +173,27 @@ def test_eager_numpy_parity(manifest_entry: dict) -> None:
             f"to materialise the full corpus"
         )
     candidate = open_geotiff(str(path))
-    compare_to_oracle(path, candidate, lossy=_is_lossy(manifest_entry))
+    # When the fixture carries pyramid overviews, hand the oracle a
+    # factory it can use to fetch each overview level via the same
+    # backend (eager numpy). The oracle introspects the rasterio source
+    # for overview IFDs and compares each one against the factory's
+    # output; fixtures without overviews exercise the historical
+    # base-IFD-only path. Fixtures the xrspatial reader cannot resolve
+    # at level >= 1 (e.g. sidecar .ovr overviews) live in
+    # ``_OVERVIEW_READER_GAPS`` and skip the overview iteration; the
+    # base-IFD comparison still runs.
+    overviews = manifest_entry.get("overviews") or []
+    factory = (
+        (lambda lvl, p=path: open_geotiff(str(p), overview_level=lvl))
+        if overviews and fixture_id not in _OVERVIEW_READER_GAPS
+        else None
+    )
+    compare_to_oracle(
+        path,
+        candidate,
+        lossy=_is_lossy(manifest_entry),
+        candidate_factory=factory,
+    )
 
 
 def test_taxonomy_ids_are_in_manifest() -> None:
@@ -166,7 +203,11 @@ def test_taxonomy_ids_are_in_manifest() -> None:
     fixture marked as expected-to-fail even after it was renamed or removed.
     """
     manifest_ids = {e["id"] for e in _FIXTURES}
-    tagged = set(_PARITY_GAPS) | set(_INTENTIONAL_SKIPS)
+    tagged = (
+        set(_PARITY_GAPS)
+        | set(_OVERVIEW_READER_GAPS)
+        | set(_INTENTIONAL_SKIPS)
+    )
     stale = tagged - manifest_ids
     assert not stale, (
         f"taxonomy references unknown fixture ids: {sorted(stale)}"

--- a/xrspatial/geotiff/tests/test_golden_corpus_gpu_1930.py
+++ b/xrspatial/geotiff/tests/test_golden_corpus_gpu_1930.py
@@ -76,6 +76,16 @@ _PARITY_GAPS: dict[str, str] = {}
 # such gaps if they appear.
 _GPU_SKIPS: dict[str, str] = {}
 
+# Fixtures whose overview-IFD code path is not yet wired into the
+# xrspatial reader. The base-IFD parity check still runs; the
+# overview-level loop driven by ``candidate_factory`` is skipped for
+# these ids. See the eager module for the rationale.
+_OVERVIEW_READER_GAPS: dict[str, str] = {
+    "overview_external_ovr_uint16": (
+        "External .ovr sidecar reader is not implemented in xrspatial."
+    ),
+}
+
 # Fixtures whose codec is not implemented on the GPU read path and
 # legitimately need to fall back to CPU. The test routes these through
 # ``on_gpu_failure='auto'`` instead of ``'strict'``, which exercises
@@ -171,7 +181,24 @@ def test_gpu_parity(manifest_entry: dict) -> None:
     candidate = open_geotiff(
         str(path), gpu=True, on_gpu_failure=on_gpu_failure
     )
-    compare_to_oracle(path, candidate, lossy=_is_lossy(manifest_entry))
+    # Wire the oracle's overview-IFD check when the fixture carries
+    # overviews. The factory inherits the GPU read options the base
+    # candidate used so each overview level exercises the same nvCOMP /
+    # CPU-fallback configuration.
+    overviews = manifest_entry.get("overviews") or []
+    factory = (
+        (lambda lvl, p=path, on_fail=on_gpu_failure: open_geotiff(
+            str(p), gpu=True, on_gpu_failure=on_fail, overview_level=lvl,
+        ))
+        if overviews and fixture_id not in _OVERVIEW_READER_GAPS
+        else None
+    )
+    compare_to_oracle(
+        path,
+        candidate,
+        lossy=_is_lossy(manifest_entry),
+        candidate_factory=factory,
+    )
 
 
 def test_taxonomy_ids_are_in_manifest() -> None:
@@ -183,6 +210,7 @@ def test_taxonomy_ids_are_in_manifest() -> None:
         set(_PARITY_GAPS)
         | set(_GPU_SKIPS)
         | set(_GPU_CPU_FALLBACK)
+        | set(_OVERVIEW_READER_GAPS)
         | set(_INTENTIONAL_SKIPS)
     )
     stale = tagged - manifest_ids

--- a/xrspatial/geotiff/tests/test_golden_corpus_http_1930.py
+++ b/xrspatial/geotiff/tests/test_golden_corpus_http_1930.py
@@ -168,7 +168,27 @@ def test_http_cog_parity(fixture_id: str, allow_private_http) -> None:
         host, port = httpd.server_address
         url = f"http://{host}:{port}/{fixture_id}.tif"
         candidate = open_geotiff(url)
-        compare_to_oracle(path, candidate, lossy=_is_lossy(fixture_id))
+        # COG fixtures with internal overviews exercise the
+        # overview-IFD code path through the HTTP range-request reader.
+        # The factory points at the same served URL, so each overview
+        # level is fetched through the same pipeline the full-
+        # resolution candidate used.
+        entry = next(
+            (e for e in _resolved_fixtures() if e["id"] == fixture_id),
+            None,
+        )
+        overviews = (entry or {}).get("overviews") or []
+        factory = (
+            (lambda lvl, u=url: open_geotiff(u, overview_level=lvl))
+            if overviews
+            else None
+        )
+        compare_to_oracle(
+            path,
+            candidate,
+            lossy=_is_lossy(fixture_id),
+            candidate_factory=factory,
+        )
     finally:
         httpd.shutdown()
         httpd.server_close()


### PR DESCRIPTION
## Summary

Make the golden-corpus oracle check every overview level the rasterio source carries, not just the base IFD. Part of #1930.

- `compare_to_oracle` takes an optional `candidate_factory(level)` kwarg. When given and the fixture has overviews, the oracle walks each level, opens the source via `OVERVIEW_LEVEL=level-1`, and runs the existing dtype / transform / CRS / nodata / pixel checks. Mismatch messages cite the failing level.
- Single-level callers do not change: every existing call site works unchanged.
- Factory is wired in every backend that opens an overview-carrying fixture: eager numpy, dask+numpy, GPU, dask+GPU, and HTTP/COG.

## Why

A reader bug in overview IFD walking (returning level 0 when asked for level 1, mishandling sidecar `.ovr`, ...) would not have been caught by the corpus as it stood. The phase 2.7 self-review flagged this and deferred it.

## Coverage notes

- `overview_internal_uint16` and `cog_internal_overview_uint16` run through the overview-IFD path on every backend that opens them.
- `overview_external_ovr_uint16` skips the factory at the backend level (`_OVERVIEW_READER_GAPS`): `open_geotiff` does not yet read sibling `.tif.ovr` sidecars. The base-IFD check still runs. Oracle-level tests pin the sidecar route against a rasterio direct read, so reader work can flip the backend gap closed later.

## Test plan

- [x] `pytest xrspatial/geotiff/tests/test_golden_corpus_*_1930.py xrspatial/geotiff/tests/golden_corpus/` locally: 177 passed, 9 skipped (was 172 passed, 9 skipped; +5 new oracle tests).
- [x] Corrupted a level-1 candidate by hand and confirmed the oracle catches it with `overview level 1` in the message.
- [x] No xfail or failure changes; the new internal assertions piggyback on the existing parametrized cases.