### PR TITLE
geotiff: reject zero-band 3D writer inputs (#2094)

### DIFF
--- a/xrspatial/geotiff/_validation.py
+++ b/xrspatial/geotiff/_validation.py
@@ -173,6 +173,63 @@ def _validate_writer_spatial_shape(shape, dims=None,
         )
 
 
+def _validate_writer_post_layout_shape(
+        shape, entry_point: str = "to_geotiff") -> None:
+    """Reject empty / unsupported post-layout writer inputs (issue #2094).
+
+    Runs AFTER the writer has normalised its input to the internal
+    convention: 2D ``(h, w)`` or band-last 3D ``(h, w, samples)``.
+    Validates every dimension that becomes a TIFF IFD field once the
+    array is on disk: height, width, and (for 3D) samples-per-pixel.
+
+    The pre-layout sibling ``_validate_writer_spatial_shape`` only
+    inspects the two spatial dims and leaves the band axis unchecked.
+    A 3D input with a zero-length band axis (``(0, 5, 5)`` band-first
+    or ``(5, 5, 0)`` band-last) used to pass that helper, hit the
+    band-first ``moveaxis``, and then be written as a TIFF whose IFD
+    advertised ``SamplesPerPixel=1`` and ``height=5, width=5`` -- the
+    file decoded back as a non-empty single-band raster from an
+    empty input. That is silent data fabrication; the writer must
+    refuse the input instead.
+
+    ``shape`` is the array shape AFTER any band-first -> band-last
+    ``moveaxis`` has run, so the helper does not need a ``dims`` arg.
+    ``entry_point`` is the function name used in the error message
+    so direct callers of ``write`` / ``write_streaming`` /
+    ``write_geotiff_gpu`` see the function they actually invoked.
+    """
+    if shape is None:
+        return
+    ndim = len(shape)
+    if ndim not in (2, 3):
+        # Other rank errors are handled by the existing ndim check in
+        # each writer; do not shadow that message.
+        return
+    h = int(shape[0])
+    w = int(shape[1])
+    if h <= 0 or w <= 0:
+        raise ValueError(
+            f"{entry_point} cannot write an empty raster: got shape "
+            f"{tuple(int(s) for s in shape)} with height={h}, width={w}. "
+            f"Both spatial dims must be positive. A common cause is a "
+            f"clip or window that produced an empty selection; check "
+            f"the upstream operation before writing."
+        )
+    if ndim == 3:
+        samples = int(shape[2])
+        if samples <= 0:
+            raise ValueError(
+                f"{entry_point} cannot write a zero-band raster: got "
+                f"shape {tuple(int(s) for s in shape)} with "
+                f"samples_per_pixel={samples}. A 3D writer input must "
+                f"have at least one band along the band axis; an empty "
+                f"band axis used to round-trip as a single-band TIFF, "
+                f"silently fabricating one band of pixels from an empty "
+                f"input (issue #2094). Check the upstream selection "
+                f"(e.g. ``data.isel(band=slice(0, 0))``) before writing."
+            )
+
+
 def _validate_dtype_cast(source_dtype, target_dtype):
     """Validate that casting source_dtype to target_dtype is allowed.
 

--- a/xrspatial/geotiff/_writer.py
+++ b/xrspatial/geotiff/_writer.py
@@ -1620,8 +1620,19 @@ def write(data: np.ndarray, path: str, *,
     # arrays (eager moveaxis ran upstream), so the ndim-based pair
     # picked by ``_validate_writer_spatial_shape`` without ``dims`` is
     # correct.
-    from ._validation import _validate_writer_spatial_shape
+    #
+    # Issue #2094: the post-layout helper runs in addition because the
+    # pre-layout check leaves the trailing band axis unchecked. A
+    # ``(5, 5, 0)`` direct ``write`` call must be refused here too --
+    # ``write`` is the lowest writer in the stack, so this is the last
+    # defence against a zero-band IFD reaching disk.
+    from ._validation import (
+        _validate_writer_post_layout_shape,
+        _validate_writer_spatial_shape,
+    )
     _validate_writer_spatial_shape(
+        getattr(data, 'shape', None), entry_point="write")
+    _validate_writer_post_layout_shape(
         getattr(data, 'shape', None), entry_point="write")
 
     comp_tag = _compression_tag(compression)
@@ -1938,8 +1949,20 @@ def write_streaming(dask_data, path: str, *,
     # silently produces zero entries. ``to_geotiff`` already validates
     # this upstream, but direct callers of ``write_streaming`` go
     # through here too.
-    from ._validation import _validate_writer_spatial_shape
+    #
+    # Issue #2094: also reject zero-band 3D shapes at this boundary.
+    # ``write_streaming`` derives ``samples`` from ``shape[2]`` below;
+    # a zero-band input would otherwise produce an IFD whose
+    # SamplesPerPixel field is 0 and yet whose tile/strip math claims
+    # h*w pixels of data per band, silently fabricating a single-band
+    # file from an empty input.
+    from ._validation import (
+        _validate_writer_post_layout_shape,
+        _validate_writer_spatial_shape,
+    )
     _validate_writer_spatial_shape(
+        getattr(dask_data, 'shape', None), entry_point="write_streaming")
+    _validate_writer_post_layout_shape(
         getattr(dask_data, 'shape', None), entry_point="write_streaming")
 
     height, width = dask_data.shape[:2]

--- a/xrspatial/geotiff/_writers/eager.py
+++ b/xrspatial/geotiff/_writers/eager.py
@@ -46,6 +46,7 @@ from .._validation import (
     _validate_3d_writer_dims,
     _validate_nodata_arg,
     _validate_tile_size_arg,
+    _validate_writer_post_layout_shape,
     _validate_writer_spatial_shape,
     validate_write_metadata,
 )
@@ -630,6 +631,14 @@ def to_geotiff(data: xr.DataArray | np.ndarray,
             if dask_arr.ndim not in (2, 3):
                 raise ValueError(
                     f"Expected 2D or 3D array, got {dask_arr.ndim}D")
+            # Issue #2094: post-layout shape check. The pre-layout
+            # ``_validate_writer_spatial_shape`` above only inspects the
+            # spatial dims; a zero-band 3D input slips past it. Re-check
+            # the band axis now that layout has been normalised to
+            # band-last so the streaming writer cannot fabricate a
+            # single-band file from an empty input.
+            _validate_writer_post_layout_shape(
+                dask_arr.shape, entry_point="to_geotiff")
             # Validate compression_level
             if compression_level is not None:
                 level_range = _LEVEL_RANGES.get(compression.lower())
@@ -697,6 +706,12 @@ def to_geotiff(data: xr.DataArray | np.ndarray,
 
     if arr.ndim not in (2, 3):
         raise ValueError(f"Expected 2D or 3D array, got {arr.ndim}D")
+
+    # Issue #2094: post-layout shape check. Bare ndarray / cupy inputs
+    # skip the DataArray dims-aware checks above; the band axis is now
+    # the trailing one for 3D input. Refuse zero-band rasters here so
+    # an empty trailing axis cannot silently produce a single-band file.
+    _validate_writer_post_layout_shape(arr.shape, entry_point="to_geotiff")
 
     # Auto-promote unsupported dtypes
     if arr.dtype == np.float16:

--- a/xrspatial/geotiff/_writers/gpu.py
+++ b/xrspatial/geotiff/_writers/gpu.py
@@ -34,6 +34,7 @@ from .._validation import (
     _validate_3d_writer_dims,
     _validate_nodata_arg,
     _validate_tile_size_arg,
+    _validate_writer_post_layout_shape,
     _validate_writer_spatial_shape,
     validate_write_metadata,
 )
@@ -455,6 +456,16 @@ def write_geotiff_gpu(data: xr.DataArray | cupy.ndarray | np.ndarray,
 
     if arr.ndim not in (2, 3):
         raise ValueError(f"Expected 2D or 3D array, got {arr.ndim}D")
+
+    # Issue #2094: post-layout shape check. The pre-layout sibling at
+    # the top of the function only inspects spatial dims and leaves the
+    # band axis unchecked. After the band-first ``moveaxis`` above, the
+    # trailing axis is the band axis for 3D inputs; an empty band axis
+    # would otherwise reach ``gpu_compress_tiles`` with
+    # ``samples_per_pixel=0`` and produce a TIFF whose IFD silently
+    # advertises a non-empty single-band raster from an empty input.
+    _validate_writer_post_layout_shape(
+        arr.shape, entry_point="write_geotiff_gpu")
 
     height, width = arr.shape[:2]
     samples = arr.shape[2] if arr.ndim == 3 else 1

--- a/xrspatial/geotiff/tests/test_to_geotiff_zero_band_2094.py
+++ b/xrspatial/geotiff/tests/test_to_geotiff_zero_band_2094.py
@@ -1,0 +1,144 @@
+"""Regression tests for issue #2094.
+
+Before this fix, the GeoTIFF writer entry points validated empty
+spatial dims but left the band/sample axis unchecked. A 3D DataArray
+with zero bands (band-first ``(0, 5, 5)`` or band-last ``(5, 5, 0)``)
+slipped past the pre-layout guard, hit the band-first ``moveaxis``,
+and was written as a TIFF whose IFD advertised
+``SamplesPerPixel=1`` and ``height=5, width=5``. The file then read
+back as a non-empty single-band raster -- silent data fabrication
+from an empty input.
+
+The fix runs a shared post-layout shape validator after each writer
+normalises layout to its internal band-last convention. The check
+fires at every public writer entry point (eager ``to_geotiff``,
+direct ``_writer.write`` / ``write_streaming``, and
+``write_geotiff_gpu``).
+"""
+from __future__ import annotations
+
+import importlib.util
+
+import dask.array as dsk
+import numpy as np
+import pytest
+import xarray as xr
+
+from xrspatial.geotiff import to_geotiff
+from xrspatial.geotiff._writer import write, write_streaming
+
+
+def _cupy_available() -> bool:
+    if importlib.util.find_spec("cupy") is None:
+        return False
+    try:
+        import cupy
+
+        return bool(cupy.cuda.is_available())
+    except Exception:
+        return False
+
+
+_HAS_GPU = _cupy_available()
+
+
+_ZERO_BAND_LAYOUTS = [
+    pytest.param((0, 5, 5), ("band", "y", "x"), id="band-first"),
+    pytest.param((5, 5, 0), ("y", "x", "band"), id="band-last"),
+]
+
+
+@pytest.mark.parametrize("shape,dims", _ZERO_BAND_LAYOUTS)
+def test_to_geotiff_rejects_zero_band_numpy(tmp_path, shape, dims):
+    da = xr.DataArray(np.empty(shape, dtype=np.uint8), dims=dims)
+    out = tmp_path / f"tmp_2094_zero_band_{'_'.join(dims)}.tif"
+    with pytest.raises(ValueError) as excinfo:
+        to_geotiff(da, str(out), compression="none")
+    msg = str(excinfo.value)
+    # Message must name the public entry point so the traceback is
+    # useful, and must call out the offending samples_per_pixel axis
+    # so the caller knows which dim went empty.
+    assert "to_geotiff" in msg
+    assert "zero-band" in msg or "samples_per_pixel" in msg
+    assert "samples_per_pixel=0" in msg
+    assert not out.exists()
+
+
+def test_direct_write_rejects_zero_band(tmp_path):
+    """``_writer.write`` is the lowest writer in the stack; bare
+    callers (tests, the GPU fallback path) must hit the same guard
+    so a zero-band IFD cannot reach disk."""
+    arr = np.empty((5, 5, 0), dtype=np.uint8)
+    out = tmp_path / "tmp_2094_direct_write.tif"
+    with pytest.raises(ValueError) as excinfo:
+        write(arr, str(out), compression="none")
+    msg = str(excinfo.value)
+    assert "write" in msg
+    assert "samples_per_pixel=0" in msg
+    assert not out.exists()
+
+
+def test_write_streaming_rejects_zero_band(tmp_path):
+    """``write_streaming`` derives ``samples`` from ``shape[2]``; a
+    zero-band input would otherwise produce an IFD whose
+    SamplesPerPixel field is 0."""
+    arr = dsk.from_array(np.empty((5, 5, 0), dtype=np.uint8))
+    out = tmp_path / "tmp_2094_write_streaming.tif"
+    with pytest.raises(ValueError) as excinfo:
+        write_streaming(arr, str(out), compression="none")
+    msg = str(excinfo.value)
+    assert "write_streaming" in msg
+    assert "samples_per_pixel=0" in msg
+    assert not out.exists()
+
+
+@pytest.mark.parametrize("shape,dims", _ZERO_BAND_LAYOUTS)
+def test_to_geotiff_rejects_zero_band_dask(tmp_path, shape, dims):
+    """The streaming dask path runs the post-layout check after
+    ``da.moveaxis(raw, 0, -1)``, so a band-first zero-band input is
+    caught at the same boundary as a band-last one."""
+    chunks = tuple(max(1, s) for s in shape)
+    arr = dsk.from_array(np.empty(shape, dtype=np.uint8), chunks=chunks)
+    da = xr.DataArray(arr, dims=dims)
+    out = tmp_path / f"tmp_2094_zero_band_dask_{'_'.join(dims)}.tif"
+    with pytest.raises(ValueError) as excinfo:
+        to_geotiff(da, str(out), compression="none")
+    msg = str(excinfo.value)
+    assert "to_geotiff" in msg
+    assert "samples_per_pixel=0" in msg
+    assert not out.exists()
+
+
+@pytest.mark.skipif(not _HAS_GPU, reason="cupy + CUDA required")
+@pytest.mark.parametrize("shape,dims", _ZERO_BAND_LAYOUTS)
+def test_write_geotiff_gpu_rejects_zero_band(tmp_path, shape, dims):
+    """``write_geotiff_gpu`` is a public entry point that does not
+    funnel through ``to_geotiff``; verify the post-layout guard
+    fires there too."""
+    import cupy as cp
+
+    from xrspatial.geotiff._writers.gpu import write_geotiff_gpu
+
+    da = xr.DataArray(cp.empty(shape, dtype=cp.uint8), dims=dims)
+    out = tmp_path / f"tmp_2094_zero_band_gpu_{'_'.join(dims)}.tif"
+    with pytest.raises(ValueError) as excinfo:
+        write_geotiff_gpu(da, str(out), compression="none")
+    msg = str(excinfo.value)
+    assert "write_geotiff_gpu" in msg
+    assert "samples_per_pixel=0" in msg
+    assert not out.exists()
+
+
+def test_to_geotiff_still_accepts_valid_3d(tmp_path):
+    """Positive control: a non-empty 3D DataArray still writes
+    successfully through both layout conventions."""
+    for shape, dims in [
+        ((3, 5, 5), ("band", "y", "x")),
+        ((5, 5, 3), ("y", "x", "band")),
+    ]:
+        da = xr.DataArray(
+            np.zeros(shape, dtype=np.uint8), dims=dims,
+        )
+        out = tmp_path / f"tmp_2094_valid_{'_'.join(dims)}.tif"
+        to_geotiff(da, str(out), compression="none")
+        assert out.exists() and out.stat().st_size > 0


### PR DESCRIPTION
Closes #2094.

## Summary

- New shared validator `_validate_writer_post_layout_shape` runs after each writer normalises layout to its internal band-last convention; refuses height, width, or samples-per-pixel of zero with a message that names the entry point.
- Wired into `to_geotiff` (eager numpy / cupy and dask streaming paths after the band-first `moveaxis`), `_writer.write`, `_writer.write_streaming`, and `write_geotiff_gpu` after the GPU `moveaxis`.
- The pre-layout `_validate_writer_spatial_shape` stays in place; it covers the bare 2D and dims-aware spatial check. The new post-layout helper covers the band axis the pre-layout helper left unchecked.

## Backend coverage

- numpy: regression tests for band-first `(0, 5, 5)` and band-last `(5, 5, 0)` through `to_geotiff` and direct `_writer.write`.
- dask+numpy: regression test through `to_geotiff` streaming for both layouts; direct `write_streaming` test on band-last.
- cupy / dask+cupy: regression test through `write_geotiff_gpu` for both layouts (skipped when cupy is absent).

## Test plan

- [x] `pytest xrspatial/geotiff/tests/test_to_geotiff_zero_band_2094.py -v` -- 9 passed.
- [x] `pytest xrspatial/geotiff/tests/test_to_geotiff_empty_shape_2075.py xrspatial/geotiff/tests/test_degenerate_shapes_backends_2026_05_11.py xrspatial/geotiff/tests/test_strip_zero_dims_2053.py` -- 45 passed.
- [x] Broader writer sweep `pytest xrspatial/geotiff/tests/ -k "writer or roundtrip or to_geotiff or write"` -- 928 passed, 1 pre-existing failure unrelated to this change.