### PR TITLE
Validate reproject input coordinate spacing

### DIFF
--- a/xrspatial/reproject/__init__.py
+++ b/xrspatial/reproject/__init__.py
@@ -68,6 +68,8 @@ _VERTICAL_DATUM_EPSG = {
     'ellipsoidal': 4979,  # WGS 84 (3D, ellipsoidal height)
 }
 
+_SPATIAL_COORD_RTOL = 1e-6
+
 
 def _find_spatial_dims(raster):
     """Find the y and x dimension names, handling multi-band rasters.
@@ -86,6 +88,41 @@ def _find_spatial_dims(raster):
         return ydim, xdim
     # Fallback: last two dims
     return dims[-2], dims[-1]
+
+
+def _validate_regular_spatial_coords(raster, context):
+    """Validate that spatial coordinates describe a rectilinear grid."""
+    ydim, xdim = _find_spatial_dims(raster)
+    _validate_regular_axis(raster.coords[ydim].values, 'y', context)
+    _validate_regular_axis(raster.coords[xdim].values, 'x', context)
+
+
+def _validate_regular_axis(values, axis_name, context):
+    values = np.asarray(values, dtype=np.float64)
+    if values.size < 2:
+        return
+
+    diffs = np.diff(values)
+    if not np.all(np.isfinite(diffs)):
+        raise ValueError(
+            f"{context}: {axis_name} coordinates must contain finite values"
+        )
+
+    if not (np.all(diffs > 0) or np.all(diffs < 0)):
+        raise ValueError(
+            f"{context}: {axis_name} coordinates must be strictly monotonic "
+            "(all ascending or all descending)"
+        )
+
+    median_step = float(np.median(diffs))
+    worst_step_deviation = float(np.max(np.abs(diffs - median_step)))
+    tolerance = _SPATIAL_COORD_RTOL * abs(median_step)
+    if worst_step_deviation > tolerance:
+        raise ValueError(
+            f"{context}: {axis_name} coordinates must be regularly spaced; "
+            f"worst step deviation is {worst_step_deviation:g} "
+            f"(median step {median_step:g}, rtol {_SPATIAL_COORD_RTOL:g})"
+        )
 
 
 def _source_bounds(raster):
@@ -641,6 +678,8 @@ def reproject(
     )
 
     _validate_resampling(resampling)
+
+    _validate_regular_spatial_coords(raster, "reproject()")
 
     # Reject unknown vertical-datum tokens at the API boundary so we never
     # write None into attrs['vertical_crs'] for typos / unsupported values.
@@ -1751,6 +1790,7 @@ def merge(
         # (#2027). Reject 3-D up front so callers get a clear error.
         _validate_raster(r, func_name='merge', name=f'rasters[{i}]',
                          ndim=(2,))
+        _validate_regular_spatial_coords(r, f"merge(): rasters[{i}]")
 
     _validate_grid_params(
         resolution=resolution,

--- a/xrspatial/tests/test_reproject.py
+++ b/xrspatial/tests/test_reproject.py
@@ -505,6 +505,33 @@ class TestReproject:
         with pytest.raises(ValueError, match="source CRS"):
             reproject(raster, 'EPSG:3857')
 
+    def test_reproject_rejects_irregular_x_before_crs_resolution(self):
+        from xrspatial.reproject import reproject
+        raster = xr.DataArray(
+            np.zeros((4, 4)), dims=['y', 'x'],
+            coords={'y': [3.0, 2.0, 1.0, 0.0],
+                    'x': [0.0, 1.0, 2.3, 3.0]},
+        )
+        with pytest.raises(
+            ValueError,
+            match=r"reproject\(\): x coordinates.*regular.*worst step deviation",
+        ):
+            reproject(raster, 'EPSG:4326')
+
+    def test_reproject_rejects_non_monotonic_y(self):
+        from xrspatial.reproject import reproject
+        raster = xr.DataArray(
+            np.zeros((4, 4)), dims=['y', 'x'],
+            coords={'y': [3.0, 2.0, 2.5, 0.0],
+                    'x': [0.0, 1.0, 2.0, 3.0]},
+            attrs={'crs': 'EPSG:4326'},
+        )
+        with pytest.raises(
+            ValueError,
+            match=r"reproject\(\): y coordinates must be strictly monotonic",
+        ):
+            reproject(raster, 'EPSG:4326')
+
     def test_non_dataarray_raises(self):
         from xrspatial.reproject import reproject
         with pytest.raises(TypeError, match="xarray.DataArray"):
@@ -652,6 +679,20 @@ class TestMerge:
         raster = _gradient_raster(h=8, w=8)
         with pytest.raises(ValueError, match="strategy"):
             merge([raster], strategy='median')
+
+    def test_merge_rejects_irregular_input_coords(self):
+        from xrspatial.reproject import merge
+        raster = xr.DataArray(
+            np.zeros((4, 4)), dims=['y', 'x'],
+            coords={'y': [3.0, 2.0, 1.0, 0.0],
+                    'x': [0.0, 1.0, 2.3, 3.0]},
+            attrs={'crs': 'EPSG:4326'},
+        )
+        with pytest.raises(
+            ValueError,
+            match=r"merge\(\): rasters\[0\].*x coordinates.*regular.*worst step deviation",
+        ):
+            merge([raster], target_crs='EPSG:4326')
 
     def test_merge_strategy_last(self):
         """merge() with strategy='last' uses the last valid value."""


### PR DESCRIPTION
## Summary

- Validate `reproject()` and `merge()` input x/y coordinates before CRS resolution.
- Reject non-monotonic axes and irregular spacing with axis-specific `ValueError` messages that include the worst step deviation.
- Add regression coverage for irregular x coordinates, non-monotonic y coordinates, and merge inputs.

Closes #2184

## Validation

- `uv run pytest -q xrspatial/tests/test_reproject.py::TestReproject::test_reproject_rejects_irregular_x_before_crs_resolution xrspatial/tests/test_reproject.py::TestReproject::test_reproject_rejects_non_monotonic_y xrspatial/tests/test_reproject.py::TestMerge::test_merge_rejects_irregular_input_coords`
- `uv run pytest -q xrspatial/tests/test_reproject.py::TestReproject xrspatial/tests/test_reproject.py::TestMerge xrspatial/tests/test_reproject.py::TestMergeSameCrsYOrientation xrspatial/tests/test_reproject.py::TestMergeMixedNodata xrspatial/tests/test_reproject.py::TestMerge3DRejection`
- `uv run pytest -q xrspatial/tests/test_reproject.py -k 'not test_vertical_crs_attr_is_epsg_int'`
- `uv run python -m compileall -q xrspatial/reproject/__init__.py xrspatial/tests/test_reproject.py`
- `git diff --check`
- Manual reproduction of the issue example for both `reproject()` and `merge()`.

Notes:
- The full `uv run pytest -q xrspatial/tests/test_reproject.py` run reached 277 passed / 18 skipped, then failed in `TestVerticalShift::test_vertical_crs_attr_is_epsg_int` because local Python SSL certificate verification failed while downloading geoid data from `cdn.proj.org`.
- `uv run flake8 xrspatial/reproject/__init__.py xrspatial/tests/test_reproject.py` reports existing lint findings in those files; I left that unrelated cleanup out of this fix.

## AI-assisted review

- [x] I ran the xarray-spatial AI-assisted review workflow for this PR.
- [x] I reviewed the review output myself and made my own judgment about what to accept.
- [x] I understand this change and can maintain it.
- [x] This PR does not attribute authorship to an AI tool or service.

Review notes:
- The command-suite review checklist was applied to the diff.
- No backend-specific implementation changed; validation runs before numpy, dask, or CuPy dispatch.
- The only open concern from local verification is the unrelated SSL/download failure noted above.
