### PR TITLE
tests: gate VRT int-source tests on tifffile (#2092)

### DIFF
--- a/xrspatial/geotiff/tests/test_masked_nodata_attr_2092.py
+++ b/xrspatial/geotiff/tests/test_masked_nodata_attr_2092.py
@@ -202,7 +202,7 @@ def _write_int_vrt(tmp_path, src_basename, vrt_basename, sentinel=30):
     in-repo VRT reader; without them the reader returns a zero-fill
     buffer instead of decoding the source.
     """
-    import tifffile
+    tifffile = pytest.importorskip("tifffile")
     src = str(tmp_path / src_basename)
     tifffile.imwrite(src, np.array(
         [[10, 20, 30], [40, 50, 60]], dtype=np.int16,


### PR DESCRIPTION
## Summary
- `test_masked_nodata_attr_2092.py::_write_int_vrt` imports `tifffile` inline, but `tifffile` is not in the `[tests]` extras
- CI on main was failing with `ModuleNotFoundError: No module named 'tifffile'` for the three VRT-path tests
- Switch to `pytest.importorskip("tifffile")`, matching the pattern already used in `test_wkt_only_crs_warning_1768.py` and friends

## Test plan
- [x] `pytest xrspatial/geotiff/tests/test_masked_nodata_attr_2092.py` passes locally (12 passed)
- [ ] CI green on this branch