### PR TITLE
polygonize: honor user atol/rtol in dask cross-chunk merge

### DIFF
--- a/xrspatial/polygonize.py
+++ b/xrspatial/polygonize.py
@@ -264,24 +264,33 @@ def _is_close(
 
 # Pure-Python tolerance check that mirrors ``_is_close`` for use at the
 # orchestration layer (outside numba kernels).  Integer values fall back
-# to exact equality; floats use the same atol=1e-8, rtol=1e-5 tolerance
-# the CPU CCL uses to merge adjacent pixels.  See issue #2171.
-def _values_close(reference, value):
+# to exact equality; floats use the caller-supplied atol / rtol so the
+# cross-chunk merge honours ``polygonize(..., atol=, rtol=)`` (passing
+# atol=rtol=0 reduces the float branch to strict equality, matching the
+# CPU CCL behaviour inside a single chunk).  See issues #2171, #2173.
+def _values_close(reference, value,
+                  atol: float = _DEFAULT_ATOL,
+                  rtol: float = _DEFAULT_RTOL):
     if isinstance(reference, (int, np.integer)) and \
             isinstance(value, (int, np.integer)):
         return value == reference
-    return abs(value - reference) <= (1e-8 + 1e-5 * abs(reference))
+    return abs(value - reference) <= (atol + rtol * abs(reference))
 
 
-def _bucket_key_for_value(boundary_by_value, val):
+def _bucket_key_for_value(boundary_by_value, val,
+                          atol: float = _DEFAULT_ATOL,
+                          rtol: float = _DEFAULT_RTOL):
     """Return the dict key that ``val`` should bucket into.
 
     If an existing key in ``boundary_by_value`` is close to ``val`` under
-    ``_values_close``, return that key so close float values from adjacent
-    chunks land in the same bucket.  Otherwise return ``val`` unchanged.
+    ``_values_close`` (using the caller's ``atol`` / ``rtol``), return
+    that key so close float values from adjacent chunks land in the same
+    bucket.  Otherwise return ``val`` unchanged.
 
     This keeps Dask chunk-stitching consistent with the tolerance-based
-    grouping the NumPy / numba path uses inside a single chunk (#2171).
+    grouping the NumPy / numba path uses inside a single chunk (#2171),
+    and lets ``polygonize(atol=0, rtol=0)`` opt into exact-value
+    bucketing across chunks (#2173).
 
     Performance note: the float branch is a linear scan over existing
     keys, so total cost is O(B^2) in the number of distinct float
@@ -295,7 +304,7 @@ def _bucket_key_for_value(boundary_by_value, val):
     if isinstance(val, (int, np.integer)):
         return val
     for existing in boundary_by_value:
-        if _values_close(existing, val):
+        if _values_close(existing, val, atol, rtol):
             return existing
     return val
 
@@ -1669,7 +1678,8 @@ def _polygonize_dask(dask_data, mask_data, connectivity_8, transform,
                 ))[0]
             all_interior.extend(interior)
             for val, rings in boundary:
-                key = _bucket_key_for_value(boundary_by_value, val)
+                key = _bucket_key_for_value(
+                    boundary_by_value, val, atol, rtol)
                 boundary_by_value.setdefault(key, []).append(rings)
 
     return _merge_from_separated(all_interior, boundary_by_value, transform)

--- a/xrspatial/tests/test_polygonize.py
+++ b/xrspatial/tests/test_polygonize.py
@@ -1492,23 +1492,20 @@ def test_polygonize_dask_single_chunk_strict_float():
 
 @dask_array_available
 def test_polygonize_dask_multi_chunk_default_tolerance():
-    """Multi-chunk dask path must apply the default tolerance per chunk
-    so close floats merge inside each chunk and the merge step at chunk
-    boundaries does not split them further (#2173)."""
-    # Single-row raster, one chunk per column.  Each chunk holds a
-    # different float that is within atol of its neighbour, so the merge
-    # logic must connect them.
+    """Multi-chunk dask path applies the default atol/rtol both per-chunk
+    and at the chunk-stitching step, so close floats in adjacent chunks
+    bucket together (#2171, #2173).
+
+    Pairwise (not transitive) bucketing: with [1.0, 1.000009, 1.000018]
+    split across single-pixel chunks, 1.000009 is within tolerance of
+    1.0 (diff 9e-6, threshold ~1.0e-5) and joins that bucket, but
+    1.000018 is outside (diff 18e-6) and stays separate.  Total area
+    still covers the raster.
+    """
     raster = xr.DataArray(da.from_array(_REPRO_2173, chunks=(1, 1)))
     values, polygons = polygonize(raster)
-    # NOTE: The current dask merge keys polygons by exact value, so this
-    # specific multi-chunk case does not yet collapse to a single polygon.
-    # The contract asserted here is that the per-chunk tolerance is
-    # applied (each single-pixel chunk yields exactly one polygon with
-    # its own value, all three input values are accounted for, and the
-    # total area covers the raster).  Cross-chunk merge by-exact-value
-    # is in a separate rockout.
-    assert len(values) == 3
-    assert sorted(values) == sorted(_REPRO_2173[0].tolist())
+    assert len(values) == 2
+    assert_allclose(sorted(values), [1.0, 1.000018])
     total_area = sum(
         assert_polygon_valid_and_get_area(p) for p in polygons)
     assert_allclose(total_area, 3.0)


### PR DESCRIPTION
## Summary

CI was failing on main with two pytest failures in `xrspatial/tests/test_polygonize.py`:

- `test_polygonize_dask_multi_chunk_default_tolerance` — `assert 2 == 3`
- `test_polygonize_dask_multi_chunk_strict_float` — `assert 2 == 3`

The root cause is a gap between PRs #2171 and #2173 (both merged today):

- #2171 added tolerance-based cross-chunk bucketing via `_bucket_key_for_value` / `_values_close`, but those helpers used hardcoded `1e-8` / `1e-5` tolerances.
- #2173 then exposed `atol` / `rtol` on `polygonize()` and threaded them through the per-chunk path, but the cross-chunk merge step kept the hardcoded tolerances. So `polygonize(..., atol=0, rtol=0)` still bucketed close floats together at chunk boundaries.

The default-tolerance test also asserted exact-value cross-chunk merge (carrying over a stale NOTE from before #2171), which no longer matches the implementation.

## Changes

- Add `atol` / `rtol` kwargs to `_values_close` and `_bucket_key_for_value`, defaulting to the module-level `_DEFAULT_ATOL` / `_DEFAULT_RTOL`.
- Pass the caller's `atol` / `rtol` from `_polygonize_dask` into the bucket-key lookup, so `atol=rtol=0` opts into strict cross-chunk equality.
- Update `test_polygonize_dask_multi_chunk_default_tolerance` to reflect the post-#2171 contract: pairwise (not transitive) bucketing, so `[1.0, 1.000009, 1.000018]` across single-pixel chunks yields two polygons (`1.0` and `1.000018`) with total area 3.

## Test plan

- [x] `pytest xrspatial/tests/test_polygonize.py` — 141 passed, 13 skipped
- [x] Both previously-failing tests now pass
- [x] #2171 tolerance regression tests still pass (`test_polygonize_dask_float_tolerance_repro_2171`, `test_polygonize_dask_float_tolerance_matches_numpy_2171`)
- [x] Strict-equality tests still pass (`test_polygonize_strict_float_equality`, `test_polygonize_dask_single_chunk_strict_float`)