### PR TITLE
geotiff tests: fix stale patch target and pre-multiple-of-16 tile_size

### DIFF
--- a/xrspatial/geotiff/tests/test_predictor2_big_endian_gpu_1517.py
+++ b/xrspatial/geotiff/tests/test_predictor2_big_endian_gpu_1517.py
@@ -46,14 +46,16 @@ def _block_cpu_fallback(monkeypatch):
     ``read_geotiff_gpu`` returns a cupy-backed array even when its silent CPU
     fallback fires (the fallback wraps the CPU result with ``cupy.asarray``),
     so ``isinstance(gpu_da.data, cupy.ndarray)`` cannot distinguish the two
-    paths. Patching the module-bound ``read_to_array`` to raise turns any
-    silent fallback into a hard test failure, which is what we want when the
-    point of a test is to exercise the actual GPU decode kernels.
+    paths. ``read_geotiff_gpu`` lives in ``xrspatial.geotiff._backends.gpu``
+    and calls the locally bound ``_read_to_array`` symbol there; patching
+    that binding to raise turns any silent fallback into a hard test failure,
+    which is what we want when the point of a test is to exercise the actual
+    GPU decode kernels.
 
     Tests that legitimately rely on the CPU fallback (e.g. stripped
     layouts) must not call this helper.
     """
-    from xrspatial import geotiff as geotiff_pkg
+    from xrspatial.geotiff._backends import gpu as gpu_backend
 
     def _no_fallback(*args, **kwargs):
         raise AssertionError(
@@ -62,7 +64,7 @@ def _block_cpu_fallback(monkeypatch):
         )
 
     monkeypatch.setattr(
-        geotiff_pkg, 'read_to_array', _no_fallback, raising=True,
+        gpu_backend, '_read_to_array', _no_fallback, raising=True,
     )
 
 

--- a/xrspatial/geotiff/tests/test_size_param_validation_gpu_vrt_1776.py
+++ b/xrspatial/geotiff/tests/test_size_param_validation_gpu_vrt_1776.py
@@ -113,9 +113,10 @@ class TestWriteGeotiffGpuTileSize:
             write_geotiff_gpu(gpu_da, out, tile_size=False)
 
     def test_tile_size_positive_works(self, gpu_da, tmp_path):
-        """tile_size=4 (small but valid) still round-trips."""
+        """tile_size=16 (smallest valid multiple of 16 per TIFF 6) still
+        round-trips."""
         out = os.path.join(str(tmp_path), 'out_1776.tif')
-        write_geotiff_gpu(gpu_da, out, tile_size=4)
+        write_geotiff_gpu(gpu_da, out, tile_size=16)
         assert os.path.exists(out)
 
     def test_tile_size_numpy_int_scalar_works(self, gpu_da, tmp_path):


### PR DESCRIPTION
Closes #2101.

## Summary

Two unrelated stale-test bugs caused 8 failures in `pytest xrspatial/geotiff/tests` on GPU-enabled environments:

- `test_predictor2_big_endian_gpu_1517.py::_block_cpu_fallback` patched `xrspatial.geotiff.read_to_array`, a name that disappeared when `read_geotiff_gpu` was moved into `xrspatial/geotiff/_backends/gpu.py` (PR #1885). The package imports the symbol as `_read_to_array`, and the actual call site is the bound `_read_to_array` inside `_backends.gpu`. With `raising=True`, the monkeypatch aborted before the GPU path ran. Patch the call site instead. (7 failures.)
- `test_size_param_validation_gpu_vrt_1776.py::test_tile_size_positive_works` passed `tile_size=4`. The validator later grew a multiple-of-16 requirement (TIFF 6 spec), so 4 is no longer accepted. Use `tile_size=16`, the smallest valid value, preserving the test's intent. (1 failure.)

Backend coverage: tests-only change. No production code touched. The patched assertion still exercises numpy / cupy / dask-cupy paths exactly as before.

## Test plan

- [x] `pytest xrspatial/geotiff/tests/test_predictor2_big_endian_gpu_1517.py xrspatial/geotiff/tests/test_size_param_validation_gpu_vrt_1776.py` -- 56 passed.
- [x] `pytest xrspatial/geotiff/tests` -- no failures.