### PR TITLE
geotiff: share lazy finalization helper across dask backends (PR C of #2162)

### DIFF
--- a/xrspatial/geotiff/_attrs.py
+++ b/xrspatial/geotiff/_attrs.py
@@ -1434,3 +1434,39 @@ def _finalize_lazy_read_attrs(
     )
 
     return attrs
+
+
+def _apply_caller_dtype_cast(
+    attrs: dict,
+    *,
+    caller_dtype,
+    has_nodata: bool,
+) -> None:
+    """Stamp ``attrs['nodata_dtype_cast']`` from a caller-supplied ``dtype=``.
+
+    Companion to :func:`_finalize_lazy_read_attrs` for the two dask
+    backends (issue #2178). The helper's ``dtype`` argument doubles as
+    the resolved graph dtype (driving ``masked_nodata``) and the
+    caller-supplied cast attr (driving ``nodata_dtype_cast``); the
+    dask paths must keep those separate because ``mask_nodata=True``
+    on an integer source auto-promotes the graph dtype to ``float64``
+    without the caller asking, and that auto-promotion must not leak
+    out as ``nodata_dtype_cast``.
+
+    Call this immediately after :func:`_finalize_lazy_read_attrs` to
+    overwrite the attr with the caller's intent:
+
+    * ``caller_dtype is None`` -- the caller did not ask for a cast;
+      drop any value the helper wrote.
+    * ``caller_dtype is not None`` AND ``has_nodata`` -- the caller
+      asked for a cast on a source with a declared sentinel; write
+      ``np.dtype(caller_dtype).name``.
+    * ``caller_dtype is not None`` AND not ``has_nodata`` -- no
+      sentinel was declared, so the attr is meaningless and should
+      stay absent (matches the pre-helper contract where
+      ``_set_nodata_attrs(..., nodata=None)`` short-circuited).
+    """
+    if caller_dtype is None:
+        attrs.pop('nodata_dtype_cast', None)
+    elif has_nodata:
+        attrs['nodata_dtype_cast'] = np.dtype(caller_dtype).name

--- a/xrspatial/geotiff/_backends/dask.py
+++ b/xrspatial/geotiff/_backends/dask.py
@@ -17,11 +17,7 @@ from __future__ import annotations
 import numpy as np
 import xarray as xr
 
-from .._attrs import (
-    _populate_attrs_from_geo_info,
-    _set_nodata_attrs,
-    _validate_read_geo_info,
-)
+from .._attrs import _finalize_lazy_read_attrs
 from .._coords import (
     coords_from_geo_info as _coords_from_geo_info,
     geo_to_coords as _geo_to_coords,
@@ -368,35 +364,41 @@ def read_geotiff_dask(source: str, *,
         import os
         name = os.path.splitext(os.path.basename(source))[0]
 
-    # Issue #1987 ambiguous-metadata checks.
-    _validate_read_geo_info(
-        geo_info, window=window,
+    # Wave 2 of #2162: share the validate-then-populate-then-stamp
+    # block with the dask+GPU backend via ``_finalize_lazy_read_attrs``.
+    #
+    # The helper conflates two ``dtype`` concepts (see the helper
+    # docstring): the **graph dtype** used to compute ``masked_nodata``
+    # and the **caller cast** recorded as ``nodata_dtype_cast``. The
+    # dask path distinguishes the two because masking on an integer
+    # source auto-promotes the graph dtype to ``float64`` without the
+    # caller asking for a cast, and we do not want that auto-promotion
+    # to surface as ``nodata_dtype_cast``.
+    #
+    # Pass ``target_dtype`` so ``masked_nodata`` reflects the resolved
+    # graph dtype, then overwrite ``nodata_dtype_cast`` to match the
+    # caller-supplied ``dtype=`` kwarg: omitted when ``dtype is None``,
+    # set to ``np.dtype(dtype).name`` otherwise. This preserves the
+    # pre-helper attr contract on the dask path.
+    #
+    # ``nodata_attr`` (not the MinIsWhite-inverted ``nodata``) is what
+    # ``attrs['nodata']`` must carry; the helper threads it through
+    # ``_set_nodata_attrs``. ``nodata_pixels_present`` stays unset on
+    # this path so the lazy contract from #2135 holds (a strict
+    # per-chunk reduction would force eager compute).
+    attrs = _finalize_lazy_read_attrs(
+        geo_info=geo_info,
+        nodata=nodata_attr,
+        mask_nodata=mask_nodata,
+        dtype=target_dtype,
+        window=window,
         allow_rotated=allow_rotated,
         allow_unparseable_crs=allow_unparseable_crs,
     )
-
-    attrs = {}
-    _populate_attrs_from_geo_info(attrs, geo_info, window=window)
-    # ``masked_nodata`` reflects whether per-chunk masking actually
-    # runs in the lazy graph (#2092). With ``mask_nodata=False`` each
-    # chunk skips the sentinel-to-NaN step, so even if the graph
-    # dtype happens to be float (e.g. caller-supplied ``dtype=float64``
-    # on an int file), the in-memory buffers hold literal sentinel
-    # values. True iff the caller opted into masking and the graph
-    # dtype is float.
-    # ``nodata_pixels_present`` is intentionally left unset on the
-    # dask path (issue #2135). A strict per-chunk reduction would force
-    # an eager ``.compute()`` here, defeating the lazy contract; callers
-    # that need the answer can fall back to scanning the materialised
-    # array. ``nodata_dtype_cast`` is recorded when the caller passed an
-    # explicit ``dtype=`` kwarg so downstream can tell float-by-cast
-    # apart from float-by-masking on the lazy output.
-    _set_nodata_attrs(
-        attrs, nodata_attr,
-        masked=(mask_nodata and target_dtype.kind == 'f'),
-        pixels_present=None,
-        dtype_cast=(np.dtype(dtype).name if dtype is not None else None),
-    )
+    if dtype is None:
+        attrs.pop('nodata_dtype_cast', None)
+    elif nodata_attr is not None:
+        attrs['nodata_dtype_cast'] = np.dtype(dtype).name
 
     if isinstance(chunks, int):
         ch_h = ch_w = chunks

--- a/xrspatial/geotiff/_backends/dask.py
+++ b/xrspatial/geotiff/_backends/dask.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import numpy as np
 import xarray as xr
 
-from .._attrs import _finalize_lazy_read_attrs
+from .._attrs import _apply_caller_dtype_cast, _finalize_lazy_read_attrs
 from .._coords import (
     coords_from_geo_info as _coords_from_geo_info,
     geo_to_coords as _geo_to_coords,
@@ -395,10 +395,9 @@ def read_geotiff_dask(source: str, *,
         allow_rotated=allow_rotated,
         allow_unparseable_crs=allow_unparseable_crs,
     )
-    if dtype is None:
-        attrs.pop('nodata_dtype_cast', None)
-    elif nodata_attr is not None:
-        attrs['nodata_dtype_cast'] = np.dtype(dtype).name
+    _apply_caller_dtype_cast(
+        attrs, caller_dtype=dtype, has_nodata=nodata_attr is not None,
+    )
 
     if isinstance(chunks, int):
         ch_h = ch_w = chunks

--- a/xrspatial/geotiff/_backends/gpu.py
+++ b/xrspatial/geotiff/_backends/gpu.py
@@ -21,6 +21,7 @@ import numpy as np
 import xarray as xr
 
 from .._attrs import (
+    _finalize_lazy_read_attrs,
     _populate_attrs_from_geo_info,
     _set_nodata_attrs,
     _validate_read_geo_info,
@@ -1560,30 +1561,32 @@ def _read_geotiff_gpu_chunked_gds(source, ifd, geo_info, header, *,
     else:
         dims = ['y', 'x']
 
-    _validate_read_geo_info(
-        geo_info, window=window,
+    # Wave 2 of #2162: share the validate-then-populate-then-stamp
+    # block with the dask+numpy backend via ``_finalize_lazy_read_attrs``.
+    #
+    # The helper takes ``dtype`` as the resolved graph dtype so
+    # ``masked_nodata`` reflects whether per-chunk masking actually
+    # runs in the lazy graph (#2092). ``nodata_pixels_present`` stays
+    # unset on this path for the same reason as the dask+numpy path:
+    # a strict per-chunk reduction would force an eager ``.compute()``
+    # (#2135). The helper's ``dtype`` argument is conflated with the
+    # caller-supplied cast attr; fix the attr up here so
+    # ``nodata_dtype_cast`` surfaces only when the caller explicitly
+    # asked for a cast, not when masking auto-promoted the graph
+    # dtype to float64.
+    attrs = _finalize_lazy_read_attrs(
+        geo_info=geo_info,
+        nodata=nodata,
+        mask_nodata=mask_nodata,
+        dtype=declared_dtype,
+        window=window,
         allow_rotated=allow_rotated,
         allow_unparseable_crs=allow_unparseable_crs,
     )
-
-    attrs = {}
-    _populate_attrs_from_geo_info(attrs, geo_info, window=window)
-    # ``masked_nodata`` reflects whether per-chunk masking actually
-    # runs in the lazy graph (#2092); mirrors the dask+numpy backend
-    # contract. With ``mask_nodata=False`` ``declared_dtype`` stays
-    # equal to ``file_dtype`` (see the float-promotion gate earlier
-    # in this function), so the rule below is equivalent to "graph
-    # dtype is float AND the caller opted into masking."
-    # ``nodata_pixels_present`` stays unset on the dask+GPU path for the
-    # same reason as the dask+numpy path: a strict per-chunk reduction
-    # would force an eager ``.compute()`` (issue #2135). ``dtype_cast``
-    # records the caller-supplied ``dtype=`` kwarg when present.
-    _set_nodata_attrs(
-        attrs, nodata,
-        masked=(mask_nodata and declared_dtype.kind == 'f'),
-        pixels_present=None,
-        dtype_cast=(np.dtype(dtype).name if dtype is not None else None),
-    )
+    if dtype is None:
+        attrs.pop('nodata_dtype_cast', None)
+    elif nodata is not None:
+        attrs['nodata_dtype_cast'] = np.dtype(dtype).name
 
     if name is None:
         import os

--- a/xrspatial/geotiff/_backends/gpu.py
+++ b/xrspatial/geotiff/_backends/gpu.py
@@ -21,6 +21,7 @@ import numpy as np
 import xarray as xr
 
 from .._attrs import (
+    _apply_caller_dtype_cast,
     _finalize_lazy_read_attrs,
     _populate_attrs_from_geo_info,
     _set_nodata_attrs,
@@ -1583,10 +1584,9 @@ def _read_geotiff_gpu_chunked_gds(source, ifd, geo_info, header, *,
         allow_rotated=allow_rotated,
         allow_unparseable_crs=allow_unparseable_crs,
     )
-    if dtype is None:
-        attrs.pop('nodata_dtype_cast', None)
-    elif nodata is not None:
-        attrs['nodata_dtype_cast'] = np.dtype(dtype).name
+    _apply_caller_dtype_cast(
+        attrs, caller_dtype=dtype, has_nodata=nodata is not None,
+    )
 
     if name is None:
         import os

--- a/xrspatial/geotiff/tests/test_lazy_finalization_parity_2162.py
+++ b/xrspatial/geotiff/tests/test_lazy_finalization_parity_2162.py
@@ -1,0 +1,340 @@
+"""Lazy-read finalization parity between the two dask backends (PR C of #2162).
+
+Wave 2 of issue #2162 migrates ``read_geotiff_dask`` (the CPU+dask
+backend) and the dask branch of ``read_geotiff_gpu`` (the GPU+dask
+backend) onto the shared :func:`_finalize_lazy_read_attrs` helper from
+#2177. Both sites had ~25 lines of validate-then-populate-then-stamp
+code that produced the same attrs surface; the helper centralises that
+logic so a single bug fix lands in both backends at once.
+
+The tests in this module pin the lazy-attrs contract across the two
+backends so a future change to the helper (or to one backend's call
+site) cannot drift them apart without a visible failure. Each test
+opens the same fixture through ``read_geotiff_dask`` and
+``read_geotiff_gpu(chunks=...)`` and compares the attrs dicts after
+stripping backend-specific markers.
+
+Pins per the issue body:
+
+* ``attrs['nodata_pixels_present']`` is absent on both backends (the
+  per-chunk reduction would force eager compute; #2135 contract).
+* ``attrs['nodata_dtype_cast']`` matches when the caller forced a cast.
+* ``attrs['georef_status']`` matches across the five reader states
+  (full, transform_only, crs_only, none, rotated_dropped).
+
+GPU tests skip when CUDA is unavailable using the project's standard
+``cupy + CUDA`` gate.
+"""
+from __future__ import annotations
+
+import importlib.util
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from xrspatial.geotiff import (
+    read_geotiff_dask,
+    to_geotiff,
+)
+from xrspatial.geotiff._attrs import (
+    GEOREF_STATUS_CRS_ONLY,
+    GEOREF_STATUS_FULL,
+    GEOREF_STATUS_NONE,
+    GEOREF_STATUS_ROTATED_DROPPED,
+    GEOREF_STATUS_TRANSFORM_ONLY,
+)
+from xrspatial.geotiff._coords import _NO_GEOREF_KEY
+
+tifffile = pytest.importorskip("tifffile")
+
+from xrspatial.geotiff.tests.test_allow_rotated_geotiff_2115 import (  # noqa: E402
+    _write_rotated_tiff,
+)
+
+
+def _gpu_available() -> bool:
+    if importlib.util.find_spec("cupy") is None:
+        return False
+    try:
+        import cupy
+        return bool(cupy.cuda.is_available())
+    except Exception:
+        return False
+
+
+_HAS_GPU = _gpu_available()
+_gpu_only = pytest.mark.skipif(not _HAS_GPU, reason="cupy + CUDA required")
+
+
+# Backend-specific keys that we ignore when diffing two attrs dicts.
+# ``_xrspatial_no_georef`` is a private back-compat marker that lands on
+# both backends together; it's part of the shared output and stays in
+# the comparison. Nothing in the lazy attrs surface is backend-specific
+# today, but the set is here so adding (say) a GPU-only key in the
+# future doesn't quietly drop a real divergence.
+_BACKEND_MARKER_KEYS: frozenset[str] = frozenset()
+
+
+def _strip_backend_markers(attrs):
+    """Return a dict copy with backend-specific keys removed."""
+    return {
+        k: v for k, v in attrs.items() if k not in _BACKEND_MARKER_KEYS
+    }
+
+
+def _open_cpu_dask(path, **kwargs):
+    return read_geotiff_dask(path, chunks=2, **kwargs)
+
+
+def _open_gpu_dask(path, **kwargs):
+    # Lazy import so the module loads under CPU-only sandboxes.
+    from xrspatial.geotiff import read_geotiff_gpu
+    return read_geotiff_gpu(path, chunks=2, **kwargs)
+
+
+_BACKENDS = [
+    pytest.param(_open_cpu_dask, id="dask+numpy"),
+    pytest.param(_open_gpu_dask, id="dask+cupy", marks=_gpu_only),
+]
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders, mirroring the per-state fixtures in test_georef_status_2136
+# ---------------------------------------------------------------------------
+
+
+def _make_full_tiff(path):
+    """Float coords + CRS -> ``full``."""
+    da = xr.DataArray(
+        np.zeros((4, 4), dtype=np.float32),
+        coords={
+            'y': np.array([200.0, 199.0, 198.0, 197.0]),
+            'x': np.array([100.0, 101.0, 102.0, 103.0]),
+        },
+        dims=('y', 'x'),
+        attrs={'crs': 4326},
+    )
+    to_geotiff(da, path)
+
+
+def _make_transform_only_tiff(path):
+    """Float coords, no CRS -> ``transform_only``."""
+    da = xr.DataArray(
+        np.zeros((4, 4), dtype=np.float32),
+        coords={
+            'y': np.array([200.0, 199.0, 198.0, 197.0]),
+            'x': np.array([100.0, 101.0, 102.0, 103.0]),
+        },
+        dims=('y', 'x'),
+    )
+    to_geotiff(da, path)
+
+
+def _make_crs_only_tiff(path):
+    """No-georef marker + CRS -> ``crs_only``."""
+    da = xr.DataArray(
+        np.zeros((4, 4), dtype=np.float32),
+        coords={
+            'y': np.arange(4, dtype=np.int64),
+            'x': np.arange(4, dtype=np.int64),
+        },
+        dims=('y', 'x'),
+        attrs={_NO_GEOREF_KEY: True, 'crs': 4326},
+    )
+    to_geotiff(da, path)
+
+
+def _make_none_tiff(path):
+    """Bare TIFF with no GeoTIFF tags at all -> ``none``."""
+    arr = np.zeros((4, 4), dtype=np.float32)
+    tifffile.imwrite(
+        path, arr, photometric='minisblack', planarconfig='contig',
+        metadata=None,
+    )
+
+
+def _make_rotated_tiff(path):
+    """Rotated ``ModelTransformationTag`` (opened with ``allow_rotated``)
+    -> ``rotated_dropped``. The data is uint16 because the rotated-TIFF
+    writer in the #2115 test only emits integer pixels; that's fine for
+    a metadata pin."""
+    arr = np.arange(16, dtype='<u2').reshape(4, 4)
+    _write_rotated_tiff(path, arr)
+
+
+def _make_float_with_nodata_tiff(path, sentinel=-9999.0):
+    """Float raster carrying a GDAL_NODATA tag. Used to exercise the
+    nodata lifecycle attrs without forcing the int->float promotion
+    branch."""
+    arr = np.arange(16, dtype=np.float32).reshape(4, 4)
+    arr[0, 0] = sentinel
+    da = xr.DataArray(
+        arr,
+        coords={
+            'y': np.array([200.0, 199.0, 198.0, 197.0]),
+            'x': np.array([100.0, 101.0, 102.0, 103.0]),
+        },
+        dims=('y', 'x'),
+        attrs={'crs': 4326, 'nodata': sentinel},
+    )
+    to_geotiff(da, path)
+
+
+def _make_int_with_nodata_tiff(path, sentinel=30):
+    """Integer raster carrying a sentinel. Lets the dtype-cast tests
+    distinguish "graph dtype auto-promoted by masking" from
+    "caller asked for an explicit cast"."""
+    arr = np.array([[10, 20, 25], [30, 40, 50]], dtype=np.int16)
+    da = xr.DataArray(
+        arr,
+        coords={
+            'y': np.array([200.0, 199.0]),
+            'x': np.array([100.0, 101.0, 102.0]),
+        },
+        dims=('y', 'x'),
+        attrs={'crs': 4326, 'nodata': sentinel},
+    )
+    to_geotiff(da, path)
+
+
+# ---------------------------------------------------------------------------
+# Cross-backend parity tests
+# ---------------------------------------------------------------------------
+
+
+_GEOREF_FIXTURES = [
+    pytest.param(_make_full_tiff, GEOREF_STATUS_FULL, False,
+                 id="full"),
+    pytest.param(_make_transform_only_tiff, GEOREF_STATUS_TRANSFORM_ONLY,
+                 False, id="transform_only"),
+    pytest.param(_make_crs_only_tiff, GEOREF_STATUS_CRS_ONLY, False,
+                 id="crs_only"),
+    pytest.param(_make_none_tiff, GEOREF_STATUS_NONE, False,
+                 id="none"),
+    pytest.param(_make_rotated_tiff, GEOREF_STATUS_ROTATED_DROPPED,
+                 True, id="rotated_dropped"),
+]
+
+
+@pytest.mark.parametrize("fixture,expected_status,allow_rotated",
+                         _GEOREF_FIXTURES)
+def test_georef_status_parity(tmp_path, fixture, expected_status,
+                              allow_rotated):
+    """Both dask backends emit the same ``georef_status`` for each
+    of the five reader states."""
+    path = str(tmp_path / f"tmp_2178_status_{expected_status}.tif")
+    fixture(path)
+
+    kwargs = {'allow_rotated': True} if allow_rotated else {}
+    cpu = _open_cpu_dask(path, **kwargs)
+    assert cpu.attrs.get('georef_status') == expected_status
+
+    if _HAS_GPU:
+        gpu = _open_gpu_dask(path, **kwargs)
+        assert gpu.attrs.get('georef_status') == expected_status
+        # The status attr must agree across backends even if other
+        # attrs diverge for backend-specific reasons.
+        assert cpu.attrs['georef_status'] == gpu.attrs['georef_status']
+
+
+@pytest.mark.parametrize("fixture,expected_status,allow_rotated",
+                         _GEOREF_FIXTURES)
+def test_attrs_dict_parity(tmp_path, fixture, expected_status,
+                           allow_rotated):
+    """Modulo the backend-marker filter, both dask backends emit the
+    same attrs dict for each fixture."""
+    if not _HAS_GPU:
+        pytest.skip("dask+cupy parity requires CUDA")
+    path = str(tmp_path / f"tmp_2178_parity_{expected_status}.tif")
+    fixture(path)
+
+    kwargs = {'allow_rotated': True} if allow_rotated else {}
+    cpu = _open_cpu_dask(path, **kwargs)
+    gpu = _open_gpu_dask(path, **kwargs)
+
+    cpu_attrs = _strip_backend_markers(cpu.attrs)
+    gpu_attrs = _strip_backend_markers(gpu.attrs)
+    assert cpu_attrs == gpu_attrs, (
+        f"attrs dicts diverged for fixture={expected_status}:\n"
+        f"  cpu only: {set(cpu_attrs) - set(gpu_attrs)}\n"
+        f"  gpu only: {set(gpu_attrs) - set(cpu_attrs)}\n"
+        f"  shared keys with different values: "
+        f"{[k for k in set(cpu_attrs) & set(gpu_attrs) if cpu_attrs[k] != gpu_attrs[k]]}"
+    )
+
+
+@pytest.mark.parametrize("opener", _BACKENDS)
+def test_nodata_pixels_present_absent_on_lazy(tmp_path, opener):
+    """Lazy contract from #2135: ``nodata_pixels_present`` stays unset
+    on both dask backends."""
+    path = str(tmp_path / "tmp_2178_pixels_absent.tif")
+    _make_float_with_nodata_tiff(path)
+    out = opener(path)
+    assert 'nodata_pixels_present' not in out.attrs
+
+
+def test_nodata_pixels_present_cross_backend(tmp_path):
+    """Both backends agree on the absence of ``nodata_pixels_present``
+    when reading the same fixture."""
+    if not _HAS_GPU:
+        pytest.skip("dask+cupy parity requires CUDA")
+    path = str(tmp_path / "tmp_2178_pixels_cross.tif")
+    _make_float_with_nodata_tiff(path)
+    cpu = _open_cpu_dask(path)
+    gpu = _open_gpu_dask(path)
+    assert 'nodata_pixels_present' not in cpu.attrs
+    assert 'nodata_pixels_present' not in gpu.attrs
+
+
+@pytest.mark.parametrize("opener", _BACKENDS)
+def test_dtype_cast_absent_without_caller_dtype(tmp_path, opener):
+    """No ``dtype=`` kwarg: ``nodata_dtype_cast`` stays unset, even
+    when masking auto-promotes the graph dtype to float64."""
+    path = str(tmp_path / "tmp_2178_no_cast.tif")
+    _make_int_with_nodata_tiff(path)
+    out = opener(path)
+    # Masking promoted the int source to float64 on the graph dtype,
+    # but the caller did not ask for a cast.
+    assert out.dtype == np.float64
+    assert out.attrs.get('masked_nodata') is True
+    assert 'nodata_dtype_cast' not in out.attrs
+
+
+@pytest.mark.parametrize("opener", _BACKENDS)
+def test_dtype_cast_records_target(tmp_path, opener):
+    """Explicit ``dtype=`` kwarg: ``nodata_dtype_cast`` records the
+    requested dtype on both backends."""
+    path = str(tmp_path / "tmp_2178_with_cast.tif")
+    _make_int_with_nodata_tiff(path)
+    out = opener(path, mask_nodata=False, dtype=np.float64)
+    assert out.attrs.get('masked_nodata') is False
+    assert out.attrs.get('nodata_dtype_cast') == 'float64'
+    assert 'nodata_pixels_present' not in out.attrs
+
+
+def test_dtype_cast_parity_cross_backend(tmp_path):
+    """Cross-backend: same input + same ``dtype=`` kwarg yields the
+    same ``nodata_dtype_cast`` value."""
+    if not _HAS_GPU:
+        pytest.skip("dask+cupy parity requires CUDA")
+    path = str(tmp_path / "tmp_2178_cast_cross.tif")
+    _make_int_with_nodata_tiff(path)
+    cpu = _open_cpu_dask(path, mask_nodata=False, dtype=np.float64)
+    gpu = _open_gpu_dask(path, mask_nodata=False, dtype=np.float64)
+    assert cpu.attrs.get('nodata_dtype_cast') == gpu.attrs.get('nodata_dtype_cast')
+    assert cpu.attrs.get('nodata_dtype_cast') == 'float64'
+
+
+def test_dtype_cast_absent_parity_cross_backend(tmp_path):
+    """Cross-backend: same int input without an explicit ``dtype=``
+    leaves ``nodata_dtype_cast`` absent on both backends (the auto-
+    promoted graph dtype must not leak as a caller cast)."""
+    if not _HAS_GPU:
+        pytest.skip("dask+cupy parity requires CUDA")
+    path = str(tmp_path / "tmp_2178_no_cast_cross.tif")
+    _make_int_with_nodata_tiff(path)
+    cpu = _open_cpu_dask(path)
+    gpu = _open_gpu_dask(path)
+    assert 'nodata_dtype_cast' not in cpu.attrs
+    assert 'nodata_dtype_cast' not in gpu.attrs

--- a/xrspatial/geotiff/tests/test_lazy_finalization_parity_2162.py
+++ b/xrspatial/geotiff/tests/test_lazy_finalization_parity_2162.py
@@ -11,8 +11,7 @@ The tests in this module pin the lazy-attrs contract across the two
 backends so a future change to the helper (or to one backend's call
 site) cannot drift them apart without a visible failure. Each test
 opens the same fixture through ``read_geotiff_dask`` and
-``read_geotiff_gpu(chunks=...)`` and compares the attrs dicts after
-stripping backend-specific markers.
+``read_geotiff_gpu(chunks=...)`` and compares the attrs dicts.
 
 Pins per the issue body:
 
@@ -65,22 +64,6 @@ def _gpu_available() -> bool:
 
 _HAS_GPU = _gpu_available()
 _gpu_only = pytest.mark.skipif(not _HAS_GPU, reason="cupy + CUDA required")
-
-
-# Backend-specific keys that we ignore when diffing two attrs dicts.
-# ``_xrspatial_no_georef`` is a private back-compat marker that lands on
-# both backends together; it's part of the shared output and stays in
-# the comparison. Nothing in the lazy attrs surface is backend-specific
-# today, but the set is here so adding (say) a GPU-only key in the
-# future doesn't quietly drop a real divergence.
-_BACKEND_MARKER_KEYS: frozenset[str] = frozenset()
-
-
-def _strip_backend_markers(attrs):
-    """Return a dict copy with backend-specific keys removed."""
-    return {
-        k: v for k, v in attrs.items() if k not in _BACKEND_MARKER_KEYS
-    }
 
 
 def _open_cpu_dask(path, **kwargs):
@@ -233,8 +216,6 @@ def test_georef_status_parity(tmp_path, fixture, expected_status,
     if _HAS_GPU:
         gpu = _open_gpu_dask(path, **kwargs)
         assert gpu.attrs.get('georef_status') == expected_status
-        # The status attr must agree across backends even if other
-        # attrs diverge for backend-specific reasons.
         assert cpu.attrs['georef_status'] == gpu.attrs['georef_status']
 
 
@@ -242,8 +223,7 @@ def test_georef_status_parity(tmp_path, fixture, expected_status,
                          _GEOREF_FIXTURES)
 def test_attrs_dict_parity(tmp_path, fixture, expected_status,
                            allow_rotated):
-    """Modulo the backend-marker filter, both dask backends emit the
-    same attrs dict for each fixture."""
+    """Both dask backends emit the same attrs dict for each fixture."""
     if not _HAS_GPU:
         pytest.skip("dask+cupy parity requires CUDA")
     path = str(tmp_path / f"tmp_2178_parity_{expected_status}.tif")
@@ -253,8 +233,8 @@ def test_attrs_dict_parity(tmp_path, fixture, expected_status,
     cpu = _open_cpu_dask(path, **kwargs)
     gpu = _open_gpu_dask(path, **kwargs)
 
-    cpu_attrs = _strip_backend_markers(cpu.attrs)
-    gpu_attrs = _strip_backend_markers(gpu.attrs)
+    cpu_attrs = dict(cpu.attrs)
+    gpu_attrs = dict(gpu.attrs)
     assert cpu_attrs == gpu_attrs, (
         f"attrs dicts diverged for fixture={expected_status}:\n"
         f"  cpu only: {set(cpu_attrs) - set(gpu_attrs)}\n"
@@ -338,3 +318,22 @@ def test_dtype_cast_absent_parity_cross_backend(tmp_path):
     gpu = _open_gpu_dask(path)
     assert 'nodata_dtype_cast' not in cpu.attrs
     assert 'nodata_dtype_cast' not in gpu.attrs
+
+
+@pytest.mark.parametrize("opener", _BACKENDS)
+def test_dtype_cast_records_integer_target(tmp_path, opener):
+    """Caller-supplied integer ``dtype=`` kwarg: ``nodata_dtype_cast``
+    records the integer dtype on both backends. Pins the
+    ``dtype.kind != 'f'`` branch of the call-site fixup (review
+    follow-up for #2178)."""
+    path = str(tmp_path / "tmp_2178_int_cast.tif")
+    _make_int_with_nodata_tiff(path)
+    # ``mask_nodata=False`` keeps the integer dtype; the caller cast
+    # then routes the graph dtype to ``int32`` without the masking
+    # auto-promotion firing. The pre-helper contract emits
+    # ``nodata_dtype_cast='int32'`` and ``masked_nodata=False`` here.
+    out = opener(path, mask_nodata=False, dtype=np.int32)
+    assert out.dtype == np.int32
+    assert out.attrs.get('masked_nodata') is False
+    assert out.attrs.get('nodata_dtype_cast') == 'int32'
+    assert 'nodata_pixels_present' not in out.attrs


### PR DESCRIPTION
## Summary

Wave 2 of #2162. Both dask read paths had a 25-line validate-populate-stamp block that was identical except for a couple of comment differences. Replace each with one call to `_finalize_lazy_read_attrs` from #2177 (now on main) so a future fix lands in both backends at once.

- `xrspatial/geotiff/_backends/dask.py`: CPU+dask finalization in `read_geotiff_dask` now goes through the helper.
- `xrspatial/geotiff/_backends/gpu.py`: GPU+dask finalization in the dask branch of `read_geotiff_gpu` now goes through the helper. The three eager GPU sites in this file are out of scope (sibling PR D, #2179).

There is one wrinkle. The helper's `dtype` argument is used for two things at once: the resolved graph dtype (which drives `masked_nodata`) and the caller's cast attr (which drives `nodata_dtype_cast`). The dask path has to keep those separate, because `mask_nodata=True` on an integer source auto-promotes the graph dtype to `float64` without the caller asking, and that auto-promotion must not leak out as `nodata_dtype_cast`. The migration passes the resolved `target_dtype` / `declared_dtype` so `masked_nodata` is right, then fixes up `nodata_dtype_cast` at the call site to match the pre-helper contract.

Preserved behavior:

- `attrs['nodata_pixels_present']` stays absent on lazy outputs (#2135 contract).
- `attrs['nodata_dtype_cast']` is recorded only when the caller passed `dtype=`.
- MinIsWhite inversion (`dask.py:227-238`) still preempts the sentinel before chunk tasks see it; `nodata_attr` (the pre-inversion value) is what reaches `attrs['nodata']`.

Closes #2178. Depends on #2177 (merged).

## Test plan

- [x] New `test_lazy_finalization_parity_2162.py` (19 tests) covering:
  - `nodata_pixels_present` absent on both backends.
  - `nodata_dtype_cast` matches across backends when caller forces a cast.
  - `nodata_dtype_cast` absent on both backends when the graph dtype was auto-promoted by masking.
  - `georef_status` matches across both backends for full / transform_only / crs_only / none / rotated_dropped.
  - Full attrs-dict parity (modulo backend markers) per fixture.
- [x] All 91 existing tests in `test_nodata_lifecycle_attrs_2135.py`, `test_nodata_semantics_split_1988.py`, `test_georef_status_2136.py` pass.
- [x] Full `xrspatial/geotiff/tests/` run: 4571 passed, 45 skipped. One pre-existing failure (`test_lowlevel_write_pushdown_2138.py::test_write_vs_to_geotiff_byte_parity_uint8[lz4]`) reproduces on main and is unrelated.