### PR TITLE
geotiff: validate overview_level up front on dask/gpu backends

### DIFF
--- a/xrspatial/geotiff/_backends/dask.py
+++ b/xrspatial/geotiff/_backends/dask.py
@@ -109,14 +109,10 @@ def read_geotiff_dask(source: str, *,
 
     from .._reader import _coerce_path
 
-    # Reject bool and non-int ``overview_level`` up front (issue #2160).
-    # ``open_geotiff`` runs the same check at its entry point; without
-    # this guard a caller who passes a bad ``overview_level`` together
-    # with a bad source or bad ``chunks=`` gets the unrelated source /
-    # chunk error first, so the real defect in the call is masked.
-    # ``select_overview_ifd`` does still validate later as defense in
-    # depth, but the user-facing error is supposed to match
-    # ``open_geotiff`` regardless of which public entry point is hit.
+    # Match ``open_geotiff``'s ordering so a bad ``overview_level`` is
+    # reported before unrelated source / ``chunks=`` errors mask it
+    # (issue #2160). ``select_overview_ifd`` revalidates as defense in
+    # depth.
     _validate_overview_level_arg(overview_level)
 
     source = _coerce_path(source)

--- a/xrspatial/geotiff/_backends/dask.py
+++ b/xrspatial/geotiff/_backends/dask.py
@@ -27,7 +27,11 @@ from .._coords import (
     geo_to_coords as _geo_to_coords,
 )
 from .._reader import read_to_array as _read_to_array
-from .._validation import _validate_chunks_arg, _validate_dtype_cast
+from .._validation import (
+    _validate_chunks_arg,
+    _validate_dtype_cast,
+    _validate_overview_level_arg,
+)
 from .vrt import read_vrt
 
 
@@ -104,6 +108,16 @@ def read_geotiff_dask(source: str, *,
     import dask.array as da
 
     from .._reader import _coerce_path
+
+    # Reject bool and non-int ``overview_level`` up front (issue #2160).
+    # ``open_geotiff`` runs the same check at its entry point; without
+    # this guard a caller who passes a bad ``overview_level`` together
+    # with a bad source or bad ``chunks=`` gets the unrelated source /
+    # chunk error first, so the real defect in the call is masked.
+    # ``select_overview_ifd`` does still validate later as defense in
+    # depth, but the user-facing error is supposed to match
+    # ``open_geotiff`` regardless of which public entry point is hit.
+    _validate_overview_level_arg(overview_level)
 
     source = _coerce_path(source)
 

--- a/xrspatial/geotiff/_backends/gpu.py
+++ b/xrspatial/geotiff/_backends/gpu.py
@@ -193,15 +193,10 @@ def read_geotiff_gpu(source: str, *,
     xr.DataArray
         CuPy-backed DataArray on GPU device.
     """
-    # Reject bool and non-int ``overview_level`` up front (issue #2160).
-    # ``open_geotiff`` runs the same check at its entry point; without
-    # this guard a caller who passes a bad ``overview_level`` together
-    # with a bad ``on_gpu_failure``, bad ``chunks=``, or bad source gets
-    # the unrelated kwarg / source error first, so the real defect in
-    # the call is masked. ``select_overview_ifd`` does still validate
-    # later as defense in depth, but the user-facing error is supposed
-    # to match ``open_geotiff`` regardless of which public entry point
-    # is hit.
+    # Match ``open_geotiff``'s ordering so a bad ``overview_level`` is
+    # reported before unrelated ``on_gpu_failure`` / ``chunks=`` / source
+    # errors mask it (issue #2160). ``select_overview_ifd`` revalidates
+    # as defense in depth.
     _validate_overview_level_arg(overview_level)
 
     new_passed = on_gpu_failure is not _ON_GPU_FAILURE_SENTINEL

--- a/xrspatial/geotiff/_backends/gpu.py
+++ b/xrspatial/geotiff/_backends/gpu.py
@@ -37,6 +37,7 @@ from .._runtime import (
 from .._validation import (
     _validate_chunks_arg,
     _validate_dtype_cast,
+    _validate_overview_level_arg,
     _validate_predictor_sample_format,
 )
 from ._gpu_helpers import (
@@ -192,6 +193,17 @@ def read_geotiff_gpu(source: str, *,
     xr.DataArray
         CuPy-backed DataArray on GPU device.
     """
+    # Reject bool and non-int ``overview_level`` up front (issue #2160).
+    # ``open_geotiff`` runs the same check at its entry point; without
+    # this guard a caller who passes a bad ``overview_level`` together
+    # with a bad ``on_gpu_failure``, bad ``chunks=``, or bad source gets
+    # the unrelated kwarg / source error first, so the real defect in
+    # the call is masked. ``select_overview_ifd`` does still validate
+    # later as defense in depth, but the user-facing error is supposed
+    # to match ``open_geotiff`` regardless of which public entry point
+    # is hit.
+    _validate_overview_level_arg(overview_level)
+
     new_passed = on_gpu_failure is not _ON_GPU_FAILURE_SENTINEL
     old_passed = gpu is not _GPU_DEPRECATED_SENTINEL
     if new_passed and old_passed:

--- a/xrspatial/geotiff/tests/test_overview_level_validation_backends_2160.py
+++ b/xrspatial/geotiff/tests/test_overview_level_validation_backends_2160.py
@@ -229,3 +229,18 @@ def test_gpu_overview_level_check_runs_before_on_gpu_failure_validation(
     path, _ = cog_with_overview
     with pytest.raises(TypeError, match="bool"):
         read_geotiff_gpu(path, on_gpu_failure="bogus", overview_level=True)
+
+
+def test_gpu_overview_level_check_runs_before_chunked_dispatch(
+        cog_with_overview):
+    """``chunks=`` routes through ``_read_geotiff_gpu_chunked``; the
+    validator at the top of ``read_geotiff_gpu`` must fire before that
+    branch, otherwise a bad ``overview_level`` would only surface via
+    the inner ``read_geotiff_dask`` call (which now also validates,
+    but the contract is that the outer entry point reports it first).
+    """
+    from xrspatial.geotiff import read_geotiff_gpu
+
+    path, _ = cog_with_overview
+    with pytest.raises(TypeError, match="bool"):
+        read_geotiff_gpu(path, chunks=32, overview_level=True)

--- a/xrspatial/geotiff/tests/test_overview_level_validation_backends_2160.py
+++ b/xrspatial/geotiff/tests/test_overview_level_validation_backends_2160.py
@@ -1,0 +1,231 @@
+"""Type validation for ``overview_level`` on the direct backend entry points.
+
+Issue #2074 added the up-front ``_validate_overview_level_arg`` guard to
+``open_geotiff`` so callers got a clean ``TypeError`` naming the offending
+type (``bool`` / ``str`` / ``float``) instead of a leaked low-level error
+from numeric comparison or list indexing. The direct backends
+(``read_geotiff_dask``, ``read_geotiff_gpu``) reach the same selector but
+only after source coercion, chunk validation, and (on the GPU path)
+``on_gpu_failure`` resolution. A caller who passes both a bad
+``overview_level`` and a bad source or bad ``chunks=`` got the unrelated
+source / chunk error first, so the real defect in the call was hidden.
+
+This module mirrors the issue #2074 tests against the two direct backends
+and asserts ordering: the ``overview_level`` type check fires before
+``_coerce_path``, ``_validate_chunks_arg``, or the ``on_gpu_failure``
+alias handling. See issue #2160.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+
+tifffile = pytest.importorskip("tifffile")
+
+
+def _write_cog_with_one_overview(path: str) -> np.ndarray:
+    """Write a 64x64 single-band TIFF with one half-resolution overview."""
+    rng = np.random.RandomState(0x2160)
+    arr = rng.randint(0, 256, size=(64, 64), dtype=np.uint8)
+    half = arr[::2, ::2]
+    with tifffile.TiffWriter(path) as tw:
+        tw.write(arr, tile=(32, 32), photometric="minisblack")
+        tw.write(half, tile=(32, 32), photometric="minisblack",
+                 subfiletype=1)
+    return arr
+
+
+@pytest.fixture
+def cog_with_overview(tmp_path):
+    path = str(tmp_path / "cog_overview_backend_2160.tif")
+    arr = _write_cog_with_one_overview(path)
+    return path, arr
+
+
+# ---------------------------------------------------------------------------
+# read_geotiff_dask
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_dask_overview_level_bool_raises_typeerror(cog_with_overview, value):
+    from xrspatial.geotiff import read_geotiff_dask
+
+    path, _ = cog_with_overview
+    with pytest.raises(TypeError, match="bool"):
+        read_geotiff_dask(path, overview_level=value)
+
+
+def test_dask_overview_level_str_raises_typeerror(cog_with_overview):
+    from xrspatial.geotiff import read_geotiff_dask
+
+    path, _ = cog_with_overview
+    with pytest.raises(TypeError, match="str"):
+        read_geotiff_dask(path, overview_level="0")
+
+
+def test_dask_overview_level_float_raises_typeerror(cog_with_overview):
+    from xrspatial.geotiff import read_geotiff_dask
+
+    path, _ = cog_with_overview
+    with pytest.raises(TypeError, match="float"):
+        read_geotiff_dask(path, overview_level=1.0)
+
+
+def test_dask_overview_level_zero_succeeds(cog_with_overview):
+    from xrspatial.geotiff import read_geotiff_dask
+
+    path, arr = cog_with_overview
+    result = read_geotiff_dask(path, overview_level=0)
+    assert result.shape == arr.shape
+
+
+def test_dask_overview_level_one_succeeds(cog_with_overview):
+    from xrspatial.geotiff import read_geotiff_dask
+
+    path, arr = cog_with_overview
+    result = read_geotiff_dask(path, overview_level=1)
+    assert result.shape == (arr.shape[0] // 2, arr.shape[1] // 2)
+
+
+def test_dask_overview_level_none_succeeds(cog_with_overview):
+    from xrspatial.geotiff import read_geotiff_dask
+
+    path, arr = cog_with_overview
+    result = read_geotiff_dask(path, overview_level=None)
+    assert result.shape == arr.shape
+
+
+@pytest.mark.parametrize("value", [np.int64(0), np.int32(0)])
+def test_dask_overview_level_numpy_int_zero_succeeds(cog_with_overview, value):
+    """``np.int64`` / ``np.int32`` should be accepted like Python ints."""
+    from xrspatial.geotiff import read_geotiff_dask
+
+    path, arr = cog_with_overview
+    result = read_geotiff_dask(path, overview_level=value)
+    assert result.shape == arr.shape
+
+
+@pytest.mark.parametrize("value", [np.int64(1), np.int32(1)])
+def test_dask_overview_level_numpy_int_one_succeeds(cog_with_overview, value):
+    from xrspatial.geotiff import read_geotiff_dask
+
+    path, arr = cog_with_overview
+    result = read_geotiff_dask(path, overview_level=value)
+    assert result.shape == (arr.shape[0] // 2, arr.shape[1] // 2)
+
+
+def test_dask_overview_level_typeerror_names_value(cog_with_overview):
+    from xrspatial.geotiff import read_geotiff_dask
+
+    path, _ = cog_with_overview
+    with pytest.raises(TypeError) as exc_info:
+        read_geotiff_dask(path, overview_level="not-an-int")
+    msg = str(exc_info.value)
+    assert "str" in msg
+    assert "not-an-int" in msg
+
+
+# Ordering checks: the overview_level type error must fire before the
+# unrelated source / chunk errors, matching open_geotiff's behaviour.
+
+
+def test_dask_overview_level_check_runs_before_source_coercion():
+    """Bad source + bad overview_level should report overview_level first."""
+    from xrspatial.geotiff import read_geotiff_dask
+
+    with pytest.raises(TypeError, match="bool"):
+        read_geotiff_dask("/nonexistent/path-2160.tif", overview_level=True)
+
+
+def test_dask_overview_level_check_runs_before_chunks_validation(
+        cog_with_overview):
+    """Bad chunks + bad overview_level should report overview_level first."""
+    from xrspatial.geotiff import read_geotiff_dask
+
+    path, _ = cog_with_overview
+    with pytest.raises(TypeError, match="bool"):
+        read_geotiff_dask(path, chunks=0, overview_level=True)
+
+
+# ---------------------------------------------------------------------------
+# read_geotiff_gpu
+# ---------------------------------------------------------------------------
+#
+# These tests must not import cupy. The validator runs at the top of
+# ``read_geotiff_gpu`` before the cupy import, so the bad-input cases
+# raise ``TypeError`` on a CPU-only machine. The "succeeds" cases that
+# actually need a GPU stay gated on cupy via ``importorskip``.
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_gpu_overview_level_bool_raises_typeerror_no_cupy(
+        cog_with_overview, value):
+    from xrspatial.geotiff import read_geotiff_gpu
+
+    path, _ = cog_with_overview
+    with pytest.raises(TypeError, match="bool"):
+        read_geotiff_gpu(path, overview_level=value)
+
+
+def test_gpu_overview_level_str_raises_typeerror_no_cupy(cog_with_overview):
+    from xrspatial.geotiff import read_geotiff_gpu
+
+    path, _ = cog_with_overview
+    with pytest.raises(TypeError, match="str"):
+        read_geotiff_gpu(path, overview_level="0")
+
+
+def test_gpu_overview_level_float_raises_typeerror_no_cupy(cog_with_overview):
+    from xrspatial.geotiff import read_geotiff_gpu
+
+    path, _ = cog_with_overview
+    with pytest.raises(TypeError, match="float"):
+        read_geotiff_gpu(path, overview_level=1.0)
+
+
+def test_gpu_overview_level_typeerror_names_value_no_cupy(cog_with_overview):
+    from xrspatial.geotiff import read_geotiff_gpu
+
+    path, _ = cog_with_overview
+    with pytest.raises(TypeError) as exc_info:
+        read_geotiff_gpu(path, overview_level="not-an-int")
+    msg = str(exc_info.value)
+    assert "str" in msg
+    assert "not-an-int" in msg
+
+
+def test_gpu_overview_level_check_runs_before_source_coercion():
+    """Bad source + bad overview_level should report overview_level first."""
+    from xrspatial.geotiff import read_geotiff_gpu
+
+    with pytest.raises(TypeError, match="bool"):
+        read_geotiff_gpu("/nonexistent/path-2160.tif", overview_level=True)
+
+
+def test_gpu_overview_level_check_runs_before_chunks_validation(
+        cog_with_overview):
+    """Bad chunks + bad overview_level should report overview_level first."""
+    from xrspatial.geotiff import read_geotiff_gpu
+
+    path, _ = cog_with_overview
+    with pytest.raises(TypeError, match="bool"):
+        read_geotiff_gpu(path, chunks=0, overview_level=True)
+
+
+def test_gpu_overview_level_check_runs_before_on_gpu_failure_validation(
+        cog_with_overview):
+    """Bad on_gpu_failure + bad overview_level reports overview_level first.
+
+    The ``on_gpu_failure`` alias handling and the ``not in ('auto',
+    'strict')`` check sit before the cupy import. Without the up-front
+    overview validator, a caller who passes both a bad
+    ``on_gpu_failure`` and a bad ``overview_level`` would get the
+    ValueError from the policy check, masking the real type bug.
+    """
+    from xrspatial.geotiff import read_geotiff_gpu
+
+    path, _ = cog_with_overview
+    with pytest.raises(TypeError, match="bool"):
+        read_geotiff_gpu(path, on_gpu_failure="bogus", overview_level=True)


### PR DESCRIPTION
Closes #2160.

## Summary

- `open_geotiff` rejected `overview_level=True` / `"0"` / `1.0` up front, but `read_geotiff_dask` and `read_geotiff_gpu` only reached the same check inside `select_overview_ifd`, after source coercion, chunk validation, and (on GPU) `on_gpu_failure` alias handling. A bad `overview_level` paired with a bad source or bad `chunks=` surfaced the source / chunk error first, hiding the real defect.
- Call the existing `_validate_overview_level_arg` validator at the top of both direct backends so the user-facing error matches `open_geotiff` regardless of which entry point is hit. `select_overview_ifd` still validates as defense in depth.
- Mirror the issue #2074 tests against both backends, plus ordering checks: the type error must fire before `_coerce_path`, `_validate_chunks_arg`, and the `on_gpu_failure` policy check.

## Backend coverage

- numpy: not applicable (eager numpy path goes through `open_geotiff`, already validated)
- cupy: covered via `read_geotiff_gpu` (CPU-machine path; validator fires before the cupy import)
- dask+numpy: covered via `read_geotiff_dask`
- dask+cupy: covered via `read_geotiff_gpu(chunks=...)` which routes through `read_geotiff_dask` after the validator fires

## Test plan

- [x] `pytest xrspatial/geotiff/tests/test_overview_level_validation_backends_2160.py` (22 passed)
- [x] `pytest xrspatial/geotiff/tests/test_overview_level_type_validation_2074.py` (regression check, 11 passed)
- [x] `pytest xrspatial/geotiff/tests/test_overview_filter.py` (selector defense-in-depth still works)
