### PR TITLE
reproject.merge: honor y orientation in same-CRS fast path (#2186)

### DIFF
--- a/xrspatial/reproject/__init__.py
+++ b/xrspatial/reproject/__init__.py
@@ -1913,6 +1913,14 @@ def _place_same_crs(src_data, src_bounds, src_shape, y_desc,
 
     No reprojection needed -- just index the output rows/columns that
     overlap with the source tile and copy the data.
+
+    The output grid is always north-up (row 0 is the top of
+    ``out_bounds``). When ``y_desc`` is ``False`` the source is
+    y-ascending (row 0 is the bottom of ``src_bounds``); in that case
+    the source window is flipped along y before being written so the
+    placed data has the same north-up orientation as the rest of the
+    output. Without this, ``merge([r])`` of a y-ascending raster
+    silently differs from ``reproject(r, target_crs=r.crs)`` (#2186).
     """
     out_h, out_w = out_shape
     src_h, src_w = src_shape
@@ -1924,7 +1932,8 @@ def _place_same_crs(src_data, src_bounds, src_shape, y_desc,
     s_res_x = (s_right - s_left) / src_w
     s_res_y = (s_top - s_bottom) / src_h
 
-    # Output pixel range that this tile covers
+    # Output pixel range that this tile covers. The output is always
+    # north-up so ``row_start`` is measured from ``o_top`` downward.
     col_start = int(round((s_left - o_left) / o_res_x))
     col_end = int(round((s_right - o_left) / o_res_x))
     row_start = int(round((o_top - s_top) / o_res_y))
@@ -1939,33 +1948,62 @@ def _place_same_crs(src_data, src_bounds, src_shape, y_desc,
     if col_start_clip >= col_end_clip or row_start_clip >= row_end_clip:
         return np.full(out_shape, nodata, dtype=np.float64)
 
-    # Source pixel range (handle offset if tile extends beyond output)
-    src_col_start = col_start_clip - col_start
-    src_row_start = row_start_clip - row_start
-
     # Resolutions may differ slightly; if close enough, do direct copy
     res_ratio_x = s_res_x / o_res_x
     res_ratio_y = s_res_y / o_res_y
     if abs(res_ratio_x - 1.0) > 0.01 or abs(res_ratio_y - 1.0) > 0.01:
         return None  # resolutions too different, fall back to reproject
 
-    out_data = np.full(out_shape, nodata, dtype=np.float64)
-    n_rows = row_end_clip - row_start_clip
-    n_cols = col_end_clip - col_start_clip
+    # Source column offset (columns always run left-to-right).
+    src_col_start = col_start_clip - col_start
 
-    # Clamp source window
-    src_r_end = min(src_row_start + n_rows, src_h)
+    n_cols = col_end_clip - col_start_clip
     src_c_end = min(src_col_start + n_cols, src_w)
-    actual_rows = src_r_end - src_row_start
     actual_cols = src_c_end - src_col_start
 
-    if actual_rows <= 0 or actual_cols <= 0:
+    out_data = np.full(out_shape, nodata, dtype=np.float64)
+
+    if actual_cols <= 0:
         return out_data
 
-    src_window = np.asarray(src_data[src_row_start:src_r_end,
-                                     src_col_start:src_c_end],
-                            dtype=np.float64)
-    out_data[row_start_clip:row_start_clip + actual_rows,
+    if y_desc:
+        # Source is north-up: rows go top-to-bottom, same as output.
+        # Output row R corresponds to source row ``R - row_start``.
+        src_row_start = row_start_clip - row_start
+        src_r_end = min(src_row_start + (row_end_clip - row_start_clip),
+                        src_h)
+        actual_rows = src_r_end - src_row_start
+        if actual_rows <= 0:
+            return out_data
+        src_window = np.asarray(
+            src_data[src_row_start:src_r_end,
+                     src_col_start:src_c_end],
+            dtype=np.float64,
+        )
+        out_row_start = row_start_clip
+    else:
+        # Source is south-up: source row 0 sits at the bottom of
+        # ``src_bounds``. Output row R corresponds to source row
+        # ``row_end - 1 - R`` (with R and row_end both measured from
+        # ``o_top`` downward). Read a contiguous ascending slice of
+        # source rows and reverse it so the result is north-up.
+        src_lo = max(0, row_end - row_end_clip)
+        src_hi = min(src_h, row_end - row_start_clip)
+        actual_rows = src_hi - src_lo
+        if actual_rows <= 0:
+            return out_data
+        src_window = np.asarray(
+            src_data[src_lo:src_hi, src_col_start:src_c_end],
+            dtype=np.float64,
+        )[::-1, :]
+        # The reversed slice's first row corresponds to source row
+        # ``src_hi - 1``, which maps to output row ``row_end - src_hi``.
+        # When the source is not clipped at the top, this equals
+        # ``row_start_clip``; clipping at the source top shifts the
+        # placement downward by the clipped row count.
+        out_row_start = row_end - src_hi
+
+    out_data[out_row_start:out_row_start + actual_rows,
              col_start_clip:col_start_clip + actual_cols] = src_window
     return out_data
 

--- a/xrspatial/reproject/__init__.py
+++ b/xrspatial/reproject/__init__.py
@@ -1956,9 +1956,7 @@ def _place_same_crs(src_data, src_bounds, src_shape, y_desc,
 
     # Source column offset (columns always run left-to-right).
     src_col_start = col_start_clip - col_start
-
-    n_cols = col_end_clip - col_start_clip
-    src_c_end = min(src_col_start + n_cols, src_w)
+    src_c_end = min(src_col_start + (col_end_clip - col_start_clip), src_w)
     actual_cols = src_c_end - src_col_start
 
     out_data = np.full(out_shape, nodata, dtype=np.float64)
@@ -1985,8 +1983,12 @@ def _place_same_crs(src_data, src_bounds, src_shape, y_desc,
         # Source is south-up: source row 0 sits at the bottom of
         # ``src_bounds``. Output row R corresponds to source row
         # ``row_end - 1 - R`` (with R and row_end both measured from
-        # ``o_top`` downward). Read a contiguous ascending slice of
-        # source rows and reverse it so the result is north-up.
+        # ``o_top`` downward, so larger R means lower latitude and
+        # smaller source row index). Concretely, if src_h=4 and
+        # row_end=4, output row 0 maps to source row 3, output row 3
+        # maps to source row 0 -- a vertical flip. Read a contiguous
+        # ascending slice of source rows and reverse it so the
+        # placed window comes out north-up.
         src_lo = max(0, row_end - row_end_clip)
         src_hi = min(src_h, row_end - row_start_clip)
         actual_rows = src_hi - src_lo

--- a/xrspatial/tests/test_reproject.py
+++ b/xrspatial/tests/test_reproject.py
@@ -806,10 +806,12 @@ class TestMergeSameCrsYOrientation:
         right_col = vals[:, x > 2]
         valid_l = ~np.isnan(left_col)
         valid_r = ~np.isnan(right_col)
-        if valid_l.any():
-            np.testing.assert_allclose(left_col[valid_l], 1.0, atol=1e-9)
-        if valid_r.any():
-            np.testing.assert_allclose(right_col[valid_r], 2.0, atol=1e-9)
+        # Up-front asserts so the test can't quietly degenerate into a
+        # no-op if the output grid shape ever shifts.
+        assert valid_l.any(), "left tile produced no valid output pixels"
+        assert valid_r.any(), "right tile produced no valid output pixels"
+        np.testing.assert_allclose(left_col[valid_l], 1.0, atol=1e-9)
+        np.testing.assert_allclose(right_col[valid_r], 2.0, atol=1e-9)
 
     def test_mixed_orientation_gradient_alignment(self):
         """Per-cell parity for a gradient that pins the orientation."""

--- a/xrspatial/tests/test_reproject.py
+++ b/xrspatial/tests/test_reproject.py
@@ -718,6 +718,145 @@ class TestMerge:
         assert computed.shape[0] > 0
 
 
+class TestMergeSameCrsYOrientation:
+    """``merge()`` same-CRS fast path must honor input y orientation (#2186).
+
+    The output of ``merge()`` is always north-up. When the source CRS
+    equals the target CRS, ``_place_same_crs`` does a direct pixel copy
+    of the source window into the output. A y-ascending source must be
+    flipped along y during placement so the result matches what
+    ``reproject(r, target_crs=r.crs)`` would emit.
+    """
+
+    @staticmethod
+    def _y_ascending_raster(values=None, shape=(16, 16),
+                            x_range=(-5, 5), y_range=(-5, 5),
+                            crs='EPSG:4326'):
+        h, w = shape
+        if values is None:
+            values = np.arange(h * w, dtype=np.float64).reshape(h, w)
+        y = np.linspace(y_range[0], y_range[1], h)  # ascending
+        x = np.linspace(x_range[0], x_range[1], w)
+        return xr.DataArray(
+            values, dims=['y', 'x'],
+            coords={'y': y, 'x': x},
+            attrs={'crs': crs, 'nodata': np.nan},
+        )
+
+    def test_y_ascending_single_raster_matches_reproject(self):
+        from xrspatial.reproject import merge, reproject
+        r = self._y_ascending_raster()
+        merged = merge([r], target_crs='EPSG:4326')
+        reprojected = reproject(r, target_crs='EPSG:4326',
+                                width=merged.shape[1],
+                                height=merged.shape[0])
+        np.testing.assert_allclose(
+            merged.values, reprojected.values,
+            atol=1e-10, equal_nan=True,
+        )
+
+    def test_y_ascending_preserves_north_south_gradient(self):
+        """Encode latitude in the data and verify the row order is north-up."""
+        from xrspatial.reproject import merge
+        h, w = 16, 16
+        y_asc = np.linspace(-5.0, 5.0, h)
+        # data[i, j] = y[i] -- so y-ascending input has small values in
+        # row 0 (south) and large values in row -1 (north).
+        data = np.broadcast_to(y_asc[:, None], (h, w)).astype(np.float64)
+        r = self._y_ascending_raster(values=data)
+        merged = merge([r])
+        # Output is always north-up: row 0 (top) should hold the
+        # largest y values, row -1 (bottom) the smallest.
+        assert merged.values[0, 0] > merged.values[-1, 0]
+        np.testing.assert_allclose(merged.values[0], y_asc[-1])
+        np.testing.assert_allclose(merged.values[-1], y_asc[0])
+
+    def test_y_descending_single_raster_unchanged(self):
+        """Regression guard: north-up inputs must keep working."""
+        from xrspatial.reproject import merge, reproject
+        data = np.arange(16 * 16, dtype=np.float64).reshape(16, 16)
+        r = _make_raster(data, x_range=(-5, 5), y_range=(-5, 5))
+        merged = merge([r], target_crs='EPSG:4326')
+        reprojected = reproject(r, target_crs='EPSG:4326',
+                                width=merged.shape[1],
+                                height=merged.shape[0])
+        np.testing.assert_allclose(
+            merged.values, reprojected.values,
+            atol=1e-10, equal_nan=True,
+        )
+
+    def test_mixed_orientation_multi_raster_merge(self):
+        """Two tiles with different y orientations should merge cleanly."""
+        from xrspatial.reproject import merge
+        h, w = 16, 16
+        left_vals = np.full((h, w), 1.0)
+        right_vals = np.full((h, w), 2.0)
+        # Left tile is y-descending (north-up); right tile is y-ascending.
+        left = _make_raster(left_vals, x_range=(-10, 0), y_range=(-5, 5))
+        right = xr.DataArray(
+            right_vals, dims=['y', 'x'],
+            coords={'y': np.linspace(-5, 5, h),  # ascending
+                    'x': np.linspace(0, 10, w)},
+            attrs={'crs': 'EPSG:4326', 'nodata': np.nan},
+        )
+        merged = merge([left, right], resolution=1.0)
+        vals = merged.values
+        x = merged.coords['x'].values
+        left_col = vals[:, x < -2]
+        right_col = vals[:, x > 2]
+        valid_l = ~np.isnan(left_col)
+        valid_r = ~np.isnan(right_col)
+        if valid_l.any():
+            np.testing.assert_allclose(left_col[valid_l], 1.0, atol=1e-9)
+        if valid_r.any():
+            np.testing.assert_allclose(right_col[valid_r], 2.0, atol=1e-9)
+
+    def test_mixed_orientation_gradient_alignment(self):
+        """Per-cell parity for a gradient that pins the orientation."""
+        from xrspatial.reproject import merge, reproject
+        h, w = 16, 16
+        y_asc = np.linspace(-5, 5, h)
+        x = np.linspace(-5, 5, w)
+        # values depend on y so any vertical flip is visible.
+        vals = np.broadcast_to(y_asc[:, None], (h, w)).astype(np.float64)
+        r = xr.DataArray(
+            vals, dims=['y', 'x'],
+            coords={'y': y_asc, 'x': x},
+            attrs={'crs': 'EPSG:4326', 'nodata': np.nan},
+        )
+        merged = merge([r], target_crs='EPSG:4326')
+        # Compare row-by-row vs reproject() with the same output grid.
+        reprojected = reproject(r, target_crs='EPSG:4326',
+                                width=merged.shape[1],
+                                height=merged.shape[0])
+        np.testing.assert_allclose(
+            merged.values, reprojected.values,
+            atol=1e-10, equal_nan=True,
+        )
+
+    @pytest.mark.skipif(not HAS_DASK, reason="dask required")
+    def test_dask_y_ascending_matches_numpy(self):
+        from xrspatial.reproject import merge
+        h, w = 32, 32
+        y_asc = np.linspace(-5, 5, h)
+        vals = np.broadcast_to(y_asc[:, None], (h, w)).astype(np.float64)
+        np_raster = xr.DataArray(
+            vals, dims=['y', 'x'],
+            coords={'y': y_asc, 'x': np.linspace(-5, 5, w)},
+            attrs={'crs': 'EPSG:4326', 'nodata': np.nan},
+        )
+        dask_raster = np_raster.copy()
+        dask_raster.data = da.from_array(vals, chunks=(16, 16))
+
+        numpy_result = merge([np_raster], chunk_size=16)
+        dask_result = merge([dask_raster], chunk_size=16)
+        assert isinstance(dask_result.data, da.Array)
+        np.testing.assert_allclose(
+            numpy_result.values, dask_result.compute().values,
+            atol=1e-10, equal_nan=True,
+        )
+
+
 class TestMergeMixedNodata:
     """merge() must honor each raster's own nodata sentinel."""
 


### PR DESCRIPTION
Closes #2186.

## Summary
- `_place_same_crs()` accepted a `y_desc` flag but discarded it, so y-ascending inputs were copied directly into the always-north-up merge output without flipping. `merge([r], target_crs=r.crs)` therefore disagreed with `reproject(r, target_crs=r.crs)` for the same raster.
- Read the source window in the correct direction when `y_desc` is `False` and place it so the result is north-up. The branch handles tiles that extend past the output bounds on either side.
- Both backends (`_merge_inmemory`, `_merge_block_adapter`) call the shared helper, so numpy and dask paths get the fix together.

## Test plan
- [x] `pytest xrspatial/tests/test_reproject.py::TestMergeSameCrsYOrientation -v`
  - Single y-ascending raster: `merge` vs `reproject` parity
  - Single y-ascending raster: latitude-encoded gradient appears north-up
  - Single y-descending raster regression guard
  - Multi-raster merge with mixed orientations (constant values)
  - Multi-raster merge with mixed orientations (gradient parity vs reproject)
  - Dask vs numpy parity for y-ascending input
- [x] Full reproject suite: `pytest xrspatial/tests/test_reproject.py` -- 274 passed.

## Backends
- numpy
- dask + numpy
- cupy / dask + cupy share the same Python adapter, so the fix flows through; no GPU-only kernel path involved.