### PR TITLE
polygonize: tolerate near-equal floats in Dask chunk-stitching (#2171)

### DIFF
--- a/xrspatial/polygonize.py
+++ b/xrspatial/polygonize.py
@@ -247,6 +247,37 @@ def _is_close(
             abs(value - reference) <= (atol + rtol*abs(reference))
 
 
+# Pure-Python tolerance check that mirrors ``_is_close`` for use at the
+# orchestration layer (outside numba kernels).  Integer values fall back
+# to exact equality; floats use the same atol=1e-8, rtol=1e-5 tolerance
+# the CPU CCL uses to merge adjacent pixels.  See issue #2171.
+def _values_close(reference, value):
+    if isinstance(reference, (int, np.integer)) and \
+            isinstance(value, (int, np.integer)):
+        return value == reference
+    return abs(value - reference) <= (1e-8 + 1e-5 * abs(reference))
+
+
+def _bucket_key_for_value(boundary_by_value, val):
+    """Return the dict key that ``val`` should bucket into.
+
+    If an existing key in ``boundary_by_value`` is close to ``val`` under
+    ``_values_close``, return that key so close float values from adjacent
+    chunks land in the same bucket.  Otherwise return ``val`` unchanged.
+
+    This keeps Dask chunk-stitching consistent with the tolerance-based
+    grouping the NumPy / numba path uses inside a single chunk (#2171).
+    """
+    # Integer-valued rasters use exact equality, so the existing dict
+    # lookup is already correct -- skip the linear scan.
+    if isinstance(val, (int, np.integer)):
+        return val
+    for existing in boundary_by_value:
+        if _values_close(existing, val):
+            return existing
+    return val
+
+
 # Calculate region connectivity for the specified values raster and optional
 # mask raster.  Each region is labelled with a unique integer ID starting at
 # 1.  Regions corresponding to masked out pixels are all given the same region
@@ -1486,7 +1517,8 @@ def _merge_chunk_polygons(chunk_results, transform):
     for interior, boundary in chunk_results:
         all_interior.extend(interior)
         for val, rings in boundary:
-            boundary_by_value.setdefault(val, []).append(rings)
+            key = _bucket_key_for_value(boundary_by_value, val)
+            boundary_by_value.setdefault(key, []).append(rings)
 
     # Merge boundary polygons per value using edge cancellation.
     merged = []
@@ -1599,7 +1631,8 @@ def _polygonize_dask(dask_data, mask_data, connectivity_8, transform):
                 ))[0]
             all_interior.extend(interior)
             for val, rings in boundary:
-                boundary_by_value.setdefault(val, []).append(rings)
+                key = _bucket_key_for_value(boundary_by_value, val)
+                boundary_by_value.setdefault(key, []).append(rings)
 
     return _merge_from_separated(all_interior, boundary_by_value, transform)
 

--- a/xrspatial/polygonize.py
+++ b/xrspatial/polygonize.py
@@ -267,6 +267,13 @@ def _bucket_key_for_value(boundary_by_value, val):
 
     This keeps Dask chunk-stitching consistent with the tolerance-based
     grouping the NumPy / numba path uses inside a single chunk (#2171).
+
+    Performance note: the float branch is a linear scan over existing
+    keys, so total cost is O(B^2) in the number of distinct float
+    buckets B.  Polygonize inputs in practice have a small B (a handful
+    of categorical values), so the scan is cheap.  If a workload with
+    many thousand distinct float buckets shows up, swap the scan for a
+    sorted-keys structure (e.g. bisect over a sorted list).
     """
     # Integer-valued rasters use exact equality, so the existing dict
     # lookup is already correct -- skip the linear scan.

--- a/xrspatial/tests/test_polygonize.py
+++ b/xrspatial/tests/test_polygonize.py
@@ -515,6 +515,104 @@ def test_polygonize_cupy_float_tolerance_matches_numpy_2151(data):
         assert_allclose(areas_cp[v], a, atol=1e-10)
 
 
+# --- Dask float tolerance regression tests (#2171) ---
+
+@dask_array_available
+def test_polygonize_dask_float_tolerance_repro_2171():
+    """The original `[[1.0, 1.000001]]` repro from #2171.
+
+    The numpy path and the single-chunk Dask path return one polygon
+    because `_is_close` (atol=1e-8, rtol=1e-5) groups the two near-equal
+    values.  Before the fix the (1, 1) chunked Dask run returned two
+    polygons because the chunk-stitching step keyed on raw float values.
+    """
+    data = np.array([[1.0, 1.000001]], dtype=np.float64)
+
+    vals_np, polys_np = polygonize(xr.DataArray(data))
+    vals_single, polys_single = polygonize(
+        xr.DataArray(da.from_array(data, chunks=data.shape)))
+    vals_multi, polys_multi = polygonize(
+        xr.DataArray(da.from_array(data, chunks=(1, 1))))
+
+    assert len(polys_np) == 1
+    assert len(polys_single) == 1
+    assert len(polys_multi) == 1
+
+    # All three backends pick the same representative value.
+    assert vals_np == vals_single == vals_multi
+
+
+@dask_array_available
+@pytest.mark.parametrize(
+    "data,chunks",
+    [
+        # Single row, two near-equal cells, one cell per chunk.
+        (np.array([[1.0, 1.000001]], dtype=np.float64), (1, 1)),
+        # 2x2 with near-equal floats and a clearly different value,
+        # each cell in its own chunk.
+        (np.array([[1.0, 1.000001], [1.000001, 2.0]], dtype=np.float64),
+         (1, 1)),
+        # 3x3 with near-equal floats and a distinct value column.
+        (np.array([
+            [1.0, 1.000001, 2.0],
+            [1.000001, 1.0, 2.0],
+            [1.0, 1.0, 2.0],
+        ], dtype=np.float64), (1, 1)),
+        # Larger pattern at a slightly bigger chunk size to exercise
+        # multiple boundary segments per chunk.
+        (np.array([
+            [1.0, 1.000001, 1.0, 2.0],
+            [1.000001, 1.0, 1.000001, 2.0],
+            [1.0, 1.000001, 1.0, 2.0],
+            [1.000001, 1.0, 1.000001, 2.0],
+        ], dtype=np.float64), (2, 2)),
+    ],
+    ids=["1x2_chunks_1x1", "2x2_chunks_1x1", "3x3_chunks_1x1",
+         "4x4_chunks_2x2"],
+)
+def test_polygonize_dask_float_tolerance_matches_numpy_2171(data, chunks):
+    """Multi-chunk Dask must match numpy on near-equal float inputs.
+
+    The Dask chunk-stitching step must use the same `_is_close`
+    tolerance the numpy/numba path uses inside a single chunk so the
+    polygon count and per-value areas are independent of chunking.
+    """
+    raster_np = xr.DataArray(data)
+    raster_da = xr.DataArray(da.from_array(data, chunks=chunks))
+
+    vals_np, polys_np = polygonize(raster_np, connectivity=4)
+    vals_da, polys_da = polygonize(raster_da, connectivity=4)
+
+    assert len(polys_np) == len(polys_da), (
+        f"polygon count differs: numpy={len(polys_np)} "
+        f"dask={len(polys_da)}; numpy values={vals_np}, "
+        f"dask values={vals_da}"
+    )
+
+    areas_np = _area_by_value(vals_np, polys_np)
+    areas_da = _area_by_value(vals_da, polys_da)
+
+    # Per-value areas must agree under the tolerance: dask may report a
+    # nearby float (e.g. 1.000001 vs 1.0) as the bucket representative,
+    # so match each numpy bucket to the closest dask bucket within
+    # _is_close tolerance.
+    atol = 1e-8
+    rtol = 1e-5
+    unmatched_da = dict(areas_da)
+    for v_np, a_np in areas_np.items():
+        match = None
+        for v_da in unmatched_da:
+            if abs(v_da - v_np) <= atol + rtol * abs(v_np):
+                match = v_da
+                break
+        assert match is not None, (
+            f"numpy value {v_np!r} not found in dask values "
+            f"{list(unmatched_da.keys())}"
+        )
+        assert_allclose(unmatched_da.pop(match), a_np, atol=1e-10)
+    assert not unmatched_da, f"extra dask buckets: {unmatched_da}"
+
+
 # --- Performance-related regression tests (#1008) ---
 
 def test_polygonize_1008_jit_merge_helpers():


### PR DESCRIPTION
## Summary

- Bucket Dask boundary polygons using the same float tolerance the numpy path already uses, so `polygonize` results stop depending on chunking when the raster has near-equal floats.
- Mirror `_is_close` at the Python orchestration layer as `_values_close` and route the three boundary-merge dict insertions through a `_bucket_key_for_value` helper. Integer-valued rasters short-circuit to exact equality, so the int path keeps its current behaviour and cost.

Closes #2171

## Backend coverage

- numpy / cupy: unchanged.
- dask+numpy: fixed. Multi-chunk boundary merging matches the single-chunk numpy result on near-equal float inputs.
- dask+cupy: same orchestration code path as dask+numpy (per-chunk results flow through the same boundary dict), so the fix applies there too.

## Test plan

- [x] `[[1.0, 1.000001]]` returns one polygon across numpy, dask single-chunk, and dask `(1, 1)` chunked
- [x] Multi-chunk dask polygon count and per-value areas match numpy for a few near-equal float patterns at (1, 1) and (2, 2) chunks
- [x] Existing polygonize tests still pass
- [x] Integer rasters unchanged (exact-equality fast path)