### PR TITLE
geotiff: move no-georef signal off coord shape onto attrs marker

### DIFF
--- a/docs/source/user_guide/attrs_contract.rst
+++ b/docs/source/user_guide/attrs_contract.rst
@@ -102,6 +102,16 @@ write.
    * - ``_xrspatial_geotiff_contract``
      - int
      - Contract version. Currently ``2``. See `Versioning`_.
+   * - ``_xrspatial_no_georef``
+     - bool
+     - Stamped ``True`` on reads of files with no GeoTIFF transform
+       tags. The reader emits int64 placeholder y/x coords for these
+       files; the marker tells the writer to reproduce that
+       no-georef shape on round-trip rather than synthesising a
+       fake unit transform. Absence of the marker means the array
+       has spatial coords the writer can interpret as georef. A
+       caller can opt into no-georef writes on a hand-built array
+       by setting this attr explicitly. See issue #2120.
 
 
 Compatibility aliases

--- a/xrspatial/geotiff/_attrs.py
+++ b/xrspatial/geotiff/_attrs.py
@@ -129,7 +129,11 @@ import numpy as np
 from ._coords import (
     transform_tuple_from_pixel_geometry as _transform_tuple_from_pixel_geometry,
 )
-from ._geotags import RASTER_PIXEL_IS_AREA, RASTER_PIXEL_IS_POINT
+from ._geotags import (
+    RASTER_PIXEL_IS_AREA,
+    RASTER_PIXEL_IS_POINT,
+    _NO_GEOREF_KEY,
+)
 
 
 # Per-codec valid compression-level ranges, used by ``to_geotiff`` for
@@ -167,13 +171,6 @@ _TIFF_SHORT = 3
 # ``DeprecationWarning``. Downstream code that read those keys via
 # ``attrs[key]`` now sees ``KeyError`` rather than the deprecated value.
 _ATTRS_CONTRACT_VERSION = 2
-
-
-# The no-georef marker key lives in ``_coords`` to avoid a circular
-# import (``_attrs`` already imports from ``_coords``). Re-export here
-# so callers using ``_attrs`` for the contract constants can find it
-# alongside.
-from ._coords import _NO_GEOREF_KEY  # noqa: E402,F401
 
 
 # String identifiers (used in xrspatial attrs) -> TIFF ResolutionUnit tag ids.

--- a/xrspatial/geotiff/_attrs.py
+++ b/xrspatial/geotiff/_attrs.py
@@ -169,6 +169,13 @@ _TIFF_SHORT = 3
 _ATTRS_CONTRACT_VERSION = 2
 
 
+# The no-georef marker key lives in ``_coords`` to avoid a circular
+# import (``_attrs`` already imports from ``_coords``). Re-export here
+# so callers using ``_attrs`` for the contract constants can find it
+# alongside.
+from ._coords import _NO_GEOREF_KEY  # noqa: E402,F401
+
+
 # String identifiers (used in xrspatial attrs) -> TIFF ResolutionUnit tag ids.
 _RESOLUTION_UNIT_IDS = {'none': 1, 'inch': 2, 'centimeter': 3}
 
@@ -378,6 +385,14 @@ def _populate_attrs_from_geo_info(attrs: dict, geo_info, *, window=None) -> None
             src_t.pixel_width, src_t.pixel_height,
             window=window,
         )
+    else:
+        # Stamp the no-georef marker so the writer can tell our
+        # placeholder int64 step-1 coords apart from a user-authored
+        # integer-coord grid (#2120). Pre-#2120 the writer detected the
+        # placeholder by shape alone, which silently stripped georef
+        # from any user array whose coords matched the same arange
+        # pattern.
+        attrs[_NO_GEOREF_KEY] = True
 
     # Contract v2 (issue #2016) removed the 13 secondary GeoKey-derived
     # attrs that v1 emitted under a ``DeprecationWarning`` (``crs_name``,

--- a/xrspatial/geotiff/_backends/vrt.py
+++ b/xrspatial/geotiff/_backends/vrt.py
@@ -18,6 +18,7 @@ from .._coords import (
     coords_from_pixel_geometry as _coords_from_pixel_geometry,
     transform_tuple_from_pixel_geometry as _transform_tuple_from_pixel_geometry,
 )
+from .._geotags import _NO_GEOREF_KEY
 from .._crs import _wkt_to_epsg
 from .._validation import _validate_chunks_arg, _validate_dtype_cast
 
@@ -272,6 +273,14 @@ def read_vrt(source: str, *,
     # ``_populate_attrs_from_geo_info``; stamp the contract version here
     # so both code paths emit the same marker.
     attrs = {'_xrspatial_geotiff_contract': _ATTRS_CONTRACT_VERSION}
+    if gt is None:
+        # Mirror the eager non-VRT no-georef path: stamp the no-georef
+        # marker whenever the source carries no transform. The current
+        # VRT no-transform branch emits empty coords so the writer has
+        # nothing to misinterpret, but stamping defensively keeps the
+        # contract consistent if a future change adds placeholder
+        # coords here. See issue #2120.
+        attrs[_NO_GEOREF_KEY] = True
     if vrt.crs_wkt:
         epsg = _wkt_to_epsg(vrt.crs_wkt)
         if epsg is not None:
@@ -688,6 +697,9 @@ def _read_vrt_chunked(source, *, window, band, name, chunks, gpu, dtype,
             origin_x, origin_y, res_x, res_y,
             window=(win_r0, win_c0, 0, 0),
         )
+    else:
+        # Defensive marker (issue #2120). See the eager VRT branch.
+        attrs[_NO_GEOREF_KEY] = True
 
     if vrt.crs_wkt:
         epsg = _wkt_to_epsg(vrt.crs_wkt)

--- a/xrspatial/geotiff/_coords.py
+++ b/xrspatial/geotiff/_coords.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import numpy as np
 import xarray as xr
 
-from ._geotags import GeoTransform, RASTER_PIXEL_IS_POINT
+from ._geotags import _NO_GEOREF_KEY, GeoTransform, RASTER_PIXEL_IS_POINT
 
 
 # Names of dims that ``to_geotiff`` / ``write_geotiff_gpu`` treat as the
@@ -34,18 +34,6 @@ from ._geotags import GeoTransform, RASTER_PIXEL_IS_POINT
 # ``(y, x, band)`` before writing and to skip the band axis when inferring
 # a GeoTransform from coords (see :func:`coords_to_transform` / #1643).
 _BAND_DIM_NAMES = ('band', 'bands', 'channel')
-
-
-# Stamped on reads from files that carry no GeoTIFF transform tags
-# (ModelTransformation, ModelPixelScale, or ModelTiepoint). The
-# reader emits ``np.arange(start, stop, dtype=int64)`` placeholder y/x
-# coords in that case, and the writer needs an unambiguous signal to
-# distinguish those from user-authored int64 step-1 coord grids that
-# happen to match the same shape (issue #2120). Treating any int64
-# ascending-step-1 grid as the placeholder silently stripped georef
-# from real user data; treating the marker as the signal makes that
-# round-trip safe again.
-_NO_GEOREF_KEY = '_xrspatial_no_georef'
 
 
 def _has_no_georef_marker(da: xr.DataArray) -> bool:
@@ -57,10 +45,19 @@ def _has_no_georef_marker(da: xr.DataArray) -> bool:
     that an int64 step-1 grid is the placeholder and skipping transform
     synthesis. See issue #2120 for the silent-strip regression this
     replaced.
+
+    The identity check (``is True``) is deliberate: only the exact
+    boolean ``True`` flips the writer into no-georef mode. A stray
+    third-party stamp like ``attrs['_xrspatial_no_georef'] = 'yes'``
+    should not be treated as truthy and silently drop a transform.
     """
     return da.attrs.get(_NO_GEOREF_KEY) is True
 
 
+# Kept for diagnostic / test pinning only. The writer no longer
+# calls this helper -- it checks ``attrs[_NO_GEOREF_KEY]`` instead
+# (see :func:`_has_no_georef_marker` / issue #2120). Only the tests
+# in ``test_int_coord_sentinel_2087.py`` reference it now.
 def _is_no_georef_sentinel(coord: np.ndarray) -> bool:
     """True iff ``coord`` matches the read-side no-georef placeholder shape.
 

--- a/xrspatial/geotiff/_coords.py
+++ b/xrspatial/geotiff/_coords.py
@@ -36,36 +36,48 @@ from ._geotags import GeoTransform, RASTER_PIXEL_IS_POINT
 _BAND_DIM_NAMES = ('band', 'bands', 'channel')
 
 
+# Stamped on reads from files that carry no GeoTIFF transform tags
+# (ModelTransformation, ModelPixelScale, or ModelTiepoint). The
+# reader emits ``np.arange(start, stop, dtype=int64)`` placeholder y/x
+# coords in that case, and the writer needs an unambiguous signal to
+# distinguish those from user-authored int64 step-1 coord grids that
+# happen to match the same shape (issue #2120). Treating any int64
+# ascending-step-1 grid as the placeholder silently stripped georef
+# from real user data; treating the marker as the signal makes that
+# round-trip safe again.
+_NO_GEOREF_KEY = '_xrspatial_no_georef'
+
+
+def _has_no_georef_marker(da: xr.DataArray) -> bool:
+    """True iff ``da`` was stamped by the reader as carrying no georef.
+
+    The reader sets ``attrs[_NO_GEOREF_KEY] = True`` whenever it emits
+    the placeholder int64 step-1 y/x coords for files without GeoTIFF
+    transform tags. The writer checks the same marker before deciding
+    that an int64 step-1 grid is the placeholder and skipping transform
+    synthesis. See issue #2120 for the silent-strip regression this
+    replaced.
+    """
+    return da.attrs.get(_NO_GEOREF_KEY) is True
+
+
 def _is_no_georef_sentinel(coord: np.ndarray) -> bool:
-    """True iff ``coord`` matches the read-side no-georef placeholder.
+    """True iff ``coord`` matches the read-side no-georef placeholder shape.
 
     ``coords_from_pixel_geometry`` emits ``np.arange(start, stop,
     dtype=np.int64)`` for the y/x coords whenever the source file
     carries no GeoTIFF transform tags -- both for full reads
     (``start=0``) and windowed reads (``start=window_offset``). See
-    issues #1710, #1753, #1949. Round-tripping such an array through
-    ``to_geotiff`` should not invent a synthetic unit transform, so
-    the writer's transform-inference code paths skip it.
+    issues #1710, #1753, #1949.
 
-    The pre-#2087 check was ``dtype.kind in ('i', 'u')`` on either
-    axis, which also caught user-authored projected grids with
-    integer-spaced coords (e.g. ``x=[100, 101, 102]``,
-    ``y=[200, 199]``). Those were silently stripped of georef on
-    write -- the file landed on disk with no transform tags and read
-    back as pixel coords. This helper tightens the match to the
-    exact pattern the reader emits: ``int64`` dtype, ascending,
-    contiguous step ``+1``, starting at an arbitrary integer
-    (windowed reads do not start at 0). A descending or
-    non-unit-step int array does not match, so the writer falls
-    through to the normal ``coords_to_transform`` path and either
-    synthesises a real transform or raises ``NonUniformCoordsError``.
-
-    Trade-off: a user-authored array whose coords happen to match
-    the read-side ``arange`` pattern exactly (e.g. ascending step-1
-    int64 starting at any integer, with no ``attrs['transform']``
-    set) is still treated as no-georef. Callers in that niche can
-    write a real transform by setting ``attrs['transform']``
-    explicitly or by using float coords.
+    The writer no longer treats coord shape alone as the no-georef
+    signal: it checks ``attrs[_NO_GEOREF_KEY]`` instead. See
+    :func:`_has_no_georef_marker` and issue #2120. This helper remains
+    available as a diagnostic for the placeholder shape, and the
+    existing tests in ``test_int_coord_sentinel_2087.py`` still pin
+    the predicate. It is no longer called from the writer path, so
+    user-authored int64 step-1 grids that match this pattern but lack
+    the marker keep their georef on round-trip.
     """
     if coord.dtype != np.int64:
         return False
@@ -303,20 +315,16 @@ def require_transform_for_georeferenced(
         ydim = da.dims[-2]
         xdim = da.dims[-1]
     if xdim in da.coords and ydim in da.coords:
-        x = da.coords[xdim].values
-        y = da.coords[ydim].values
-        # The read-side no-georef sentinel is ``np.arange(start, stop,
-        # dtype=int64)`` on both axes (#1710, #1753, #1949). When both
-        # axes match that shape, ``coords_to_transform`` returns
-        # ``None`` and the array round-trips cleanly without a fake
-        # unit transform; mirror that here so the validator doesn't
-        # fail-close on a legitimate no-georef write. A
-        # user-authored integer-coord grid that does *not* match the
-        # sentinel (e.g. ``x=[100,101,102], y=[200,199]``) falls
-        # through to the raise below and the caller has to either
-        # supply ``attrs['transform']`` or accept the
-        # ``coords_to_transform`` path (#2087).
-        if _is_no_georef_sentinel(x) and _is_no_georef_sentinel(y):
+        # The reader stamps ``attrs[_NO_GEOREF_KEY] = True`` when it
+        # emits its int64 step-1 placeholder coords for files without
+        # GeoTIFF transform tags (#1710, #1753, #1949). The writer
+        # checks that marker rather than the coord shape itself so a
+        # user-authored int64 grid that happens to match the placeholder
+        # pattern (e.g. ``x=[500,501,502], y=[1000,1001]``) keeps its
+        # georef on round-trip. Pre-#2120 the writer detected the
+        # placeholder by shape alone and silently stripped georef from
+        # real user data with that shape.
+        if _has_no_georef_marker(da):
             return
         raise ValueError(
             f"Cannot infer GeoTIFF transform from a "
@@ -348,14 +356,13 @@ def coords_to_transform(da: xr.DataArray) -> 'GeoTransform | None':
     helper must handle both layouts to keep the geo-transform consistent
     with the file's coord arrays. See issue #1643.
 
-    Coords matching the read-side no-georef placeholder
-    (``np.arange(start, stop, dtype=int64)`` on both axes) return
-    ``None`` before the uniformity check runs; this is intentional
-    so the placeholder round-trips without inventing a fake unit
-    transform (#1949). The check was tightened in #2087 from "any
-    integer dtype" to the exact ``arange`` pattern because the
-    broader check was silently stripping georef from user-authored
-    integer-coord projected grids.
+    DataArrays carrying ``attrs[_NO_GEOREF_KEY] = True`` (stamped by
+    the reader for files without GeoTIFF transform tags) return
+    ``None`` before the uniformity check runs so the placeholder
+    round-trips without inventing a fake unit transform (#1949,
+    #2120). Pre-#2120 the placeholder was detected by coord shape
+    alone, which silently stripped georef from user-authored int64
+    step-1 grids that matched the same arange pattern.
     """
     if da.ndim == 3:
         # Drop the band-like dim and keep the two spatial dims in their
@@ -387,29 +394,27 @@ def coords_to_transform(da: xr.DataArray) -> 'GeoTransform | None':
     if len(x) < 2 and len(y) < 2:
         return None
 
-    # No-georef sentinel: the ``has_georef=False`` branch in
-    # ``coords_from_pixel_geometry`` emits
-    # ``np.arange(start, stop, dtype=np.int64)`` for files without
-    # GeoTIFF transform tags (#1710, #1753). Synthesising a
-    # GeoTransform from those arrays would inject a fake unit
-    # transform (``pixel_width=1.0``, origin derived from
-    # ``coord[0]``) into the written file's ModelPixelScale /
-    # ModelTiepoint tags. The next read then takes the georef branch
-    # and the coord dtype silently flips to ``float64`` with
-    # ``attrs['transform']`` present, breaking the no-georef
-    # contract that downstream code branches on (#1949).
+    # No-georef path: the reader stamps
+    # ``attrs[_NO_GEOREF_KEY] = True`` whenever it emits the int64
+    # step-1 placeholder y/x coords for files without GeoTIFF transform
+    # tags (#1710, #1753, #1949). Synthesising a GeoTransform from those
+    # arrays would inject a fake unit transform (``pixel_width=1.0``,
+    # origin derived from ``coord[0]``) into the written file's
+    # ModelPixelScale / ModelTiepoint tags. The next read would then
+    # take the georef branch and the coord dtype silently flip to
+    # ``float64`` with ``attrs['transform']`` present, breaking the
+    # no-georef contract that downstream code branches on.
     #
-    # The check used to be ``dtype.kind in ('i', 'u')`` on either
-    # axis, which was too broad: user-authored projected grids with
-    # integer-spaced coords (e.g. ``x=[100, 101, 102]``,
-    # ``y=[200, 199]``) matched the sentinel and lost their georef
-    # silently on write. The tightened check accepts only the exact
-    # shape the reader emits (``int64``, ascending, contiguous step
-    # ``+1`` on both axes). Anything else falls through here and
-    # gets a real transform synthesised below, or raises
-    # ``NonUniformCoordsError`` if the spacing is irregular. See
-    # issue #2087.
-    if _is_no_georef_sentinel(x) and _is_no_georef_sentinel(y):
+    # Older revisions of this code detected the placeholder by coord
+    # shape: first ``dtype.kind in ('i', 'u')`` (broad, then tightened
+    # in #2087 to the exact ``arange(start, start+n, dtype=int64)``
+    # pattern). Both shape-based checks misclassified user-authored
+    # int64 step-1 grids (e.g. ``x=[500,501,502], y=[1000,1001]``) as
+    # the placeholder and silently stripped their georef on write
+    # (#2120). The marker is now the only signal: shape-matching coords
+    # without the marker fall through to the regular transform
+    # synthesis below.
+    if _has_no_georef_marker(da):
         return None
 
     # GeoTIFF only supports an affine transform; non-uniform spacing

--- a/xrspatial/geotiff/_geotags.py
+++ b/xrspatial/geotiff/_geotags.py
@@ -4,6 +4,17 @@ from __future__ import annotations
 import struct
 from dataclasses import dataclass, field
 
+
+# Stamped by the reader on arrays read from files that carry no
+# GeoTIFF transform tags (ModelTransformation, ModelPixelScale, or
+# ModelTiepoint). The reader emits int64 ``arange`` placeholder y/x
+# coords for those files, and the writer checks this marker to
+# distinguish them from user-authored int64 step-1 grids that match
+# the same shape. Lives here (alongside the other geotiff tag
+# constants) so both ``_coords`` and ``_attrs`` can import it
+# without a cycle. See issue #2120.
+_NO_GEOREF_KEY = '_xrspatial_no_georef'
+
 from ._header import (
     IFD,
     TAG_NEW_SUBFILE_TYPE,

--- a/xrspatial/geotiff/tests/test_int_coord_sentinel_2087.py
+++ b/xrspatial/geotiff/tests/test_int_coord_sentinel_2087.py
@@ -1,29 +1,26 @@
-"""User-authored integer spatial coords must not silently drop georef (#2087).
+"""User-authored integer spatial coords must not silently drop georef (#2087, #2120).
 
-The pre-fix sentinel at ``_coords.py:272`` and ``:353`` returned
-``None`` from ``coords_to_transform`` (and waved the validator
-through) whenever either x or y had an integer dtype. The intent
-was to round-trip the read-side ``np.arange(N, dtype=int64)``
-placeholder that ``coords_from_pixel_geometry`` emits for files
-with no GeoTIFF transform tags. The sentinel was too broad: it
-also caught user-authored projected grids with integer-spaced
-coords, which lost their georef silently on write.
+Pre-#2087, ``coords_to_transform`` returned ``None`` whenever either x
+or y had an integer dtype, which silently stripped georef from any
+user-authored integer-coord grid. Issue #2087 tightened the shape
+check to the exact reader pattern (int64 ascending step-1 on both
+axes), but the same trade-off bit a smaller niche: user grids that
+happened to be int64 ascending step-1 starting at non-zero offsets
+(e.g. ``x=[500,501,502], y=[1000,1001]``) still lost their georef.
 
-The tightened sentinel matches only the exact reader pattern:
-``int64`` dtype, ascending, contiguous step ``+1`` on both axes.
-These tests pin both directions:
+Issue #2120 moved the placeholder signal off coord shape entirely:
+the reader stamps ``attrs[_NO_GEOREF_KEY] = True`` together with the
+placeholder coords, and the writer checks that marker instead of
+guessing from shape. These tests pin the contract:
 
-1. The legitimate no-georef round-trip still works -- a file
-   with no transform tags reads back with int64 coords and
-   writes back without inventing a transform.
-2. User-authored integer-coord grids are no longer silently
-   stripped. ``x=[100,101,102], y=[200,199]`` now writes a real
-   transform and round-trips with float coords.
-3. Subsets and windowed reads of the no-georef placeholder
-   (which still produce ``arange``-shaped int64 arrays) continue
-   to round-trip cleanly.
-4. Non-uniform int coords raise ``NonUniformCoordsError`` instead
-   of silently stripping.
+1. The legitimate no-georef round-trip still works when the marker
+   is carried forward.
+2. User-authored integer-coord grids are not silently stripped, even
+   if they match the placeholder shape. Without the marker the writer
+   synthesises a real unit transform and the array round-trips with
+   float coords.
+3. Non-uniform int coords raise ``NonUniformCoordsError`` rather than
+   the silent strip.
 """
 from __future__ import annotations
 
@@ -97,13 +94,16 @@ def test_user_authored_int_grid_writes_real_transform(tmp_path):
     assert out.attrs.get('transform') is not None
 
 
-def test_both_axes_ascending_int64_step1_trade_off(tmp_path):
-    # Documented trade-off corner: when both axes are int64 ascending
-    # step-1 (i.e. both match the read-side arange pattern exactly),
-    # the sentinel cannot distinguish a user-authored grid from the
-    # read-side no-georef placeholder. The writer resolves to
-    # no-georef. A caller wanting georef on this pattern must set
-    # ``attrs['transform']`` explicitly (see the next test).
+def test_both_axes_ascending_int64_step1_round_trips_with_georef(tmp_path):
+    # Pre-#2120 the writer treated any int64 ascending step-1 grid as
+    # the no-georef placeholder (because the reader emits coords of that
+    # shape) and silently stripped the georef. That trade-off bit real
+    # users whose projected grids happened to start at integer offsets
+    # like ``x=[500, 501, 502], y=[1000, 1001]``. Issue #2120 moved the
+    # placeholder signal to ``attrs[_NO_GEOREF_KEY]`` so the writer no
+    # longer guesses from coord shape alone. A user-authored grid that
+    # matches the arange pattern but lacks the marker now writes a
+    # real transform and round-trips with float coords.
     da = xr.DataArray(
         np.zeros((3, 3), dtype=np.float32),
         coords={
@@ -112,18 +112,14 @@ def test_both_axes_ascending_int64_step1_trade_off(tmp_path):
         },
         dims=('y', 'x'),
     )
-    # Both axes match the sentinel exactly (int64 ascending step 1).
-    # This is the documented trade-off: ambiguous between
-    # "read-side placeholder" and "user-authored arange-shaped grid".
-    # The sentinel resolves to no-georef. A caller wanting georef on
-    # this pattern must set attrs['transform'] explicitly.
     path = str(tmp_path / "tmp_2087_both_arange.tif")
     to_geotiff(da, path)
     out = open_geotiff(path)
-    # No-georef round-trip: coords come back as int64 0..N-1
-    # placeholders, not the original values.
-    assert out.coords['x'].dtype == np.int64
-    assert out.coords['y'].dtype == np.int64
+    assert out.coords['x'].dtype.kind == 'f'
+    assert out.coords['y'].dtype.kind == 'f'
+    np.testing.assert_array_equal(out.coords['x'].values, [100.0, 101.0, 102.0])
+    np.testing.assert_array_equal(out.coords['y'].values, [200.0, 201.0, 202.0])
+    assert out.attrs.get('transform') is not None
 
 
 def test_user_authored_int_grid_with_explicit_transform(tmp_path):
@@ -188,14 +184,20 @@ def test_int_x_float_y_writes_transform(tmp_path):
 
 
 def test_no_georef_roundtrip_preserved(tmp_path):
-    # Build a no-georef file via the read-side path: write a file with
-    # ``attrs['transform']`` explicitly cleared, then re-read it.
-    # ``open_geotiff`` returns int64 ``np.arange``-shaped coords; the
-    # next write must not invent a transform.
+    # The no-georef round-trip starts from a real no-georef file: the
+    # reader stamps ``attrs[_NO_GEOREF_KEY] = True`` together with the
+    # int64 ``np.arange``-shaped coords, and the writer carries the
+    # marker forward so the next ``to_geotiff`` does not invent a
+    # transform. Issue #2120 made the marker the only signal -- a
+    # user constructing the same coord arrays from scratch without the
+    # marker now writes a real unit transform instead (see
+    # ``test_both_axes_ascending_int64_step1_round_trips_with_georef``).
+    from xrspatial.geotiff._coords import _NO_GEOREF_KEY
     src = xr.DataArray(
         np.zeros((4, 4), dtype=np.float32),
         coords={'y': np.arange(4, dtype=np.int64), 'x': np.arange(4, dtype=np.int64)},
         dims=('y', 'x'),
+        attrs={_NO_GEOREF_KEY: True},
     )
     path = str(tmp_path / "tmp_2087_no_georef.tif")
     to_geotiff(src, path)
@@ -205,6 +207,7 @@ def test_no_georef_roundtrip_preserved(tmp_path):
     assert out.coords['x'].dtype == np.int64
     assert out.coords['y'].dtype == np.int64
     assert out.attrs.get('transform') is None
+    assert out.attrs.get(_NO_GEOREF_KEY) is True
 
     # Round-trip: write again. No transform should be invented.
     path2 = str(tmp_path / "tmp_2087_no_georef_rt.tif")
@@ -212,13 +215,16 @@ def test_no_georef_roundtrip_preserved(tmp_path):
     out2 = open_geotiff(path2)
     assert out2.coords['x'].dtype == np.int64
     assert out2.attrs.get('transform') is None
+    assert out2.attrs.get(_NO_GEOREF_KEY) is True
 
 
-def test_windowed_no_georef_roundtrip(tmp_path):
-    # The read-side emits ``np.arange(c0, c1, dtype=int64)`` for
-    # windowed reads, so the sentinel must accept arange starting at
-    # any integer, not just 0. Test by writing an array whose coords
-    # mimic a windowed no-georef read.
+def test_windowed_no_georef_roundtrip_with_marker(tmp_path):
+    # When a caller explicitly opts into no-georef writes via
+    # ``attrs[_NO_GEOREF_KEY] = True``, the windowed-offset arange
+    # pattern that windowed reads return round-trips cleanly. Without
+    # the marker, the same coord values write a real transform
+    # (covered by ``test_both_axes_ascending_int64_step1_round_trips``).
+    from xrspatial.geotiff._coords import _NO_GEOREF_KEY
     da = xr.DataArray(
         np.zeros((3, 4), dtype=np.float32),
         coords={
@@ -226,12 +232,11 @@ def test_windowed_no_georef_roundtrip(tmp_path):
             'x': np.arange(20, 24, dtype=np.int64),
         },
         dims=('y', 'x'),
+        attrs={_NO_GEOREF_KEY: True},
     )
     path = str(tmp_path / "tmp_2087_windowed.tif")
     to_geotiff(da, path)
     out = open_geotiff(path)
-    # Under the documented trade-off this is still treated as
-    # no-georef (both axes match the arange pattern). Coords come
-    # back as 0..N-1 placeholders.
     assert out.coords['x'].dtype == np.int64
     assert out.attrs.get('transform') is None
+    assert out.attrs.get(_NO_GEOREF_KEY) is True

--- a/xrspatial/geotiff/tests/test_no_georef_marker_2120.py
+++ b/xrspatial/geotiff/tests/test_no_georef_marker_2120.py
@@ -1,0 +1,116 @@
+"""User int64 step-1 grids must keep their georef on round-trip (#2120).
+
+#2087 tightened the no-georef detection from "any integer dtype" to
+"int64 ascending step-1 on both axes", which fixed the original silent
+strip for non-arange grids. A smaller niche still tripped over the
+shape-based check: user grids with int64 step-1 coords starting at a
+non-zero offset (e.g. ``x=[500,501,502], y=[1000,1001]``) still matched
+the reader's placeholder pattern and were silently emitted as no-georef.
+
+The fix moves the placeholder signal to ``attrs[_NO_GEOREF_KEY]``
+(stamped by the reader, checked by the writer). These tests pin the
+new contract:
+
+1. A user-authored int64 step-1 grid with no marker keeps CRS and gets
+   a synthesised unit transform.
+2. Round-tripping a real no-georef file (where the reader stamps the
+   marker) still produces a no-transform output.
+3. Manually opting in to no-georef via the marker on a user-built
+   DataArray writes without a transform, even with integer coords.
+"""
+from __future__ import annotations
+
+import numpy as np
+import xarray as xr
+
+from xrspatial.geotiff import open_geotiff, to_geotiff
+from xrspatial.geotiff._coords import _NO_GEOREF_KEY
+
+
+def test_int64_step1_user_grid_keeps_crs_on_round_trip(tmp_path):
+    x = np.array([500, 501, 502], dtype=np.int64)
+    y = np.array([1000, 1001], dtype=np.int64)
+    da = xr.DataArray(
+        np.zeros((2, 3), dtype=np.float32),
+        coords={'y': y, 'x': x}, dims=('y', 'x'),
+        attrs={'crs': 4326},
+    )
+
+    path = str(tmp_path / "tmp_2120_user_int64_grid.tif")
+    to_geotiff(da, path)
+    out = open_geotiff(path)
+
+    # Coord values round-trip exactly, dtype flips int -> float because
+    # the file now carries a real transform.
+    np.testing.assert_array_equal(out.coords['x'].values, [500.0, 501.0, 502.0])
+    np.testing.assert_array_equal(out.coords['y'].values, [1000.0, 1001.0])
+    assert out.attrs.get('crs') == 4326
+    assert out.attrs.get('transform') is not None
+    # The marker must not be set on a georef read.
+    assert _NO_GEOREF_KEY not in out.attrs
+
+
+def test_no_georef_file_carries_marker_and_round_trips(tmp_path):
+    # Build a no-georef file via the explicit-marker write path.
+    src = xr.DataArray(
+        np.zeros((4, 4), dtype=np.float32),
+        coords={'y': np.arange(4, dtype=np.int64),
+                'x': np.arange(4, dtype=np.int64)},
+        dims=('y', 'x'),
+        attrs={_NO_GEOREF_KEY: True},
+    )
+    path = str(tmp_path / "tmp_2120_no_georef.tif")
+    to_geotiff(src, path)
+
+    out = open_geotiff(path)
+    assert out.attrs.get(_NO_GEOREF_KEY) is True
+    assert out.attrs.get('transform') is None
+    assert out.coords['x'].dtype == np.int64
+
+    # Round-trip preserves the marker and the absence of a transform.
+    path2 = str(tmp_path / "tmp_2120_no_georef_rt.tif")
+    to_geotiff(out, path2)
+    out2 = open_geotiff(path2)
+    assert out2.attrs.get(_NO_GEOREF_KEY) is True
+    assert out2.attrs.get('transform') is None
+
+
+def test_int64_step1_user_grid_without_marker_writes_transform(tmp_path):
+    # Direct repro of the silent-strip the pre-fix code would emit.
+    # x and y both match the reader's arange placeholder shape exactly,
+    # but the marker is absent, so the writer treats this as a normal
+    # georef grid and synthesises a unit transform.
+    da = xr.DataArray(
+        np.zeros((3, 3), dtype=np.float32),
+        coords={
+            'y': np.array([200, 201, 202], dtype=np.int64),
+            'x': np.array([100, 101, 102], dtype=np.int64),
+        },
+        dims=('y', 'x'),
+    )
+    path = str(tmp_path / "tmp_2120_step1_no_marker.tif")
+    to_geotiff(da, path)
+    out = open_geotiff(path)
+    assert out.attrs.get('transform') is not None
+    np.testing.assert_array_equal(out.coords['x'].values, [100.0, 101.0, 102.0])
+    np.testing.assert_array_equal(out.coords['y'].values, [200.0, 201.0, 202.0])
+
+
+def test_marker_on_user_grid_skips_transform_synthesis(tmp_path):
+    # A caller can opt into a no-georef write on an int-coord array by
+    # setting the marker explicitly. The writer trusts the marker
+    # rather than re-deriving a transform from the coords.
+    da = xr.DataArray(
+        np.zeros((3, 3), dtype=np.float32),
+        coords={
+            'y': np.arange(3, dtype=np.int64),
+            'x': np.arange(3, dtype=np.int64),
+        },
+        dims=('y', 'x'),
+        attrs={_NO_GEOREF_KEY: True},
+    )
+    path = str(tmp_path / "tmp_2120_explicit_marker.tif")
+    to_geotiff(da, path)
+    out = open_geotiff(path)
+    assert out.attrs.get('transform') is None
+    assert out.attrs.get(_NO_GEOREF_KEY) is True

--- a/xrspatial/geotiff/tests/test_no_georef_writer_round_trip_1949.py
+++ b/xrspatial/geotiff/tests/test_no_georef_writer_round_trip_1949.py
@@ -126,11 +126,37 @@ def test_coords_to_transform_float_coords_unchanged():
     assert gt.pixel_height == pytest.approx(1.0)
 
 
-def test_coords_to_transform_3d_yxband_int_y_returns_none():
-    """3D (y, x, band) with int y coords also short-circuits.
+def test_coords_to_transform_3d_yxband_with_marker_returns_none():
+    """3D (y, x, band) carrying the no-georef marker short-circuits.
 
-    The helper picks the y/x dims (filtering out 'band'); the integer
-    check must apply to those, not to the band axis.
+    Pre-#2120 the helper short-circuited on coord shape alone (int64
+    step-1 on both spatial axes). After #2120 the marker
+    ``attrs[_NO_GEOREF_KEY] = True`` is the only signal; the same
+    coord shape without the marker now synthesises a real transform.
+    The helper picks the y/x dims (filtering out 'band'); the marker
+    check applies regardless of the band-axis layout.
+    """
+    from xrspatial.geotiff._coords import _NO_GEOREF_KEY
+    da = xr.DataArray(
+        np.zeros((4, 5, 3), dtype=np.float32),
+        dims=['y', 'x', 'band'],
+        coords={
+            'y': np.arange(4, dtype=np.int64),
+            'x': np.arange(5, dtype=np.int64),
+            'band': np.arange(3),
+        },
+        attrs={_NO_GEOREF_KEY: True},
+    )
+    assert _coords_to_transform(da) is None
+
+
+def test_coords_to_transform_3d_yxband_without_marker_synthesises_transform():
+    """3D (y, x, band) without the marker now writes a real transform.
+
+    Pre-#2120 this returned ``None`` because the shape-based check
+    treated the int64 step-1 coords as the no-georef placeholder. That
+    silently stripped georef from user-authored 3D arrays with
+    integer-aligned coords.
     """
     da = xr.DataArray(
         np.zeros((4, 5, 3), dtype=np.float32),
@@ -141,7 +167,10 @@ def test_coords_to_transform_3d_yxband_int_y_returns_none():
             'band': np.arange(3),
         },
     )
-    assert _coords_to_transform(da) is None
+    gt = _coords_to_transform(da)
+    assert gt is not None
+    assert gt.pixel_width == pytest.approx(1.0)
+    assert gt.pixel_height == pytest.approx(1.0)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #2120

## Summary

- The writer used to detect the read-side no-georef placeholder by coord shape (int64 ascending step-1 on both axes). User-authored grids matching that pattern lost their georef on round-trip with no warning. The reproducer `x=[500,501,502], y=[1000,1001]` came back as `[0,1,2]` with no transform.
- Move the signal off shape onto `attrs['_xrspatial_no_georef']`. The reader stamps the marker together with the placeholder coords; the writer checks the marker and ignores coord shape.
- A user-authored int64 step-1 grid without the marker now falls through to `coords_to_transform`, which synthesises a unit transform and preserves CRS attrs.

## Backend coverage

- numpy, dask+numpy, GPU (cupy + dask+cupy): all go through `_populate_attrs_from_geo_info`, which now stamps the marker.
- VRT: emits empty coords on the no-georef path so the marker is not needed there.

## Test plan

- [x] New regression tests in `test_no_georef_marker_2120.py` covering: user grid keeps CRS and gains a transform; explicit-marker writes skip transform synthesis; round-trip via a real no-georef file preserves the marker.
- [x] Updated `test_int_coord_sentinel_2087.py` and `test_no_georef_writer_round_trip_1949.py` to pin the new contract (shape alone is no longer the signal).
- [x] Full `xrspatial/geotiff/tests` suite: 4222 passed, 25 skipped.
- [x] Full non-geotiff suite: 3672 passed, 15 skipped.