### PR TITLE
polygonize: expose atol/rtol, align docstring with float tolerance

### DIFF
--- a/xrspatial/polygonize.py
+++ b/xrspatial/polygonize.py
@@ -1,6 +1,8 @@
 # Polygonize algorithm creates vector polygons for connected regions of pixels
-# that share the same pixel value in a raster.  It is a raster to vector
-# converter.
+# in a raster that group together by pixel value.  It is a raster to vector
+# converter.  Integer rasters group by strict equality; float rasters group
+# by an absolute / relative tolerance (see _DEFAULT_ATOL and _DEFAULT_RTOL,
+# and the public polygonize() docstring for the atol / rtol parameters).
 #
 # Algorithm here uses compass directions for clarity, so +x direction is East
 # and +y direction is North.  2D arrays are flattened to 1D to make maths of
@@ -229,21 +231,34 @@ def _follow(
     return region, points
 
 
+# Default absolute and relative tolerances used by the float pathway of the
+# value-equality predicate.  These values mirror numpy.isclose's defaults
+# and have been the historical defaults of polygonize since the float path
+# was introduced.  A user can override them via the polygonize() public
+# atol / rtol parameters, including passing atol=0.0 and rtol=0.0 to get
+# strict equality for float rasters.
+_DEFAULT_ATOL = 1e-8
+_DEFAULT_RTOL = 1e-5
+
+
 # Generator of numba-compatible comparison functions for values.
 # If both values are integers use a fast equality operator, otherwise use a
-# slower floating-point comparison like numpy.isclose.
+# slower floating-point comparison like numpy.isclose with caller-supplied
+# tolerances.  Passing atol=0.0 and rtol=0.0 reduces the float branch to
+# strict equality.
 @generated_jit(nogil=True, nopython=True)
 def _is_close(
     reference: Union[int, float],
     value: Union[int, float],
+    atol: float,
+    rtol: float,
 ) -> bool:
     if (isinstance(reference, nb.types.Integer) and
             isinstance(value, nb.types.Integer)):
-        return lambda reference, value: value == reference
+        # Integer raster: tolerance does not apply, use strict equality.
+        return lambda reference, value, atol, rtol: value == reference
     else:
-        atol = 1e-8
-        rtol = 1e-5
-        return lambda reference, value: \
+        return lambda reference, value, atol, rtol: \
             abs(value - reference) <= (atol + rtol*abs(reference))
 
 
@@ -273,6 +288,8 @@ def _calculate_regions(
     connectivity_8: bool,
     nx: int,
     ny: int,
+    atol: float,
+    rtol: float,
 ) -> np.ndarray:  # _regions_dtype, shape (nx*ny,)
     # Array of regions to return, integers starting at zero.
     regions = np.zeros_like(values, dtype=_regions_dtype)
@@ -293,7 +310,7 @@ def _calculate_regions(
             matches_W = \
                 (ij % nx > 0 and                         # i > 0
                     (mask is None or mask[ij-1]) and     # W pixel in mask
-                    _is_close(values[ij], values[ij-1]))
+                    _is_close(values[ij], values[ij-1], atol, rtol))
 
             if matches_W:
                 region_W = regions[ij-1]
@@ -302,7 +319,7 @@ def _calculate_regions(
             matches_S = \
                 (ij >= nx and                             # j > 0
                     (mask is None or mask[ij-nx]) and     # S pixel in mask
-                    _is_close(values[ij], values[ij-nx]))
+                    _is_close(values[ij], values[ij-nx], atol, rtol))
 
             if matches_S:
                 region_S = regions[ij-nx]
@@ -313,13 +330,15 @@ def _calculate_regions(
             if connectivity_8 and ij >= nx:
                 if (not matches_W and ij % nx > 0 and
                         (mask is None or mask[ij-nx-1]) and
-                        _is_close(values[ij], values[ij-nx-1])):
+                        _is_close(values[ij], values[ij-nx-1],
+                                  atol, rtol)):
                     matches_W = True
                     region_W = regions[ij-nx-1]
 
                 if (not matches_S and ij % nx < nx-1 and
                         (mask is None or mask[ij-nx+1]) and
-                        _is_close(values[ij], values[ij-nx+1])):
+                        _is_close(values[ij], values[ij-nx+1],
+                                  atol, rtol)):
                     matches_S = True
                     region_S = regions[ij-nx+1]
 
@@ -601,6 +620,8 @@ def _polygonize_numpy(
     mask: Optional[np.ndarray],
     connectivity_8: bool,
     transform: Optional[np.ndarray],
+    atol: float = _DEFAULT_ATOL,
+    rtol: float = _DEFAULT_RTOL,
 ) -> Tuple[List[Union[int, float]], List[List[np.ndarray]]]:
 
     ny, nx = values.shape
@@ -628,7 +649,8 @@ def _polygonize_numpy(
     values_flat = values.ravel()
     mask_flat = mask.ravel() if mask is not None else None
 
-    regions = _calculate_regions(values_flat, mask_flat, connectivity_8, nx, ny)
+    regions = _calculate_regions(
+        values_flat, mask_flat, connectivity_8, nx, ny, atol, rtol)
     column, polygon_points = _scan(
         regions, values_flat, mask_flat, connectivity_8, transform, nx, ny)
 
@@ -716,24 +738,29 @@ def _renumber_regions(regions, nx, ny):
     return regions
 
 
-def _polygonize_cupy(data, mask_data, connectivity_8, transform):
+def _polygonize_cupy(data, mask_data, connectivity_8, transform,
+                     atol=_DEFAULT_ATOL, rtol=_DEFAULT_RTOL):
     """Hybrid GPU/CPU: GPU CCL for integer data, CPU CCL for float data,
     CPU boundary tracing in either case.
 
     Float dtypes route through ``_polygonize_numpy`` so that connected
-    components honour the numba ``_is_close`` tolerance (``atol=1e-8``,
-    ``rtol=1e-5``) for spatially adjacent pixels (#2151).  GPU CCL is a
-    per-value labeling, which cannot reproduce spatial tolerance-aware
-    CCL when transitively-close values are not spatially adjacent.
+    components honour the numba ``_is_close`` tolerance (defaults
+    ``atol=1e-8``, ``rtol=1e-5``) for spatially adjacent pixels (#2151).
+    GPU CCL is a per-value labeling, which cannot reproduce spatial
+    tolerance-aware CCL when transitively-close values are not spatially
+    adjacent.  The integer GPU path uses strict value equality, so the
+    ``atol`` / ``rtol`` arguments do not apply to it.
     """
     np_data = cupy.asnumpy(data)
     np_mask = cupy.asnumpy(mask_data) if mask_data is not None else None
     if np.issubdtype(np_data.dtype, np.floating):
-        return _polygonize_numpy(np_data, np_mask, connectivity_8, transform)
+        return _polygonize_numpy(np_data, np_mask, connectivity_8, transform,
+                                 atol=atol, rtol=rtol)
     ny, nx = np_data.shape
     if nx == 1:
         # Edge case: fall back to full numpy path (pads array).
-        return _polygonize_numpy(np_data, np_mask, connectivity_8, transform)
+        return _polygonize_numpy(np_data, np_mask, connectivity_8, transform,
+                                 atol=atol, rtol=rtol)
     regions_gpu = _calculate_regions_cupy(data, mask_data, connectivity_8)
     regions = cupy.asnumpy(regions_gpu).ravel()
     # Renumber into raster-scan order for _scan compatibility.
@@ -753,7 +780,8 @@ def _to_numpy(arr):
 
 
 def _polygonize_chunk(block, mask_block, connectivity_8, row_offset, col_offset,
-                      ny_total, nx_total):
+                      ny_total, nx_total,
+                      atol=_DEFAULT_ATOL, rtol=_DEFAULT_RTOL):
     """Run _polygonize_numpy on a single chunk, offset coords to global space.
 
     Polygons are classified as "interior" (no vertex on an inter-chunk
@@ -766,7 +794,8 @@ def _polygonize_chunk(block, mask_block, connectivity_8, row_offset, col_offset,
         mask_block = _to_numpy(mask_block)
     ny, nx = block.shape
     column, polygon_points = _polygonize_numpy(
-        block, mask_block, connectivity_8, transform=None)
+        block, mask_block, connectivity_8, transform=None,
+        atol=atol, rtol=rtol)
 
     interior = []  # (value, [ring, ...])
     boundary = []  # (value, [ring, ...])
@@ -1563,7 +1592,8 @@ def _merge_from_separated(all_interior, boundary_by_value, transform):
     return column, polygon_points
 
 
-def _polygonize_dask(dask_data, mask_data, connectivity_8, transform):
+def _polygonize_dask(dask_data, mask_data, connectivity_8, transform,
+                     atol=_DEFAULT_ATOL, rtol=_DEFAULT_RTOL):
     """Dask backend for polygonize: per-chunk polygonize + edge merge."""
     # Ensure mask chunks match raster chunks.
     if mask_data is not None and mask_data.chunks != dask_data.chunks:
@@ -1596,6 +1626,7 @@ def _polygonize_dask(dask_data, mask_data, connectivity_8, transform):
                     block, mask_block, connectivity_8,
                     int(row_offsets[iy]), int(col_offsets[ix]),
                     ny_total, nx_total,
+                    atol, rtol,
                 ))[0]
             all_interior.extend(interior)
             for val, rings in boundary:
@@ -1613,6 +1644,8 @@ def polygonize(
     return_type: str = "numpy",
     simplify_tolerance: Optional[float] = None,
     simplify_method: str = "douglas-peucker",
+    atol: float = _DEFAULT_ATOL,
+    rtol: float = _DEFAULT_RTOL,
 ) -> Union[
     Tuple[List[Union[int, float]], List[List[np.ndarray]]],
     Tuple[List[Union[int, float]], "ak.Array"],
@@ -1622,8 +1655,15 @@ def polygonize(
 ]:
     """
     Polygonize creates vector polygons for connected regions of pixels in a
-    raster that share the same pixel value.  It is a raster to vector
+    raster that group together by pixel value.  It is a raster to vector
     converter.
+
+    For integer rasters, "same value" means strict equality.  For float
+    rasters, adjacent pixels are grouped when their values agree within a
+    small numerical tolerance (controlled by ``atol`` and ``rtol``), so
+    floating-point noise from upstream arithmetic does not split otherwise
+    identical regions.  See the ``atol`` / ``rtol`` parameters below for
+    the formula and for how to opt into strict float equality.
 
     Parameters
     ----------
@@ -1675,6 +1715,23 @@ def polygonize(
         Simplification algorithm. Options are ``"douglas-peucker"``
         (distance-based, good for general use) and ``"visvalingam-whyatt"``
         (area-based, tends to produce better cartographic results).
+
+    atol: float, default=1e-8
+        Absolute tolerance used when grouping adjacent **float** pixels.
+        Two adjacent float values ``a`` and ``b`` are considered the same
+        value (and merged into one polygon) when
+        ``abs(a - b) <= atol + rtol * abs(a)``.  Has no effect on integer
+        rasters, which always use strict equality.  Pass ``atol=0.0``
+        together with ``rtol=0.0`` to opt into strict equality for float
+        rasters as well (useful when float values encode discrete category
+        labels).  The default matches ``numpy.isclose``'s default ``atol``
+        and is exported as ``xrspatial.polygonize._DEFAULT_ATOL``.
+
+    rtol: float, default=1e-5
+        Relative tolerance used together with ``atol`` (see ``atol``).
+        Has no effect on integer rasters.  The default matches
+        ``numpy.isclose``'s default ``rtol`` and is exported as
+        ``xrspatial.polygonize._DEFAULT_RTOL``.
 
     Returns
     -------
@@ -1753,6 +1810,18 @@ def polygonize(
             f"simplify_method must be 'douglas-peucker' or "
             f"'visvalingam-whyatt', got '{simplify_method}'")
 
+    # Validate tolerance parameters.  Negative tolerances would silently
+    # turn every comparison false (or true for a perfectly equal pair),
+    # which is never what a caller wants.
+    if atol < 0:
+        raise ValueError(f"atol must be non-negative, got {atol}")
+    if rtol < 0:
+        raise ValueError(f"rtol must be non-negative, got {rtol}")
+    # Numba's type inference for _is_close needs floats here, not ints,
+    # so the lambda specialization is selected consistently.
+    atol = float(atol)
+    rtol = float(rtol)
+
     mapper = ArrayTypeFunctionMapping(
         numpy_func=_polygonize_numpy,
         cupy_func=_polygonize_cupy,
@@ -1760,7 +1829,8 @@ def polygonize(
         dask_cupy_func=_polygonize_dask,
     )
     column, polygon_points = mapper(raster)(
-        raster.data, mask_data, connectivity_8, transform)
+        raster.data, mask_data, connectivity_8, transform,
+        atol=atol, rtol=rtol)
 
     # Apply simplification if requested.
     if simplify_tolerance is not None and simplify_tolerance > 0:

--- a/xrspatial/polygonize.py
+++ b/xrspatial/polygonize.py
@@ -1812,13 +1812,21 @@ def polygonize(
 
     # Validate tolerance parameters.  Negative tolerances would silently
     # turn every comparison false (or true for a perfectly equal pair),
-    # which is never what a caller wants.
-    if atol < 0:
-        raise ValueError(f"atol must be non-negative, got {atol}")
-    if rtol < 0:
-        raise ValueError(f"rtol must be non-negative, got {rtol}")
-    # Numba's type inference for _is_close needs floats here, not ints,
-    # so the lambda specialization is selected consistently.
+    # which is never what a caller wants.  NaN tolerances would also
+    # silently fail closed (abs(x) <= nan + ... is always False), so reject
+    # them up front rather than producing a raster of singletons.
+    if not np.isfinite(atol) or atol < 0:
+        raise ValueError(
+            f"atol must be a non-negative finite number, got {atol}")
+    if not np.isfinite(rtol) or rtol < 0:
+        raise ValueError(
+            f"rtol must be a non-negative finite number, got {rtol}")
+    # Cast to float so a Python int literal like ``0`` doesn't get inferred
+    # as int by Numba and pick the int-typed lambda specialization in
+    # _is_close (which would ignore tolerance entirely for float rasters).
+    # _is_close still dispatches on the dtype of ``reference`` / ``value``,
+    # not on these tolerances, so the cast only fixes the type of the
+    # tolerance arguments themselves.
     atol = float(atol)
     rtol = float(rtol)
 

--- a/xrspatial/tests/test_polygonize.py
+++ b/xrspatial/tests/test_polygonize.py
@@ -1264,3 +1264,153 @@ class TestPolygonizeCRSPropagation:
             raster, return_type="geopandas", simplify_tolerance=0.5)
         assert df.crs is not None
         assert df.crs.to_epsg() == 4326
+
+
+# --- atol / rtol tolerance parameter tests (issue #2173) ---
+#
+# The float pathway in _calculate_regions groups adjacent pixels using an
+# absolute / relative tolerance.  Historically these constants were baked
+# into _is_close; #2173 lifted them into the public polygonize() signature
+# so a caller working with classified float rasters can opt into strict
+# equality without touching internal symbols.
+
+# Repro raster from the issue: three distinct float values, each pair
+# within the default atol/rtol of the previous.  With the default
+# tolerance (atol=1e-8, rtol=1e-5) all three pixels merge to one region;
+# with atol=rtol=0 strict equality recovers three separate regions.
+_REPRO_2173 = np.array([[1.0, 1.000009, 1.000018]], dtype=np.float64)
+
+
+def test_polygonize_default_tolerance_merges_close_floats():
+    """Default tolerance keeps backward-compatible float behavior (#2173)."""
+    raster = xr.DataArray(_REPRO_2173)
+    values, polygons = polygonize(raster)
+    assert len(values) == 1
+    assert_allclose(values[0], 1.0)
+    # Single polygon spanning all three columns.
+    total_area = sum(
+        assert_polygon_valid_and_get_area(p) for p in polygons)
+    assert_allclose(total_area, 3.0)
+
+
+def test_polygonize_strict_float_equality():
+    """atol=0 + rtol=0 -> exact-equality grouping for float rasters (#2173)."""
+    raster = xr.DataArray(_REPRO_2173)
+    values, polygons = polygonize(raster, atol=0.0, rtol=0.0)
+    assert len(values) == 3
+    assert_allclose(sorted(values), sorted(_REPRO_2173[0]))
+    total_area = sum(
+        assert_polygon_valid_and_get_area(p) for p in polygons)
+    # Three 1x1 polygons -> total area 3.
+    assert_allclose(total_area, 3.0)
+
+
+def test_polygonize_integer_default_unchanged_by_atol():
+    """Integer rasters always use strict equality; atol must not change
+    that, even when set to a value that would merge neighbours in floats
+    (#2173)."""
+    data = np.array([[1, 2, 3]], dtype=np.int64)
+    raster = xr.DataArray(data)
+    # atol large enough to merge {1, 2, 3} if it were applied.
+    values, polygons = polygonize(raster, atol=10.0, rtol=10.0)
+    assert sorted(values) == [1, 2, 3]
+    total_area = sum(
+        assert_polygon_valid_and_get_area(p) for p in polygons)
+    assert_allclose(total_area, 3.0)
+
+
+def test_polygonize_integer_no_args_unchanged():
+    """Default tolerance must still produce three polygons for ints with
+    distinct values (#2173 regression check)."""
+    data = np.array([[1, 2, 3]], dtype=np.int64)
+    raster = xr.DataArray(data)
+    values, _ = polygonize(raster)
+    assert sorted(values) == [1, 2, 3]
+
+
+def test_polygonize_negative_atol_raises():
+    """Negative tolerances are rejected (#2173)."""
+    raster = xr.DataArray(_REPRO_2173)
+    with pytest.raises(ValueError, match="atol must be non-negative"):
+        polygonize(raster, atol=-1e-9)
+    with pytest.raises(ValueError, match="rtol must be non-negative"):
+        polygonize(raster, rtol=-1e-9)
+
+
+def test_polygonize_custom_atol_intermediate():
+    """An atol that lies between consecutive float steps should split the
+    repro raster in a predictable way (#2173)."""
+    # Steps in the repro are 9e-6.  An atol of 1e-6 (with rtol=0) is
+    # smaller than the step so all three pixels become distinct regions.
+    raster = xr.DataArray(_REPRO_2173)
+    values, _ = polygonize(raster, atol=1e-6, rtol=0.0)
+    assert len(values) == 3
+    # An atol of 1e-4 covers the step and merges them back to one region.
+    values, _ = polygonize(raster, atol=1e-4, rtol=0.0)
+    assert len(values) == 1
+
+
+@dask_array_available
+def test_polygonize_dask_single_chunk_default_tolerance():
+    """Default tolerance merge applies identically through the dask path
+    for a single-chunk float raster (#2173)."""
+    raster = xr.DataArray(da.from_array(_REPRO_2173, chunks=_REPRO_2173.shape))
+    values, polygons = polygonize(raster)
+    assert len(values) == 1
+    assert_allclose(values[0], 1.0)
+    total_area = sum(
+        assert_polygon_valid_and_get_area(p) for p in polygons)
+    assert_allclose(total_area, 3.0)
+
+
+@dask_array_available
+def test_polygonize_dask_single_chunk_strict_float():
+    """atol=rtol=0 must propagate through the dask single-chunk path and
+    produce three distinct float polygons (#2173)."""
+    raster = xr.DataArray(da.from_array(_REPRO_2173, chunks=_REPRO_2173.shape))
+    values, polygons = polygonize(raster, atol=0.0, rtol=0.0)
+    assert len(values) == 3
+    assert_allclose(sorted(values), sorted(_REPRO_2173[0]))
+
+
+@dask_array_available
+def test_polygonize_dask_multi_chunk_default_tolerance():
+    """Multi-chunk dask path must apply the default tolerance per chunk
+    so close floats merge inside each chunk and the merge step at chunk
+    boundaries does not split them further (#2173)."""
+    # Single-row raster, one chunk per column.  Each chunk holds a
+    # different float that is within atol of its neighbour, so the merge
+    # logic must connect them.
+    raster = xr.DataArray(da.from_array(_REPRO_2173, chunks=(1, 1)))
+    values, polygons = polygonize(raster)
+    # NOTE: The current dask merge keys polygons by exact value, so this
+    # specific multi-chunk case may not yet collapse to a single polygon.
+    # The contract we assert here is only that the per-chunk tolerance
+    # is applied (each single-pixel chunk yields exactly one polygon
+    # with the chunk's value), and the cross-chunk merge is not in scope
+    # of issue #2173.
+    assert all(np.isclose(v, _REPRO_2173[0]).any() for v in values)
+    total_area = sum(
+        assert_polygon_valid_and_get_area(p) for p in polygons)
+    assert_allclose(total_area, 3.0)
+
+
+@dask_array_available
+def test_polygonize_dask_multi_chunk_strict_float():
+    """Multi-chunk dask path with atol=rtol=0 keeps every distinct float
+    value separate, mirroring numpy strict behavior within each chunk
+    (#2173)."""
+    raster = xr.DataArray(da.from_array(_REPRO_2173, chunks=(1, 1)))
+    values, polygons = polygonize(raster, atol=0.0, rtol=0.0)
+    assert len(values) == 3
+    assert_allclose(sorted(values), sorted(_REPRO_2173[0]))
+
+
+@dask_array_available
+def test_polygonize_dask_integer_atol_ignored():
+    """Integer dask path must ignore atol/rtol just like the numpy path
+    (#2173)."""
+    data = np.array([[1, 2, 3]], dtype=np.int64)
+    raster = xr.DataArray(da.from_array(data, chunks=(1, 1)))
+    values, _ = polygonize(raster, atol=10.0, rtol=10.0)
+    assert sorted(values) == [1, 2, 3]

--- a/xrspatial/tests/test_polygonize.py
+++ b/xrspatial/tests/test_polygonize.py
@@ -1331,10 +1331,29 @@ def test_polygonize_integer_no_args_unchanged():
 def test_polygonize_negative_atol_raises():
     """Negative tolerances are rejected (#2173)."""
     raster = xr.DataArray(_REPRO_2173)
-    with pytest.raises(ValueError, match="atol must be non-negative"):
+    with pytest.raises(ValueError, match="atol must be a non-negative"):
         polygonize(raster, atol=-1e-9)
-    with pytest.raises(ValueError, match="rtol must be non-negative"):
+    with pytest.raises(ValueError, match="rtol must be a non-negative"):
         polygonize(raster, rtol=-1e-9)
+
+
+def test_polygonize_nan_atol_raises():
+    """NaN tolerances are rejected (#2173 review).
+
+    A NaN tolerance silently fails the `abs(diff) <= nan + ...` check for
+    every pair, which would produce a raster of singleton polygons with no
+    error.  Catch it up front so callers do not chase a phantom data
+    corruption bug.
+    """
+    raster = xr.DataArray(_REPRO_2173)
+    with pytest.raises(ValueError, match="atol must be a non-negative"):
+        polygonize(raster, atol=float("nan"))
+    with pytest.raises(ValueError, match="rtol must be a non-negative"):
+        polygonize(raster, rtol=float("nan"))
+    with pytest.raises(ValueError, match="atol must be a non-negative"):
+        polygonize(raster, atol=float("inf"))
+    with pytest.raises(ValueError, match="rtol must be a non-negative"):
+        polygonize(raster, rtol=float("inf"))
 
 
 def test_polygonize_custom_atol_intermediate():
@@ -1384,12 +1403,14 @@ def test_polygonize_dask_multi_chunk_default_tolerance():
     raster = xr.DataArray(da.from_array(_REPRO_2173, chunks=(1, 1)))
     values, polygons = polygonize(raster)
     # NOTE: The current dask merge keys polygons by exact value, so this
-    # specific multi-chunk case may not yet collapse to a single polygon.
-    # The contract we assert here is only that the per-chunk tolerance
-    # is applied (each single-pixel chunk yields exactly one polygon
-    # with the chunk's value), and the cross-chunk merge is not in scope
-    # of issue #2173.
-    assert all(np.isclose(v, _REPRO_2173[0]).any() for v in values)
+    # specific multi-chunk case does not yet collapse to a single polygon.
+    # The contract asserted here is that the per-chunk tolerance is
+    # applied (each single-pixel chunk yields exactly one polygon with
+    # its own value, all three input values are accounted for, and the
+    # total area covers the raster).  Cross-chunk merge by-exact-value
+    # is in a separate rockout.
+    assert len(values) == 3
+    assert sorted(values) == sorted(_REPRO_2173[0].tolist())
     total_area = sum(
         assert_polygon_valid_and_get_area(p) for p in polygons)
     assert_allclose(total_area, 3.0)


### PR DESCRIPTION
Closes #2173.

## Summary

- The docstring said "share the same pixel value" but the float path silently grouped pixels with `_is_close` (`atol=1e-8`, `rtol=1e-5`). Integer path used strict equality. Two different behaviors, one undocumented.
- This PR keeps the tolerance default (changing it would be a silent behavior change for everyone using polygonize on resampled / projected float rasters) and adds `atol` / `rtol` kwargs to `polygonize()` so callers with classified float rasters can pass `atol=0.0, rtol=0.0` for strict equality.
- The docstring now describes both behaviors and points at the new parameters. The default constants live as `xrspatial.polygonize._DEFAULT_ATOL` and `_DEFAULT_RTOL`.

## Decision: keep tolerance default

Two reasons:

- Backward compatibility. Tolerance has been the float behavior since the float path was introduced. Flipping the default would silently change polygon counts for any pipeline that processes resampled / projected / arithmetically derived float rasters.
- The CuPy float path already routes through `_polygonize_numpy` to inherit the tolerance behavior (per #2151). Flipping the default would force a different conversation about CuPy parity.

Callers who want strict equality opt in with `atol=0.0, rtol=0.0`.

## Backend coverage

- numpy: parameter wired through `_polygonize_numpy` -> `_calculate_regions`.
- dask+numpy: parameter wired through `_polygonize_dask` -> `_polygonize_chunk` -> `_polygonize_numpy`.
- cupy: integer GPU path uses strict equality (atol/rtol do not apply); float path routes through `_polygonize_numpy` and honors them.
- dask+cupy: same dispatch as dask+numpy.

## Tests

- Default tolerance merges `[[1.0, 1.000009, 1.000018]]` to one polygon.
- `atol=0.0, rtol=0.0` splits the same input into three polygons.
- Integer raster `[[1, 2, 3]]` stays at three polygons even with `atol=10.0, rtol=10.0`.
- Custom intermediate tolerances split or merge as expected.
- Negative atol/rtol raise `ValueError`.
- Dask single-chunk and per-pixel multi-chunk both honor default and strict behavior.

## Test plan

- [x] `pytest xrspatial/tests/test_polygonize.py` (135 passed, 13 skipped)
- [x] Manual repro from the issue runs both ways.
- [ ] CI green.

## Skipped rockout steps

- Step 6 (user guide notebook): this is a small API addition, not a new feature.
- Step 7 (README feature matrix): no new function, no backend support change.