### PR TITLE
geotiff: share dispatch-kwarg validation across read entry points (#2175)

### DIFF
--- a/xrspatial/geotiff/__init__.py
+++ b/xrspatial/geotiff/__init__.py
@@ -548,6 +548,11 @@ def open_geotiff(source: str | BinaryIO, *,
         # ``overview_level=0`` is documented as "full resolution" (the
         # default), so treat it as a no-op the same as ``None`` rather
         # than rejecting a kwarg value the caller could have omitted.
+        # Mirrored at ``_backends/vrt.py`` (the direct-call entry point)
+        # so callers see the same rejection through both paths. The
+        # value-level rejection stays here rather than in
+        # ``_validate_dispatch_kwargs`` so the helper does not need a
+        # special-case for ``overview_level=0`` vs ``overview_level=N``.
         if overview_level not in (None, 0):
             raise ValueError(
                 "overview_level is not supported for VRT sources. "

--- a/xrspatial/geotiff/__init__.py
+++ b/xrspatial/geotiff/__init__.py
@@ -509,84 +509,33 @@ def open_geotiff(source: str | BinaryIO, *,
 
     source = _coerce_path(source)
 
-    # Reject bool and non-int ``overview_level`` up front (issue #2074).
-    # Without this guard, ``overview_level=True`` is coerced to ``1`` and
-    # silently returns the first overview level, and non-int types leak
-    # raw ``TypeError`` messages from the internal numeric comparison or
-    # list indexing.
-    from ._validation import _validate_overview_level_arg
-    _validate_overview_level_arg(overview_level)
+    # All dispatcher-level kwarg rejection lives in
+    # ``_validate_dispatch_kwargs`` so the three direct backends
+    # (``read_geotiff_dask``, ``read_geotiff_gpu``, ``read_vrt``)
+    # surface the same errors when called directly (issue #2175,
+    # parent #2162). The previous inline block at this line is now
+    # a single call that runs ``_validate_overview_level_arg`` (issue
+    # #2074), the ``on_gpu_failure`` GPU-only guard (issue #1615),
+    # the ``missing_sources`` VRT-only guard (issue #1810), the
+    # ``band_nodata`` VRT-only guard (issue #1987), the
+    # ``max_cloud_bytes`` non-VRT non-GPU non-dask guard (issue #1974),
+    # and the file-like source restrictions for gpu/chunks.
+    from ._validation import _validate_dispatch_kwargs
+    _validate_dispatch_kwargs(
+        source=source,
+        gpu=gpu,
+        chunks=chunks,
+        overview_level=overview_level,
+        on_gpu_failure=on_gpu_failure,
+        missing_sources=missing_sources,
+        band_nodata=band_nodata,
+        max_cloud_bytes=max_cloud_bytes,
+    )
 
-    # ``on_gpu_failure`` is GPU-only. Reject it up front for CPU/dask paths
-    # rather than silently dropping it once dispatch is decided -- callers
-    # otherwise have no way to learn that the policy is being ignored.
-    # ``gpu=False`` (the default) on a ``.vrt`` source still routes through
-    # ``read_vrt`` below which has no GPU-failure concept, so the same
-    # rejection rule applies there.
-    if on_gpu_failure is not _ON_GPU_FAILURE_SENTINEL and not gpu:
-        raise ValueError(
-            "on_gpu_failure only applies when gpu=True. "
-            "Pass gpu=True to enable the GPU pipeline, or drop "
-            "on_gpu_failure to keep the default CPU path.")
-
-    # ``missing_sources`` is VRT-only. Reject it up front when the source
-    # is not a ``.vrt`` file so callers learn the policy is being ignored
-    # instead of getting a silent drop -- same pattern ``on_gpu_failure``
-    # uses above for the GPU-only kwarg, and the same class of dispatcher
-    # silently-drops-backend-kwarg bug #1561 / #1605 / #1685 / #1795 fixed
-    # for the other VRT/GPU kwargs. See issue #1810.
     missing_sources_passed = (
         missing_sources is not _MISSING_SOURCES_SENTINEL)
     _is_vrt_source = (
         isinstance(source, str) and source.lower().endswith('.vrt'))
-    if missing_sources_passed and not _is_vrt_source:
-        raise ValueError(
-            "missing_sources only applies to VRT sources. "
-            "Pass a .vrt path to enable the VRT pipeline, or drop "
-            "missing_sources to keep the default GeoTIFF path.")
-
-    # ``band_nodata`` is the #1987 PR 5 opt-out for the mixed-band
-    # metadata fail-closed check. It only has meaning on the VRT pipeline
-    # (a plain GeoTIFF has one nodata sentinel per file, not per band),
-    # so reject the kwarg up front on non-VRT sources rather than letting
-    # it leak into ``read_vrt`` and confuse the caller about what the
-    # opt-out actually controls.
-    if band_nodata is not None and not _is_vrt_source:
-        raise ValueError(
-            "band_nodata only applies to VRT sources. "
-            "Pass a .vrt path to enable the VRT pipeline, or drop "
-            "band_nodata to keep the default GeoTIFF path. "
-            "See issue #1987.")
-
-    # ``max_cloud_bytes`` is the eager fsspec-read budget. Only
-    # ``_read_to_array`` on the eager non-VRT, non-GPU, non-dask branch
-    # consumes it; the GPU (``read_geotiff_gpu``), dask
-    # (``read_geotiff_dask``), and VRT (``read_vrt``) branches all ignore
-    # the kwarg silently. Reject it up front on those paths so callers
-    # learn the budget is being dropped, matching the
-    # ``on_gpu_failure`` / ``missing_sources`` guards above and the
-    # silently-drops-backend-kwarg fixes in #1561 / #1605 / #1685 / #1810.
-    # See issue #1974.
-    if max_cloud_bytes is not _MAX_CLOUD_BYTES_SENTINEL:
-        if _is_vrt_source:
-            raise ValueError(
-                "max_cloud_bytes is not supported for VRT sources. "
-                "The VRT reader does not apply the cloud-byte budget; "
-                "drop the kwarg, or call open_geotiff on the underlying "
-                ".tif source.")
-        if gpu:
-            raise ValueError(
-                "max_cloud_bytes is not supported when gpu=True. "
-                "The GPU reader does not accept the kwarg directly; "
-                "for URL/fsspec sources the budget is honoured via "
-                "the XRSPATIAL_GEOTIFF_MAX_CLOUD_BYTES env var "
-                "(see issue #2161). Drop the kwarg, set the env var, "
-                "or pass gpu=False to use the eager CPU path.")
-        if chunks is not None:
-            raise ValueError(
-                "max_cloud_bytes is not supported when chunks=... (dask). "
-                "The dask reader does not apply the cloud-byte budget; "
-                "drop the kwarg, or drop chunks to use the eager path.")
 
     # VRT files (string paths only -- VRT XML references other files on disk)
     if _is_vrt_source:
@@ -628,18 +577,9 @@ def open_geotiff(source: str | BinaryIO, *,
                         mask_nodata=mask_nodata,
                         **vrt_kwargs)
 
-    # File-like buffers don't support the GPU or dask code paths because
-    # those re-open the source by path from worker tasks or device-side
-    # readers. Reject early with a clear message.
-    if not isinstance(source, str):
-        if gpu:
-            raise ValueError(
-                "gpu=True is not supported for file-like sources. "
-                "Pass a path string instead.")
-        if chunks is not None:
-            raise ValueError(
-                "chunks=... (dask) is not supported for file-like sources. "
-                "Pass a path string instead.")
+    # File-like buffer rejections for ``gpu=True`` / ``chunks=...`` already
+    # fired inside ``_validate_dispatch_kwargs`` above; the non-VRT branches
+    # below run with a string source or an eager file-like.
 
     # GPU path
     if gpu:

--- a/xrspatial/geotiff/_backends/dask.py
+++ b/xrspatial/geotiff/_backends/dask.py
@@ -26,11 +26,12 @@ from .._coords import (
     coords_from_geo_info as _coords_from_geo_info,
     geo_to_coords as _geo_to_coords,
 )
-from .._reader import read_to_array as _read_to_array
+from .._reader import _MAX_CLOUD_BYTES_SENTINEL, read_to_array as _read_to_array
+from .._runtime import _MISSING_SOURCES_SENTINEL, _ON_GPU_FAILURE_SENTINEL
 from .._validation import (
     _validate_chunks_arg,
+    _validate_dispatch_kwargs,
     _validate_dtype_cast,
-    _validate_overview_level_arg,
 )
 from .vrt import read_vrt
 
@@ -43,6 +44,9 @@ def read_geotiff_dask(source: str, *,
                       name: str | None = None,
                       chunks: int | tuple = 512,
                       max_pixels: int | None = None,
+                      max_cloud_bytes: int | None = _MAX_CLOUD_BYTES_SENTINEL,  # type: ignore[assignment]
+                      on_gpu_failure: str = _ON_GPU_FAILURE_SENTINEL,
+                      missing_sources: str = _MISSING_SOURCES_SENTINEL,
                       allow_rotated: bool = False,
                       allow_unparseable_crs: bool = False,
                       band_nodata: str | None = None,
@@ -109,13 +113,28 @@ def read_geotiff_dask(source: str, *,
 
     from .._reader import _coerce_path
 
-    # Match ``open_geotiff``'s ordering so a bad ``overview_level`` is
-    # reported before unrelated source / ``chunks=`` errors mask it
-    # (issue #2160). ``select_overview_ifd`` revalidates as defense in
-    # depth.
-    _validate_overview_level_arg(overview_level)
-
     source = _coerce_path(source)
+
+    # Shared dispatcher-kwarg validator so direct callers see the same
+    # rejections as ``open_geotiff`` (issue #2175 / parent #2162).
+    # Runs ``_validate_overview_level_arg`` first to match ``open_geotiff``'s
+    # ordering -- a bad ``overview_level`` is reported before unrelated
+    # source / ``chunks=`` errors mask it (issue #2160). The helper also
+    # rejects ``on_gpu_failure`` (CPU dask has no GPU policy),
+    # ``missing_sources`` on non-VRT, ``band_nodata`` on non-VRT (issue
+    # #1987), ``max_cloud_bytes`` (dask reader does not apply the
+    # cloud-byte budget, issue #1974), and the file-like-source guard.
+    # ``gpu=False`` because this entry point is always CPU dask.
+    _validate_dispatch_kwargs(
+        source=source,
+        gpu=False,
+        chunks=chunks,
+        overview_level=overview_level,
+        on_gpu_failure=on_gpu_failure,
+        missing_sources=missing_sources,
+        band_nodata=band_nodata,
+        max_cloud_bytes=max_cloud_bytes,
+    )
 
     # Reject non-positive chunk sizes up front. ``chunks=0`` and negative
     # values otherwise propagate into dask chunk math (``range(0, N, 0)``
@@ -134,6 +153,9 @@ def read_geotiff_dask(source: str, *,
     # rather than letting the windowed-read path try to parse VRT XML as
     # TIFF bytes. ``read_vrt`` is the single source of truth for VRT.
     if isinstance(source, str) and source.lower().endswith('.vrt'):
+        vrt_kwargs = {}
+        if missing_sources is not _MISSING_SOURCES_SENTINEL:
+            vrt_kwargs['missing_sources'] = missing_sources
         return read_vrt(
             source, dtype=dtype, window=window, band=band, name=name,
             chunks=chunks, max_pixels=max_pixels,
@@ -141,17 +163,8 @@ def read_geotiff_dask(source: str, *,
             allow_unparseable_crs=allow_unparseable_crs,
             band_nodata=band_nodata,
             mask_nodata=mask_nodata,
+            **vrt_kwargs,
         )
-    # ``band_nodata`` only has meaning for the VRT path (per-band sentinel
-    # ambiguity). Reject the kwarg up front on non-VRT GeoTIFF inputs so
-    # callers learn the opt-out is being dropped, matching the
-    # ``open_geotiff`` guard. See issue #1987 PR 5.
-    if band_nodata is not None:
-        raise ValueError(
-            "band_nodata only applies to VRT sources. "
-            "Pass a .vrt path to enable the VRT pipeline, or drop "
-            "band_nodata to keep the default GeoTIFF path. "
-            "See issue #1987.")
 
     # P5: HTTP COG sources used to fire one IFD/header GET per chunk
     # task. Parse metadata once here so every delayed task can reuse it.

--- a/xrspatial/geotiff/_backends/gpu.py
+++ b/xrspatial/geotiff/_backends/gpu.py
@@ -201,6 +201,16 @@ def read_geotiff_gpu(source: str, *,
     xr.DataArray
         CuPy-backed DataArray on GPU device.
     """
+    # Coerce ``pathlib.Path`` and other ``os.PathLike`` inputs to ``str``
+    # before the validator so the file-like guard inside
+    # ``_validate_dispatch_kwargs`` does not misclassify a Path as a
+    # file-like buffer (review feedback on #2175). The downstream
+    # ``_coerce_path`` call near the eager-path setup below is now
+    # redundant for the same object but kept as a no-op for paths that
+    # arrive on the chunked branch via a different route.
+    from .._reader import _coerce_path as _coerce_path_dispatch
+    source = _coerce_path_dispatch(source)
+
     # Shared dispatcher-kwarg validator so direct callers see the same
     # rejections as ``open_geotiff`` (issue #2175 / parent #2162). Runs
     # ``_validate_overview_level_arg`` first to match ``open_geotiff``'s

--- a/xrspatial/geotiff/_backends/gpu.py
+++ b/xrspatial/geotiff/_backends/gpu.py
@@ -28,7 +28,11 @@ from .._attrs import (
 from .._coords import (
     coords_from_geo_info as _coords_from_geo_info,
 )
-from .._reader import _MAX_CLOUD_BYTES_SENTINEL, read_to_array as _read_to_array
+from .._reader import (
+    _MAX_CLOUD_BYTES_SENTINEL,
+    _coerce_path,
+    read_to_array as _read_to_array,
+)
 from .._runtime import (
     _GPU_DEPRECATED_SENTINEL,
     _MISSING_SOURCES_SENTINEL,
@@ -205,11 +209,10 @@ def read_geotiff_gpu(source: str, *,
     # before the validator so the file-like guard inside
     # ``_validate_dispatch_kwargs`` does not misclassify a Path as a
     # file-like buffer (review feedback on #2175). The downstream
-    # ``_coerce_path`` call near the eager-path setup below is now
-    # redundant for the same object but kept as a no-op for paths that
-    # arrive on the chunked branch via a different route.
-    from .._reader import _coerce_path as _coerce_path_dispatch
-    source = _coerce_path_dispatch(source)
+    # ``_coerce_path`` call near the eager-path setup below is now a
+    # no-op for the same object but kept for the chunked branch's
+    # reuse of the same imported binding.
+    source = _coerce_path(source)
 
     # Shared dispatcher-kwarg validator so direct callers see the same
     # rejections as ``open_geotiff`` (issue #2175 / parent #2162). Runs
@@ -300,7 +303,7 @@ def read_geotiff_gpu(source: str, *,
         )
 
     from .._reader import (
-        _FileSource, _check_dimensions, MAX_PIXELS_DEFAULT, _coerce_path,
+        _FileSource, _check_dimensions, MAX_PIXELS_DEFAULT,
         _is_fsspec_uri, _max_tile_bytes_from_env, _resolve_masked_fill,
     )
     from .._compression import COMPRESSION_LERC
@@ -311,7 +314,8 @@ def read_geotiff_gpu(source: str, *,
     from .._geotags import extract_geo_info_with_overview_inheritance
     from .._gpu_decode import gpu_decode_tiles
 
-    source = _coerce_path(source)
+    # ``source`` is already coerced above (before the dispatch
+    # validator); no need to re-coerce here.
 
     if max_pixels is None:
         max_pixels = MAX_PIXELS_DEFAULT

--- a/xrspatial/geotiff/_backends/gpu.py
+++ b/xrspatial/geotiff/_backends/gpu.py
@@ -28,16 +28,17 @@ from .._attrs import (
 from .._coords import (
     coords_from_geo_info as _coords_from_geo_info,
 )
-from .._reader import read_to_array as _read_to_array
+from .._reader import _MAX_CLOUD_BYTES_SENTINEL, read_to_array as _read_to_array
 from .._runtime import (
     _GPU_DEPRECATED_SENTINEL,
+    _MISSING_SOURCES_SENTINEL,
     _ON_GPU_FAILURE_SENTINEL,
     _geotiff_strict_mode,
 )
 from .._validation import (
     _validate_chunks_arg,
+    _validate_dispatch_kwargs,
     _validate_dtype_cast,
-    _validate_overview_level_arg,
     _validate_predictor_sample_format,
 )
 from ._gpu_helpers import (
@@ -85,9 +86,12 @@ def read_geotiff_gpu(source: str, *,
                      name: str | None = None,
                      chunks: int | tuple | None = None,
                      max_pixels: int | None = None,
+                     max_cloud_bytes: int | None = _MAX_CLOUD_BYTES_SENTINEL,  # type: ignore[assignment]
                      on_gpu_failure: str = _ON_GPU_FAILURE_SENTINEL,
+                     missing_sources: str = _MISSING_SOURCES_SENTINEL,
                      allow_rotated: bool = False,
                      allow_unparseable_crs: bool = False,
+                     band_nodata: str | None = None,
                      mask_nodata: bool = True,
                      gpu: str = _GPU_DEPRECATED_SENTINEL,
                      ) -> xr.DataArray:
@@ -197,11 +201,26 @@ def read_geotiff_gpu(source: str, *,
     xr.DataArray
         CuPy-backed DataArray on GPU device.
     """
-    # Match ``open_geotiff``'s ordering so a bad ``overview_level`` is
-    # reported before unrelated ``on_gpu_failure`` / ``chunks=`` / source
-    # errors mask it (issue #2160). ``select_overview_ifd`` revalidates
-    # as defense in depth.
-    _validate_overview_level_arg(overview_level)
+    # Shared dispatcher-kwarg validator so direct callers see the same
+    # rejections as ``open_geotiff`` (issue #2175 / parent #2162). Runs
+    # ``_validate_overview_level_arg`` first to match ``open_geotiff``'s
+    # ordering -- a bad ``overview_level`` is reported before unrelated
+    # ``on_gpu_failure`` / ``chunks=`` / source errors mask it (issue
+    # #2160). The helper also rejects ``missing_sources`` on non-VRT,
+    # ``band_nodata`` on non-VRT (issue #1987), ``max_cloud_bytes`` (the
+    # GPU reader does not consume the cloud-byte budget, issue #1974),
+    # and the file-like-source guard. ``gpu=True`` because this entry
+    # point is always GPU.
+    _validate_dispatch_kwargs(
+        source=source,
+        gpu=True,
+        chunks=chunks,
+        overview_level=overview_level,
+        on_gpu_failure=on_gpu_failure,
+        missing_sources=missing_sources,
+        band_nodata=band_nodata,
+        max_cloud_bytes=max_cloud_bytes,
+    )
 
     new_passed = on_gpu_failure is not _ON_GPU_FAILURE_SENTINEL
     old_passed = gpu is not _GPU_DEPRECATED_SENTINEL

--- a/xrspatial/geotiff/_backends/vrt.py
+++ b/xrspatial/geotiff/_backends/vrt.py
@@ -24,7 +24,13 @@ from .._coords import (
     transform_tuple_from_pixel_geometry as _transform_tuple_from_pixel_geometry,
 )
 from .._crs import _wkt_to_epsg
-from .._validation import _validate_chunks_arg, _validate_dtype_cast
+from .._reader import _MAX_CLOUD_BYTES_SENTINEL
+from .._runtime import _ON_GPU_FAILURE_SENTINEL
+from .._validation import (
+    _validate_chunks_arg,
+    _validate_dispatch_kwargs,
+    _validate_dtype_cast,
+)
 
 
 # Hard cap on the per-VRT chunk task count. Matches the
@@ -37,11 +43,14 @@ _MAX_VRT_DASK_CHUNKS = 50_000
 def read_vrt(source: str, *,
              dtype: str | np.dtype | None = None,
              window: tuple | None = None,
+             overview_level: int | None = None,
              band: int | None = None,
              name: str | None = None,
              chunks: int | tuple | None = None,
              gpu: bool = False,
              max_pixels: int | None = None,
+             max_cloud_bytes: int | None = _MAX_CLOUD_BYTES_SENTINEL,  # type: ignore[assignment]
+             on_gpu_failure: str = _ON_GPU_FAILURE_SENTINEL,
              missing_sources: str = 'raise',
              allow_rotated: bool = False,
              allow_unparseable_crs: bool = False,
@@ -165,6 +174,39 @@ def read_vrt(source: str, *,
     )
 
     source = _coerce_path(source)
+
+    # Shared dispatcher-kwarg validator so direct callers see the same
+    # rejections as ``open_geotiff`` (issue #2175 / parent #2162). For
+    # ``read_vrt`` the helper rejects ``on_gpu_failure`` (VRT reads do
+    # not go through a GPU decoder pipeline), ``max_cloud_bytes`` (the
+    # VRT reader does not consume the cloud-byte budget, issue #1974),
+    # and validates ``overview_level``'s type. ``missing_sources`` and
+    # ``band_nodata`` are legitimate VRT kwargs so the helper's
+    # VRT-only guard is a no-op here. ``gpu=False`` is passed so that
+    # an explicit ``on_gpu_failure`` is rejected regardless of the
+    # ``read_vrt(gpu=)`` output-device kwarg.
+    _validate_dispatch_kwargs(
+        source=source,
+        gpu=False,
+        chunks=chunks,
+        overview_level=overview_level,
+        on_gpu_failure=on_gpu_failure,
+        missing_sources=missing_sources,
+        band_nodata=band_nodata,
+        max_cloud_bytes=max_cloud_bytes,
+    )
+
+    # ``overview_level`` is not consumed by ``read_vrt`` (the VRT XML
+    # references its own source files; overview selection would need to
+    # apply to each one). ``overview_level=0`` matches the documented
+    # "full resolution" default, so treat it as a no-op. Mirrors the
+    # existing rejection inside ``open_geotiff``'s VRT branch
+    # (issue #1685).
+    if overview_level not in (None, 0):
+        raise ValueError(
+            "overview_level is not supported for VRT sources. "
+            "VRT references its own source files; pass overview_level "
+            "to open_geotiff on a .tif source, or drop the kwarg.")
 
     # Reject non-positive chunk sizes up front so the VRT dask path
     # surfaces the same error as ``read_geotiff_dask`` (#1776). Without

--- a/xrspatial/geotiff/_backends/vrt.py
+++ b/xrspatial/geotiff/_backends/vrt.py
@@ -200,8 +200,10 @@ def read_vrt(source: str, *,
     # references its own source files; overview selection would need to
     # apply to each one). ``overview_level=0`` matches the documented
     # "full resolution" default, so treat it as a no-op. Mirrors the
-    # existing rejection inside ``open_geotiff``'s VRT branch
-    # (issue #1685).
+    # existing rejection inside ``open_geotiff``'s VRT branch at
+    # ``__init__.py:551-555`` (issue #1685). Keep both sites in sync; a
+    # future refactor that moves this into ``_validate_dispatch_kwargs``
+    # should drop both at once.
     if overview_level not in (None, 0):
         raise ValueError(
             "overview_level is not supported for VRT sources. "

--- a/xrspatial/geotiff/_validation.py
+++ b/xrspatial/geotiff/_validation.py
@@ -34,7 +34,13 @@ from ._errors import (
     RotatedTransformError,
     UnparseableCRSError,
 )
-from ._runtime import _TIME_DIM_NAMES, _X_DIM_NAMES, _Y_DIM_NAMES
+from ._runtime import (
+    _MISSING_SOURCES_SENTINEL,
+    _ON_GPU_FAILURE_SENTINEL,
+    _TIME_DIM_NAMES,
+    _X_DIM_NAMES,
+    _Y_DIM_NAMES,
+)
 
 
 def _is_temporal_dim_name(name) -> bool:
@@ -342,6 +348,146 @@ def _validate_overview_level_arg(overview_level) -> None:
             f"overview_level must be an int or None, got "
             f"{type(overview_level).__name__}: {overview_level!r}"
         )
+
+
+def _validate_dispatch_kwargs(
+    *,
+    source,
+    gpu: bool,
+    chunks,
+    overview_level,
+    on_gpu_failure,
+    missing_sources,
+    band_nodata,
+    max_cloud_bytes,
+) -> None:
+    """Validate dispatcher-level kwargs across the GeoTIFF read entry points.
+
+    Holds the kwarg-rejection rules that ``open_geotiff`` used to run
+    inline at ``__init__.py:508-584`` so the three direct backends
+    (``read_geotiff_dask``, ``read_geotiff_gpu``, ``read_vrt``) get the
+    same validation when called directly. Before this helper, a caller
+    who passed ``max_cloud_bytes`` straight to ``read_geotiff_dask`` (or
+    ``band_nodata`` to ``read_geotiff_gpu``) got no error at all because
+    the kwarg either silently dropped or raised an unrelated
+    ``TypeError`` from the signature. See issue #2175 (parent #2162).
+
+    Rules enforced:
+
+    - ``overview_level`` must be ``None`` or a non-bool int. Delegates to
+      :func:`_validate_overview_level_arg` (issue #2074).
+    - ``on_gpu_failure`` requires ``gpu=True`` when explicit. The
+      CPU/dask branches have no GPU failure policy and would otherwise
+      drop the kwarg silently (issue #1615).
+    - ``missing_sources`` requires a ``.vrt`` source when explicit. The
+      non-VRT branches do not run the VRT mosaic loop (issue #1810).
+    - ``band_nodata`` requires a ``.vrt`` source when not ``None``. The
+      fail-closed mixed-band-metadata check is VRT-only (issue #1987).
+    - ``max_cloud_bytes`` is incompatible with ``.vrt``, ``gpu=True``,
+      and ``chunks=...`` when explicit. The eager non-VRT non-GPU
+      non-dask branch is the only consumer (issue #1974).
+    - File-like sources reject ``gpu=True`` and ``chunks=...``. The GPU
+      and dask paths re-open the source by path from worker tasks.
+
+    Sentinel defaults (``_ON_GPU_FAILURE_SENTINEL``,
+    ``_MISSING_SOURCES_SENTINEL``, ``_MAX_CLOUD_BYTES_SENTINEL``) keep
+    "caller did not pass this kwarg" silent so defaults round-trip
+    through every entry point without tripping a rejection.
+
+    Parameters
+    ----------
+    source : str or binary file-like
+        Already coerced by ``_coerce_path`` so the helper can detect
+        a ``.vrt`` extension via ``isinstance(source, str)``.
+    gpu : bool
+        True when the call routes through the GPU pipeline (either
+        ``open_geotiff(gpu=True)`` or a direct ``read_geotiff_gpu``).
+    chunks : int, tuple, or None
+        Caller's ``chunks=`` value. ``None`` means eager.
+    overview_level
+        Forwarded to ``_validate_overview_level_arg`` verbatim.
+    on_gpu_failure
+        ``_ON_GPU_FAILURE_SENTINEL`` when omitted; any other value is
+        treated as caller-set.
+    missing_sources
+        ``_MISSING_SOURCES_SENTINEL`` when omitted; any other value is
+        treated as caller-set.
+    band_nodata
+        ``None`` when omitted; any other value is treated as caller-set.
+    max_cloud_bytes
+        ``_MAX_CLOUD_BYTES_SENTINEL`` when omitted; any other value
+        (including an explicit ``None``) is treated as caller-set.
+
+    Raises
+    ------
+    TypeError
+        If ``overview_level`` has a non-int / bool type.
+    ValueError
+        On any of the rule violations listed above.
+    """
+    # Local import avoids a circular dependency with ``_reader`` when
+    # ``_validation`` is imported at module load time of the geotiff
+    # subpackage. The sentinel binding is cheap to look up.
+    from ._reader import _MAX_CLOUD_BYTES_SENTINEL
+
+    _validate_overview_level_arg(overview_level)
+
+    if on_gpu_failure is not _ON_GPU_FAILURE_SENTINEL and not gpu:
+        raise ValueError(
+            "on_gpu_failure only applies when gpu=True. "
+            "Pass gpu=True to enable the GPU pipeline, or drop "
+            "on_gpu_failure to keep the default CPU path.")
+
+    missing_sources_passed = (
+        missing_sources is not _MISSING_SOURCES_SENTINEL)
+    is_vrt_source = (
+        isinstance(source, str) and source.lower().endswith('.vrt'))
+    if missing_sources_passed and not is_vrt_source:
+        raise ValueError(
+            "missing_sources only applies to VRT sources. "
+            "Pass a .vrt path to enable the VRT pipeline, or drop "
+            "missing_sources to keep the default GeoTIFF path.")
+
+    if band_nodata is not None and not is_vrt_source:
+        raise ValueError(
+            "band_nodata only applies to VRT sources. "
+            "Pass a .vrt path to enable the VRT pipeline, or drop "
+            "band_nodata to keep the default GeoTIFF path. "
+            "See issue #1987.")
+
+    if max_cloud_bytes is not _MAX_CLOUD_BYTES_SENTINEL:
+        if is_vrt_source:
+            raise ValueError(
+                "max_cloud_bytes is not supported for VRT sources. "
+                "The VRT reader does not apply the cloud-byte budget; "
+                "drop the kwarg, or call open_geotiff on the underlying "
+                ".tif source.")
+        if gpu:
+            raise ValueError(
+                "max_cloud_bytes is not supported when gpu=True. "
+                "The GPU reader does not accept the kwarg directly; "
+                "for URL/fsspec sources the budget is honoured via "
+                "the XRSPATIAL_GEOTIFF_MAX_CLOUD_BYTES env var "
+                "(see issue #2161). Drop the kwarg, set the env var, "
+                "or pass gpu=False to use the eager CPU path.")
+        if chunks is not None:
+            raise ValueError(
+                "max_cloud_bytes is not supported when chunks=... (dask). "
+                "The dask reader does not apply the cloud-byte budget; "
+                "drop the kwarg, or drop chunks to use the eager path.")
+
+    # File-like buffers do not support the GPU or dask code paths
+    # because those re-open the source by path from worker tasks or
+    # device-side readers. Reject early with a clear message.
+    if not isinstance(source, str):
+        if gpu:
+            raise ValueError(
+                "gpu=True is not supported for file-like sources. "
+                "Pass a path string instead.")
+        if chunks is not None:
+            raise ValueError(
+                "chunks=... (dask) is not supported for file-like sources. "
+                "Pass a path string instead.")
 
 
 def _validate_predictor_sample_format(predictor, sample_format) -> None:

--- a/xrspatial/geotiff/_validation.py
+++ b/xrspatial/geotiff/_validation.py
@@ -428,6 +428,9 @@ def _validate_dispatch_kwargs(
     # Local import avoids a circular dependency with ``_reader`` when
     # ``_validation`` is imported at module load time of the geotiff
     # subpackage. The sentinel binding is cheap to look up.
+    # TODO(#2162 follow-up): move ``_MAX_CLOUD_BYTES_SENTINEL`` to
+    # ``_runtime`` alongside the other dispatch sentinels so this local
+    # import can hoist to module scope.
     from ._reader import _MAX_CLOUD_BYTES_SENTINEL
 
     _validate_overview_level_arg(overview_level)
@@ -437,6 +440,25 @@ def _validate_dispatch_kwargs(
             "on_gpu_failure only applies when gpu=True. "
             "Pass gpu=True to enable the GPU pipeline, or drop "
             "on_gpu_failure to keep the default CPU path.")
+
+    # File-like buffers do not support the GPU or dask code paths
+    # because those re-open the source by path from worker tasks or
+    # device-side readers. Reject early with a clear message that names
+    # the actual blocker (gpu=True or chunks=...), ahead of the
+    # VRT-dependent kwarg checks below. A file-like source cannot be a
+    # VRT either, so the later VRT-only rejections would fire on
+    # ``missing_sources`` / ``band_nodata`` with a less specific
+    # diagnostic. Surfacing the file-like restriction first gives the
+    # caller the direct fix (pass a path string).
+    if not isinstance(source, str):
+        if gpu:
+            raise ValueError(
+                "gpu=True is not supported for file-like sources. "
+                "Pass a path string instead.")
+        if chunks is not None:
+            raise ValueError(
+                "chunks=... (dask) is not supported for file-like sources. "
+                "Pass a path string instead.")
 
     missing_sources_passed = (
         missing_sources is not _MISSING_SOURCES_SENTINEL)
@@ -475,19 +497,6 @@ def _validate_dispatch_kwargs(
                 "max_cloud_bytes is not supported when chunks=... (dask). "
                 "The dask reader does not apply the cloud-byte budget; "
                 "drop the kwarg, or drop chunks to use the eager path.")
-
-    # File-like buffers do not support the GPU or dask code paths
-    # because those re-open the source by path from worker tasks or
-    # device-side readers. Reject early with a clear message.
-    if not isinstance(source, str):
-        if gpu:
-            raise ValueError(
-                "gpu=True is not supported for file-like sources. "
-                "Pass a path string instead.")
-        if chunks is not None:
-            raise ValueError(
-                "chunks=... (dask) is not supported for file-like sources. "
-                "Pass a path string instead.")
 
 
 def _validate_predictor_sample_format(predictor, sample_format) -> None:

--- a/xrspatial/geotiff/tests/test_dispatch_validation_parity_2162.py
+++ b/xrspatial/geotiff/tests/test_dispatch_validation_parity_2162.py
@@ -433,10 +433,10 @@ def test_gpu_path_object_does_not_raise_file_like_error(tmp_path):
         assert "file-like" not in str(e), (
             f"validator misclassified Path as file-like: {e}"
         )
-    except Exception:
-        # Any non-ValueError failure (ImportError, RuntimeError from
-        # the CUDA preflight, etc.) is acceptable -- it is not the
-        # regression we are pinning.
+    except (ImportError, RuntimeError):
+        # ImportError: cupy not installed.
+        # RuntimeError: CUDA preflight failed.
+        # Both are unrelated to the Path-coercion regression.
         pass
 
 

--- a/xrspatial/geotiff/tests/test_dispatch_validation_parity_2162.py
+++ b/xrspatial/geotiff/tests/test_dispatch_validation_parity_2162.py
@@ -1,0 +1,498 @@
+"""Dispatcher kwarg parity across GeoTIFF read entry points (issue #2175).
+
+``open_geotiff`` used to validate ``overview_level``,
+``on_gpu_failure``, ``missing_sources``, ``band_nodata``,
+``max_cloud_bytes``, and the file-like source restrictions inline at
+the top of its body. The three direct backends -- ``read_geotiff_dask``,
+``read_geotiff_gpu``, and ``read_vrt`` -- each ran their own
+``_validate_overview_level_arg`` call but skipped the rest. A caller
+who passed an invalid ``band_nodata`` to dask or ``max_cloud_bytes``
+to the GPU reader got no error at all, or got an unrelated
+``TypeError`` from the signature.
+
+This module pins parity. ``_validate_dispatch_kwargs`` lives in
+``xrspatial/geotiff/_validation.py`` and is called from the top of
+every public read entry point. The matrix below walks each kwarg
+through every entry point and asserts that the exception type and
+message match.
+
+See issue #2175 (parent #2162).
+"""
+from __future__ import annotations
+
+import importlib.util
+import io
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from xrspatial.geotiff import (
+    open_geotiff,
+    read_geotiff_dask,
+    read_geotiff_gpu,
+    read_vrt,
+    to_geotiff,
+    write_vrt,
+)
+
+
+# --------------------------------------------------------------------------
+# Skip helpers + small fixtures
+# --------------------------------------------------------------------------
+
+
+def _gpu_available() -> bool:
+    """Return True iff cupy imports cleanly AND a CUDA device is up."""
+    if importlib.util.find_spec("cupy") is None:
+        return False
+    try:
+        import cupy
+        return bool(cupy.cuda.is_available())
+    except Exception:
+        return False
+
+
+_HAS_GPU = _gpu_available()
+_gpu_only = pytest.mark.skipif(
+    not _HAS_GPU, reason="cupy + CUDA required",
+)
+
+
+def _build_local_tif(tmp_path, name='src_2175.tif'):
+    """Write a small valid GeoTIFF used as the dispatcher's source."""
+    arr = np.arange(8 * 8, dtype=np.float32).reshape(8, 8)
+    da = xr.DataArray(
+        arr,
+        dims=['y', 'x'],
+        coords={'y': np.arange(8.0, 0, -1), 'x': np.arange(8.0)},
+        attrs={
+            'crs': 4326,
+            'transform': (1.0, 0, 0.0, 0, -1.0, 8.0),
+        },
+    )
+    path = str(tmp_path / name)
+    to_geotiff(da, path)
+    return path
+
+
+def _build_vrt(tmp_path):
+    """Build a 1-source VRT mosaic referencing a small local GeoTIFF."""
+    src = _build_local_tif(tmp_path, name='vrt_src_2175.tif')
+    vrt = str(tmp_path / 'mosaic_2175.vrt')
+    write_vrt(vrt, [src])
+    return vrt, src
+
+
+# --------------------------------------------------------------------------
+# overview_level type rejection through every entry point
+# --------------------------------------------------------------------------
+#
+# ``_validate_overview_level_arg`` rejects bool / str / float with a
+# ``TypeError`` whose message names the offending type. The helper runs
+# this check first across all four entry points (issue #2074, #2160).
+# The cupy gate skips GPU cases when CUDA is unavailable. The GPU and
+# VRT entry points also reach the validator before any GPU / source
+# parse, so the bad-input path raises on CPU-only hosts.
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_open_geotiff_overview_level_bool(tmp_path, value):
+    path = _build_local_tif(tmp_path)
+    with pytest.raises(TypeError, match="bool"):
+        open_geotiff(path, overview_level=value)
+
+
+def test_open_geotiff_overview_level_str(tmp_path):
+    path = _build_local_tif(tmp_path)
+    with pytest.raises(TypeError, match="str"):
+        open_geotiff(path, overview_level="0")
+
+
+def test_open_geotiff_overview_level_float(tmp_path):
+    path = _build_local_tif(tmp_path)
+    with pytest.raises(TypeError, match="float"):
+        open_geotiff(path, overview_level=1.0)
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_dask_overview_level_bool(tmp_path, value):
+    path = _build_local_tif(tmp_path)
+    with pytest.raises(TypeError, match="bool"):
+        read_geotiff_dask(path, overview_level=value)
+
+
+def test_dask_overview_level_str(tmp_path):
+    path = _build_local_tif(tmp_path)
+    with pytest.raises(TypeError, match="str"):
+        read_geotiff_dask(path, overview_level="0")
+
+
+def test_dask_overview_level_float(tmp_path):
+    path = _build_local_tif(tmp_path)
+    with pytest.raises(TypeError, match="float"):
+        read_geotiff_dask(path, overview_level=1.0)
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_gpu_overview_level_bool(tmp_path, value):
+    path = _build_local_tif(tmp_path)
+    with pytest.raises(TypeError, match="bool"):
+        read_geotiff_gpu(path, overview_level=value)
+
+
+def test_gpu_overview_level_str(tmp_path):
+    path = _build_local_tif(tmp_path)
+    with pytest.raises(TypeError, match="str"):
+        read_geotiff_gpu(path, overview_level="0")
+
+
+def test_gpu_overview_level_float(tmp_path):
+    path = _build_local_tif(tmp_path)
+    with pytest.raises(TypeError, match="float"):
+        read_geotiff_gpu(path, overview_level=1.0)
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_vrt_overview_level_bool(tmp_path, value):
+    vrt, _src = _build_vrt(tmp_path)
+    with pytest.raises(TypeError, match="bool"):
+        read_vrt(vrt, overview_level=value)
+
+
+def test_vrt_overview_level_str(tmp_path):
+    vrt, _src = _build_vrt(tmp_path)
+    with pytest.raises(TypeError, match="str"):
+        read_vrt(vrt, overview_level="0")
+
+
+def test_vrt_overview_level_float(tmp_path):
+    vrt, _src = _build_vrt(tmp_path)
+    with pytest.raises(TypeError, match="float"):
+        read_vrt(vrt, overview_level=1.0)
+
+
+# --------------------------------------------------------------------------
+# max_cloud_bytes incompatibility through every applicable backend
+# --------------------------------------------------------------------------
+#
+# Only the eager non-VRT non-GPU non-dask branch in ``open_geotiff``
+# consumes ``max_cloud_bytes``. The three direct backends never look
+# at it and would silently drop the budget before #2175. Parity means
+# each backend rejects an explicit value with a ``ValueError`` whose
+# message names the kwarg.
+
+
+def test_open_geotiff_dask_rejects_max_cloud_bytes(tmp_path):
+    path = _build_local_tif(tmp_path)
+    with pytest.raises(ValueError, match=r"max_cloud_bytes"):
+        open_geotiff(path, chunks=4, max_cloud_bytes=8)
+
+
+def test_open_geotiff_gpu_rejects_max_cloud_bytes(tmp_path):
+    path = _build_local_tif(tmp_path)
+    with pytest.raises(ValueError, match=r"max_cloud_bytes"):
+        open_geotiff(path, gpu=True, max_cloud_bytes=8)
+
+
+def test_open_geotiff_vrt_rejects_max_cloud_bytes(tmp_path):
+    vrt, _src = _build_vrt(tmp_path)
+    with pytest.raises(ValueError, match=r"max_cloud_bytes"):
+        open_geotiff(vrt, max_cloud_bytes=8)
+
+
+def test_dask_rejects_max_cloud_bytes(tmp_path):
+    path = _build_local_tif(tmp_path)
+    with pytest.raises(ValueError, match=r"max_cloud_bytes"):
+        read_geotiff_dask(path, max_cloud_bytes=8)
+
+
+def test_gpu_rejects_max_cloud_bytes(tmp_path):
+    path = _build_local_tif(tmp_path)
+    with pytest.raises(ValueError, match=r"max_cloud_bytes"):
+        read_geotiff_gpu(path, max_cloud_bytes=8)
+
+
+def test_vrt_rejects_max_cloud_bytes(tmp_path):
+    vrt, _src = _build_vrt(tmp_path)
+    with pytest.raises(ValueError, match=r"max_cloud_bytes"):
+        read_vrt(vrt, max_cloud_bytes=8)
+
+
+def test_explicit_none_max_cloud_bytes_rejected_on_dask_direct(tmp_path):
+    """``max_cloud_bytes=None`` is the documented "disable budget" value
+    on the eager path. On the dask path it has no consumer, so an
+    explicit ``None`` is still rejected -- the sentinel default is the
+    only way to pass through without setting an opinion.
+    """
+    path = _build_local_tif(tmp_path)
+    with pytest.raises(ValueError, match=r"max_cloud_bytes"):
+        read_geotiff_dask(path, max_cloud_bytes=None)
+
+
+def test_explicit_none_max_cloud_bytes_rejected_on_gpu_direct(tmp_path):
+    path = _build_local_tif(tmp_path)
+    with pytest.raises(ValueError, match=r"max_cloud_bytes"):
+        read_geotiff_gpu(path, max_cloud_bytes=None)
+
+
+def test_explicit_none_max_cloud_bytes_rejected_on_vrt_direct(tmp_path):
+    vrt, _src = _build_vrt(tmp_path)
+    with pytest.raises(ValueError, match=r"max_cloud_bytes"):
+        read_vrt(vrt, max_cloud_bytes=None)
+
+
+# --------------------------------------------------------------------------
+# missing_sources on non-VRT sources
+# --------------------------------------------------------------------------
+#
+# ``missing_sources`` controls the VRT mosaic loop. On a plain GeoTIFF
+# the kwarg has no meaning. Every non-VRT entry point rejects an
+# explicit value with a ``ValueError`` whose message names the kwarg.
+
+
+def test_open_geotiff_rejects_missing_sources_on_tif(tmp_path):
+    path = _build_local_tif(tmp_path)
+    with pytest.raises(ValueError, match=r"missing_sources only applies"):
+        open_geotiff(path, missing_sources='raise')
+
+
+def test_dask_rejects_missing_sources_on_tif(tmp_path):
+    path = _build_local_tif(tmp_path)
+    with pytest.raises(ValueError, match=r"missing_sources only applies"):
+        read_geotiff_dask(path, missing_sources='raise')
+
+
+def test_gpu_rejects_missing_sources_on_tif(tmp_path):
+    path = _build_local_tif(tmp_path)
+    with pytest.raises(ValueError, match=r"missing_sources only applies"):
+        read_geotiff_gpu(path, missing_sources='raise')
+
+
+# --------------------------------------------------------------------------
+# band_nodata on non-VRT sources
+# --------------------------------------------------------------------------
+#
+# ``band_nodata`` is the #1987 PR 5 opt-out for the VRT mixed-band
+# metadata check. On a plain GeoTIFF the kwarg has no meaning -- each
+# non-VRT entry point rejects an explicit value.
+
+
+def test_open_geotiff_rejects_band_nodata_on_tif(tmp_path):
+    path = _build_local_tif(tmp_path)
+    with pytest.raises(ValueError, match=r"band_nodata only applies"):
+        open_geotiff(path, band_nodata='first')
+
+
+def test_dask_rejects_band_nodata_on_tif(tmp_path):
+    path = _build_local_tif(tmp_path)
+    with pytest.raises(ValueError, match=r"band_nodata only applies"):
+        read_geotiff_dask(path, band_nodata='first')
+
+
+def test_gpu_rejects_band_nodata_on_tif(tmp_path):
+    path = _build_local_tif(tmp_path)
+    with pytest.raises(ValueError, match=r"band_nodata only applies"):
+        read_geotiff_gpu(path, band_nodata='first')
+
+
+# --------------------------------------------------------------------------
+# on_gpu_failure when GPU is disabled
+# --------------------------------------------------------------------------
+#
+# ``on_gpu_failure`` is the GPU pipeline's strict/auto fallback policy.
+# The CPU and dask paths have no such concept, and ``read_vrt`` does
+# not route through the GPU decoder. Each non-GPU entry point rejects
+# an explicit value with a ``ValueError`` whose message names the kwarg.
+
+
+def test_open_geotiff_rejects_on_gpu_failure_when_gpu_false(tmp_path):
+    path = _build_local_tif(tmp_path)
+    with pytest.raises(ValueError, match=r"on_gpu_failure only applies"):
+        open_geotiff(path, on_gpu_failure='strict')
+
+
+def test_dask_rejects_on_gpu_failure(tmp_path):
+    path = _build_local_tif(tmp_path)
+    with pytest.raises(ValueError, match=r"on_gpu_failure only applies"):
+        read_geotiff_dask(path, on_gpu_failure='strict')
+
+
+def test_vrt_rejects_on_gpu_failure(tmp_path):
+    vrt, _src = _build_vrt(tmp_path)
+    with pytest.raises(ValueError, match=r"on_gpu_failure only applies"):
+        read_vrt(vrt, on_gpu_failure='strict')
+
+
+# --------------------------------------------------------------------------
+# File-like sources reject gpu=True / chunks=...
+# --------------------------------------------------------------------------
+#
+# The GPU and dask paths re-open the source by path from worker tasks,
+# so a file-like buffer cannot survive the trip. ``open_geotiff`` and
+# the direct backends share the rejection now via the helper.
+
+
+def test_open_geotiff_rejects_file_like_with_chunks(tmp_path):
+    path = _build_local_tif(tmp_path)
+    with open(path, 'rb') as f:
+        buf = io.BytesIO(f.read())
+    with pytest.raises(
+            ValueError,
+            match=r"chunks=\.\.\. \(dask\) is not supported for file-like"):
+        open_geotiff(buf, chunks=4)
+
+
+def test_open_geotiff_rejects_file_like_with_gpu(tmp_path):
+    path = _build_local_tif(tmp_path)
+    with open(path, 'rb') as f:
+        buf = io.BytesIO(f.read())
+    with pytest.raises(
+            ValueError,
+            match=r"gpu=True is not supported for file-like"):
+        open_geotiff(buf, gpu=True)
+
+
+def test_dask_rejects_file_like(tmp_path):
+    path = _build_local_tif(tmp_path)
+    with open(path, 'rb') as f:
+        buf = io.BytesIO(f.read())
+    with pytest.raises(
+            ValueError,
+            match=r"chunks=\.\.\. \(dask\) is not supported for file-like"):
+        read_geotiff_dask(buf)
+
+
+def test_gpu_rejects_file_like(tmp_path):
+    path = _build_local_tif(tmp_path)
+    with open(path, 'rb') as f:
+        buf = io.BytesIO(f.read())
+    with pytest.raises(
+            ValueError,
+            match=r"gpu=True is not supported for file-like"):
+        read_geotiff_gpu(buf)
+
+
+# --------------------------------------------------------------------------
+# Default sentinel pins (no regressions on the happy path)
+# --------------------------------------------------------------------------
+#
+# Every entry point must accept its sentinel defaults without raising.
+# A regression on a default would break every call site that omits the
+# kwarg.
+
+
+def test_open_geotiff_defaults_round_trip(tmp_path):
+    path = _build_local_tif(tmp_path)
+    out = open_geotiff(path)
+    assert out.shape == (8, 8)
+
+
+def test_dask_defaults_round_trip(tmp_path):
+    path = _build_local_tif(tmp_path)
+    out = read_geotiff_dask(path)
+    assert out.shape == (8, 8)
+
+
+def test_vrt_defaults_round_trip(tmp_path):
+    vrt, _src = _build_vrt(tmp_path)
+    out = read_vrt(vrt)
+    assert out.shape == (8, 8)
+
+
+# --------------------------------------------------------------------------
+# Cross-entry-point message parity. The same invalid input through
+# different entry points should produce the same exception text so
+# callers can match on a single regex regardless of which backend they
+# hit.
+# --------------------------------------------------------------------------
+
+
+def _get_error_message(callable_, *args, **kwargs) -> str:
+    """Invoke ``callable_`` and return the exception message it raises."""
+    try:
+        callable_(*args, **kwargs)
+    except Exception as e:
+        return f"{type(e).__name__}: {e}"
+    raise AssertionError("expected an exception, none raised")
+
+
+def test_max_cloud_bytes_message_parity(tmp_path):
+    path = _build_local_tif(tmp_path)
+    vrt, _ = _build_vrt(tmp_path)
+    open_dask_msg = _get_error_message(
+        open_geotiff, path, chunks=4, max_cloud_bytes=8)
+    direct_dask_msg = _get_error_message(
+        read_geotiff_dask, path, max_cloud_bytes=8)
+    # Both messages mention max_cloud_bytes and the dask incompatibility.
+    assert "max_cloud_bytes" in open_dask_msg
+    assert "max_cloud_bytes" in direct_dask_msg
+    assert "dask" in open_dask_msg
+    assert "dask" in direct_dask_msg
+
+    open_gpu_msg = _get_error_message(
+        open_geotiff, path, gpu=True, max_cloud_bytes=8)
+    direct_gpu_msg = _get_error_message(
+        read_geotiff_gpu, path, max_cloud_bytes=8)
+    assert "max_cloud_bytes" in open_gpu_msg
+    assert "max_cloud_bytes" in direct_gpu_msg
+    assert "gpu" in open_gpu_msg.lower()
+    assert "gpu" in direct_gpu_msg.lower()
+
+    open_vrt_msg = _get_error_message(
+        open_geotiff, vrt, max_cloud_bytes=8)
+    direct_vrt_msg = _get_error_message(
+        read_vrt, vrt, max_cloud_bytes=8)
+    assert "max_cloud_bytes" in open_vrt_msg
+    assert "max_cloud_bytes" in direct_vrt_msg
+    assert "vrt" in open_vrt_msg.lower()
+    assert "vrt" in direct_vrt_msg.lower()
+
+
+def test_band_nodata_message_parity(tmp_path):
+    path = _build_local_tif(tmp_path)
+    open_msg = _get_error_message(
+        open_geotiff, path, band_nodata='first')
+    dask_msg = _get_error_message(
+        read_geotiff_dask, path, band_nodata='first')
+    gpu_msg = _get_error_message(
+        read_geotiff_gpu, path, band_nodata='first')
+    for msg in (open_msg, dask_msg, gpu_msg):
+        assert "band_nodata only applies" in msg
+
+
+def test_missing_sources_message_parity(tmp_path):
+    path = _build_local_tif(tmp_path)
+    open_msg = _get_error_message(
+        open_geotiff, path, missing_sources='raise')
+    dask_msg = _get_error_message(
+        read_geotiff_dask, path, missing_sources='raise')
+    gpu_msg = _get_error_message(
+        read_geotiff_gpu, path, missing_sources='raise')
+    for msg in (open_msg, dask_msg, gpu_msg):
+        assert "missing_sources only applies" in msg
+
+
+def test_on_gpu_failure_message_parity(tmp_path):
+    path = _build_local_tif(tmp_path)
+    vrt, _ = _build_vrt(tmp_path)
+    open_msg = _get_error_message(
+        open_geotiff, path, on_gpu_failure='strict')
+    dask_msg = _get_error_message(
+        read_geotiff_dask, path, on_gpu_failure='strict')
+    vrt_msg = _get_error_message(
+        read_vrt, vrt, on_gpu_failure='strict')
+    for msg in (open_msg, dask_msg, vrt_msg):
+        assert "on_gpu_failure only applies" in msg
+
+
+def test_overview_level_message_parity(tmp_path):
+    path = _build_local_tif(tmp_path)
+    vrt, _ = _build_vrt(tmp_path)
+    open_msg = _get_error_message(open_geotiff, path, overview_level="bad")
+    dask_msg = _get_error_message(read_geotiff_dask, path, overview_level="bad")
+    gpu_msg = _get_error_message(read_geotiff_gpu, path, overview_level="bad")
+    vrt_msg = _get_error_message(read_vrt, vrt, overview_level="bad")
+    for msg in (open_msg, dask_msg, gpu_msg, vrt_msg):
+        assert "overview_level must be an int or None" in msg
+        assert "str" in msg

--- a/xrspatial/geotiff/tests/test_dispatch_validation_parity_2162.py
+++ b/xrspatial/geotiff/tests/test_dispatch_validation_parity_2162.py
@@ -374,6 +374,73 @@ def test_gpu_rejects_file_like(tmp_path):
 
 
 # --------------------------------------------------------------------------
+# Path-object sources survive the helper's file-like guard
+# --------------------------------------------------------------------------
+#
+# ``pathlib.Path`` is an ``os.PathLike`` instance, not a string. Each
+# entry point coerces ``Path`` to ``str`` via ``_coerce_path`` before the
+# dispatch validator runs so the file-like guard
+# (``not isinstance(source, str)``) does not misclassify a Path as a
+# file-like buffer. Regression for the review feedback on the original
+# #2175 PR (the GPU entry point was coercing AFTER the validator).
+
+
+def test_open_geotiff_accepts_path_object(tmp_path):
+    from pathlib import Path
+    path = _build_local_tif(tmp_path)
+    out = open_geotiff(Path(path))
+    assert out.shape == (8, 8)
+
+
+def test_dask_accepts_path_object(tmp_path):
+    from pathlib import Path
+    path = _build_local_tif(tmp_path)
+    out = read_geotiff_dask(Path(path), chunks=4)
+    assert out.shape == (8, 8)
+
+
+def test_vrt_accepts_path_object(tmp_path):
+    from pathlib import Path
+    vrt, _src = _build_vrt(tmp_path)
+    out = read_vrt(Path(vrt))
+    assert out.shape == (8, 8)
+
+
+@_gpu_only
+def test_gpu_accepts_path_object(tmp_path):
+    from pathlib import Path
+    path = _build_local_tif(tmp_path)
+    out = read_geotiff_gpu(Path(path))
+    assert out.shape == (8, 8)
+
+
+def test_gpu_path_object_does_not_raise_file_like_error(tmp_path):
+    """Even on a CPU-only host the validator must accept a Path object.
+
+    The dispatch validator runs before any cupy import, so the bad
+    behaviour on `main` (treating Path as file-like) raises before any
+    GPU code executes. With the fix the validator coerces Path to str
+    first and the error only surfaces (if at all) from the GPU stack.
+    """
+    from pathlib import Path
+    path = _build_local_tif(tmp_path)
+    # Either the call succeeds (GPU available) or it fails for a real
+    # GPU reason. The one thing it must NOT raise is the file-like
+    # ValueError introduced by the validator misclassifying Path.
+    try:
+        read_geotiff_gpu(Path(path))
+    except ValueError as e:
+        assert "file-like" not in str(e), (
+            f"validator misclassified Path as file-like: {e}"
+        )
+    except Exception:
+        # Any non-ValueError failure (ImportError, RuntimeError from
+        # the CUDA preflight, etc.) is acceptable -- it is not the
+        # regression we are pinning.
+        pass
+
+
+# --------------------------------------------------------------------------
 # Default sentinel pins (no regressions on the happy path)
 # --------------------------------------------------------------------------
 #
@@ -408,91 +475,95 @@ def test_vrt_defaults_round_trip(tmp_path):
 # --------------------------------------------------------------------------
 
 
-def _get_error_message(callable_, *args, **kwargs) -> str:
-    """Invoke ``callable_`` and return the exception message it raises."""
+def _get_error(callable_, *args, **kwargs):
+    """Invoke ``callable_`` and return the (type_name, message) of the
+    exception it raises. Asserting on the type and message separately
+    catches a regression where the exception type changes silently
+    while the message stays the same.
+    """
     try:
         callable_(*args, **kwargs)
     except Exception as e:
-        return f"{type(e).__name__}: {e}"
+        return type(e).__name__, str(e)
     raise AssertionError("expected an exception, none raised")
 
 
 def test_max_cloud_bytes_message_parity(tmp_path):
     path = _build_local_tif(tmp_path)
     vrt, _ = _build_vrt(tmp_path)
-    open_dask_msg = _get_error_message(
-        open_geotiff, path, chunks=4, max_cloud_bytes=8)
-    direct_dask_msg = _get_error_message(
-        read_geotiff_dask, path, max_cloud_bytes=8)
-    # Both messages mention max_cloud_bytes and the dask incompatibility.
-    assert "max_cloud_bytes" in open_dask_msg
-    assert "max_cloud_bytes" in direct_dask_msg
-    assert "dask" in open_dask_msg
-    assert "dask" in direct_dask_msg
+    open_dask = _get_error(open_geotiff, path, chunks=4, max_cloud_bytes=8)
+    direct_dask = _get_error(read_geotiff_dask, path, max_cloud_bytes=8)
+    # Both raise ValueError with the same dask-incompatibility message.
+    assert open_dask[0] == "ValueError"
+    assert direct_dask[0] == "ValueError"
+    for _, msg in (open_dask, direct_dask):
+        assert "max_cloud_bytes" in msg
+        assert "dask" in msg
 
-    open_gpu_msg = _get_error_message(
-        open_geotiff, path, gpu=True, max_cloud_bytes=8)
-    direct_gpu_msg = _get_error_message(
-        read_geotiff_gpu, path, max_cloud_bytes=8)
-    assert "max_cloud_bytes" in open_gpu_msg
-    assert "max_cloud_bytes" in direct_gpu_msg
-    assert "gpu" in open_gpu_msg.lower()
-    assert "gpu" in direct_gpu_msg.lower()
+    open_gpu = _get_error(open_geotiff, path, gpu=True, max_cloud_bytes=8)
+    direct_gpu = _get_error(read_geotiff_gpu, path, max_cloud_bytes=8)
+    assert open_gpu[0] == "ValueError"
+    assert direct_gpu[0] == "ValueError"
+    for _, msg in (open_gpu, direct_gpu):
+        assert "max_cloud_bytes" in msg
+        assert "gpu" in msg.lower()
 
-    open_vrt_msg = _get_error_message(
-        open_geotiff, vrt, max_cloud_bytes=8)
-    direct_vrt_msg = _get_error_message(
-        read_vrt, vrt, max_cloud_bytes=8)
-    assert "max_cloud_bytes" in open_vrt_msg
-    assert "max_cloud_bytes" in direct_vrt_msg
-    assert "vrt" in open_vrt_msg.lower()
-    assert "vrt" in direct_vrt_msg.lower()
+    open_vrt = _get_error(open_geotiff, vrt, max_cloud_bytes=8)
+    direct_vrt = _get_error(read_vrt, vrt, max_cloud_bytes=8)
+    assert open_vrt[0] == "ValueError"
+    assert direct_vrt[0] == "ValueError"
+    for _, msg in (open_vrt, direct_vrt):
+        assert "max_cloud_bytes" in msg
+        assert "vrt" in msg.lower()
 
 
 def test_band_nodata_message_parity(tmp_path):
     path = _build_local_tif(tmp_path)
-    open_msg = _get_error_message(
-        open_geotiff, path, band_nodata='first')
-    dask_msg = _get_error_message(
-        read_geotiff_dask, path, band_nodata='first')
-    gpu_msg = _get_error_message(
-        read_geotiff_gpu, path, band_nodata='first')
-    for msg in (open_msg, dask_msg, gpu_msg):
+    results = [
+        _get_error(open_geotiff, path, band_nodata='first'),
+        _get_error(read_geotiff_dask, path, band_nodata='first'),
+        _get_error(read_geotiff_gpu, path, band_nodata='first'),
+    ]
+    for kind, msg in results:
+        assert kind == "ValueError"
         assert "band_nodata only applies" in msg
 
 
 def test_missing_sources_message_parity(tmp_path):
     path = _build_local_tif(tmp_path)
-    open_msg = _get_error_message(
-        open_geotiff, path, missing_sources='raise')
-    dask_msg = _get_error_message(
-        read_geotiff_dask, path, missing_sources='raise')
-    gpu_msg = _get_error_message(
-        read_geotiff_gpu, path, missing_sources='raise')
-    for msg in (open_msg, dask_msg, gpu_msg):
+    results = [
+        _get_error(open_geotiff, path, missing_sources='raise'),
+        _get_error(read_geotiff_dask, path, missing_sources='raise'),
+        _get_error(read_geotiff_gpu, path, missing_sources='raise'),
+    ]
+    for kind, msg in results:
+        assert kind == "ValueError"
         assert "missing_sources only applies" in msg
 
 
 def test_on_gpu_failure_message_parity(tmp_path):
     path = _build_local_tif(tmp_path)
     vrt, _ = _build_vrt(tmp_path)
-    open_msg = _get_error_message(
-        open_geotiff, path, on_gpu_failure='strict')
-    dask_msg = _get_error_message(
-        read_geotiff_dask, path, on_gpu_failure='strict')
-    vrt_msg = _get_error_message(
-        read_vrt, vrt, on_gpu_failure='strict')
-    for msg in (open_msg, dask_msg, vrt_msg):
+    results = [
+        _get_error(open_geotiff, path, on_gpu_failure='strict'),
+        _get_error(read_geotiff_dask, path, on_gpu_failure='strict'),
+        _get_error(read_vrt, vrt, on_gpu_failure='strict'),
+    ]
+    for kind, msg in results:
+        assert kind == "ValueError"
         assert "on_gpu_failure only applies" in msg
 
 
 def test_overview_level_message_parity(tmp_path):
     path = _build_local_tif(tmp_path)
     vrt, _ = _build_vrt(tmp_path)
-    open_msg = _get_error_message(open_geotiff, path, overview_level="bad")
-    dask_msg = _get_error_message(read_geotiff_dask, path, overview_level="bad")
-    gpu_msg = _get_error_message(read_geotiff_gpu, path, overview_level="bad")
-    vrt_msg = _get_error_message(read_vrt, vrt, overview_level="bad")
-    for msg in (open_msg, dask_msg, gpu_msg, vrt_msg):
+    results = [
+        _get_error(open_geotiff, path, overview_level="bad"),
+        _get_error(read_geotiff_dask, path, overview_level="bad"),
+        _get_error(read_geotiff_gpu, path, overview_level="bad"),
+        _get_error(read_vrt, vrt, overview_level="bad"),
+    ]
+    for kind, msg in results:
+        assert kind == "TypeError"
         assert "overview_level must be an int or None" in msg
         assert "str" in msg


### PR DESCRIPTION
## Summary

Closes #2175. Parent #2162 (wave 1 of 3).

`open_geotiff` used to run six dispatcher-level kwarg checks inline at `xrspatial/geotiff/__init__.py:508-584`. The three direct backends (`read_geotiff_dask`, `read_geotiff_gpu`, `read_vrt`) only ran the `_validate_overview_level_arg` slice and silently dropped the rest. A caller who passed `band_nodata` to dask or `max_cloud_bytes` to the GPU reader got no error at all, or got an unrelated `TypeError` from the signature.

This PR adds `_validate_dispatch_kwargs(...)` to `xrspatial/geotiff/_validation.py` and wires it into every public read entry point so the same invalid input raises the same exception text regardless of which entry point the caller used.

### Rules enforced (all pre-existing in `open_geotiff`; now mirrored on the direct backends):

- `overview_level` type check (delegates to existing helper, issue #2074).
- `on_gpu_failure` rejected on the CPU / dask / VRT paths (issue #1615).
- `missing_sources` rejected on non-VRT sources (issue #1810).
- `band_nodata` rejected on non-VRT sources (issue #1987).
- `max_cloud_bytes` rejected on VRT / GPU / dask paths (issue #1974).
- File-like sources reject `gpu=True` / `chunks=...`.

### API surface

No behavioral change for any valid input. Direct backends gain new kwargs with sentinel defaults (`_ON_GPU_FAILURE_SENTINEL`, `_MISSING_SOURCES_SENTINEL`, `_MAX_CLOUD_BYTES_SENTINEL`) so that omitted kwargs round-trip through the helper without tripping a rejection. Explicit invalid values now raise consistently across `open_geotiff`, `read_geotiff_dask`, `read_geotiff_gpu`, and `read_vrt`.

### Backend coverage

All four read entry points share the same validator. Pure CPU-side validation; no kernels or device code.

## Test plan

- [x] New `xrspatial/geotiff/tests/test_dispatch_validation_parity_2162.py` parametrizes the matrix from issue #2175 (invalid `overview_level` types through all four entry points; `max_cloud_bytes` with dask/GPU/VRT; `missing_sources` on non-VRT; `band_nodata` on non-VRT; `on_gpu_failure` without GPU; file-like + `gpu=True`/`chunks=...`).
- [x] Existing dispatcher tests (`test_overview_level_validation_backends_2160.py`, `test_max_cloud_bytes_dispatcher_silent_drop_2026_05_15.py`, `test_open_geotiff_missing_sources_1810.py`, `test_open_geotiff_on_gpu_failure_1615.py`) still pass.
- [x] Signature-order pin (`test_reader_kwarg_order_1935.py`) still passes after adding new kwargs.
- [x] Full `xrspatial/geotiff/tests/` suite green (4552 passed, 45 skipped, 1 xfailed). The pre-existing `lz4` failure on `test_lowlevel_write_pushdown_2138.py` reproduces on `main` and is unrelated.

## Scope notes

- Wave 1 of the #2162 refactor. Out of scope: finalization helpers (sibling PR in this wave), backend migration to a shared finalization pipeline (waves 2 and 3).
- The VRT-specific value rejection (`overview_level not in (None, 0)` and the legacy "on_gpu_failure on VRT" message) stays inside the VRT branch of `open_geotiff` and at the top of `read_vrt`. Folding those into the helper would expand scope beyond the issue's contract.
- GPU-only test paths are skipped when CUDA is unavailable; the bad-input tests run on CPU-only hosts because the validator fires before any CUDA import.