### PR TITLE
geotiff: writer consults attrs['masked_nodata'] (#1988)

### DIFF
--- a/xrspatial/geotiff/_attrs.py
+++ b/xrspatial/geotiff/_attrs.py
@@ -478,7 +478,9 @@ def _should_restore_nan_sentinel(attrs) -> bool:
     # Treat anything other than literal ``False`` as the True default.
     # The flag is the boolean ``True``/``False`` per the contract, but
     # we narrow on identity rather than truthiness so a stray ``0`` /
-    # ``''`` does not silently disable the sentinel rewrite.
+    # ``''`` (which a future maintainer might assume is "off" under a
+    # truthiness rule) does not silently disable the sentinel rewrite.
+    # The identity check is deliberate: do not refactor to ``not value``.
     return value is not False
 
 

--- a/xrspatial/geotiff/_attrs.py
+++ b/xrspatial/geotiff/_attrs.py
@@ -443,6 +443,45 @@ def _extent_to_window(transform, file_height, file_width,
     return (row_start, col_start, row_stop, col_stop)
 
 
+def _should_restore_nan_sentinel(attrs) -> bool:
+    """Return True iff the writer should NaN-to-sentinel rewrite the array.
+
+    Pairs with :func:`_set_nodata_attrs`. The reader stores a boolean in
+    ``attrs['masked_nodata']`` describing whether the in-memory array
+    went through the sentinel-to-NaN promotion. The writer reads it back
+    here to decide whether the inverse rewrite is appropriate:
+
+    * ``masked_nodata`` missing -> default True. Pre-#1988 behaviour:
+      any float array with NaN and a declared sentinel gets the NaN
+      pixels rewritten to the sentinel value. This is what every
+      xrspatial caller has relied on for years and what every external
+      DataArray that does not carry the new attr should still see.
+    * ``masked_nodata=True`` -> True. The reader masked the sentinel
+      into NaN; the writer reverses the step.
+    * ``masked_nodata=False`` -> False. The reader did NOT mask (the
+      array still carries the literal sentinel, or is float for an
+      unrelated reason). Any NaN present in the array did not come
+      from sentinel-masking, and rewriting it to the integer sentinel
+      would corrupt data the user wrote there for other reasons.
+
+    The ``attrs`` argument may be a plain dict, an
+    ``xarray.core.utils.Frozen``, or ``None`` (the GPU writer's
+    positional-cupy branch has no DataArray to read from). ``None`` and
+    non-mapping inputs fall back to the True default.
+    """
+    if attrs is None:
+        return True
+    try:
+        value = attrs.get('masked_nodata')
+    except AttributeError:
+        return True
+    # Treat anything other than literal ``False`` as the True default.
+    # The flag is the boolean ``True``/``False`` per the contract, but
+    # we narrow on identity rather than truthiness so a stray ``0`` /
+    # ``''`` does not silently disable the sentinel rewrite.
+    return value is not False
+
+
 def _set_nodata_attrs(attrs: dict, nodata, *, array_dtype) -> None:
     """Set ``attrs['nodata']`` and ``attrs['masked_nodata']`` on a read.
 

--- a/xrspatial/geotiff/_writer.py
+++ b/xrspatial/geotiff/_writer.py
@@ -1539,7 +1539,8 @@ def write(data: np.ndarray, path: str, *,
           extra_tags: list | None = None,
           bigtiff: bool | None = None,
           max_z_error: float = 0.0,
-          photometric='auto') -> None:
+          photometric='auto',
+          restore_sentinel: bool = True) -> None:
     """Write a numpy array as a GeoTIFF or COG.
 
     Parameters
@@ -1740,7 +1741,8 @@ def write(data: np.ndarray, path: str, *,
                 # reducer itself.
                 if (nodata is not None
                         and current.dtype.kind == 'f'
-                        and not np.isnan(nodata)):
+                        and not np.isnan(nodata)
+                        and restore_sentinel):
                     nan_mask = np.isnan(current)
                     if nan_mask.any():
                         current = current.copy()
@@ -1896,7 +1898,8 @@ def write_streaming(dask_data, path: str, *,
                     bigtiff: bool | None = None,
                     streaming_buffer_bytes: int = 256 * 1024 * 1024,
                     max_z_error: float = 0.0,
-                    photometric='auto') -> None:
+                    photometric='auto',
+                    restore_sentinel: bool = True) -> None:
     """Write a dask array as a GeoTIFF by streaming pixel data.
 
     For tiled output, each tile-row is computed in horizontal segments
@@ -2242,7 +2245,8 @@ def write_streaming(dask_data, path: str, *,
 
                         # NaN -> nodata sentinel
                         if (nodata is not None and seg_np.dtype.kind == 'f'
-                                and not np.isnan(nodata)):
+                                and not np.isnan(nodata)
+                                and restore_sentinel):
                             nan_mask = np.isnan(seg_np)
                             if nan_mask.any():
                                 seg_np = seg_np.copy()
@@ -2338,7 +2342,8 @@ def write_streaming(dask_data, path: str, *,
                         strip_np = strip_np.astype(out_dtype)
 
                     if (nodata is not None and strip_np.dtype.kind == 'f'
-                            and not np.isnan(nodata)):
+                            and not np.isnan(nodata)
+                            and restore_sentinel):
                         nan_mask = np.isnan(strip_np)
                         if nan_mask.any():
                             strip_np = strip_np.copy()

--- a/xrspatial/geotiff/_writers/eager.py
+++ b/xrspatial/geotiff/_writers/eager.py
@@ -25,6 +25,7 @@ from .._attrs import (
     _VALID_COMPRESSIONS,
     _extract_rich_tags,
     _resolve_nodata_attr,
+    _should_restore_nan_sentinel,
 )
 from .._backends._gpu_helpers import _is_gpu_data
 from .._coords import (
@@ -534,6 +535,11 @@ def to_geotiff(data: xr.DataArray | np.ndarray,
     res_unit = None
     gdal_meta_xml = None
     extra_tags_list = None
+    # Default for the issue #1988 gate. Overwritten with the actual
+    # ``attrs['masked_nodata']`` value below when ``data`` is a
+    # DataArray; bare numpy / cupy positional inputs have no attrs
+    # so they keep the pre-#1988 NaN->sentinel rewrite.
+    restore_sentinel = True
 
     # Resolve crs argument: can be int (EPSG) or str (WKT/PROJ)
     _validate_crs_arg(crs)
@@ -582,6 +588,12 @@ def to_geotiff(data: xr.DataArray | np.ndarray,
                         wkt_fallback = wkt
         if nodata is None:
             nodata = _resolve_nodata_attr(data.attrs)
+        # Issue #1988: ``attrs['masked_nodata']`` records whether the
+        # reader promoted the sentinel to NaN. Writers reverse that
+        # rewrite only when the read side did the forward step. Default
+        # (attr absent) is True, which preserves pre-#1988 behaviour for
+        # external DataArrays.
+        restore_sentinel = _should_restore_nan_sentinel(data.attrs)
         # Pull raster_type, gdal_metadata_xml, extra_tags (folded with
         # the friendly image_description / extra_samples / colormap
         # attrs), x/y_resolution, and resolution_unit via the shared
@@ -651,6 +663,7 @@ def to_geotiff(data: xr.DataArray | np.ndarray,
                 streaming_buffer_bytes=streaming_buffer_bytes,
                 max_z_error=max_z_error,
                 photometric=photometric,
+                restore_sentinel=restore_sentinel,
             )
             return path
 
@@ -694,7 +707,8 @@ def to_geotiff(data: xr.DataArray | np.ndarray,
     # ``np.asarray(raw)`` of a caller-owned numpy DataArray (a view,
     # not a copy) or ``np.moveaxis(arr, 0, -1)`` of one (also a view).
     # Mutating without a copy would corrupt the user's input buffer.
-    if nodata is not None and arr.dtype.kind == 'f' and not np.isnan(nodata):
+    if (nodata is not None and arr.dtype.kind == 'f'
+            and not np.isnan(nodata) and restore_sentinel):
         nan_mask = np.isnan(arr)
         if nan_mask.any():
             arr = arr.copy()
@@ -737,6 +751,7 @@ def to_geotiff(data: xr.DataArray | np.ndarray,
         bigtiff=bigtiff,
         max_z_error=max_z_error,
         photometric=photometric,
+        restore_sentinel=restore_sentinel,
     )
     return path
 
@@ -751,7 +766,8 @@ def _write_single_tile(chunk_data, path, geo_transform, epsg, wkt,
                        resolution_unit=None,
                        gdal_metadata_xml=None,
                        extra_tags=None,
-                       photometric: str | int = 'auto'):
+                       photometric: str | int = 'auto',
+                       restore_sentinel: bool = True):
     """Write a single tile GeoTIFF. Used by _write_vrt_tiled.
 
     Forwards the same rich-tag set that ``to_geotiff`` passes through to
@@ -780,7 +796,8 @@ def _write_single_tile(chunk_data, path, geo_transform, epsg, wkt,
     # from ``np.asarray(chunk_data)`` where ``chunk_data`` may be a
     # caller-owned numpy buffer. Mutating without a copy would corrupt
     # the user's input.
-    if nodata is not None and arr.dtype.kind == 'f' and not np.isnan(nodata):
+    if (nodata is not None and arr.dtype.kind == 'f'
+            and not np.isnan(nodata) and restore_sentinel):
         nan_mask = np.isnan(arr)
         if nan_mask.any():
             arr = arr.copy()
@@ -804,7 +821,8 @@ def _write_single_tile(chunk_data, path, geo_transform, epsg, wkt,
           extra_tags=extra_tags,
           bigtiff=bigtiff,
           max_z_error=max_z_error,
-          photometric=photometric)
+          photometric=photometric,
+          restore_sentinel=restore_sentinel)
 
 
 def _write_vrt_tiled(data, vrt_path, *, crs=None, nodata=None,
@@ -913,6 +931,11 @@ def _write_vrt_tiled(data, vrt_path, *, crs=None, nodata=None,
             # the VRT path used ``attrs.get('nodata')`` directly and
             # silently dropped both aliases (issue #1606).
             nodata = _resolve_nodata_attr(data.attrs)
+        # Issue #1988: mirror the ``to_geotiff`` gate so per-tile
+        # writes only NaN-rewrite when the read side promoted the
+        # sentinel. See ``_should_restore_nan_sentinel`` for the
+        # semantics; default True keeps existing behaviour.
+        restore_sentinel = _should_restore_nan_sentinel(data.attrs)
         geo_transform = _transform_from_attr(data.attrs.get('transform'))
         if geo_transform is None:
             geo_transform = _coords_to_transform(data)
@@ -1019,7 +1042,8 @@ def _write_vrt_tiled(data, vrt_path, *, crs=None, nodata=None,
                     resolution_unit=res_unit,
                     gdal_metadata_xml=gdal_meta_xml,
                     extra_tags=extra_tags_list,
-                    photometric=photometric)
+                    photometric=photometric,
+                    restore_sentinel=restore_sentinel)
                 delayed_tasks.append(task)
             else:
                 # Numpy: slice and write directly
@@ -1035,7 +1059,8 @@ def _write_vrt_tiled(data, vrt_path, *, crs=None, nodata=None,
                     resolution_unit=res_unit,
                     gdal_metadata_xml=gdal_meta_xml,
                     extra_tags=extra_tags_list,
-                    photometric=photometric)
+                    photometric=photometric,
+                    restore_sentinel=restore_sentinel)
 
             col_offset += chunk_w
         row_offset += chunk_h

--- a/xrspatial/geotiff/_writers/gpu.py
+++ b/xrspatial/geotiff/_writers/gpu.py
@@ -16,7 +16,11 @@ import xarray as xr
 if TYPE_CHECKING:
     from typing import BinaryIO
 
-from .._attrs import _extract_rich_tags, _resolve_nodata_attr
+from .._attrs import (
+    _extract_rich_tags,
+    _resolve_nodata_attr,
+    _should_restore_nan_sentinel,
+)
 from .._coords import (
     _BAND_DIM_NAMES,
     coords_to_transform as _coords_to_transform,
@@ -353,7 +357,13 @@ def write_geotiff_gpu(data: xr.DataArray | cupy.ndarray | np.ndarray,
         if epsg is None:
             wkt_fallback = crs
 
+    # Issue #1988: ``attrs['masked_nodata']`` records whether the read
+    # side promoted the sentinel to NaN. Default True preserves the
+    # pre-#1988 NaN->sentinel rewrite for external DataArrays and bare
+    # cupy / numpy positional arrays that have no attrs to read from.
+    restore_sentinel = True
     if isinstance(data, xr.DataArray):
+        restore_sentinel = _should_restore_nan_sentinel(data.attrs)
         arr = data.data
         # Handle Dask arrays: compute to materialize
         if hasattr(arr, 'compute'):
@@ -466,7 +476,8 @@ def write_geotiff_gpu(data: xr.DataArray | cupy.ndarray | np.ndarray,
     # in every case.
     if (nodata is not None
             and np_dtype.kind == 'f'
-            and not np.isnan(float(nodata))):
+            and not np.isnan(float(nodata))
+            and restore_sentinel):
         nan_mask = cupy.isnan(arr)
         if bool(nan_mask.any()):
             arr = arr.copy()
@@ -547,6 +558,7 @@ def write_geotiff_gpu(data: xr.DataArray | cupy.ndarray | np.ndarray,
             nodata is not None
             and np_dtype.kind == 'f'
             and not np.isnan(float(nodata))
+            and restore_sentinel
         )
         sentinel_scalar = (
             np_dtype.type(nodata) if rewrite_nodata else None

--- a/xrspatial/geotiff/tests/test_nodata_semantics_split_1988.py
+++ b/xrspatial/geotiff/tests/test_nodata_semantics_split_1988.py
@@ -858,6 +858,72 @@ class TestWriteStreamingRestoreSentinelKwarg:
         assert (on_disk == -9999.0).sum() == 0
 
 
+class TestWriteCOGOverviewGateInteraction:
+    """The ``write()`` function's only gated branch is the overview-
+    level NaN-to-sentinel rewrite (the user-data rewrite has already
+    been done by ``to_geotiff`` upstream). Close that coverage gap
+    with a direct ``write(..., cog=True, ...)`` exercise of the
+    gated branch at ``_writer.py:1742-1749``."""
+
+    def test_cog_overview_rewrite_runs_by_default(self, tmp_path):
+        """Default ``restore_sentinel=True`` rewrites NaN in overviews."""
+        from xrspatial.geotiff._writer import write
+
+        path = tmp_path / "test_1988_cog_default.tif"
+        # 64x64 with a sentinel-valued patch that the float pyramid
+        # will average down through several overview levels. The
+        # sentinel value (-9999.0) becomes the literal float pixel
+        # value the writer expects (NaN was already rewritten by an
+        # upstream ``to_geotiff`` in a normal flow; here we hand-roll
+        # an array that contains NaN to trigger the gated overview
+        # rewrite inside ``write``).
+        arr = np.ones((64, 64), dtype=np.float32)
+        arr[0:16, 0:16] = np.nan
+        write(
+            arr, str(path),
+            nodata=-9999.0,
+            compression='none',
+            tiled=True,
+            tile_size=32,
+            cog=True,
+            overview_levels=[2, 4],
+        )
+        with rasterio.open(str(path)) as ds:
+            assert ds.nodata == -9999.0
+            # Read overview level 1 (factor=2). Pure-NaN 2x2 blocks
+            # reduce to NaN under nanmean; the gated branch rewrites
+            # those back to the sentinel.
+            ov = ds.read(1, out_shape=(32, 32))
+        # Overview tiles covering the all-NaN corner should hold the
+        # sentinel, not NaN.
+        assert (ov[0:8, 0:8] == -9999.0).any() or np.isnan(ov[0:8, 0:8]).sum() == 0
+
+    def test_cog_overview_rewrite_skipped_when_gated_off(self, tmp_path):
+        """``restore_sentinel=False`` preserves NaN in overview pyramid."""
+        from xrspatial.geotiff._writer import write
+
+        path = tmp_path / "test_1988_cog_gated.tif"
+        arr = np.ones((64, 64), dtype=np.float32)
+        arr[0:16, 0:16] = np.nan
+        write(
+            arr, str(path),
+            nodata=-9999.0,
+            compression='none',
+            tiled=True,
+            tile_size=32,
+            cog=True,
+            overview_levels=[2, 4],
+            restore_sentinel=False,
+        )
+        with rasterio.open(str(path)) as ds:
+            assert ds.nodata == -9999.0
+            # Same overview read. With the gate off, the all-NaN 2x2
+            # blocks stay NaN through the pyramid.
+            ov = ds.read(1, out_shape=(32, 32))
+        # NaN survives in the overview corner.
+        assert np.isnan(ov[0:8, 0:8]).any()
+
+
 @_gpu_only
 class TestWriterGPU:
     """GPU writer also gates on ``attrs['masked_nodata']``."""

--- a/xrspatial/geotiff/tests/test_nodata_semantics_split_1988.py
+++ b/xrspatial/geotiff/tests/test_nodata_semantics_split_1988.py
@@ -535,3 +535,391 @@ class TestSetNodataAttrsHelper:
         attrs = {}
         _set_nodata_attrs(attrs, 0, array_dtype="uint8")
         assert attrs["masked_nodata"] is False
+
+
+# ----------------------------------------------------------------------------
+# Writer-side consultation of ``attrs['masked_nodata']``.
+#
+# The forward (read) step promotes the file sentinel to NaN and tags
+# the result with ``attrs['masked_nodata'] = True``. The reverse
+# (write) step rewrites NaN back to the sentinel. The reverse must
+# only run when the forward ran. When ``masked_nodata=False`` the
+# array did not go through the forward step, so any NaN present came
+# from elsewhere and the writer must preserve it rather than silently
+# converting to the integer sentinel.
+# ----------------------------------------------------------------------------
+
+
+class TestShouldRestoreNanSentinelHelper:
+    """Direct coverage of :func:`_should_restore_nan_sentinel`."""
+
+    def test_missing_attr_defaults_to_true(self):
+        from xrspatial.geotiff._attrs import _should_restore_nan_sentinel
+        assert _should_restore_nan_sentinel({}) is True
+        # The default preserves pre-#1988 behaviour for any DataArray
+        # that did not pass through xrspatial's reader.
+        assert _should_restore_nan_sentinel({"nodata": -9999}) is True
+
+    def test_masked_nodata_true_returns_true(self):
+        from xrspatial.geotiff._attrs import _should_restore_nan_sentinel
+        attrs = {"nodata": -9999, "masked_nodata": True}
+        assert _should_restore_nan_sentinel(attrs) is True
+
+    def test_masked_nodata_false_returns_false(self):
+        from xrspatial.geotiff._attrs import _should_restore_nan_sentinel
+        attrs = {"nodata": -9999, "masked_nodata": False}
+        assert _should_restore_nan_sentinel(attrs) is False
+
+    def test_none_attrs_defaults_to_true(self):
+        """GPU writer's positional-cupy branch has no attrs to read."""
+        from xrspatial.geotiff._attrs import _should_restore_nan_sentinel
+        assert _should_restore_nan_sentinel(None) is True
+
+    def test_non_mapping_defaults_to_true(self):
+        """A misuse that hands in a non-mapping must not crash the writer."""
+        from xrspatial.geotiff._attrs import _should_restore_nan_sentinel
+        assert _should_restore_nan_sentinel("not a dict") is True
+
+    def test_stray_truthy_value_is_true(self):
+        """Only literal ``False`` disables. Stray ``0`` / ``''`` stays True."""
+        from xrspatial.geotiff._attrs import _should_restore_nan_sentinel
+        # Anything other than literal False should keep the default
+        # behaviour. ``0`` is falsy but is not the contract value.
+        assert _should_restore_nan_sentinel({"masked_nodata": 0}) is True
+        assert _should_restore_nan_sentinel({"masked_nodata": None}) is True
+
+
+class TestWriterRoundTripEager:
+    """Round-trip through ``to_geotiff`` to verify the writer respects
+    ``attrs['masked_nodata']``."""
+
+    def test_masked_nodata_true_restores_sentinel(self, tmp_path):
+        """Reader-style attrs (masked_nodata=True): NaN -> sentinel on write."""
+        from xrspatial.geotiff import to_geotiff
+        import xarray as xr
+
+        path = tmp_path / "test_1988_writer_masked.tif"
+        arr = np.array(
+            [[1.0, 2.0, np.nan, 4.0],
+             [5.0, np.nan, 7.0, 8.0]],
+            dtype=np.float32,
+        )
+        da = xr.DataArray(
+            arr,
+            dims=("y", "x"),
+            coords={"y": [1.0, 0.0], "x": [0.0, 1.0, 2.0, 3.0]},
+            attrs={
+                "crs": 4326,
+                "transform": (1.0, 0.0, 0.0, 0.0, -1.0, 2.0),
+                "nodata": -9999.0,
+                "masked_nodata": True,
+            },
+        )
+        to_geotiff(da, str(path), compression="none")
+
+        with rasterio.open(str(path)) as ds:
+            on_disk = ds.read(1)
+            assert ds.nodata == -9999.0
+        # NaN pixels should have been rewritten to the sentinel.
+        assert not np.isnan(on_disk).any()
+        assert (on_disk == -9999.0).sum() == 2
+
+    def test_masked_nodata_false_preserves_nan(self, tmp_path):
+        """``masked_nodata=False`` -> NaN survives, no silent sentinel rewrite."""
+        from xrspatial.geotiff import to_geotiff
+        import xarray as xr
+
+        path = tmp_path / "test_1988_writer_unmasked.tif"
+        arr = np.array(
+            [[1.0, 2.0, np.nan, 4.0],
+             [5.0, np.nan, 7.0, 8.0]],
+            dtype=np.float32,
+        )
+        da = xr.DataArray(
+            arr,
+            dims=("y", "x"),
+            coords={"y": [1.0, 0.0], "x": [0.0, 1.0, 2.0, 3.0]},
+            attrs={
+                "crs": 4326,
+                "transform": (1.0, 0.0, 0.0, 0.0, -1.0, 2.0),
+                "nodata": -9999.0,
+                "masked_nodata": False,
+            },
+        )
+        to_geotiff(da, str(path), compression="none")
+
+        with rasterio.open(str(path)) as ds:
+            on_disk = ds.read(1)
+            # The GDAL_NODATA tag is still set, regardless of the
+            # in-memory masking state. The two attrs carry independent
+            # meanings (see issue #1988).
+            assert ds.nodata == -9999.0
+        # NaN pixels survive unchanged: the writer must NOT rewrite
+        # them to the integer sentinel because the array did not pass
+        # through the reader's sentinel-to-NaN promotion.
+        assert np.isnan(on_disk).sum() == 2
+        assert (on_disk == -9999.0).sum() == 0
+
+    def test_missing_masked_nodata_attr_restores_sentinel(self, tmp_path):
+        """External DataArrays without the attr keep pre-#1988 behaviour."""
+        from xrspatial.geotiff import to_geotiff
+        import xarray as xr
+
+        path = tmp_path / "test_1988_writer_no_attr.tif"
+        arr = np.array(
+            [[1.0, 2.0, np.nan, 4.0],
+             [5.0, np.nan, 7.0, 8.0]],
+            dtype=np.float32,
+        )
+        # No ``masked_nodata`` attr -> default True.
+        da = xr.DataArray(
+            arr,
+            dims=("y", "x"),
+            coords={"y": [1.0, 0.0], "x": [0.0, 1.0, 2.0, 3.0]},
+            attrs={
+                "crs": 4326,
+                "transform": (1.0, 0.0, 0.0, 0.0, -1.0, 2.0),
+                "nodata": -9999.0,
+            },
+        )
+        to_geotiff(da, str(path), compression="none")
+
+        with rasterio.open(str(path)) as ds:
+            on_disk = ds.read(1)
+            assert ds.nodata == -9999.0
+        # Pre-#1988 behaviour: missing attr = treat as masked.
+        assert not np.isnan(on_disk).any()
+        assert (on_disk == -9999.0).sum() == 2
+
+    def test_round_trip_preserves_masked_nodata_true(self, tmp_path):
+        """Read sentinel TIFF -> attrs say masked=True -> write -> reread.
+
+        Closes the loop: a file with a declared sentinel reads back
+        with NaN-masked pixels and ``masked_nodata=True``. Writing it
+        out then reading again must produce the same sentinel-tagged
+        file (the writer correctly inverts the read-side promotion).
+        """
+        from xrspatial.geotiff import to_geotiff
+
+        src = tmp_path / "test_1988_round_trip_src.tif"
+        _write_float_tiff(str(src), with_sentinel=True)
+
+        da = open_geotiff(str(src))
+        assert da.attrs["masked_nodata"] is True
+        # The reader promoted the sentinel value to NaN.
+        arr_in = np.asarray(da.data)
+        assert np.isnan(arr_in).sum() == 2
+
+        dst = tmp_path / "test_1988_round_trip_dst.tif"
+        to_geotiff(da, str(dst), compression="none")
+
+        with rasterio.open(str(dst)) as ds:
+            on_disk = ds.read(1)
+            assert ds.nodata == _SENTINEL
+        # Sentinel values restored at the expected positions.
+        assert (on_disk == _SENTINEL).sum() == 2
+        assert not np.isnan(on_disk).any()
+
+    def test_dask_streaming_path_respects_flag(self, tmp_path):
+        """Dask + tiled streaming write must honour the gate too."""
+        from xrspatial.geotiff import to_geotiff
+        import dask.array as da_mod
+        import xarray as xr
+
+        path = tmp_path / "test_1988_writer_dask.tif"
+        # 32x32 with NaN sprinkled in -- the tiled streaming writer
+        # requires tile_size to be a positive multiple of 16.
+        arr = np.arange(32 * 32, dtype=np.float32).reshape(32, 32)
+        arr[5, 7] = np.nan
+        arr[12, 19] = np.nan
+        dask_arr = da_mod.from_array(arr, chunks=(16, 16))
+        da = xr.DataArray(
+            dask_arr,
+            dims=("y", "x"),
+            coords={
+                "y": np.arange(32, 0, -1, dtype=np.float64),
+                "x": np.arange(32, dtype=np.float64),
+            },
+            attrs={
+                "crs": 4326,
+                "transform": (1.0, 0.0, 0.0, 0.0, -1.0, 32.0),
+                "nodata": -9999.0,
+                "masked_nodata": False,
+            },
+        )
+        to_geotiff(
+            da, str(path), compression="none",
+            tile_size=16, tiled=True,
+        )
+
+        with rasterio.open(str(path)) as ds:
+            on_disk = ds.read(1)
+            assert ds.nodata == -9999.0
+        # NaN preserved through the streaming path.
+        assert np.isnan(on_disk).sum() == 2
+        assert (on_disk == -9999.0).sum() == 0
+
+
+class TestWriteStreamingRestoreSentinelKwarg:
+    """Direct coverage of ``restore_sentinel`` on the low-level
+    ``write_streaming`` callable surface, where the gate actually
+    suppresses an internal NaN-to-sentinel rewrite step.
+
+    The non-streaming ``write`` function expects its caller (e.g.
+    ``to_geotiff``) to have already performed the NaN-to-sentinel
+    rewrite, so its own ``restore_sentinel`` flag only gates the
+    overview-decimation rewrite (a no-op when ``cog=False``).
+    """
+
+    def test_streaming_restore_sentinel_true_rewrites(self, tmp_path):
+        import dask.array as da_mod
+        from xrspatial.geotiff._writer import write_streaming
+
+        path = tmp_path / "test_1988_stream_true.tif"
+        arr = np.arange(32 * 32, dtype=np.float32).reshape(32, 32)
+        arr[5, 7] = np.nan
+        dask_arr = da_mod.from_array(arr, chunks=(16, 16))
+        write_streaming(
+            dask_arr, str(path),
+            nodata=-9999.0,
+            compression='none',
+            tiled=True,
+            tile_size=16,
+            restore_sentinel=True,
+        )
+        with rasterio.open(str(path)) as ds:
+            on_disk = ds.read(1)
+        assert (on_disk == -9999.0).sum() == 1
+        assert not np.isnan(on_disk).any()
+
+    def test_streaming_restore_sentinel_false_preserves_nan(self, tmp_path):
+        import dask.array as da_mod
+        from xrspatial.geotiff._writer import write_streaming
+
+        path = tmp_path / "test_1988_stream_false.tif"
+        arr = np.arange(32 * 32, dtype=np.float32).reshape(32, 32)
+        arr[5, 7] = np.nan
+        dask_arr = da_mod.from_array(arr, chunks=(16, 16))
+        write_streaming(
+            dask_arr, str(path),
+            nodata=-9999.0,
+            compression='none',
+            tiled=True,
+            tile_size=16,
+            restore_sentinel=False,
+        )
+        with rasterio.open(str(path)) as ds:
+            on_disk = ds.read(1)
+        # GDAL_NODATA tag still set; only the array bytes change.
+        assert ds.nodata == -9999.0
+        assert np.isnan(on_disk).sum() == 1
+        assert (on_disk == -9999.0).sum() == 0
+
+    def test_streaming_default_is_true(self, tmp_path):
+        """Default preserves pre-#1988 behaviour."""
+        import dask.array as da_mod
+        from xrspatial.geotiff._writer import write_streaming
+
+        path = tmp_path / "test_1988_stream_default.tif"
+        arr = np.arange(32 * 32, dtype=np.float32).reshape(32, 32)
+        arr[5, 7] = np.nan
+        dask_arr = da_mod.from_array(arr, chunks=(16, 16))
+        write_streaming(
+            dask_arr, str(path),
+            nodata=-9999.0,
+            compression='none',
+            tiled=True,
+            tile_size=16,
+        )
+        with rasterio.open(str(path)) as ds:
+            on_disk = ds.read(1)
+        assert (on_disk == -9999.0).sum() == 1
+        assert not np.isnan(on_disk).any()
+
+    def test_streaming_strip_layout_restore_false_preserves_nan(self, tmp_path):
+        """The strip-write branch in ``write_streaming`` must honour the gate."""
+        import dask.array as da_mod
+        from xrspatial.geotiff._writer import write_streaming
+
+        path = tmp_path / "test_1988_stream_strip_false.tif"
+        arr = np.arange(32 * 32, dtype=np.float32).reshape(32, 32)
+        arr[5, 7] = np.nan
+        dask_arr = da_mod.from_array(arr, chunks=(16, 16))
+        write_streaming(
+            dask_arr, str(path),
+            nodata=-9999.0,
+            compression='none',
+            tiled=False,
+            restore_sentinel=False,
+        )
+        with rasterio.open(str(path)) as ds:
+            on_disk = ds.read(1)
+        assert np.isnan(on_disk).sum() == 1
+        assert (on_disk == -9999.0).sum() == 0
+
+
+@_gpu_only
+class TestWriterGPU:
+    """GPU writer also gates on ``attrs['masked_nodata']``."""
+
+    def test_masked_nodata_false_preserves_nan_gpu(self, tmp_path):
+        import cupy
+        import xarray as xr
+        from xrspatial.geotiff import write_geotiff_gpu
+
+        path = tmp_path / "test_1988_writer_gpu_unmasked.tif"
+        arr_np = np.array(
+            [[1.0, 2.0, np.nan, 4.0],
+             [5.0, np.nan, 7.0, 8.0]],
+            dtype=np.float32,
+        )
+        arr = cupy.asarray(arr_np)
+        da = xr.DataArray(
+            arr,
+            dims=("y", "x"),
+            coords={"y": [1.0, 0.0], "x": [0.0, 1.0, 2.0, 3.0]},
+            attrs={
+                "crs": 4326,
+                "transform": (1.0, 0.0, 0.0, 0.0, -1.0, 2.0),
+                "nodata": -9999.0,
+                "masked_nodata": False,
+            },
+        )
+        write_geotiff_gpu(da, str(path), compression="none")
+
+        with rasterio.open(str(path)) as ds:
+            on_disk = ds.read(1)
+            assert ds.nodata == -9999.0
+        assert np.isnan(on_disk).sum() == 2
+        assert (on_disk == -9999.0).sum() == 0
+
+    def test_masked_nodata_true_restores_sentinel_gpu(self, tmp_path):
+        import cupy
+        import xarray as xr
+        from xrspatial.geotiff import write_geotiff_gpu
+
+        path = tmp_path / "test_1988_writer_gpu_masked.tif"
+        arr_np = np.array(
+            [[1.0, 2.0, np.nan, 4.0],
+             [5.0, np.nan, 7.0, 8.0]],
+            dtype=np.float32,
+        )
+        arr = cupy.asarray(arr_np)
+        da = xr.DataArray(
+            arr,
+            dims=("y", "x"),
+            coords={"y": [1.0, 0.0], "x": [0.0, 1.0, 2.0, 3.0]},
+            attrs={
+                "crs": 4326,
+                "transform": (1.0, 0.0, 0.0, 0.0, -1.0, 2.0),
+                "nodata": -9999.0,
+                "masked_nodata": True,
+            },
+        )
+        write_geotiff_gpu(da, str(path), compression="none")
+
+        with rasterio.open(str(path)) as ds:
+            on_disk = ds.read(1)
+            assert ds.nodata == -9999.0
+        assert not np.isnan(on_disk).any()
+        assert (on_disk == -9999.0).sum() == 2


### PR DESCRIPTION
Closes #1988 writer-side scope.

The reader side (PR #2008) records ``attrs['masked_nodata']`` on every read path. This PR wires the writers up to read it back.

## What changes

- New ``_should_restore_nan_sentinel(attrs)`` helper in ``_attrs.py``. Returns ``True`` when the attr is missing (the pre-#1988 default), the literal ``True``, or any value other than literal ``False``.
- ``to_geotiff`` (eager and dask streaming branches), ``_write_single_tile``, ``_write_vrt_tiled``, and ``write_geotiff_gpu`` read the flag from ``data.attrs`` once at entry. Bare numpy / cupy positional arrays keep the True default.
- ``write`` and ``write_streaming`` grow a ``restore_sentinel: bool = True`` kwarg. Every internal NaN-to-sentinel rewrite site gates on it: the upstream rewrite in ``_writers/eager.py``, the overview-level rewrite in ``write``, the tile-segment and strip-layout rewrites in ``write_streaming``, and the eager / chunked overview rewrites in the GPU writer.

## What this means

Pre-#1988 behaviour is preserved for every existing caller. External DataArrays do not carry the flag, the helper returns True, and the NaN-to-sentinel rewrite runs as before.

The flag only flips behaviour when a DataArray explicitly carries ``attrs['masked_nodata'] = False`` -- meaning the reader did not promote a sentinel to NaN. Any NaN present in such an array did not come from sentinel masking, and the writer now leaves it alone instead of silently rewriting it to the integer sentinel.

## Test plan

- [x] ``pytest xrspatial/geotiff/tests/test_nodata_semantics_split_1988.py`` (37 passed; was 20 before this PR)
- [x] Helper unit tests for ``_should_restore_nan_sentinel`` (missing attr, True, False, None, non-mapping, stray truthy value)
- [x] Round-trip tests: ``masked_nodata=True`` restores the sentinel; ``masked_nodata=False`` preserves NaN; missing attr defaults to True
- [x] Dask-tiled streaming write path honours the flag (segment and strip layouts both)
- [x] GPU writer (skipped without cupy + CUDA): tests for both ``True`` and ``False`` paths
- [x] All existing nodata test suites stay green: ``test_nodata_attr_aliases_1582``, ``test_nodata_int64_precision_1847``, ``test_nodata_nan_int_1774``, ``test_miniswhite_nodata_1809``, ``test_vrt_band_nodata_1598``, ``test_overview_nodata_inheritance_1739``, ``test_vrt_int_source_float_dtype_1616``, ``test_vrt_multiband_int_nodata_1611``, ``test_writer_matrix`` (231 passed)

## What this does not change

The contract for external readers (rasterio, GDAL, QGIS) is unchanged: ``GDAL_NODATA`` is still set whenever ``attrs['nodata']`` resolves to a sentinel. The two attrs carry independent meanings, exactly as the issue's design specified.