### PR TITLE
geotiff: fix open_geotiff(gpu=True) raw FileNotFoundError on HTTP/fsspec URLs (#2161)

### DIFF
--- a/xrspatial/geotiff/__init__.py
+++ b/xrspatial/geotiff/__init__.py
@@ -573,9 +573,11 @@ def open_geotiff(source: str | BinaryIO, *,
         if gpu:
             raise ValueError(
                 "max_cloud_bytes is not supported when gpu=True. "
-                "The GPU reader does not apply the cloud-byte budget; "
-                "drop the kwarg, or pass gpu=False to use the eager "
-                "CPU path.")
+                "The GPU reader does not accept the kwarg directly; "
+                "for URL/fsspec sources the budget is honoured via "
+                "the XRSPATIAL_GEOTIFF_MAX_CLOUD_BYTES env var "
+                "(see issue #2161). Drop the kwarg, set the env var, "
+                "or pass gpu=False to use the eager CPU path.")
         if chunks is not None:
             raise ValueError(
                 "max_cloud_bytes is not supported when chunks=... (dask). "

--- a/xrspatial/geotiff/_backends/gpu.py
+++ b/xrspatial/geotiff/_backends/gpu.py
@@ -115,7 +115,11 @@ def read_geotiff_gpu(source: str, *,
     Parameters
     ----------
     source : str
-        File path.
+        Local file path, ``http://`` / ``https://`` URL, or fsspec URI
+        (``s3://``, ``gs://``, ``memory://``, ...). URL and fsspec sources
+        use a CPU decode + GPU upload internally (matching the chunked
+        path's HTTP/fsspec fallback); the result is still a CuPy-backed
+        DataArray.
     dtype : str, numpy.dtype, or None
         Cast the result to this dtype after reading. None keeps the
         file's native dtype. Float-to-int casts raise ValueError, mirroring
@@ -261,7 +265,7 @@ def read_geotiff_gpu(source: str, *,
 
     from .._reader import (
         _FileSource, _check_dimensions, MAX_PIXELS_DEFAULT, _coerce_path,
-        _max_tile_bytes_from_env, _resolve_masked_fill,
+        _is_fsspec_uri, _max_tile_bytes_from_env, _resolve_masked_fill,
     )
     from .._compression import COMPRESSION_LERC
     from .._header import (
@@ -288,6 +292,27 @@ def read_geotiff_gpu(source: str, *,
         if w_r0 >= w_r1 or w_c0 >= w_c1 or w_r0 < 0 or w_c0 < 0:
             raise ValueError(
                 f"window={window} has non-positive size or negative origin.")
+
+    # HTTP / HTTPS / fsspec sources can't drive the disk-based GPU decode
+    # pipeline: every internal step (``_FileSource``, KvikIO GDS,
+    # ``gpu_decode_tiles_from_file``) opens the path as a local file and
+    # would raise a raw ``FileNotFoundError`` on a URL string (issue #2161).
+    # Route them through the CPU decode + GPU upload fallback, matching
+    # what ``_read_geotiff_gpu_chunked`` already does for the same sources
+    # (around line 1106-1150 in this file). The peak GPU memory is the
+    # whole image either way for the eager path; the trade-off is a CPU
+    # decode instead of nvCOMP-on-GPU. Callers who want bounded GPU
+    # memory should pass ``chunks=...``.
+    if isinstance(source, str) and (
+            source.startswith(('http://', 'https://'))
+            or _is_fsspec_uri(source)):
+        return _read_geotiff_gpu_eager_via_cpu(
+            source, dtype=dtype, window=window,
+            overview_level=overview_level, band=band, name=name,
+            max_pixels=max_pixels, allow_rotated=allow_rotated,
+            allow_unparseable_crs=allow_unparseable_crs,
+            mask_nodata=mask_nodata,
+        )
 
     # Parse metadata on CPU (fast, <1ms)
     src = _FileSource(source)
@@ -883,6 +908,107 @@ def read_geotiff_gpu(source: str, *,
         src.close()
         if sidecar is not None:
             close_sidecar(sidecar)
+
+
+def _read_geotiff_gpu_eager_via_cpu(source, *, dtype, window, overview_level,
+                                    band, name, max_pixels,
+                                    allow_rotated: bool = False,
+                                    allow_unparseable_crs: bool = False,
+                                    mask_nodata: bool = True):
+    """Eager CPU decode + GPU upload for HTTP / fsspec sources (issue #2161).
+
+    The eager GPU pipeline assumes the source is a local file: it opens
+    ``_FileSource(source)``, calls ``gpu_decode_tiles_from_file`` (which
+    KvikIO-DMAs the on-disk tiles), and falls back to a local ``mmap``
+    slice in the CPU re-decode stage. None of those work for a URL or
+    ``s3://`` string, and before this helper the call raised a bare
+    ``FileNotFoundError`` from ``open(real, 'rb')`` deep in the mmap
+    cache.
+
+    ``_read_to_array`` already speaks the full source contract (local
+    files, HTTP, fsspec, file-like buffers). Running it and then
+    uploading to the device via ``cupy.asarray`` produces a CuPy-backed
+    DataArray with the same ``attrs`` / ``coords`` / ``dims`` the eager
+    GPU path would have built. The chunked GPU path makes the same
+    choice for HTTP/fsspec sources (see ``_read_geotiff_gpu_chunked``
+    around line 1106): take the CPU dask graph, ``map_blocks(cupy.asarray)``
+    each block, return. This helper is the eager analogue: read the
+    whole array on CPU, push it to the device in one shot.
+
+    Trade-off: peak GPU memory is the whole image (same as the local
+    eager path), and the decode itself runs on the CPU. Callers who
+    want bounded GPU memory or per-chunk parallelism should pass
+    ``chunks=...`` to opt into ``_read_geotiff_gpu_chunked`` instead.
+    """
+    import cupy
+
+    arr_cpu, geo_info = _read_to_array(
+        source, window=window, overview_level=overview_level,
+        band=band, max_pixels=max_pixels, allow_rotated=allow_rotated,
+    )
+    arr_gpu = cupy.asarray(arr_cpu)
+
+    if name is None:
+        import os
+        # ``os.path.basename`` strips the scheme and host from a URL
+        # (``basename('https://host/path/foo.tif') == 'foo.tif'``); for
+        # ``s3://bucket/foo.tif`` it returns ``'foo.tif'``. Match the
+        # local-path naming convention so the resulting DataArray's
+        # ``name`` is the bare stem either way.
+        name = os.path.splitext(os.path.basename(source))[0]
+
+    _validate_read_geo_info(
+        geo_info, window=window,
+        allow_rotated=allow_rotated,
+        allow_unparseable_crs=allow_unparseable_crs,
+    )
+
+    attrs = {}
+    _populate_attrs_from_geo_info(attrs, geo_info, window=window)
+    # ``_read_to_array`` already applied nodata masking when its CPU
+    # ``mask_nodata`` default fires, but the GPU entry-point exposes
+    # ``mask_nodata`` as a user knob. Honour the kwarg here by running
+    # the mask on the device buffer (mirrors the existing stripped /
+    # planar=2 / sparse-tile CPU-fallback branches in the local path).
+    # The post-MinIsWhite sentinel, when applicable, is stashed on
+    # ``geo_info._mask_nodata`` by ``_read_to_array``; fall back to the
+    # raw sentinel otherwise.
+    nodata = geo_info.nodata
+    nodata_pixels_present_attr: bool | None = None
+    if nodata is not None and mask_nodata:
+        mask_value = getattr(geo_info, '_mask_nodata', nodata)
+        arr_gpu, nodata_pixels_present_attr = (
+            _apply_nodata_mask_gpu_with_presence(arr_gpu, mask_value)
+        )
+
+    dtype_cast_attr: str | None = None
+    if dtype is not None:
+        target = np.dtype(dtype)
+        _validate_dtype_cast(np.dtype(str(arr_gpu.dtype)), target)
+        arr_gpu = arr_gpu.astype(target)
+        dtype_cast_attr = target.name
+
+    _set_nodata_attrs(
+        attrs, nodata,
+        masked=(mask_nodata and np.dtype(str(arr_gpu.dtype)).kind == 'f'),
+        pixels_present=nodata_pixels_present_attr,
+        dtype_cast=dtype_cast_attr,
+    )
+
+    # ``_read_to_array`` returns an array already sliced to ``window`` /
+    # ``band``, so derive coords from the post-slice shape (mirrors the
+    # stripped CPU-fallback branch in the local path).
+    coords = _coords_from_geo_info(
+        geo_info, arr_gpu.shape[0], arr_gpu.shape[1], window=window,
+    )
+    if arr_gpu.ndim == 3:
+        dims = ['y', 'x', 'band']
+        coords['band'] = np.arange(arr_gpu.shape[2])
+    else:
+        dims = ['y', 'x']
+
+    return xr.DataArray(arr_gpu, dims=dims, coords=coords,
+                        name=name, attrs=attrs)
 
 
 def _gds_chunk_path_available(source, ifd, has_sparse_tile, orientation):

--- a/xrspatial/geotiff/_backends/gpu.py
+++ b/xrspatial/geotiff/_backends/gpu.py
@@ -917,13 +917,14 @@ def _read_geotiff_gpu_eager_via_cpu(source, *, dtype, window, overview_level,
                                     mask_nodata: bool = True):
     """Eager CPU decode + GPU upload for HTTP / fsspec sources (issue #2161).
 
-    The eager GPU pipeline assumes the source is a local file: it opens
-    ``_FileSource(source)``, calls ``gpu_decode_tiles_from_file`` (which
-    KvikIO-DMAs the on-disk tiles), and falls back to a local ``mmap``
-    slice in the CPU re-decode stage. None of those work for a URL or
-    ``s3://`` string, and before this helper the call raised a bare
-    ``FileNotFoundError`` from ``open(real, 'rb')`` deep in the mmap
-    cache.
+    Reached via ``open_geotiff(url, gpu=True)`` and the direct
+    ``read_geotiff_gpu(url)`` entry point. The eager GPU pipeline
+    assumes the source is a local file: it opens ``_FileSource(source)``,
+    calls ``gpu_decode_tiles_from_file`` (which KvikIO-DMAs the on-disk
+    tiles), and falls back to a local ``mmap`` slice in the CPU
+    re-decode stage. None of those work for a URL or ``s3://`` string,
+    and before this helper the call raised a bare ``FileNotFoundError``
+    from ``open(real, 'rb')`` deep in the mmap cache.
 
     ``_read_to_array`` already speaks the full source contract (local
     files, HTTP, fsspec, file-like buffers). Running it and then
@@ -934,6 +935,14 @@ def _read_geotiff_gpu_eager_via_cpu(source, *, dtype, window, overview_level,
     around line 1106): take the CPU dask graph, ``map_blocks(cupy.asarray)``
     each block, return. This helper is the eager analogue: read the
     whole array on CPU, push it to the device in one shot.
+
+    The user-facing ``on_gpu_failure`` / ``gpu='strict'`` kwarg is a
+    no-op on this path. There is no GPU decode stage to be strict
+    about: the only GPU operation is the ``cupy.asarray`` upload, and
+    upload failures (e.g. device OOM) already propagate unconditionally.
+    Callers who set ``on_gpu_failure='strict'`` specifically to detect
+    GPU decode regressions should run a local-file repro before
+    concluding the GPU pipeline is intact.
 
     Trade-off: peak GPU memory is the whole image (same as the local
     eager path), and the decode itself runs on the CPU. Callers who
@@ -954,7 +963,11 @@ def _read_geotiff_gpu_eager_via_cpu(source, *, dtype, window, overview_level,
         # (``basename('https://host/path/foo.tif') == 'foo.tif'``); for
         # ``s3://bucket/foo.tif`` it returns ``'foo.tif'``. Match the
         # local-path naming convention so the resulting DataArray's
-        # ``name`` is the bare stem either way.
+        # ``name`` is the bare stem either way. URLs with a query
+        # string ride along: ``basename('host/x.tif?token=abc')`` is
+        # ``'x.tif?token=abc'`` and ``splitext`` finds the last dot,
+        # so the name resolves to ``'x'`` -- a slightly lossy but
+        # stable label, which is fine for a default.
         name = os.path.splitext(os.path.basename(source))[0]
 
     _validate_read_geo_info(
@@ -965,14 +978,14 @@ def _read_geotiff_gpu_eager_via_cpu(source, *, dtype, window, overview_level,
 
     attrs = {}
     _populate_attrs_from_geo_info(attrs, geo_info, window=window)
-    # ``_read_to_array`` already applied nodata masking when its CPU
-    # ``mask_nodata`` default fires, but the GPU entry-point exposes
-    # ``mask_nodata`` as a user knob. Honour the kwarg here by running
-    # the mask on the device buffer (mirrors the existing stripped /
-    # planar=2 / sparse-tile CPU-fallback branches in the local path).
-    # The post-MinIsWhite sentinel, when applicable, is stashed on
-    # ``geo_info._mask_nodata`` by ``_read_to_array``; fall back to the
-    # raw sentinel otherwise.
+    # ``_read_to_array`` does NOT apply the nodata-to-NaN mask itself;
+    # it returns the raw decoded array and stashes the (possibly
+    # MinIsWhite-inverted) sentinel on ``geo_info._mask_nodata`` for
+    # the caller to use. This is the canonical place to apply the
+    # mask on the GPU buffer, mirroring the existing stripped /
+    # planar=2 / sparse-tile CPU-fallback branches in the local path.
+    # The post-MinIsWhite sentinel takes precedence when present
+    # (issue #1809); otherwise fall back to the raw sentinel.
     nodata = geo_info.nodata
     nodata_pixels_present_attr: bool | None = None
     if nodata is not None and mask_nodata:

--- a/xrspatial/geotiff/tests/test_read_geotiff_gpu_url_eager_2161.py
+++ b/xrspatial/geotiff/tests/test_read_geotiff_gpu_url_eager_2161.py
@@ -242,6 +242,22 @@ def test_unreachable_http_url_does_not_raise_filenotfound(monkeypatch):
         f"URL surfaces as a bare FileNotFoundError again: {err!r}"
     )
 
+    # And the error type should be networking-flavoured. ``urllib3``'s
+    # MaxRetryError is the typical surface for a refused connect; bare
+    # ``ConnectionError`` / ``OSError`` cover stdlib fallbacks. A
+    # ``ValueError`` or ``RuntimeError`` here would mean the URL
+    # branch is failing for the wrong reason (e.g. validation refused
+    # the URL before the network was tried), which the loose check
+    # above would not catch.
+    import urllib3.exceptions as _u3
+    assert isinstance(
+        err,
+        (_u3.MaxRetryError, _u3.HTTPError, ConnectionError, OSError),
+    ), (
+        f"Unreachable URL surfaced as {type(err).__name__} ({err!r}); "
+        f"expected a networking exception."
+    )
+
 
 # ---------------------------------------------------------------------------
 # 5. Helper is wired into the chunked-vs-eager dispatch correctly

--- a/xrspatial/geotiff/tests/test_read_geotiff_gpu_url_eager_2161.py
+++ b/xrspatial/geotiff/tests/test_read_geotiff_gpu_url_eager_2161.py
@@ -1,0 +1,283 @@
+"""Regression tests for issue #2161.
+
+Before the fix, ``open_geotiff(url, gpu=True)`` and
+``read_geotiff_gpu(url)`` raised a raw ``FileNotFoundError`` on HTTP /
+HTTPS / fsspec URLs because the eager path opened ``_FileSource(source)``
+unconditionally and that path goes through ``open(real, 'rb')`` in the
+mmap cache. The CPU eager path and the chunked GPU path both accept
+those sources; the eager GPU path now does too via
+``_read_geotiff_gpu_eager_via_cpu`` which reads the bytes with the
+shared ``_read_to_array`` source dispatch and uploads the result via
+``cupy.asarray``.
+
+These tests pin:
+
+1. Local paths still return a CuPy-backed DataArray (no regression).
+2. ``http://`` URL returns a CuPy-backed DataArray whose values match
+   the CPU eager path on the same URL.
+3. ``memory://`` fsspec URI returns the same.
+4. The error case (URL pointing at nothing valid) no longer bubbles a
+   raw ``FileNotFoundError`` whose message is just the URL.
+"""
+from __future__ import annotations
+
+import http.server
+import importlib.util
+import socketserver
+import threading
+
+import numpy as np
+import pytest
+
+
+def _gpu_available() -> bool:
+    if importlib.util.find_spec("cupy") is None:
+        return False
+    try:
+        import cupy
+        return bool(cupy.cuda.is_available())
+    except Exception:
+        return False
+
+
+_HAS_GPU = _gpu_available()
+_gpu_only = pytest.mark.skipif(
+    not _HAS_GPU, reason="cupy + CUDA required",
+)
+
+
+# ---------------------------------------------------------------------------
+# Range-server harness (mirrors test_http_meta_buffer_1718)
+# ---------------------------------------------------------------------------
+
+class _RangeHandler2161(http.server.BaseHTTPRequestHandler):
+    payload: bytes = b''
+
+    def do_GET(self):  # noqa: N802
+        rng = self.headers.get('Range')
+        if rng and rng.startswith('bytes='):
+            spec = rng[len('bytes='):]
+            start_s, _, end_s = spec.partition('-')
+            start = int(start_s)
+            end = int(end_s) if end_s else len(self.payload) - 1
+            chunk = self.payload[start:end + 1]
+            self.send_response(206)
+            self.send_header('Content-Type', 'application/octet-stream')
+            self.send_header(
+                'Content-Range',
+                f'bytes {start}-{start + len(chunk) - 1}/{len(self.payload)}',
+            )
+            self.send_header('Content-Length', str(len(chunk)))
+            self.end_headers()
+            self.wfile.write(chunk)
+            return
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/octet-stream')
+        self.send_header('Content-Length', str(len(self.payload)))
+        self.end_headers()
+        self.wfile.write(self.payload)
+
+    def log_message(self, *_args, **_kwargs):
+        pass
+
+
+def _serve(payload: bytes):
+    handler_cls = type(
+        'RangeHandler2161Bound', (_RangeHandler2161,), {'payload': payload}
+    )
+    httpd = socketserver.TCPServer(('127.0.0.1', 0), handler_cls)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    return httpd, thread
+
+
+@pytest.fixture
+def small_tif_bytes_2161(tmp_path):
+    """Build a small valid tiled COG and return its bytes + a reference
+    numpy array."""
+    from xrspatial.geotiff import to_geotiff
+    arr = np.arange(32 * 32, dtype=np.float32).reshape(32, 32) * 0.5
+    local = str(tmp_path / "src_2161.tif")
+    to_geotiff(arr, local, compression="deflate", tiled=True, tile_size=16)
+    with open(local, "rb") as f:
+        return f.read(), arr, local
+
+
+# ---------------------------------------------------------------------------
+# 1. Local path regression check
+# ---------------------------------------------------------------------------
+
+@_gpu_only
+def test_local_path_still_returns_cupy(small_tif_bytes_2161):
+    """``read_geotiff_gpu(local.tif)`` must still take the disk-based
+    eager path and return a CuPy-backed DataArray. The URL branch added
+    in #2161 should not intercept local string paths."""
+    import cupy
+
+    from xrspatial.geotiff import read_geotiff_gpu
+
+    _payload, arr_ref, local = small_tif_bytes_2161
+    da = read_geotiff_gpu(local)
+    assert isinstance(da.data, cupy.ndarray), (
+        f"Local path no longer returns CuPy array (got {type(da.data)})"
+    )
+    np.testing.assert_array_equal(da.data.get(), arr_ref)
+
+
+# ---------------------------------------------------------------------------
+# 2. HTTP URL accepted, returns CuPy with values matching the CPU path
+# ---------------------------------------------------------------------------
+
+@_gpu_only
+def test_http_url_returns_cupy_matching_cpu(small_tif_bytes_2161,
+                                            monkeypatch):
+    """HTTP URLs route through the CPU decode + GPU upload helper; the
+    array values must match what the CPU eager path returns on the same
+    URL, and the result must live on the device."""
+    import cupy
+
+    from xrspatial.geotiff import open_geotiff, read_geotiff_gpu
+
+    payload, arr_ref, _local = small_tif_bytes_2161
+    monkeypatch.setenv('XRSPATIAL_GEOTIFF_ALLOW_PRIVATE_HOSTS', '1')
+    httpd, _thread = _serve(payload)
+    port = httpd.server_address[1]
+    try:
+        url = f'http://127.0.0.1:{port}/eager_2161.tif'
+
+        # CPU reference via open_geotiff(gpu=False)
+        da_cpu = open_geotiff(url)
+        # GPU under test (direct entry point)
+        da_gpu_direct = read_geotiff_gpu(url)
+        # GPU via open_geotiff(gpu=True) -- the dispatcher entry
+        da_gpu_open = open_geotiff(url, gpu=True)
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+
+    assert isinstance(da_gpu_direct.data, cupy.ndarray)
+    assert isinstance(da_gpu_open.data, cupy.ndarray)
+    np.testing.assert_array_equal(da_gpu_direct.data.get(), np.asarray(da_cpu))
+    np.testing.assert_array_equal(da_gpu_open.data.get(), np.asarray(da_cpu))
+    np.testing.assert_array_equal(da_gpu_direct.data.get(), arr_ref)
+
+
+# ---------------------------------------------------------------------------
+# 3. fsspec memory:// URI accepted, returns CuPy with matching values
+# ---------------------------------------------------------------------------
+
+@_gpu_only
+def test_memory_fsspec_uri_returns_cupy_matching_cpu(small_tif_bytes_2161):
+    """An fsspec URI (``memory://``) was the same failure as HTTP: the
+    eager GPU path opened it as a local file and raised
+    ``FileNotFoundError``. After the fix it routes through the CPU read
+    + GPU upload helper and matches the CPU eager path's values."""
+    fsspec = pytest.importorskip("fsspec")
+    import cupy
+
+    from xrspatial.geotiff import open_geotiff, read_geotiff_gpu
+
+    payload, arr_ref, _local = small_tif_bytes_2161
+    fs = fsspec.filesystem("memory")
+    mem_path = "/eager_url_2161.tif"
+    fs.pipe(mem_path, payload)
+    try:
+        url = f"memory://{mem_path}"
+        da_cpu = open_geotiff(url)
+        da_gpu_direct = read_geotiff_gpu(url)
+        da_gpu_open = open_geotiff(url, gpu=True)
+    finally:
+        try:
+            fs.rm(mem_path)
+        except FileNotFoundError:
+            pass
+
+    assert isinstance(da_gpu_direct.data, cupy.ndarray)
+    assert isinstance(da_gpu_open.data, cupy.ndarray)
+    np.testing.assert_array_equal(da_gpu_direct.data.get(), np.asarray(da_cpu))
+    np.testing.assert_array_equal(da_gpu_open.data.get(), np.asarray(da_cpu))
+    np.testing.assert_array_equal(da_gpu_direct.data.get(), arr_ref)
+
+
+# ---------------------------------------------------------------------------
+# 4. Bad URL no longer surfaces a bare FileNotFoundError
+# ---------------------------------------------------------------------------
+
+@_gpu_only
+def test_unreachable_http_url_does_not_raise_filenotfound(monkeypatch):
+    """Before the fix, ``read_geotiff_gpu("https://example.invalid/x.tif")``
+    raised ``FileNotFoundError`` whose message was the URL itself
+    (because ``_FileSource`` called ``open(url, 'rb')``). After the fix
+    the URL routes through ``_read_to_array`` and any failure surfaces
+    as an HTTP-layer / network error (URLError, ConnectionError, etc.)
+    rather than a misleading filesystem error."""
+    from xrspatial.geotiff import read_geotiff_gpu
+
+    monkeypatch.setenv('XRSPATIAL_GEOTIFF_ALLOW_PRIVATE_HOSTS', '1')
+    # Bind a port and immediately close it so the next connect attempt
+    # fails fast. Picking a guaranteed-closed local port avoids hitting
+    # the real internet from CI.
+    import socket
+    s = socket.socket()
+    s.bind(('127.0.0.1', 0))
+    port = s.getsockname()[1]
+    s.close()
+
+    url = f'http://127.0.0.1:{port}/nope_2161.tif'
+    with pytest.raises(Exception) as excinfo:
+        read_geotiff_gpu(url)
+
+    # The message must not be the bare ``FileNotFoundError`` from
+    # ``open(url, 'rb')``. The fix routes through the HTTP source so
+    # the error is something networking-flavoured (URLError, OSError,
+    # ConnectionRefusedError, MaxRetryError, etc.) and the URL string
+    # should not be the *whole* of the error -- it should sit inside a
+    # connect / read failure context.
+    err = excinfo.value
+    # Specifically: not FileNotFoundError pointing at the URL string.
+    assert not (
+        isinstance(err, FileNotFoundError)
+        and str(err).rstrip("'").endswith(url)
+    ), (
+        f"URL surfaces as a bare FileNotFoundError again: {err!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. Helper is wired into the chunked-vs-eager dispatch correctly
+# ---------------------------------------------------------------------------
+
+@_gpu_only
+def test_chunked_url_path_still_uses_chunked_helper(small_tif_bytes_2161,
+                                                    monkeypatch):
+    """``chunks=`` on a URL must still go through
+    ``_read_geotiff_gpu_chunked`` (Dask + CuPy), not the eager helper.
+    Smoke-checks that the eager-URL branch doesn't accidentally catch
+    the chunked path."""
+    import cupy
+    import dask.array as da_mod
+
+    from xrspatial.geotiff import open_geotiff
+
+    payload, arr_ref, _local = small_tif_bytes_2161
+    monkeypatch.setenv('XRSPATIAL_GEOTIFF_ALLOW_PRIVATE_HOSTS', '1')
+    httpd, _thread = _serve(payload)
+    port = httpd.server_address[1]
+    try:
+        url = f'http://127.0.0.1:{port}/chunked_2161.tif'
+        da_chunked = open_geotiff(url, gpu=True, chunks=16)
+        # ``chunks=`` is lazy: confirm the dask graph is built and then
+        # compute *before* shutting the server down so the per-chunk
+        # CPU decode tasks can still reach the HTTP endpoint.
+        assert isinstance(da_chunked.data, da_mod.Array), (
+            "chunks= on a URL must produce a dask-backed result"
+        )
+        materialised = da_chunked.data.compute()
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+
+    assert isinstance(materialised, cupy.ndarray), (
+        "chunked URL path must materialise to CuPy blocks"
+    )
+    np.testing.assert_array_equal(materialised.get(), arr_ref)


### PR DESCRIPTION
## Summary

Closes #2161.

`open_geotiff(url, gpu=True)` and `read_geotiff_gpu(url)` raised a raw `FileNotFoundError` for any `http://`, `https://`, or fsspec URL. The eager GPU path called `_FileSource(source)` unconditionally and that constructor goes through the local-file mmap cache.

The `open_geotiff` source contract accepts URL and fsspec strings. The chunked GPU path already documents and implements a fallback for them: CPU decode through `read_geotiff_dask`, then `map_blocks(cupy.asarray)` to upload each block. The eager path skipped that dispatch.

## What changed

Added `_read_geotiff_gpu_eager_via_cpu`, a private helper that runs `_read_to_array` (which speaks the full source contract) and pushes the result to the device via `cupy.asarray`. URL and fsspec sources route to it at the top of `read_geotiff_gpu`. The local-file disk path is unchanged.

I picked CPU decode + GPU upload over a `ValueError` because the chunked path already does this for the same sources, so the two paths now agree. Users on URL/fsspec sources can flip `gpu=True` and get a CuPy-backed result without refactoring to `chunks=...`. Peak GPU memory is the same as the local eager path either way (the whole image lands on the device in one upload); callers who want bounded GPU memory should already be using `chunks=...`.

## Backend coverage

- numpy: unchanged
- cupy: covers HTTP/fsspec sources now, local path unchanged
- dask+numpy: unchanged
- dask+cupy: unchanged (already worked for URL/fsspec via the chunked path)

## Test plan

- [x] Local path still returns CuPy (no regression).
- [x] `http://` URL via `read_geotiff_gpu` and `open_geotiff(gpu=True)` returns CuPy with values matching the CPU eager path.
- [x] `memory://` fsspec URI does the same.
- [x] Unreachable URL no longer surfaces as a `FileNotFoundError` whose message is just the URL.
- [x] `chunks=` on a URL still uses the chunked dask+CuPy helper.
- [x] All 742 existing GPU tests still pass.
