### PR TITLE
rasterize: reject non-uniformly spaced like grids (#2168)

### DIFF
--- a/xrspatial/rasterize.py
+++ b/xrspatial/rasterize.py
@@ -1924,6 +1924,42 @@ def _parse_input(geometries, column=None, columns=None):
     return geom_list, props_array, None
 
 
+def _check_uniform_axis(axis_name, coords, expected_step):
+    """Raise ``ValueError`` if ``coords`` is not uniformly spaced.
+
+    ``coords`` is a 1-D float64 array of dim-coord values for the named
+    axis (``'x'`` or ``'y'``).  ``expected_step`` is the magnitude of the
+    first interval (already computed by the caller).  Axes with fewer
+    than three points cannot be non-uniform in a way this check would
+    catch, so they pass trivially.
+
+    The comparison is on ``abs(diff)`` so the validation does not care
+    whether the axis is ascending or descending -- a sibling change is
+    expected to allow ascending-y ``like`` inputs, and gating on the
+    sign here would block that work.  ``np.allclose`` is used (rather
+    than strict equality) because affine-transform-derived coords drift
+    by a few ulps in practice.
+    """
+    if coords.size < 3:
+        return
+
+    diffs = np.abs(np.diff(coords))
+    if expected_step == 0 or not np.isfinite(expected_step):
+        # Degenerate step: defer to downstream code so the error path
+        # here doesn't mask a different underlying problem.
+        return
+
+    if not np.allclose(diffs, expected_step, rtol=1e-5, atol=1e-8):
+        max_dev = float(np.max(np.abs(diffs - expected_step)))
+        raise ValueError(
+            "'like' DataArray has non-uniform spacing along the "
+            f"{axis_name!r} axis (expected step {expected_step}, "
+            f"largest deviation {max_dev}). rasterize() requires a "
+            "regular grid; resample 'like' to a uniform grid before "
+            "passing it."
+        )
+
+
 def _extract_grid_from_like(like):
     """Extract width, height, bounds, dtype from a template DataArray.
 
@@ -1953,6 +1989,21 @@ def _extract_grid_from_like(like):
         py = abs(float(y[0] - y[1]))
     else:
         py = 1.0
+
+    # The rasterizer assumes a uniform grid.  If ``like`` has non-uniform
+    # spacing on either axis, ``px``/``py`` (taken from the first interval)
+    # will not describe the rest of the grid, and reusing ``like.coords``
+    # on the output (see ``rasterize`` below) would mislabel where each
+    # pixel lives.  Validate uniform spacing here so the rasterizer never
+    # produces a DataArray whose coords disagree with its data layout.
+    #
+    # Compare ``abs(diff)`` against the first interval so the check stays
+    # agnostic to axis direction -- ascending or descending y both pass as
+    # long as the spacing is uniform.  Use ``np.allclose`` rather than
+    # strict equality because affine-transform-derived coords drift by a
+    # few ulps.
+    _check_uniform_axis('x', x, px)
+    _check_uniform_axis('y', y, py)
 
     xmin = float(np.min(x)) - px / 2
     xmax = float(np.max(x)) + px / 2
@@ -2051,6 +2102,10 @@ def rasterize(
     like : xr.DataArray, optional
         Template raster.  Width, height, bounds, and dtype are copied
         from this array (any can still be overridden explicitly).
+        Must have uniformly spaced ``x`` and ``y`` dim coords -- the
+        rasterizer only writes to a regular grid, so a non-uniform
+        ``like`` is rejected with ``ValueError`` rather than silently
+        producing pixel labels that don't match the data.
     merge : str or callable, default 'last'
         How to combine values when geometries overlap.
 

--- a/xrspatial/rasterize.py
+++ b/xrspatial/rasterize.py
@@ -1943,20 +1943,35 @@ def _check_uniform_axis(axis_name, coords, expected_step):
     if coords.size < 3:
         return
 
-    diffs = np.abs(np.diff(coords))
-    if expected_step == 0 or not np.isfinite(expected_step):
-        # Degenerate step: defer to downstream code so the error path
-        # here doesn't mask a different underlying problem.
+    # A non-finite ``expected_step`` (NaN / inf) is a separate kind of
+    # broken; let the downstream rasterizer surface that rather than
+    # masking it with a misleading "non-uniform spacing" message here.
+    if not np.isfinite(expected_step):
         return
 
+    # An all-equal coord vector gives expected_step==0 and diffs all
+    # zero; allclose would pass and the rasterizer would later trip on
+    # a zero-sized pixel.  Reject up front with the same "non-uniform"
+    # framing so users get one diagnostic, not two.
+    if expected_step == 0:
+        raise ValueError(
+            f"'like' DataArray has zero-width pixels along the "
+            f"{axis_name!r} axis (consecutive coords are equal). "
+            "rasterize() requires a regular grid with non-zero "
+            "spacing; resample 'like' to a uniform grid (e.g. with "
+            "xarray's ``interp`` or ``reindex``) before passing it."
+        )
+
+    diffs = np.abs(np.diff(coords))
     if not np.allclose(diffs, expected_step, rtol=1e-5, atol=1e-8):
         max_dev = float(np.max(np.abs(diffs - expected_step)))
         raise ValueError(
             "'like' DataArray has non-uniform spacing along the "
             f"{axis_name!r} axis (expected step {expected_step}, "
             f"largest deviation {max_dev}). rasterize() requires a "
-            "regular grid; resample 'like' to a uniform grid before "
-            "passing it."
+            "regular grid; resample 'like' to a uniform grid (e.g. "
+            "with xarray's ``interp`` or ``reindex``) before passing "
+            "it."
         )
 
 

--- a/xrspatial/tests/test_rasterize.py
+++ b/xrspatial/tests/test_rasterize.py
@@ -2150,6 +2150,8 @@ class TestLikeUniformGridValidation:
             result.coords['y'].values, y_2168)
 
     def test_error_message_names_axis_and_deviation(self):
+        import re
+
         x_2168 = np.array([0.0, 1.0, 2.5, 3.5])
         y_2168 = np.array([3.0, 2.0, 1.0, 0.0])
         like_2168 = xr.DataArray(
@@ -2165,9 +2167,29 @@ class TestLikeUniformGridValidation:
         msg = str(excinfo.value)
         assert "'x'" in msg
         assert "non-uniform" in msg.lower()
-        # The largest deviation should be reported numerically; the
-        # diffs are [1.0, 1.5, 1.0], so deviation from expected 1.0 is 0.5.
-        assert "0.5" in msg
+        # The largest deviation should be reported numerically.  Match
+        # any reasonable float formatting (0.5, 5e-1, 0.5000...) rather
+        # than coupling to ``repr(0.5)``.
+        m = re.search(r"largest deviation\s+([\d.eE+-]+)", msg)
+        assert m is not None, msg
+        assert float(m.group(1)) == pytest.approx(0.5, rel=1e-6)
+
+    def test_zero_step_like_raises(self):
+        # All-equal x coords are a degenerate "grid".  The validator
+        # should reject this up front rather than letting a zero-width
+        # pixel reach the rasterizer.
+        x_2168 = np.array([1.0, 1.0, 1.0, 1.0])  # zero-width pixels
+        y_2168 = np.linspace(3.0, 0.0, 4)
+        like_2168 = xr.DataArray(
+            np.zeros((4, 4)),
+            dims=('y', 'x'),
+            coords={'y': y_2168, 'x': x_2168},
+        )
+        with pytest.raises(ValueError, match=r"'x'"):
+            rasterize(
+                [(box(0, 0, 3.5, 3.0), 1.0)],
+                like=like_2168, fill=0,
+            )
 
     def test_tiny_float_drift_is_tolerated(self):
         # Affine-transform-derived coords drift by a few ulps; ensure

--- a/xrspatial/tests/test_rasterize.py
+++ b/xrspatial/tests/test_rasterize.py
@@ -2085,3 +2085,121 @@ class TestPolysToWkb:
         assert len(restored) == len(geoms)
         for original, copy in zip(geoms, restored):
             assert original.equals(copy)
+
+
+# ---------------------------------------------------------------------------
+# Issue #2168: reject non-uniformly spaced `like` grids
+# ---------------------------------------------------------------------------
+
+class TestLikeUniformGridValidation:
+    """The rasterizer only supports uniform grids.  If ``like`` has
+    non-uniform x or y spacing the previous code silently produced an
+    output whose coords disagreed with where pixels actually landed.
+    The fix raises a clear ValueError naming the offending axis.
+    """
+
+    def test_non_uniform_x_raises(self):
+        # Deliberately non-uniform x spacing: 0->1->2.5->3.5
+        x_2168 = np.array([0.0, 1.0, 2.5, 3.5])
+        y_2168 = np.array([3.0, 2.0, 1.0, 0.0])
+        like_2168 = xr.DataArray(
+            np.zeros((4, 4)),
+            dims=('y', 'x'),
+            coords={'y': y_2168, 'x': x_2168},
+        )
+        with pytest.raises(ValueError, match=r"'x'"):
+            rasterize(
+                [(box(0, 0, 3.5, 3.0), 1.0)],
+                like=like_2168, fill=0,
+            )
+
+    def test_non_uniform_y_raises(self):
+        # Uniform x, non-uniform y
+        x_2168 = np.array([0.5, 1.5, 2.5, 3.5])
+        y_2168 = np.array([3.0, 2.0, 0.5, 0.0])  # not evenly spaced
+        like_2168 = xr.DataArray(
+            np.zeros((4, 4)),
+            dims=('y', 'x'),
+            coords={'y': y_2168, 'x': x_2168},
+        )
+        with pytest.raises(ValueError, match=r"'y'"):
+            rasterize(
+                [(box(0, 0, 3.5, 3.0), 1.0)],
+                like=like_2168, fill=0,
+            )
+
+    def test_uniform_like_still_works(self):
+        # The existing happy path: a uniformly-spaced like still passes
+        # and burns the geometry in.
+        x_2168 = np.linspace(0.5, 9.5, 10)
+        y_2168 = np.linspace(9.5, 0.5, 10)
+        like_2168 = xr.DataArray(
+            np.zeros((10, 10)),
+            dims=('y', 'x'),
+            coords={'y': y_2168, 'x': x_2168},
+        )
+        result = rasterize(
+            [(box(2, 2, 8, 8), 1.0)],
+            like=like_2168, fill=0,
+        )
+        assert np.any(result.values == 1.0)
+        # Coords are reused bit-identically on the happy path.
+        np.testing.assert_array_equal(
+            result.coords['x'].values, x_2168)
+        np.testing.assert_array_equal(
+            result.coords['y'].values, y_2168)
+
+    def test_error_message_names_axis_and_deviation(self):
+        x_2168 = np.array([0.0, 1.0, 2.5, 3.5])
+        y_2168 = np.array([3.0, 2.0, 1.0, 0.0])
+        like_2168 = xr.DataArray(
+            np.zeros((4, 4)),
+            dims=('y', 'x'),
+            coords={'y': y_2168, 'x': x_2168},
+        )
+        with pytest.raises(ValueError) as excinfo:
+            rasterize(
+                [(box(0, 0, 3.5, 3.0), 1.0)],
+                like=like_2168, fill=0,
+            )
+        msg = str(excinfo.value)
+        assert "'x'" in msg
+        assert "non-uniform" in msg.lower()
+        # The largest deviation should be reported numerically; the
+        # diffs are [1.0, 1.5, 1.0], so deviation from expected 1.0 is 0.5.
+        assert "0.5" in msg
+
+    def test_tiny_float_drift_is_tolerated(self):
+        # Affine-transform-derived coords drift by a few ulps; ensure
+        # the check uses a tolerance rather than strict equality.
+        base = np.linspace(0.5, 9.5, 10)
+        x_2168 = base.copy()
+        x_2168[5] += 1e-12  # well below np.allclose's rtol
+        y_2168 = np.linspace(9.5, 0.5, 10)
+        like_2168 = xr.DataArray(
+            np.zeros((10, 10)),
+            dims=('y', 'x'),
+            coords={'y': y_2168, 'x': x_2168},
+        )
+        # Should not raise.
+        result = rasterize(
+            [(box(2, 2, 8, 8), 1.0)],
+            like=like_2168, fill=0,
+        )
+        assert result.shape == (10, 10)
+
+    def test_single_row_or_column_like_passes(self):
+        # Width == 1: only one x cell, cannot be non-uniform.  The
+        # validation needs to short-circuit rather than divide by zero.
+        x_2168 = np.array([0.5])
+        y_2168 = np.linspace(9.5, 0.5, 10)
+        like_2168 = xr.DataArray(
+            np.zeros((10, 1)),
+            dims=('y', 'x'),
+            coords={'y': y_2168, 'x': x_2168},
+        )
+        # Should not raise on x; y is uniform.
+        rasterize(
+            [(box(0, 0, 1, 10), 1.0)],
+            like=like_2168, fill=0,
+        )


### PR DESCRIPTION
Closes #2168.

## Summary

- `_extract_grid_from_like()` now validates that the `like` DataArray's `x` and `y` coords are uniformly spaced before the rasterizer commits to a single `px`/`py`.
- If either axis is non-uniform (beyond `np.allclose`'s default tolerance), `rasterize(..., like=...)` raises `ValueError` naming the axis and the largest deviation.
- The check works on `abs(diff)` so it stays direction-agnostic, leaving room for the sibling ascending-y support without conflict.
- Docstring updated to call out the uniform-grid requirement on `like=`.

## Backend coverage

The validation runs in the shared `_extract_grid_from_like()` helper. Every entry point (numpy, cupy, dask+numpy, dask+cupy) calls into it, so all four backends get the same rejection behaviour.

## Test plan

- [x] New tests in `xrspatial/tests/test_rasterize.py::TestLikeUniformGridValidation` cover non-uniform x, non-uniform y, the uniform happy path, error message contents, ulp-level float drift tolerance, and a 1-cell-wide degenerate axis.
- [x] Full rasterize test suite (`test_rasterize*.py`) is green: 281 passed, 2 skipped.