### PR TITLE
geotiff: route eager backends through shared finalization helper (#2179)

### DIFF
--- a/xrspatial/geotiff/__init__.py
+++ b/xrspatial/geotiff/__init__.py
@@ -46,10 +46,8 @@ if TYPE_CHECKING:
 
 from ._coords import (
     _BAND_DIM_NAMES,
-    coords_from_geo_info as _coords_from_geo_info,
     coords_from_pixel_geometry as _coords_from_pixel_geometry,
     transform_tuple_from_pixel_geometry as _transform_tuple_from_pixel_geometry,
-    geo_to_coords as _geo_to_coords,
     transform_tuple as _transform_tuple,
     transform_from_attr as _transform_from_attr,
     coords_to_transform as _coords_to_transform,
@@ -84,10 +82,8 @@ from ._attrs import (
     _VALID_COMPRESSIONS,
     _extent_to_window,
     _extract_rich_tags,
-    _populate_attrs_from_geo_info,
-    _validate_read_geo_info,
+    _finalize_eager_read,
     _resolve_nodata_attr,
-    _set_nodata_attrs,
 )
 from ._backends._gpu_helpers import _is_gpu_data
 # Re-export only; called by xrspatial/geotiff/tests/test_nodata_*.py.
@@ -112,7 +108,6 @@ from ._runtime import (
 from ._validation import (
     _validate_3d_writer_dims,
     _validate_chunks_arg,
-    _validate_dtype_cast,
     _validate_tile_size_arg,
 )
 # ``_writer.write`` (alias for ``_writer._write``) is module-private;
@@ -630,20 +625,6 @@ def open_geotiff(source: str | BinaryIO, *,
         **kwargs,
     )
 
-    height, width = arr.shape[:2]
-    coords = _geo_to_coords(geo_info, height, width)
-
-    if window is not None:
-        # Adjust coordinates for windowed read. ``read_to_array`` rejected
-        # out-of-bounds windows above, so ``r0/c0/r1/c1`` are guaranteed
-        # in-range here (no clamp needed). For files with no GeoTIFF
-        # tags (``has_georef=False``), the default unit transform is
-        # not real, so fall back to integer pixel coords matching the
-        # ``_geo_to_coords`` shortcut taken on full reads. See #1710.
-        coords = _coords_from_geo_info(
-            geo_info, height, width, window=window,
-        )
-
     if name is None:
         # Derive from source path. File-like buffers don't have a path,
         # so leave name unset rather than fabricating one.
@@ -651,166 +632,30 @@ def open_geotiff(source: str | BinaryIO, *,
             import os
             name = os.path.splitext(os.path.basename(source))[0]
 
-    # Issue #1987 ambiguous-metadata checks. Run before attrs population
-    # so a rejected file does not leak a partly-populated attrs dict.
-    _validate_read_geo_info(
-        geo_info, window=window,
+    # Hand the post-decode buffer to the shared eager finalizer
+    # (issue #2179). The helper runs the same validate -> populate attrs
+    # -> mask -> cast -> set_nodata_attrs -> build DataArray pipeline
+    # the inline block used to do. ``mask_sentinel`` honours the
+    # post-MinIsWhite inversion stashed on ``geo_info._mask_nodata`` by
+    # ``read_to_array`` / ``_read_cog_http`` (#1809); on non-MinIsWhite
+    # files it falls back to the raw declared sentinel.
+    nodata = geo_info.nodata
+    mask_sentinel = (
+        getattr(geo_info, '_mask_nodata', nodata)
+        if nodata is not None else None
+    )
+    return _finalize_eager_read(
+        arr,
+        geo_info=geo_info,
+        nodata=nodata,
+        mask_sentinel=mask_sentinel,
+        mask_nodata=mask_nodata,
+        dtype=dtype,
+        window=window,
+        name=name,
         allow_rotated=allow_rotated,
         allow_unparseable_crs=allow_unparseable_crs,
     )
-
-    attrs = {}
-    _populate_attrs_from_geo_info(attrs, geo_info, window=window)
-
-    # Apply nodata mask: replace nodata sentinel values with NaN.
-    # ``arr`` came from ``read_to_array``, which returns a freshly
-    # allocated buffer from ``_read_tiles`` / ``_read_strips`` (and is
-    # ``np.ascontiguousarray``-wrapped if the orientation tag triggered
-    # a remap). Nothing else holds a reference here, so the in-place
-    # write is safe; an extra ``arr.copy()`` would just double peak
-    # memory for a multi-MB raster.
-    nodata = geo_info.nodata
-    # Track whether any sentinel pixel was present in the read window.
-    # Only meaningful when a declared sentinel exists; reported via
-    # ``attrs['nodata_pixels_present']`` (issue #2135) so consumers can
-    # answer "any nodata in this tile" without rescanning. ``None``
-    # keeps the attr out when no scan happened: that includes the no
-    # sentinel declared case (early-return in ``_set_nodata_attrs``) and
-    # any exotic dtype branch (e.g. complex source) that neither the
-    # float nor integer mask gates handle. Do not "fix" the asymmetry by
-    # forcing a False default -- the absence-means-unknown contract is
-    # deliberate so downstream can distinguish "scanned and saw nothing"
-    # from "did not scan."
-    nodata_pixels_present: bool | None = None
-    if nodata is not None and mask_nodata:
-        # When the reader applied MinIsWhite, the sentinel-equality mask
-        # must compare against the inverted sentinel value (issue #1809).
-        # ``read_to_array`` / ``_read_cog_http`` stash that value on
-        # ``geo_info._mask_nodata``; fall back to the original sentinel
-        # on non-MinIsWhite files. Renamed from ``mask_nodata`` to
-        # ``nodata_sentinel`` so the local does not shadow the
-        # ``mask_nodata`` opt-out kwarg (#2052).
-        nodata_sentinel = getattr(geo_info, '_mask_nodata', nodata)
-        if arr.dtype.kind == 'f':
-            if nodata_sentinel is not None and not np.isnan(nodata_sentinel):
-                mask_f = arr == arr.dtype.type(nodata_sentinel)
-                nodata_pixels_present = bool(mask_f.any())
-                if nodata_pixels_present:
-                    arr[mask_f] = np.nan
-            else:
-                # NaN-only sentinel on a float buffer: ``mask_nodata`` is
-                # a no-op, but downstream may want to know if any NaN
-                # pixels already exist in the source so the attr stays
-                # informative.
-                nodata_pixels_present = (
-                    bool(np.isnan(arr).any())
-                    if nodata_sentinel is not None
-                    else False
-                )
-        elif arr.dtype.kind in ('u', 'i'):
-            # Integer arrays: convert to float to represent NaN.
-            # An out-of-range sentinel (e.g. uint16 file with
-            # GDAL_NODATA="-9999") cannot match any decoded pixel, so the
-            # mask would be all-False -- skip the cast that would otherwise
-            # raise OverflowError and leave the array unchanged. A
-            # non-finite sentinel ("NaN" / "Inf" GDAL_NODATA strings) also
-            # cannot match an integer pixel, so the ``int(nodata)`` cast
-            # below would raise ValueError; gate on ``np.isfinite`` first
-            # to mirror ``_resolve_masked_fill`` / ``_sparse_fill_value``
-            # in ``_reader.py`` (#1774). A fractional sentinel (e.g.
-            # ``GDAL_NODATA="3.5"`` on a ``uint16`` file) also cannot match
-            # an integer pixel; ``int(3.5)`` would truncate to 3 and
-            # silently mask a real pixel value, so gate on
-            # ``float(nodata).is_integer()`` as well (mirrors the
-            # ``_writer.py`` / ``_vrt.py`` pattern used for #1564 / #1616).
-            # attrs['nodata'] still carries the raw sentinel so a write
-            # round-trip preserves the tag.
-            if (nodata_sentinel is not None
-                    and np.isfinite(nodata_sentinel)
-                    and float(nodata_sentinel).is_integer()):
-                nodata_int = int(nodata_sentinel)
-                info = np.iinfo(arr.dtype)
-                if info.min <= nodata_int <= info.max:
-                    mask = arr == arr.dtype.type(nodata_int)
-                    nodata_pixels_present = bool(mask.any())
-                    if nodata_pixels_present:
-                        arr = arr.astype(np.float64)
-                        arr[mask] = np.nan
-                else:
-                    # Sentinel cannot match any pixel in this dtype's
-                    # range. No mask was run; no pixels were present.
-                    nodata_pixels_present = False
-            else:
-                nodata_pixels_present = False
-    elif nodata is not None and not mask_nodata:
-        # ``mask_nodata=False``: the masking branch above is skipped,
-        # but ``attrs['nodata_pixels_present']`` should still surface so
-        # callers know whether literal sentinel pixels survive in the
-        # buffer (issue #2135). Mirror the same dtype / range / integer
-        # gates as the masking branch so an out-of-range or non-integer
-        # sentinel cleanly resolves to ``False`` rather than crashing in
-        # the equality check.
-        nodata_sentinel = getattr(geo_info, '_mask_nodata', nodata)
-        if nodata_sentinel is not None:
-            if arr.dtype.kind == 'f':
-                if np.isnan(nodata_sentinel):
-                    nodata_pixels_present = bool(np.isnan(arr).any())
-                else:
-                    nodata_pixels_present = bool(
-                        (arr == arr.dtype.type(nodata_sentinel)).any()
-                    )
-            elif arr.dtype.kind in ('u', 'i'):
-                if (np.isfinite(nodata_sentinel)
-                        and float(nodata_sentinel).is_integer()):
-                    nodata_int = int(nodata_sentinel)
-                    info = np.iinfo(arr.dtype)
-                    if info.min <= nodata_int <= info.max:
-                        nodata_pixels_present = bool(
-                            (arr == arr.dtype.type(nodata_int)).any()
-                        )
-                    else:
-                        nodata_pixels_present = False
-                else:
-                    nodata_pixels_present = False
-
-    dtype_cast_attr: str | None = None
-    if dtype is not None:
-        target = np.dtype(dtype)
-        _validate_dtype_cast(arr.dtype, target)
-        arr = arr.astype(target)
-        # Record the post-mask cast so downstream can tell
-        # float-because-masked from float-because-promoted (issue #2135).
-        dtype_cast_attr = target.name
-
-    # ``attrs['masked_nodata']`` reflects whether the function
-    # actually replaced sentinel pixels with NaN (#2092). The pre-fix
-    # implementation inferred it from final dtype, which lied when
-    # ``mask_nodata=False`` left literal sentinel values in a float
-    # buffer. True iff the caller opted into masking and the result
-    # is a float-dtype buffer (the mask block above either ran the
-    # float-replacement step or promoted an int input to float64;
-    # either way the buffer holds NaN where the sentinel used to be).
-    _set_nodata_attrs(
-        attrs, nodata,
-        masked=(mask_nodata and arr.dtype.kind == 'f'),
-        pixels_present=nodata_pixels_present,
-        dtype_cast=dtype_cast_attr,
-    )
-
-    if arr.ndim == 3:
-        dims = ['y', 'x', 'band']
-        coords['band'] = np.arange(arr.shape[2])
-    else:
-        dims = ['y', 'x']
-
-    da = xr.DataArray(
-        arr,
-        dims=dims,
-        coords=coords,
-        name=name,
-        attrs=attrs,
-    )
-    return da
 
 
 def plot_geotiff(da: xr.DataArray, **kwargs):

--- a/xrspatial/geotiff/_backends/gpu.py
+++ b/xrspatial/geotiff/_backends/gpu.py
@@ -21,6 +21,7 @@ import numpy as np
 import xarray as xr
 
 from .._attrs import (
+    _finalize_eager_read,
     _populate_attrs_from_geo_info,
     _set_nodata_attrs,
     _validate_read_geo_info,
@@ -47,7 +48,6 @@ from .._validation import (
 )
 from ._gpu_helpers import (
     _apply_nodata_mask_gpu,
-    _apply_nodata_mask_gpu_with_presence,
     _apply_orientation_geo_info,
     _apply_orientation_gpu,
     _gpu_apply_window_band,
@@ -500,68 +500,31 @@ def read_geotiff_gpu(source: str, *,
             if name is None:
                 import os
                 name = os.path.splitext(os.path.basename(source))[0]
-            _validate_read_geo_info(
-                geo_info, window=window,
+            # Hand the windowed+banded GPU buffer to the shared eager
+            # finalizer (issue #2179). ``read_to_array`` stashes the
+            # post-MinIsWhite sentinel on ``_stripped_geo._mask_nodata``
+            # for the masking step (#1809); fall back to the raw
+            # sentinel on non-MinIsWhite files. The helper's host-side
+            # mask block runs on CuPy arrays via numpy duck-typing and
+            # produces the same lifecycle attrs that
+            # ``_apply_nodata_mask_gpu_with_presence`` did inline.
+            nodata = geo_info.nodata
+            mask_sentinel = (
+                getattr(_stripped_geo, '_mask_nodata', nodata)
+                if nodata is not None else None
+            )
+            result = _finalize_eager_read(
+                arr_gpu,
+                geo_info=geo_info,
+                nodata=nodata,
+                mask_sentinel=mask_sentinel,
+                mask_nodata=mask_nodata,
+                dtype=dtype,
+                window=window,
+                name=name,
                 allow_rotated=allow_rotated,
                 allow_unparseable_crs=allow_unparseable_crs,
             )
-            attrs = {}
-            _populate_attrs_from_geo_info(attrs, geo_info, window=window)
-            # Apply nodata mask + record sentinel so the GPU read agrees
-            # with the CPU eager path. Without this, integer rasters keep
-            # the literal sentinel value and float rasters keep the
-            # sentinel rather than NaN -- a silent backend divergence.
-            # ``read_to_array`` stashes the post-MinIsWhite sentinel on
-            # ``_mask_nodata`` when applicable; fall back to the original
-            # sentinel otherwise (#1809).
-            nodata = geo_info.nodata
-            nodata_pixels_present_attr: bool | None = None
-            if nodata is not None and mask_nodata:
-                mask_value = getattr(_stripped_geo, '_mask_nodata', nodata)
-                arr_gpu, nodata_pixels_present_attr = (
-                    _apply_nodata_mask_gpu_with_presence(arr_gpu, mask_value)
-                )
-            dtype_cast_attr: str | None = None
-            if dtype is not None:
-                target = np.dtype(dtype)
-                _validate_dtype_cast(np.dtype(str(arr_gpu.dtype)), target)
-                arr_gpu = arr_gpu.astype(target)
-                dtype_cast_attr = target.name
-            # ``attrs['masked_nodata']`` reflects whether the function
-            # actually replaced sentinel pixels with NaN (#2092). With
-            # ``mask_nodata=False`` the GPU mask kernel above is
-            # skipped, so the buffer holds literal sentinel values
-            # even if the final dtype is float.
-            _set_nodata_attrs(
-                attrs, nodata,
-                masked=(mask_nodata
-                        and np.dtype(str(arr_gpu.dtype)).kind == 'f'),
-                pixels_present=nodata_pixels_present_attr,
-                dtype_cast=dtype_cast_attr,
-            )
-            # ``read_to_array`` already applied window + band slicing, so
-            # ``arr_gpu`` is at output shape. Compute coords for that
-            # shape without re-slicing. Mirror the eager-numpy /
-            # ``read_geotiff_dask`` / ``_gpu_apply_window_band`` checks
-            # against ``has_georef``: a non-georef TIFF carries a
-            # default ``GeoTransform()`` placeholder (``t is None`` is
-            # never true here) so a transform-based coord path would
-            # emit synthetic ``[-0.5, -1.5, ...]`` floats instead of
-            # the integer pixel coords every other backend produces
-            # (#1753 / regression of #1710).
-            coords = _coords_from_geo_info(
-                geo_info, arr_gpu.shape[0], arr_gpu.shape[1], window=window,
-            )
-            # Multi-band stripped reads come back as (y, x, band); mirror
-            # the tiled branch so dims line up with ndim. Single-band stays
-            # 2-D ('y', 'x').
-            if arr_gpu.ndim == 3:
-                dims = ['y', 'x', 'band']
-                coords['band'] = np.arange(arr_gpu.shape[2])
-            else:
-                dims = ['y', 'x']
-            result = xr.DataArray(arr_gpu, dims=dims,
-                                  coords=coords, name=name, attrs=attrs)
             # ``chunks`` was previously honoured only on the tiled path,
             # so stripped TIFFs returned an unchunked DataArray even when
             # the caller asked for a Dask+CuPy result. Mirror the tiled
@@ -852,84 +815,56 @@ def read_geotiff_gpu(source: str, *,
             elif gpu_dtype.kind == 'f':
                 arr_gpu = -arr_gpu
 
-        # Apply nodata mask + record sentinel so the GPU read agrees with the
-        # CPU eager path (issue #1542). Without this, integer rasters keep the
-        # literal sentinel value and float rasters keep the sentinel rather
-        # than NaN -- a silent backend divergence. Apply before the optional
-        # dtype cast so the float promotion for masked integer rasters doesn't
-        # surprise a user-supplied dtype.
-        nodata = geo_info.nodata
-        nodata_pixels_present_attr: bool | None = None
-        if nodata is not None and mask_nodata:
-            # When MinIsWhite was applied, the mask must use the inverted
-            # sentinel; otherwise the original sentinel. The pure GPU path
-            # records the inverted sentinel in ``_mw_mask_nodata`` above; the
-            # CPU-fallback paths (sparse-tile, planar=2 auto-fallback, and
-            # post-decode CPU fallback) get it from ``read_to_array`` via
-            # ``_cpu_fallback_geo._mask_nodata`` (Copilot review of #1817).
-            if _mw_mask_nodata is not None:
-                _gpu_mask_value = _mw_mask_nodata
-            elif _cpu_fallback_geo is not None:
-                _gpu_mask_value = getattr(
-                    _cpu_fallback_geo, '_mask_nodata', nodata)
-            else:
-                _gpu_mask_value = nodata
-            arr_gpu, nodata_pixels_present_attr = (
-                _apply_nodata_mask_gpu_with_presence(
-                    arr_gpu, _gpu_mask_value)
-            )
-
-        dtype_cast_attr: str | None = None
-        if dtype is not None:
-            target = np.dtype(dtype)
-            _validate_dtype_cast(np.dtype(str(arr_gpu.dtype)), target)
-            arr_gpu = arr_gpu.astype(target)
-            dtype_cast_attr = target.name
-
-        # Build DataArray
         if name is None:
             import os
             name = os.path.splitext(os.path.basename(source))[0]
 
-        _validate_read_geo_info(
-            geo_info, window=window,
+        # Slice the fully-decoded buffer down to the requested window/band
+        # BEFORE finalization so the shared eager helper builds the
+        # DataArray off the post-slice shape. The current path masks the
+        # full IFD then slices; the helper masks the post-slice buffer,
+        # which matches the eager-numpy contract and brings the GPU
+        # ``nodata_pixels_present`` attr in line with the rest of the
+        # backends (the attr now reports presence within the read
+        # window, not the whole IFD). The MinIsWhite inversion above
+        # already mutated the buffer in stored order, so slicing here
+        # carries through the inverted values.
+        arr_gpu, _coords_unused = _gpu_apply_window_band(
+            arr_gpu, geo_info, window=window, band=band)
+
+        # Hand the windowed+banded GPU buffer to the shared eager
+        # finalizer (issue #2179). ``mask_sentinel`` resolution mirrors
+        # the original three-way pick: prefer the post-MinIsWhite value
+        # the pure GPU path stamps on ``_mw_mask_nodata``; otherwise
+        # fall back to the CPU-fallback path's stash on
+        # ``_cpu_fallback_geo._mask_nodata`` (#1817); otherwise the raw
+        # declared sentinel. The helper's host-side mask block runs on
+        # CuPy arrays via numpy duck-typing and produces the same
+        # lifecycle attrs that ``_apply_nodata_mask_gpu_with_presence``
+        # did inline.
+        nodata = geo_info.nodata
+        if nodata is None:
+            mask_sentinel = None
+        elif _mw_mask_nodata is not None:
+            mask_sentinel = _mw_mask_nodata
+        elif _cpu_fallback_geo is not None:
+            mask_sentinel = getattr(
+                _cpu_fallback_geo, '_mask_nodata', nodata)
+        else:
+            mask_sentinel = nodata
+
+        result = _finalize_eager_read(
+            arr_gpu,
+            geo_info=geo_info,
+            nodata=nodata,
+            mask_sentinel=mask_sentinel,
+            mask_nodata=mask_nodata,
+            dtype=dtype,
+            window=window,
+            name=name,
             allow_rotated=allow_rotated,
             allow_unparseable_crs=allow_unparseable_crs,
         )
-
-        attrs = {}
-        _populate_attrs_from_geo_info(attrs, geo_info, window=window)
-        # ``attrs['masked_nodata']`` reflects whether the function
-        # actually replaced sentinel pixels with NaN (#2092). The GPU
-        # mask kernel runs only when ``mask_nodata=True`` and a sentinel
-        # is declared, so the post-cast float dtype alone is not enough
-        # to claim masking.
-        _set_nodata_attrs(
-            attrs, nodata,
-            masked=(mask_nodata
-                    and np.dtype(str(arr_gpu.dtype)).kind == 'f'),
-            pixels_present=nodata_pixels_present_attr,
-            dtype_cast=dtype_cast_attr,
-        )
-
-        # Apply window/band slicing post-decode. Coords are derived from the
-        # sliced array so the (y, x) labels line up with the user's requested
-        # subrectangle. This mirrors the ``open_geotiff`` / ``read_geotiff_dask``
-        # contract: ``attrs['transform']`` always carries the full-source
-        # GeoTransform shifted to the window origin (via
-        # ``_populate_attrs_from_geo_info(..., window=window)``), while
-        # ``coords['y']`` / ``coords['x']`` cover only the windowed cells.
-        arr_gpu, coords = _gpu_apply_window_band(
-            arr_gpu, geo_info, window=window, band=band)
-
-        if arr_gpu.ndim == 3:
-            dims = ['y', 'x', 'band']
-            coords['band'] = np.arange(arr_gpu.shape[2])
-        else:
-            dims = ['y', 'x']
-
-        result = xr.DataArray(arr_gpu, dims=dims, coords=coords,
-                              name=name, attrs=attrs)
 
         # ``chunks=`` is handled at function entry via
         # ``_read_geotiff_gpu_chunked`` for real out-of-core support; this
@@ -1010,58 +945,31 @@ def _read_geotiff_gpu_eager_via_cpu(source, *, dtype, window, overview_level,
         # stable label, which is fine for a default.
         name = os.path.splitext(os.path.basename(source))[0]
 
-    _validate_read_geo_info(
-        geo_info, window=window,
+    # Hand the GPU buffer to the shared eager finalizer (issue #2179).
+    # ``_read_to_array`` already applied window + band slicing and
+    # stashed the post-MinIsWhite sentinel on ``geo_info._mask_nodata``
+    # for the masking step (#1809); fall back to the raw sentinel on
+    # non-MinIsWhite files. The helper's host-side mask block runs on
+    # CuPy arrays via numpy duck-typing and produces the same
+    # lifecycle attrs that ``_apply_nodata_mask_gpu_with_presence``
+    # did inline.
+    nodata = geo_info.nodata
+    mask_sentinel = (
+        getattr(geo_info, '_mask_nodata', nodata)
+        if nodata is not None else None
+    )
+    return _finalize_eager_read(
+        arr_gpu,
+        geo_info=geo_info,
+        nodata=nodata,
+        mask_sentinel=mask_sentinel,
+        mask_nodata=mask_nodata,
+        dtype=dtype,
+        window=window,
+        name=name,
         allow_rotated=allow_rotated,
         allow_unparseable_crs=allow_unparseable_crs,
     )
-
-    attrs = {}
-    _populate_attrs_from_geo_info(attrs, geo_info, window=window)
-    # ``_read_to_array`` does NOT apply the nodata-to-NaN mask itself;
-    # it returns the raw decoded array and stashes the (possibly
-    # MinIsWhite-inverted) sentinel on ``geo_info._mask_nodata`` for
-    # the caller to use. This is the canonical place to apply the
-    # mask on the GPU buffer, mirroring the existing stripped /
-    # planar=2 / sparse-tile CPU-fallback branches in the local path.
-    # The post-MinIsWhite sentinel takes precedence when present
-    # (issue #1809); otherwise fall back to the raw sentinel.
-    nodata = geo_info.nodata
-    nodata_pixels_present_attr: bool | None = None
-    if nodata is not None and mask_nodata:
-        mask_value = getattr(geo_info, '_mask_nodata', nodata)
-        arr_gpu, nodata_pixels_present_attr = (
-            _apply_nodata_mask_gpu_with_presence(arr_gpu, mask_value)
-        )
-
-    dtype_cast_attr: str | None = None
-    if dtype is not None:
-        target = np.dtype(dtype)
-        _validate_dtype_cast(np.dtype(str(arr_gpu.dtype)), target)
-        arr_gpu = arr_gpu.astype(target)
-        dtype_cast_attr = target.name
-
-    _set_nodata_attrs(
-        attrs, nodata,
-        masked=(mask_nodata and np.dtype(str(arr_gpu.dtype)).kind == 'f'),
-        pixels_present=nodata_pixels_present_attr,
-        dtype_cast=dtype_cast_attr,
-    )
-
-    # ``_read_to_array`` returns an array already sliced to ``window`` /
-    # ``band``, so derive coords from the post-slice shape (mirrors the
-    # stripped CPU-fallback branch in the local path).
-    coords = _coords_from_geo_info(
-        geo_info, arr_gpu.shape[0], arr_gpu.shape[1], window=window,
-    )
-    if arr_gpu.ndim == 3:
-        dims = ['y', 'x', 'band']
-        coords['band'] = np.arange(arr_gpu.shape[2])
-    else:
-        dims = ['y', 'x']
-
-    return xr.DataArray(arr_gpu, dims=dims, coords=coords,
-                        name=name, attrs=attrs)
 
 
 def _gds_chunk_path_available(source, ifd, has_sparse_tile, orientation):

--- a/xrspatial/geotiff/_backends/gpu.py
+++ b/xrspatial/geotiff/_backends/gpu.py
@@ -828,8 +828,10 @@ def read_geotiff_gpu(source: str, *,
         # backends (the attr now reports presence within the read
         # window, not the whole IFD). The MinIsWhite inversion above
         # already mutated the buffer in stored order, so slicing here
-        # carries through the inverted values.
-        arr_gpu, _coords_unused = _gpu_apply_window_band(
+        # carries through the inverted values. ``_gpu_apply_window_band``
+        # also returns coords, but the helper rebuilds them from
+        # ``geo_info`` / ``window`` so the local copy is discarded.
+        arr_gpu, _ = _gpu_apply_window_band(
             arr_gpu, geo_info, window=window, band=band)
 
         # Hand the windowed+banded GPU buffer to the shared eager
@@ -842,6 +844,11 @@ def read_geotiff_gpu(source: str, *,
         # CuPy arrays via numpy duck-typing and produces the same
         # lifecycle attrs that ``_apply_nodata_mask_gpu_with_presence``
         # did inline.
+        #
+        # The sentinel is resolved even when ``mask_nodata=False``
+        # because the helper still needs it for the
+        # ``nodata_pixels_present`` scan in that branch (#2135); only
+        # ``nodata is None`` short-circuits the resolution.
         nodata = geo_info.nodata
         if nodata is None:
             mask_sentinel = None

--- a/xrspatial/geotiff/tests/test_eager_finalization_parity_2162.py
+++ b/xrspatial/geotiff/tests/test_eager_finalization_parity_2162.py
@@ -16,6 +16,14 @@ The matrix walks:
 * ``mask_nodata=False`` left-alone semantics.
 * Source with no declared sentinel (helper short-circuits both
   ``nodata`` and ``masked_nodata`` attrs).
+* Explicit ``dtype=`` kwarg (records ``nodata_dtype_cast``).
+* Windowed read (pins the slice-before-mask behaviour on the GPU
+  local-eager path so ``nodata_pixels_present`` reflects the
+  window, not the full IFD).
+* MinIsWhite photometric (exercises the post-inversion sentinel
+  branch of the GPU local-eager ``mask_sentinel`` resolution).
+* Stripped multi-band file (exercises the 3-D output branch on
+  both backends through the GPU CPU-fallback eager site).
 
 For each case the test reads the file via the eager numpy backend
 (``open_geotiff(path)``) and the eager GPU backend

--- a/xrspatial/geotiff/tests/test_eager_finalization_parity_2162.py
+++ b/xrspatial/geotiff/tests/test_eager_finalization_parity_2162.py
@@ -1,0 +1,278 @@
+"""Cross-backend parity for the eager finalization pipeline (issue #2179).
+
+Wave 2 of #2162 routed the eager numpy path and the three eager GPU
+paths in ``_backends/gpu.py`` through the shared
+``_finalize_eager_read`` helper introduced in #2177. The four sites
+previously inlined the same validate / populate-attrs / mask / cast /
+``_set_nodata_attrs`` block; this file pins parity for the attrs the
+helper now stamps on both backends so a future change in one branch
+cannot silently diverge from the other.
+
+The matrix walks:
+
+* Float source with a sentinel value (mask promotes via NaN).
+* Integer source with an in-range sentinel (mask promotes int -> float64).
+* Integer source with an out-of-range sentinel (mask is a no-op).
+* ``mask_nodata=False`` left-alone semantics.
+* Source with no declared sentinel (helper short-circuits both
+  ``nodata`` and ``masked_nodata`` attrs).
+
+For each case the test reads the file via the eager numpy backend
+(``open_geotiff(path)``) and the eager GPU backend
+(``open_geotiff(path, gpu=True)``) and compares the four
+``_finalize_eager_read``-stamped attrs across the two reads:
+``nodata``, ``nodata_pixels_present``, ``nodata_dtype_cast``, and
+``georef_status``. The masked-pixel locations are also compared so a
+divergence in the mask step would surface here.
+"""
+from __future__ import annotations
+
+import importlib.util
+
+import numpy as np
+import pytest
+
+
+def _gpu_available() -> bool:
+    """True if cupy is importable and CUDA is initialised."""
+    if importlib.util.find_spec("cupy") is None:
+        return False
+    try:
+        import cupy
+        return bool(cupy.cuda.is_available())
+    except Exception:
+        return False
+
+
+_HAS_GPU = _gpu_available()
+_gpu_only = pytest.mark.skipif(
+    not _HAS_GPU,
+    reason="cupy + CUDA required",
+)
+
+
+def _write_with_nodata(arr, path, *, nodata=None):
+    """Helper: write a 2-D array to a tiled GeoTIFF with an optional sentinel."""
+    from xrspatial.geotiff._writer import write
+    write(arr, path, nodata=nodata, compression='deflate',
+          tiled=True, tile_size=16)
+
+
+def _read_both(path, **kwargs):
+    """Read the same file via the eager numpy and eager GPU backends.
+
+    Returns ``(cpu_da, gpu_da)``. ``kwargs`` are forwarded to both
+    ``open_geotiff`` calls so each backend sees the same caller
+    contract.
+    """
+    from xrspatial.geotiff import open_geotiff
+    cpu = open_geotiff(path, **kwargs)
+    gpu = open_geotiff(path, gpu=True, **kwargs)
+    return cpu, gpu
+
+
+# Subset of attrs ``_finalize_eager_read`` is responsible for; mirrors
+# the issue body's parity claim list.
+_LIFECYCLE_ATTRS = (
+    'nodata',
+    'nodata_pixels_present',
+    'nodata_dtype_cast',
+    'georef_status',
+)
+
+
+def _assert_lifecycle_attrs_match(cpu_da, gpu_da):
+    """Assert the four lifecycle attrs match across backends.
+
+    ``masked_nodata`` is checked separately because the test suite
+    asserts on its boolean value when a sentinel is declared.
+    """
+    for key in _LIFECYCLE_ATTRS:
+        cpu_v = cpu_da.attrs.get(key)
+        gpu_v = gpu_da.attrs.get(key)
+        assert cpu_v == gpu_v, (
+            f"attrs[{key!r}] divergence: cpu={cpu_v!r} gpu={gpu_v!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Float source with in-buffer sentinel
+# ---------------------------------------------------------------------------
+
+
+@_gpu_only
+def test_float_sentinel_match_and_mask(tmp_path):
+    """Float source + sentinel: both backends mask in place, attrs match."""
+    arr = np.array(
+        [[1.0, 2.0, -9999.0], [4.0, -9999.0, 6.0]], dtype=np.float32)
+    path = str(tmp_path / 'eager_parity_2179_float_sentinel.tif')
+    _write_with_nodata(arr, path, nodata=-9999.0)
+
+    cpu, gpu = _read_both(path)
+
+    # dtype + masked_nodata first: float source stays at its declared
+    # dtype on both backends; the mask substitutes NaN.
+    assert cpu.dtype == gpu.dtype
+    assert cpu.attrs.get('masked_nodata') is True
+    assert gpu.attrs.get('masked_nodata') is True
+
+    # Lifecycle attrs proper. ``nodata_pixels_present`` must surface
+    # as a real bool on both backends (the issue body calls this out
+    # explicitly).
+    _assert_lifecycle_attrs_match(cpu, gpu)
+    assert isinstance(cpu.attrs.get('nodata_pixels_present'), bool)
+    assert isinstance(gpu.attrs.get('nodata_pixels_present'), bool)
+    assert cpu.attrs.get('nodata_pixels_present') is True
+
+    # And the NaN locations agree pixel-for-pixel.
+    cpu_arr = cpu.values
+    gpu_arr = gpu.data.get()
+    np.testing.assert_array_equal(np.isnan(cpu_arr), np.isnan(gpu_arr))
+
+
+# ---------------------------------------------------------------------------
+# Integer source with in-range sentinel
+# ---------------------------------------------------------------------------
+
+
+@_gpu_only
+def test_int_in_range_sentinel_promotes_to_float(tmp_path):
+    """uint16 + 65535 sentinel: both backends promote to float64 with NaN."""
+    arr = np.array([[1, 2, 3], [65535, 5, 6]], dtype=np.uint16)
+    path = str(tmp_path / 'eager_parity_2179_int_sentinel.tif')
+    _write_with_nodata(arr, path, nodata=65535)
+
+    cpu, gpu = _read_both(path)
+
+    # Integer promotion fires on both backends.
+    assert cpu.dtype == np.float64
+    assert gpu.dtype == np.float64
+    assert cpu.attrs.get('masked_nodata') is True
+    assert gpu.attrs.get('masked_nodata') is True
+
+    _assert_lifecycle_attrs_match(cpu, gpu)
+    assert cpu.attrs.get('nodata_pixels_present') is True
+
+    cpu_arr = cpu.values
+    gpu_arr = gpu.data.get()
+    np.testing.assert_array_equal(np.isnan(cpu_arr), np.isnan(gpu_arr))
+
+
+# ---------------------------------------------------------------------------
+# Integer source with out-of-range sentinel
+# ---------------------------------------------------------------------------
+
+
+@_gpu_only
+def test_int_out_of_range_sentinel_is_no_op(tmp_path):
+    """uint8 + 9999 sentinel: out-of-range, no promotion, presence=False."""
+    arr = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.uint8)
+    path = str(tmp_path / 'eager_parity_2179_int_oor.tif')
+    # 9999 cannot match any uint8 pixel. ``_writer.write`` accepts an
+    # int sentinel here without complaining (the writer only refuses
+    # bool / NaN values, not out-of-range ints), so we get a file with
+    # the literal nodata tag set to 9999 and no pixel matching it.
+    _write_with_nodata(arr, path, nodata=9999)
+
+    cpu, gpu = _read_both(path)
+
+    # No promotion when the sentinel is out of range. Both backends
+    # leave the uint8 buffer alone.
+    assert cpu.dtype == np.uint8
+    assert gpu.dtype == np.uint8
+    # ``masked_nodata`` is False because the mask did not run; the
+    # final dtype is still int.
+    assert cpu.attrs.get('masked_nodata') is False
+    assert gpu.attrs.get('masked_nodata') is False
+
+    _assert_lifecycle_attrs_match(cpu, gpu)
+    assert cpu.attrs.get('nodata_pixels_present') is False
+
+
+# ---------------------------------------------------------------------------
+# mask_nodata=False
+# ---------------------------------------------------------------------------
+
+
+@_gpu_only
+def test_mask_nodata_false_keeps_literal_sentinel(tmp_path):
+    """mask_nodata=False leaves the buffer untouched on both backends."""
+    arr = np.array(
+        [[1.0, 2.0, -9999.0], [4.0, -9999.0, 6.0]], dtype=np.float32)
+    path = str(tmp_path / 'eager_parity_2179_mask_false.tif')
+    _write_with_nodata(arr, path, nodata=-9999.0)
+
+    cpu, gpu = _read_both(path, mask_nodata=False)
+
+    # No NaN substitution; the literal sentinel survives on both
+    # backends with ``masked_nodata=False``.
+    assert cpu.dtype == np.float32
+    assert gpu.dtype == np.float32
+    assert cpu.attrs.get('masked_nodata') is False
+    assert gpu.attrs.get('masked_nodata') is False
+
+    _assert_lifecycle_attrs_match(cpu, gpu)
+    # The no-mask scan branch still surfaces presence.
+    assert cpu.attrs.get('nodata_pixels_present') is True
+
+    cpu_arr = cpu.values
+    gpu_arr = gpu.data.get()
+    np.testing.assert_array_equal(cpu_arr, gpu_arr)
+
+
+# ---------------------------------------------------------------------------
+# No declared sentinel
+# ---------------------------------------------------------------------------
+
+
+@_gpu_only
+def test_no_declared_sentinel_omits_nodata_attrs(tmp_path):
+    """Source without nodata declaration: no lifecycle attrs on either side."""
+    arr = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.uint8)
+    path = str(tmp_path / 'eager_parity_2179_no_sentinel.tif')
+    _write_with_nodata(arr, path, nodata=None)
+
+    cpu, gpu = _read_both(path)
+
+    assert cpu.dtype == np.uint8
+    assert gpu.dtype == np.uint8
+
+    # The helper's ``_set_nodata_attrs`` early-returns when there is no
+    # declared sentinel, so neither ``nodata`` nor ``masked_nodata``
+    # appear on either backend.
+    assert 'nodata' not in cpu.attrs
+    assert 'nodata' not in gpu.attrs
+    assert 'masked_nodata' not in cpu.attrs
+    assert 'masked_nodata' not in gpu.attrs
+    assert 'nodata_pixels_present' not in cpu.attrs
+    assert 'nodata_pixels_present' not in gpu.attrs
+
+    # ``georef_status`` still rides on the helper regardless of nodata
+    # state, so the parity assertion exercises that branch too.
+    _assert_lifecycle_attrs_match(cpu, gpu)
+
+
+# ---------------------------------------------------------------------------
+# nodata_dtype_cast on explicit dtype=
+# ---------------------------------------------------------------------------
+
+
+@_gpu_only
+def test_dtype_kwarg_records_post_mask_cast(tmp_path):
+    """Explicit dtype= records ``nodata_dtype_cast`` on both backends."""
+    arr = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.uint16)
+    path = str(tmp_path / 'eager_parity_2179_dtype_cast.tif')
+    # Out-of-range sentinel keeps the mask a no-op so the cast attr is
+    # the only signal that the user asked for a dtype change; this
+    # isolates the ``nodata_dtype_cast`` branch from the mask-driven
+    # promotion exercised in ``test_int_in_range_sentinel_promotes_to_float``.
+    _write_with_nodata(arr, path, nodata=9999)
+
+    cpu, gpu = _read_both(path, dtype=np.float32)
+
+    assert cpu.dtype == np.float32
+    assert gpu.dtype == np.float32
+    assert cpu.attrs.get('nodata_dtype_cast') == 'float32'
+    assert gpu.attrs.get('nodata_dtype_cast') == 'float32'
+
+    _assert_lifecycle_attrs_match(cpu, gpu)

--- a/xrspatial/geotiff/tests/test_eager_finalization_parity_2162.py
+++ b/xrspatial/geotiff/tests/test_eager_finalization_parity_2162.py
@@ -276,3 +276,122 @@ def test_dtype_kwarg_records_post_mask_cast(tmp_path):
     assert gpu.attrs.get('nodata_dtype_cast') == 'float32'
 
     _assert_lifecycle_attrs_match(cpu, gpu)
+
+
+# ---------------------------------------------------------------------------
+# Windowed reads
+# ---------------------------------------------------------------------------
+
+
+@_gpu_only
+def test_windowed_read_presence_matches_window_contents(tmp_path):
+    """Windowed read: nodata_pixels_present reflects the window, not the IFD.
+
+    Pins the slice-before-mask behaviour the GPU local-eager path
+    picked up in #2179. Pre-PR the GPU path masked the full IFD then
+    sliced, so ``nodata_pixels_present`` reported sentinel presence
+    anywhere in the file; post-PR it reports presence within the
+    requested window. The CPU path has always behaved this way, so
+    the two now agree.
+    """
+    # 4x4 raster with the sentinel only in the bottom half so the two
+    # windows below land on opposite sides of the presence bool.
+    arr = np.array(
+        [
+            [1.0, 2.0, 3.0, 4.0],
+            [5.0, 6.0, 7.0, 8.0],
+            [9.0, 10.0, -9999.0, 12.0],
+            [13.0, 14.0, 15.0, 16.0],
+        ],
+        dtype=np.float32,
+    )
+    path = str(tmp_path / 'eager_parity_2179_windowed.tif')
+    _write_with_nodata(arr, path, nodata=-9999.0)
+
+    # Top-left 2x2 window: no sentinel in scope.
+    cpu, gpu = _read_both(path, window=(0, 0, 2, 2))
+    _assert_lifecycle_attrs_match(cpu, gpu)
+    assert cpu.attrs.get('nodata_pixels_present') is False
+    assert gpu.attrs.get('nodata_pixels_present') is False
+
+    # Bottom 2x4 window: covers the sentinel.
+    cpu, gpu = _read_both(path, window=(2, 0, 4, 4))
+    _assert_lifecycle_attrs_match(cpu, gpu)
+    assert cpu.attrs.get('nodata_pixels_present') is True
+    assert gpu.attrs.get('nodata_pixels_present') is True
+
+
+# ---------------------------------------------------------------------------
+# MinIsWhite + nodata
+# ---------------------------------------------------------------------------
+
+
+@_gpu_only
+def test_miniswhite_post_inversion_sentinel_parity(tmp_path):
+    """MinIsWhite raster: post-inversion sentinel resolves identically on both backends.
+
+    Exercises the ``_mw_mask_nodata`` branch in the GPU local-eager
+    path. The reader inverts the buffer and the post-MinIsWhite
+    sentinel is what the helper's mask block compares against on the
+    GPU side; the eager numpy path takes the same sentinel off
+    ``geo_info._mask_nodata`` through ``read_to_array``. Both should
+    land on the same NaN positions and the same lifecycle attrs.
+    """
+    import tifffile
+    # uint8 + nodata=0; MinIsWhite inverts the stored value to 255
+    # before masking, and 255 is the post-inversion sentinel.
+    stored = np.array([[0, 100, 200], [50, 0, 255]], dtype=np.uint8)
+    path = str(tmp_path / 'eager_parity_2179_miniswhite.tif')
+    extratags = [("GDAL_NODATA", "s", 0, "0\0", True)]
+    tifffile.imwrite(
+        path, stored, photometric="miniswhite",
+        extratags=extratags, tile=(16, 16),
+    )
+
+    cpu, gpu = _read_both(path)
+
+    _assert_lifecycle_attrs_match(cpu, gpu)
+    cpu_arr = cpu.values
+    gpu_arr = gpu.data.get()
+    # NaN positions must agree pixel-for-pixel; the MinIsWhite
+    # sentinel resolution drives this.
+    np.testing.assert_array_equal(np.isnan(cpu_arr), np.isnan(gpu_arr))
+
+
+# ---------------------------------------------------------------------------
+# Multi-band (3D)
+# ---------------------------------------------------------------------------
+
+
+@_gpu_only
+def test_multiband_stripped_parity(tmp_path):
+    """3-band stripped read: helper builds (y, x, band) DataArray on both backends.
+
+    The GPU CPU-fallback path lands on stripped files. Multi-band
+    output goes through the helper's ``arr.ndim == 3`` branch on
+    both backends; the parity assertion covers ``georef_status`` and
+    sentinel-related attrs for the multi-band shape so a future
+    change to the 3-D coord build cannot silently diverge.
+    """
+    import xarray as xr
+    rng = np.random.RandomState(20260520)
+    data = rng.randint(0, 200, size=(32, 48, 3)).astype(np.uint8)
+    da_in = xr.DataArray(data, dims=['y', 'x', 'band'])
+
+    path = str(tmp_path / 'eager_parity_2179_multiband.tif')
+    from xrspatial.geotiff import to_geotiff
+    # Stripped (tiled=False) routes the GPU read through the
+    # CPU-fallback eager site, which is one of the three sites this
+    # PR migrated.
+    to_geotiff(da_in, path, tiled=False)
+
+    cpu, gpu = _read_both(path)
+
+    # Shape and dims line up across backends.
+    assert cpu.dims == gpu.dims
+    assert cpu.shape == gpu.shape == (32, 48, 3)
+
+    _assert_lifecycle_attrs_match(cpu, gpu)
+    cpu_arr = cpu.values
+    gpu_arr = gpu.data.get()
+    np.testing.assert_array_equal(cpu_arr, gpu_arr)


### PR DESCRIPTION
## Summary

Wave 2 of #2162 (PR D of the series). Replaces the duplicated eager
finalization block at four sites with `_finalize_eager_read` from PR
B (#2177, now on `main`):

- `xrspatial/geotiff/__init__.py` — eager numpy `open_geotiff`
- `xrspatial/geotiff/_backends/gpu.py` — GPU CPU-fallback path
- `xrspatial/geotiff/_backends/gpu.py` — GPU local main path
- `xrspatial/geotiff/_backends/gpu.py` — GPU HTTP path

Net diff: -354 / +385, removing about 250 lines of repeated `validate
/ populate-attrs / mask / cast / set_nodata_attrs / DataArray-build`
code the helper now owns.

The three GPU sites resolve `mask_sentinel` three different ways
before calling the helper:

- CPU-fallback path: `_stripped_geo._mask_nodata` from `read_to_array`
- Local main path: `_mw_mask_nodata` local, with `_cpu_fallback_geo`
  fallback, then raw `nodata`
- HTTP path: `geo_info._mask_nodata` from `read_to_array`

`_finalize_eager_read`'s host-side mask block runs on CuPy arrays via
numpy duck-typing, so no GPU-specific branch is needed.

## Behavior changes

The GPU local-eager path now slices the window/band before masking,
not after. The CPU eager path has always masked post-slice; the GPU
path was masking the full IFD then slicing. This brings the
`attrs['nodata_pixels_present']` attr in line: it now reports
sentinel presence within the read window on every backend. No
existing GPU test pinned the old IFD-level semantics.

## Tests

Adds `xrspatial/geotiff/tests/test_eager_finalization_parity_2162.py`
covering the numpy and cupy eager backends against the same files:

- float sentinel: in-place NaN mask
- int in-range sentinel: int -> float64 promotion
- int out-of-range sentinel: mask no-op
- `mask_nodata=False`: literal sentinel survives
- no declared sentinel: lifecycle attrs absent
- explicit `dtype=` kwarg: `nodata_dtype_cast` recorded

Existing eager tests still pass: `test_nodata_lifecycle_attrs_2135`,
`test_nodata_semantics_split_1988`, `test_georef_status_2136`,
`test_gpu_nodata_1542`, plus the broader GeoTIFF suite (4584 passed,
45 skipped on no-CUDA, 1 xfailed, 1 pre-existing deselected flake
unrelated to this PR).

## Test plan

- [x] `pytest xrspatial/geotiff/tests/test_eager_finalization_parity_2162.py -v`
- [x] `pytest xrspatial/geotiff/tests/test_nodata_lifecycle_attrs_2135.py`
- [x] `pytest xrspatial/geotiff/tests/test_gpu_nodata_1542.py`
- [x] `pytest xrspatial/geotiff/` (full suite, deselecting one pre-existing flake)

Closes #2179.

Parent: #2162. Sibling PR C (#2178) handles the dask backends in
parallel; sibling PR E (#2180) handles VRT in wave 3.