### PR TITLE
geotiff: honor mask_nodata=False for float VRT sources (#2158)

### DIFF
--- a/xrspatial/geotiff/_backends/vrt.py
+++ b/xrspatial/geotiff/_backends/vrt.py
@@ -415,20 +415,30 @@ def read_vrt(source: str, *,
     # follow-up).
     pre_cast_dtype = np.dtype(str(arr.dtype))
 
-    # When the inline float-NaN masking inside ``_vrt._read_data`` already
-    # ran (float source + float VRT dataType + declared sentinel), the
-    # integer helper above is a no-op but the resulting float buffer may
-    # already carry NaNs at the sentinel locations. Promote
-    # ``nodata_pixels_present`` to reflect that, since a downstream "any
-    # nodata?" check should answer yes for those tiles too.
+    # Float-NaN proxy for ``nodata_pixels_present``. The signal for a
+    # float buffer can come from any of three places, only one of which
+    # actually fires per call:
+    #
+    # * ``mask_nodata=True`` + float source + declared sentinel: the
+    #   inline NaN masking in ``_vrt._read_data`` rewrote sentinels to
+    #   NaN, so ``np.isnan(arr).any()`` is the presence answer.
+    # * ``mask_nodata=False`` + declared sentinel: ``_vrt_scan_for_sentinel``
+    #   above already set ``nodata_pixels_present`` from a literal-value
+    #   scan, so this block short-circuits via ``not present``.
+    # * ``mask_nodata=True`` + float source with no inline masking (e.g.
+    #   source's natural NaN values, sentinel absent from window): the
+    #   NaN proxy catches the in-buffer NaNs.
     #
     # Invariant: at most one branch sets ``nodata_pixels_present`` to True
     # before this block runs. ``_vrt_mask_with_presence`` only sets True
     # on integer buffers (it short-circuits on float dtype), and
     # ``_vrt_scan_for_sentinel`` is gated on the ``mask_nodata=False``
     # branch above. Either way, the float-NaN proxy below is the only
-    # presence signal for float buffers, so the ``not present`` guard
-    # is sufficient -- we will not double-scan the same buffer.
+    # remaining presence signal for float buffers, so the ``not present``
+    # guard is sufficient -- we will not double-scan the same buffer.
+    # The ``mask_nodata=False`` arm fix from #2158 means the inline NaN
+    # masking no longer runs under the opt-out; the ``_vrt_scan_for_sentinel``
+    # short-circuit above is what keeps the presence attr honest there.
     if (nodata is not None
             and pre_cast_dtype.kind == 'f'
             and not nodata_pixels_present):

--- a/xrspatial/geotiff/_backends/vrt.py
+++ b/xrspatial/geotiff/_backends/vrt.py
@@ -248,9 +248,20 @@ def read_vrt(source: str, *,
         ),
     })
 
+    # Thread ``mask_nodata`` into the internal reader so the float
+    # source NaN masking inside ``_read_data`` honors the opt-out
+    # alongside the integer ``_vrt_mask_with_presence`` helper called
+    # further down. Without this the eager path silently rewrote
+    # literal float sentinels (e.g. ``-9999.0``) to NaN regardless of
+    # the kwarg, which violates the documented opt-out and can drop
+    # legitimate sentinel pixels from downstream consumers. The
+    # ``nodata_pixels_present`` proxy below still reports correctly
+    # because it falls back to a float-buffer scan when the helper
+    # short-circuits. See issue #2158.
     arr, vrt = _read_vrt_internal(
         source, window=window, band=band, max_pixels=max_pixels,
         missing_sources=missing_sources, parsed=_parsed_vrt,
+        mask_nodata=mask_nodata,
     )
 
     if name is None:
@@ -459,9 +470,15 @@ def read_vrt(source: str, *,
         arr = arr.astype(target)
         dtype_cast_attr = target.name
 
+    # ``masked`` follows the contract documented on ``_set_nodata_attrs``:
+    # ``mask_nodata and final_dtype.kind == 'f'``. The ``mask_nodata=False``
+    # arm fix from #2158 leaves float source buffers untouched, so
+    # ``pre_cast_dtype.kind == 'f'`` alone would now stamp
+    # ``masked_nodata=True`` on a buffer that still carries literal
+    # sentinel values. AND-ing the kwarg in keeps the attr honest.
     _set_nodata_attrs(
         attrs, nodata,
-        masked=(pre_cast_dtype.kind == 'f'),
+        masked=(mask_nodata and pre_cast_dtype.kind == 'f'),
         pixels_present=nodata_pixels_present,
         dtype_cast=dtype_cast_attr,
     )
@@ -508,16 +525,22 @@ def _vrt_chunk_read(source, r0, c0, r1, c1, *,
         _apply_integer_sentinel_mask,
     )
 
+    # Forward ``mask_nodata`` to the internal reader so the float
+    # source NaN masking inside ``_read_data`` honors the opt-out too,
+    # not just the integer post-decode helper below. Without this the
+    # chunked path would silently rewrite literal float sentinels to
+    # NaN even when the caller asked to keep them. See issue #2158.
     arr, vrt = _read_vrt_internal(
         source, window=(r0, c0, r1, c1), band=band,
         max_pixels=max_pixels, missing_sources=missing_sources,
-        parsed=parsed_vrt,
+        parsed=parsed_vrt, mask_nodata=mask_nodata,
     )
 
     # Mirror the eager post-decode integer-sentinel masking via the
     # shared helper. The internal reader NaN-masks float source arrays
-    # inline but leaves integer sentinels untouched, so the eager path
-    # promotes to float64 when sentinels hit. The surrounding dask graph
+    # inline (gated on the same ``mask_nodata`` kwarg via #2158) but
+    # leaves integer sentinels untouched, so the eager path promotes
+    # to float64 when sentinels hit. The surrounding dask graph
     # already declared float64 when any band has a representable integer
     # sentinel, so any chunk that actually fires the mask returns a
     # buffer whose dtype matches the declared one. Skip the helper when
@@ -880,9 +903,15 @@ def _read_vrt_chunked(source, *, window, band, name, chunks, gpu, dtype,
     # #2135). ``dtype_cast`` records the caller-supplied ``dtype=``
     # kwarg when present so downstream can tell float-by-cast apart
     # from float-by-masking even on the lazy output.
+    # ``masked`` mirrors ``_set_nodata_attrs``'s contract:
+    # ``mask_nodata and final_dtype.kind == 'f'``. With ``mask_nodata=False``
+    # a float source is still float in ``declared_dtype``, but the
+    # per-chunk reader leaves the literal sentinel in place (#2158), so
+    # the buffer is not actually NaN-aware. AND-ing the kwarg in keeps
+    # the chunked attr in lockstep with the eager attr.
     _set_nodata_attrs(
         attrs, nodata_meta,
-        masked=(declared_dtype.kind == 'f'),
+        masked=(mask_nodata and declared_dtype.kind == 'f'),
         pixels_present=None,
         dtype_cast=(np.dtype(dtype).name if dtype is not None else None),
     )

--- a/xrspatial/geotiff/_vrt.py
+++ b/xrspatial/geotiff/_vrt.py
@@ -1352,13 +1352,12 @@ def read_vrt(vrt_path: str, *, window=None,
             # passing ``mask_nodata=False`` to ``read_vrt`` still lost
             # the literal sentinel pixels. See issue #2158.
             src_nodata = src.nodata if src.nodata is not None else nodata
-            if not mask_nodata:
-                pass
-            elif src_nodata is not None and src_arr.dtype.kind == 'f':
+            if mask_nodata and src_nodata is not None and src_arr.dtype.kind == 'f':
                 src_arr = src_arr.copy()
                 sentinel = src_arr.dtype.type(src_nodata)
                 src_arr[src_arr == sentinel] = np.nan
-            elif (src_nodata is not None
+            elif (mask_nodata
+                    and src_nodata is not None
                     and src_arr.dtype.kind in ('u', 'i')
                     and result.dtype.kind == 'f'):
                 # Integer source feeding a float-dataType VRT.  Without

--- a/xrspatial/geotiff/_vrt.py
+++ b/xrspatial/geotiff/_vrt.py
@@ -956,6 +956,7 @@ def read_vrt(vrt_path: str, *, window=None,
              max_pixels: int | None = None,
              missing_sources: str = 'raise',
              parsed: VRTDataset | None = None,
+             mask_nodata: bool = True,
              ) -> tuple[np.ndarray, VRTDataset]:
     """Read a VRT file by assembling pixel data from its source files.
 
@@ -993,6 +994,16 @@ def read_vrt(vrt_path: str, *, window=None,
         produced by :func:`parse_vrt` already, which performs the check).
         Used by the chunked dask path (issue #1825) so each per-chunk
         task can skip the redundant XML parse and allowlist validation.
+    mask_nodata : bool, default True
+        If True (the default), float source bands have their declared
+        nodata sentinel rewritten to NaN inline during assembly, and
+        integer sources feeding a float-dataType VRT have their
+        sentinel rewritten to NaN as part of the int->float
+        placement. If False, both inline masking branches are skipped
+        so the literal sentinel value survives to the public backend
+        layer, which can then honor a caller's ``mask_nodata=False``
+        opt-out symmetrically for float and integer source dtypes.
+        See issue #2158.
 
     Returns
     -------
@@ -1332,8 +1343,18 @@ def read_vrt(vrt_path: str, *, window=None,
             # the resampled-shape buffer before discovering the mask,
             # which is a waste when the source rect is much larger than
             # the destination rect.
+            # ``mask_nodata=False`` skips every inline sentinel rewrite
+            # below so the public backend's opt-out is honored
+            # symmetrically across float and integer source dtypes.
+            # Without this gate the float branch at the ``kind == 'f'``
+            # arm masked unconditionally, and the integer-feeding-float
+            # branch below promoted to NaN unconditionally, so a caller
+            # passing ``mask_nodata=False`` to ``read_vrt`` still lost
+            # the literal sentinel pixels. See issue #2158.
             src_nodata = src.nodata if src.nodata is not None else nodata
-            if src_nodata is not None and src_arr.dtype.kind == 'f':
+            if not mask_nodata:
+                pass
+            elif src_nodata is not None and src_arr.dtype.kind == 'f':
                 src_arr = src_arr.copy()
                 sentinel = src_arr.dtype.type(src_nodata)
                 src_arr[src_arr == sentinel] = np.nan

--- a/xrspatial/geotiff/tests/test_vrt_mask_nodata_float_source_2158.py
+++ b/xrspatial/geotiff/tests/test_vrt_mask_nodata_float_source_2158.py
@@ -18,7 +18,6 @@ the inline masking is skipped.
 from __future__ import annotations
 
 import numpy as np
-import pytest
 
 from xrspatial.geotiff import read_vrt
 from xrspatial.geotiff._writer import write
@@ -225,3 +224,70 @@ def test_masked_vs_unmasked_differ_only_at_sentinels(tmp_path):
     # Non-sentinel pixels bit-identical between the two reads.
     np.testing.assert_array_equal(masked[~nan_positions],
                                   unmasked[~sentinel_positions])
+
+
+# ---------------------------------------------------------------------------
+# Integer source feeding a float-dataType VRT: the other branch the fix gated.
+# ---------------------------------------------------------------------------
+
+
+def _write_uint16_with_sentinel(tmp_path, sentinel=65535,
+                                 filename='uint16_2158.tif'):
+    """uint16 GeoTIFF with a matching sentinel.
+
+    Used to exercise the integer-source-feeding-float-VRT promotion at
+    ``_vrt.py:1351-1390``. With ``mask_nodata=True`` the sentinel pixel
+    surfaces as NaN in the float buffer; with ``mask_nodata=False`` the
+    literal integer value flows through the int->float cast and lands
+    as ``65535.0``.
+    """
+    band = np.array([[1, 2], [3, sentinel]], dtype=np.uint16)
+    p = str(tmp_path / filename)
+    write(band, p, nodata=sentinel, compression='none', tiled=False)
+    return p, band
+
+
+def test_int_source_float_vrt_mask_nodata_false_keeps_literal(tmp_path):
+    """Integer source feeding a Float32 VRT preserves the literal sentinel.
+
+    Pins the second branch of the inline masking that #2158 gated.
+    Before the fix, ``_vrt._read_data`` ran the int->float-with-NaN
+    promotion unconditionally, so even ``mask_nodata=False`` lost the
+    sentinel. After the fix the integer source pixel survives the
+    int->float cast as ``65535.0`` and ``masked_nodata`` reflects
+    that no masking ran.
+    """
+    src, _ = _write_uint16_with_sentinel(tmp_path)
+    vrt = _build_vrt(tmp_path, src, 'Float32', 65535,
+                     filename='int_float_2158.vrt', shape=(2, 2))
+
+    r = read_vrt(vrt, mask_nodata=False)
+
+    assert r.dtype == np.float32
+    # No NaN substitution -- the sentinel survives as a literal float.
+    assert not np.isnan(r.values).any()
+    assert r.values[1, 1] == np.float32(65535.0)
+    assert r.values[0, 0] == 1.0
+    assert r.attrs.get('nodata') == 65535.0
+    # Buffer is not NaN-aware even though dtype is float.
+    assert r.attrs.get('masked_nodata') is False
+
+
+def test_int_source_float_vrt_default_still_promotes(tmp_path):
+    """Default ``mask_nodata=True`` still NaN-masks the int->float promotion.
+
+    Baseline that documents the pre-#2158 contract for the integer
+    source path: the existing #1616 behavior is unchanged when the
+    opt-out is not requested.
+    """
+    src, _ = _write_uint16_with_sentinel(tmp_path)
+    vrt = _build_vrt(tmp_path, src, 'Float32', 65535,
+                     filename='int_float_default_2158.vrt', shape=(2, 2))
+
+    r = read_vrt(vrt)
+
+    assert r.dtype == np.float32
+    assert np.isnan(r.values[1, 1])
+    assert r.values[0, 0] == 1.0
+    assert r.attrs.get('nodata') == 65535.0
+    assert r.attrs.get('masked_nodata') is True

--- a/xrspatial/geotiff/tests/test_vrt_mask_nodata_float_source_2158.py
+++ b/xrspatial/geotiff/tests/test_vrt_mask_nodata_float_source_2158.py
@@ -1,0 +1,227 @@
+"""Regression tests for issue #2158.
+
+Before the fix, ``read_vrt(vrt, mask_nodata=False)`` silently rewrote
+float source sentinels (e.g. ``-9999.0``) to NaN inside the internal
+VRT reader (``_vrt._read_data``), so the documented opt-out only
+worked for integer sources. The public backend's ``mask_nodata=False``
+branch skipped the integer post-decode helper but never reached the
+inline float masking, which had already destroyed the literal
+sentinel pixels by the time the buffer surfaced to the public layer.
+
+The fix threads ``mask_nodata`` into the internal reader and gates
+both inline masking branches (float source NaN substitution and
+integer-source-feeding-float-VRT promotion) on the kwarg. The
+``attrs['masked_nodata']`` stamp on the eager and chunked VRT paths
+is also AND-ed with ``mask_nodata`` so the attr does not lie when
+the inline masking is skipped.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from xrspatial.geotiff import read_vrt
+from xrspatial.geotiff._writer import write
+
+
+def _write_float32_with_sentinel(tmp_path, sentinel=-9999.0,
+                                  filename='float_2158.tif'):
+    """float32 GeoTIFF with a non-NaN sentinel and matching pixels.
+
+    The middle row has a literal ``-9999.0`` so the inline masking
+    actually has something to rewrite.
+    """
+    band = np.array([[1.0, 2.0, 3.0],
+                     [4.0, sentinel, 6.0],
+                     [7.0, sentinel, 9.0]], dtype=np.float32)
+    p = str(tmp_path / filename)
+    write(band, p, nodata=sentinel, compression='none', tiled=False)
+    return p, band
+
+
+def _write_float64_with_fractional_sentinel(tmp_path, sentinel=-9999.25,
+                                             filename='float64_2158.tif'):
+    """float64 GeoTIFF with a fractional sentinel.
+
+    Float32's exact-cast rounding would clobber a fractional value
+    like ``-9999.25``; the float64 path is the only one where the
+    sentinel survives lossless.
+    """
+    band = np.array([[1.0, 2.0],
+                     [sentinel, 4.0]], dtype=np.float64)
+    p = str(tmp_path / filename)
+    write(band, p, nodata=sentinel, compression='none', tiled=False)
+    return p, band
+
+
+def _build_vrt(tmp_path, source_path, vrt_dtype, nodata_value,
+               filename='float_2158.vrt', shape=(3, 3)):
+    """Hand-roll a single-source VRT pointing at the float source."""
+    h, w = shape
+    vrt_xml = f"""<VRTDataset rasterXSize="{w}" rasterYSize="{h}">
+  <GeoTransform>0.0, 1.0, 0.0, 0.0, 0.0, -1.0</GeoTransform>
+  <VRTRasterBand dataType="{vrt_dtype}" band="1">
+    <NoDataValue>{nodata_value}</NoDataValue>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">{source_path}</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="{w}" ySize="{h}"/>
+      <DstRect xOff="0" yOff="0" xSize="{w}" ySize="{h}"/>
+    </SimpleSource>
+  </VRTRasterBand>
+</VRTDataset>"""
+    p = str(tmp_path / filename)
+    with open(p, 'w') as f:
+        f.write(vrt_xml)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Baseline: ``mask_nodata=True`` still rewrites the float sentinel.
+# ---------------------------------------------------------------------------
+
+
+def test_default_mask_nodata_true_rewrites_float_sentinel(tmp_path):
+    """The default behaviour (mask_nodata=True) still substitutes NaN.
+
+    Pins the existing contract so the fix below does not regress the
+    masking happy path.
+    """
+    src, _ = _write_float32_with_sentinel(tmp_path)
+    vrt = _build_vrt(tmp_path, src, 'Float32', -9999.0)
+
+    r = read_vrt(vrt)
+
+    assert r.dtype == np.float32
+    # The two sentinel positions in the source array are at (1, 1)
+    # and (2, 1). Both should be NaN after masking.
+    assert np.isnan(r.values[1, 1])
+    assert np.isnan(r.values[2, 1])
+    # Non-sentinel pixels untouched.
+    assert r.values[0, 0] == 1.0
+    assert r.values[1, 0] == 4.0
+    assert r.attrs.get('nodata') == -9999.0
+    assert r.attrs.get('masked_nodata') is True
+
+
+# ---------------------------------------------------------------------------
+# The fix: ``mask_nodata=False`` preserves the literal float sentinel.
+# ---------------------------------------------------------------------------
+
+
+def test_eager_mask_nodata_false_preserves_float_sentinel(tmp_path):
+    """Eager VRT path: ``mask_nodata=False`` keeps the literal sentinel.
+
+    Before #2158 this assertion failed -- the sentinel pixels were
+    silently rewritten to NaN inside ``_vrt._read_data`` regardless
+    of the kwarg.
+    """
+    src, original = _write_float32_with_sentinel(tmp_path)
+    vrt = _build_vrt(tmp_path, src, 'Float32', -9999.0)
+
+    r = read_vrt(vrt, mask_nodata=False)
+
+    assert r.dtype == np.float32
+    # No NaNs anywhere; sentinel survives as the literal float value.
+    assert not np.isnan(r.values).any()
+    assert r.values[1, 1] == np.float32(-9999.0)
+    assert r.values[2, 1] == np.float32(-9999.0)
+    # The full array round-trips exactly when the opt-out is honored.
+    np.testing.assert_array_equal(r.values, original)
+    # The declared sentinel is still surfaced for downstream maskers.
+    assert r.attrs.get('nodata') == -9999.0
+    # The buffer is not NaN-aware: ``masked_nodata`` should reflect
+    # that, not lie.
+    assert r.attrs.get('masked_nodata') is False
+
+
+def test_chunked_mask_nodata_false_preserves_float_sentinel(tmp_path):
+    """Chunked VRT path: ``mask_nodata=False`` keeps the literal sentinel.
+
+    The chunked path used to call ``_read_vrt_internal`` from
+    ``_vrt_chunk_read`` without forwarding the kwarg, so per-chunk
+    decodes silently rewrote float sentinels too. With #2158 the
+    kwarg is forwarded into the internal reader and both paths agree.
+    """
+    src, original = _write_float32_with_sentinel(tmp_path)
+    vrt = _build_vrt(tmp_path, src, 'Float32', -9999.0)
+
+    r = read_vrt(vrt, chunks=2, mask_nodata=False)
+
+    assert r.dtype == np.float32
+    computed = r.compute()
+    assert not np.isnan(computed.values).any()
+    assert computed.values[1, 1] == np.float32(-9999.0)
+    assert computed.values[2, 1] == np.float32(-9999.0)
+    np.testing.assert_array_equal(computed.values, original)
+    assert computed.attrs.get('nodata') == -9999.0
+    assert computed.attrs.get('masked_nodata') is False
+
+
+def test_eager_and_chunked_agree_under_mask_nodata_false(tmp_path):
+    """Cross-path parity: eager and chunked produce the same buffer.
+
+    Before #2158 the two paths could disagree because both rewrote
+    the sentinel inline but at slightly different points in the
+    pipeline. With the opt-out honored, both paths land on the
+    untouched source array.
+    """
+    src, _ = _write_float32_with_sentinel(tmp_path)
+    vrt = _build_vrt(tmp_path, src, 'Float32', -9999.0)
+
+    eager = read_vrt(vrt, mask_nodata=False)
+    chunked = read_vrt(vrt, chunks=2, mask_nodata=False).compute()
+
+    np.testing.assert_array_equal(eager.values, chunked.values)
+    assert eager.attrs.get('masked_nodata') == chunked.attrs.get(
+        'masked_nodata')
+
+
+# ---------------------------------------------------------------------------
+# Fractional sentinel: float64 source with a non-integer nodata.
+# ---------------------------------------------------------------------------
+
+
+def test_mask_nodata_false_float64_fractional_sentinel(tmp_path):
+    """A fractional sentinel survives the float64 opt-out path.
+
+    Float32 would round ``-9999.25`` to the nearest representable
+    value, so this corner is float64-only. With the opt-out honored
+    the pixel keeps its exact bit pattern.
+    """
+    src, original = _write_float64_with_fractional_sentinel(tmp_path)
+    vrt = _build_vrt(tmp_path, src, 'Float64', -9999.25,
+                     filename='float64_2158.vrt', shape=(2, 2))
+
+    r = read_vrt(vrt, mask_nodata=False)
+
+    assert r.dtype == np.float64
+    assert r.values[1, 0] == -9999.25
+    np.testing.assert_array_equal(r.values, original)
+
+
+# ---------------------------------------------------------------------------
+# Bit-exact equivalence: masked NaN positions match unmasked sentinel positions.
+# ---------------------------------------------------------------------------
+
+
+def test_masked_vs_unmasked_differ_only_at_sentinels(tmp_path):
+    """``mask_nodata=True`` and ``=False`` differ only where the sentinel hits.
+
+    Every pixel that is NaN in the masked output equals the declared
+    sentinel in the unmasked output, and every non-sentinel pixel is
+    bit-identical between the two reads. This pins the contract that
+    the opt-out is a pure passthrough on the non-sentinel positions.
+    """
+    src, _ = _write_float32_with_sentinel(tmp_path)
+    vrt = _build_vrt(tmp_path, src, 'Float32', -9999.0)
+
+    masked = read_vrt(vrt).values
+    unmasked = read_vrt(vrt, mask_nodata=False).values
+
+    nan_positions = np.isnan(masked)
+    sentinel_positions = unmasked == np.float32(-9999.0)
+    np.testing.assert_array_equal(nan_positions, sentinel_positions)
+    # Non-sentinel pixels bit-identical between the two reads.
+    np.testing.assert_array_equal(masked[~nan_positions],
+                                  unmasked[~sentinel_positions])


### PR DESCRIPTION
## Summary

- Thread `mask_nodata` from the public VRT backend into `_vrt.read_vrt` so the float NaN masking inside `_read_data` honors the opt-out. Gate the integer-source-feeding-float-VRT promotion on the same kwarg so a single opt-out covers every inline masking path.
- AND `attrs['masked_nodata']` with `mask_nodata` on both eager and chunked VRT paths so the attr does not lie when the inline masking is skipped.
- Add regression tests covering the eager and chunked paths, fractional float64 sentinels, and masked vs unmasked bit-equivalence on non-sentinel pixels.

Closes #2158.

## Backend coverage

- numpy eager: covered.
- dask+numpy chunked: covered.
- cupy / dask+cupy: the GPU VRT backend reuses the same internal reader through the same call site; no separate kwarg plumbing was needed.

## Test plan

- [x] New regression tests in `test_vrt_mask_nodata_float_source_2158.py` (6 tests, all pass).
- [x] Existing `test_mask_nodata_kwarg_2052.py`, `test_mask_nodata_gpu_vrt_2052.py`, `test_vrt_int_source_float_dtype_1616.py`, `test_masked_nodata_attr_2092.py` still pass.
- [x] Full `vrt or nodata` slice (990 tests) passes.