### PR TITLE
geotiff: migrate VRT backend to shared finalization helpers (PR E of #2162)

### DIFF
--- a/xrspatial/geotiff/_backends/vrt.py
+++ b/xrspatial/geotiff/_backends/vrt.py
@@ -30,6 +30,7 @@ from .._geotags import (
 from .._reader import _MAX_CLOUD_BYTES_SENTINEL
 from .._runtime import _ON_GPU_FAILURE_SENTINEL
 from .._validation import (
+    _gdal_geotransform_to_affine_tuple,
     _validate_chunks_arg,
     _validate_dispatch_kwargs,
     _validate_dtype_cast,
@@ -89,10 +90,6 @@ def _vrt_to_synthetic_geo_info(vrt) -> GeoInfo:
         else RASTER_PIXEL_IS_AREA
     )
     if is_rotated:
-        # ``_gdal_geotransform_to_affine_tuple`` lives in ``_validation``;
-        # local import keeps the module-load surface free of a heavy
-        # transitive dependency.
-        from .._validation import _gdal_geotransform_to_affine_tuple
         rotated_affine = _gdal_geotransform_to_affine_tuple(gt)
         return GeoInfo(
             transform=GeoTransform(rotated_affine=tuple(rotated_affine)),
@@ -361,10 +358,7 @@ def read_vrt(source: str, *,
     # set here pre-read and let ``_finalize_lazy_read_attrs`` re-run the
     # ``allow_rotated`` / ``allow_unparseable_crs`` arm later as a no-op.
     import os as _os
-    from .._validation import (
-        validate_read_metadata,
-        _gdal_geotransform_to_affine_tuple,
-    )
+    from .._validation import validate_read_metadata
     from .._vrt import parse_vrt as _parse_vrt, _read_vrt_xml
     _xml_str = _read_vrt_xml(source)
     _vrt_dir = _os.path.dirname(_os.path.abspath(source))
@@ -714,10 +708,7 @@ def _read_vrt_chunked(source, *, window, band, name, chunks, gpu, dtype,
     # Issue #1987 ambiguous-metadata checks on the chunked VRT path. Run
     # before the band-count validator below so a rejected file does not
     # produce side effects.
-    from .._validation import (
-        validate_read_metadata,
-        _gdal_geotransform_to_affine_tuple,
-    )
+    from .._validation import validate_read_metadata
     validate_read_metadata({
         'allow_rotated': allow_rotated,
         'allow_unparseable_crs': allow_unparseable_crs,

--- a/xrspatial/geotiff/_backends/vrt.py
+++ b/xrspatial/geotiff/_backends/vrt.py
@@ -14,16 +14,19 @@ import numpy as np
 import xarray as xr
 
 from .._attrs import (
-    GeoTIFFMetadata,
-    _compute_georef_status_from_parts,
-    _set_nodata_attrs,
-    metadata_to_attrs,
+    _apply_caller_dtype_cast,
+    _finalize_lazy_read_attrs,
 )
 from .._coords import (
     coords_from_pixel_geometry as _coords_from_pixel_geometry,
-    transform_tuple_from_pixel_geometry as _transform_tuple_from_pixel_geometry,
 )
 from .._crs import _wkt_to_epsg
+from .._geotags import (
+    RASTER_PIXEL_IS_AREA,
+    RASTER_PIXEL_IS_POINT,
+    GeoInfo,
+    GeoTransform,
+)
 from .._reader import _MAX_CLOUD_BYTES_SENTINEL
 from .._runtime import _ON_GPU_FAILURE_SENTINEL
 from .._validation import (
@@ -38,6 +41,87 @@ from .._validation import (
 # entry points refuse the same scheduler-busting chunk grids. See
 # issue #1814.
 _MAX_VRT_DASK_CHUNKS = 50_000
+
+
+def _vrt_to_synthetic_geo_info(vrt) -> GeoInfo:
+    """Project a parsed ``VRTDataset`` onto a ``GeoInfo`` for the helpers.
+
+    Wave 3 of #2162. Lets the VRT eager and chunked paths feed the shared
+    ``_finalize_lazy_read_attrs`` helper instead of building
+    ``GeoTIFFMetadata`` from VRT internals by hand. The synthesis follows
+    the existing VRT contract:
+
+    * The rotated-VRT case (non-zero skew terms on the GDAL GeoTransform,
+      opened with ``allow_rotated=True``) sets ``has_georef=False`` and
+      stamps ``rotated_affine`` on the embedded ``GeoTransform``. The
+      ``geo_info_to_metadata`` rotated-opt-in branch then drops the
+      ``crs`` / ``crs_wkt`` / ``transform`` attrs and emits
+      ``rotated_affine`` plus the no-georef marker, matching the rotated
+      branch on the non-VRT path (#2122 / #2129).
+    * The plain no-``<GeoTransform>`` case sets ``has_georef=False`` with
+      a default-unit ``GeoTransform``. ``geo_info_to_metadata`` lands on
+      ``transform=None`` and emits only the no-georef marker plus CRS
+      attrs when the VRT carries a ``<SRS>``.
+    * The axis-aligned georeferenced case sets ``has_georef=True`` with
+      the parsed origin / pixel size.
+
+    ``vrt.crs_wkt`` carries an empty string when the VRT XML has a
+    ``<SRS>`` element with no recognised CRS body; treat empty as absent
+    so the helper does not emit ``attrs['crs_wkt']=''``. CRS resolution
+    to an EPSG code mirrors the inline code from the pre-migration
+    branch (issue #1734 / #2122 / #2136 / #2139).
+
+    The synthesised ``GeoInfo`` carries only the fields the VRT path
+    actually owns: transform, has_georef, crs_epsg / crs_wkt,
+    raster_type. ``extra_tags`` / ``gdal_metadata`` / resolution tags
+    stay at their dataclass defaults so the helper's
+    ``geo_info_to_metadata`` does not synthesise attrs the VRT branch
+    never emitted. ``vrt_holes`` is documented divergence: ``GeoInfo``
+    has no slot for it, so the call site stamps the attr post-helper.
+    """
+    gt = vrt.geo_transform
+    is_rotated = gt is not None and (gt[2] != 0.0 or gt[4] != 0.0)
+    keep_crs = bool(vrt.crs_wkt) and not is_rotated
+    crs_epsg = _wkt_to_epsg(vrt.crs_wkt) if keep_crs else None
+    crs_wkt = vrt.crs_wkt if keep_crs else None
+    raster_type = (
+        RASTER_PIXEL_IS_POINT if vrt.raster_type == 'point'
+        else RASTER_PIXEL_IS_AREA
+    )
+    if is_rotated:
+        # ``_gdal_geotransform_to_affine_tuple`` lives in ``_validation``;
+        # local import keeps the module-load surface free of a heavy
+        # transitive dependency.
+        from .._validation import _gdal_geotransform_to_affine_tuple
+        rotated_affine = _gdal_geotransform_to_affine_tuple(gt)
+        return GeoInfo(
+            transform=GeoTransform(rotated_affine=tuple(rotated_affine)),
+            has_georef=False,
+            crs_epsg=crs_epsg,
+            crs_wkt=crs_wkt,
+            raster_type=raster_type,
+        )
+    if gt is None:
+        return GeoInfo(
+            transform=GeoTransform(),
+            has_georef=False,
+            crs_epsg=crs_epsg,
+            crs_wkt=crs_wkt,
+            raster_type=raster_type,
+        )
+    origin_x, res_x, _, origin_y, _, res_y = gt
+    return GeoInfo(
+        transform=GeoTransform(
+            origin_x=float(origin_x),
+            origin_y=float(origin_y),
+            pixel_width=float(res_x),
+            pixel_height=float(res_y),
+        ),
+        has_georef=True,
+        crs_epsg=crs_epsg,
+        crs_wkt=crs_wkt,
+        raster_type=raster_type,
+    )
 
 
 def read_vrt(source: str, *,
@@ -168,7 +252,6 @@ def read_vrt(source: str, *,
     from .._reader import _coerce_path
     from .._vrt import (
         read_vrt as _read_vrt_internal,
-        _apply_integer_sentinel_mask as _vrt_apply_integer_sentinel_mask,
         _apply_integer_sentinel_mask_with_presence as _vrt_mask_with_presence,
         _scan_for_sentinel as _vrt_scan_for_sentinel,
     )
@@ -269,6 +352,14 @@ def read_vrt(source: str, *,
     # materialise the full mosaic into host memory. The parsed
     # ``VRTDataset`` is threaded into the internal reader via ``parsed=``
     # so we don't double-parse the XML.
+    #
+    # The ``band_nodata`` / ``band_nodata_values`` keys are VRT-specific
+    # documented divergence from the shared helper: the wave-1 frozen
+    # signature of ``_validate_read_geo_info`` does not carry per-band
+    # nodata context, so the mixed-band check would not fire if we
+    # routed validation only through the helper. We run the full check
+    # set here pre-read and let ``_finalize_lazy_read_attrs`` re-run the
+    # ``allow_rotated`` / ``allow_unparseable_crs`` arm later as a no-op.
     import os as _os
     from .._validation import (
         validate_read_metadata,
@@ -357,100 +448,31 @@ def read_vrt(source: str, *,
     else:
         coords = {}
 
-    # Build the VRT attrs surface via :class:`GeoTIFFMetadata` so the
-    # eager VRT, chunked VRT, and non-VRT read paths share one
-    # field-set-to-attrs marshalling step. The VRT path intentionally
-    # populates only the subset of fields it owns (CRS, transform,
-    # raster_type, no-georef marker, vrt_holes); ``extra_tags``,
-    # ``gdal_metadata`` and resolution tags continue to be omitted on
-    # this path until the migration's VRT-tag-coverage follow-up lands.
-    # See issue #2139.
-    #
-    # Rotated VRT reads (``allow_rotated=True`` opt-in, #2122) drop both
-    # the transform AND the CRS attrs because the writer cannot
-    # round-trip a rotated 6-tuple as ``attrs['transform']``. Modelled by
-    # setting ``has_georef=False`` (so ``metadata_to_attrs`` emits the
-    # no-georef marker) and clearing the CRS fields below.
-    #
-    # ``vrt.crs_wkt`` carries an empty string when the VRT XML has a
-    # ``<SRS>`` element but no recognised CRS body; treat empty as
-    # absent so ``metadata_to_attrs`` does not emit ``attrs['crs_wkt']=''``.
-    #
-    # ``georef_status`` (issue #2136) is computed from raw booleans and
-    # carried on the record so the VRT path stamps the same five-valued
-    # classifier the non-VRT read paths emit. ``has_crs`` mirrors
-    # ``_compute_georef_status`` by gating on ``is not None`` rather than
-    # truthiness, so a future parser change that returns ``""`` instead
-    # of ``None`` for a missing ``<SRS>`` would still route to ``none``
-    # via the empty-string check above. ``rotated_dropped=_vrt_is_rotated``
-    # matches the rotated arm on the non-VRT path: a VRT ``geo_transform``
-    # with non-zero rotation/skew lands the array in the same
-    # ``rotated_dropped`` bucket as a rotated ``ModelTransformationTag``.
-    _vrt_keep_crs = bool(vrt.crs_wkt) and not _vrt_is_rotated
-    _vrt_epsg = _wkt_to_epsg(vrt.crs_wkt) if _vrt_keep_crs else None
-    # Surface the rotated 6-tuple alongside ``georef_status='rotated_dropped'``
-    # so the VRT path matches the non-VRT ``ModelTransformationTag`` path
-    # introduced by issue #2129. Without this the rotated VRT would land
-    # in the same bucket as the rotated TIFF but offer no way to recover
-    # the mapping. The GDAL geo_transform is already 6-tuple ordered;
-    # ``_gdal_geotransform_to_affine_tuple`` converts to rasterio
-    # ``Affine`` ordering (a, b, c, d, e, f).
-    _vrt_rotated_affine = (
-        _gdal_geotransform_to_affine_tuple(gt) if _vrt_is_rotated else None
-    )
-    _vrt_md = GeoTIFFMetadata(
-        crs_epsg=_vrt_epsg,
-        crs_wkt=vrt.crs_wkt if _vrt_keep_crs else None,
-        raster_type='point' if vrt.raster_type == 'point' else 'area',
-        has_georef=gt is not None and not _vrt_is_rotated,
-        # Surface skipped-source records as ``attrs['vrt_holes']`` so
-        # callers can detect a partial mosaic by attribute lookup. See
-        # issue #1734.
-        vrt_holes=list(vrt.holes) if vrt.holes else None,
-        georef_status=_compute_georef_status_from_parts(
-            has_transform=gt is not None and not _vrt_is_rotated,
-            has_crs=vrt.crs_wkt is not None and not _vrt_is_rotated,
-            rotated_dropped=_vrt_is_rotated,
-        ),
-        rotated_affine=_vrt_rotated_affine,
-    )
-    attrs = metadata_to_attrs(_vrt_md)
-    # When a specific band is selected, source its nodata from that
-    # band's <NoDataValue> instead of band 0's. Otherwise multi-band
-    # VRTs with per-band sentinels would mis-mask the read: attrs would
-    # advertise band 0's sentinel, the integer-promotion block below
-    # would mask against band 0's sentinel, and band N's actual nodata
-    # pixels would survive as literal integers. See issue #1598.
-    # ``band`` has already been validated by ``_vrt.read_vrt`` as
+    # Select the per-band nodata sentinel. When a specific band is
+    # selected, source its nodata from that band's ``<NoDataValue>``
+    # instead of band 0's. Otherwise multi-band VRTs with per-band
+    # sentinels would mis-mask the read: attrs would advertise band 0's
+    # sentinel, the integer-promotion block below would mask against
+    # band 0's sentinel, and band N's actual nodata pixels would
+    # survive as literal integers. See issue #1598. ``band`` has
+    # already been validated by ``_vrt.read_vrt`` as
     # 0 <= band < len(vrt.bands), so a simple lookup is safe here.
+    #
+    # Documented divergence: per-band sentinel selection cannot ride
+    # through ``_finalize_lazy_read_attrs`` because the helper expects
+    # a single ``nodata`` value from ``geo_info.nodata``. The shared
+    # GeoInfo dataclass does not model per-band sentinels.
     nodata = None
     if vrt.bands:
         band_idx_for_nodata = band if band is not None else 0
         nodata = vrt.bands[band_idx_for_nodata].nodata
 
-    # Mirror the integer-with-nodata promotion that open_geotiff /
-    # read_geotiff_dask / read_geotiff_gpu apply post-decode. The VRT
-    # internal reader NaN-masks float source arrays inline (see
-    # ``_vrt._read_data``) but leaves integer sentinels untouched.
-    # ``attrs['nodata']`` (the declared sentinel) is set unconditionally
-    # below; ``attrs['masked_nodata']`` is computed from the final array
-    # dtype so it reflects whether NaN masking actually ran (issue #1988).
-    #
-    # The helper handles both per-band masking (multi-band reads where
-    # each band has its own ``<NoDataValue>``) and single-band masking,
-    # promoting ``arr`` to float64 on the first sentinel hit and writing
-    # NaNs in place on the promoted view. Shared with the chunked path
-    # (issue #1825) so behaviour stays in lockstep. See issue #1611.
-    # ``mask_nodata=False`` skips this so callers can preserve an
-    # integer source dtype via ``dtype=...`` (issue #2052).
-    # ``nodata_pixels_present`` tracks whether the read window contained
-    # any sentinel pixel before masking (issue #2135). On the VRT eager
-    # path it has two sources: the integer-sentinel helper below (which
-    # returns ``True`` iff at least one band hit its sentinel during
-    # promotion), and the inline float-NaN masking inside ``_read_data``
-    # (proxied via NaN presence on the resulting float buffer when the
-    # source declared a sentinel). Stays ``None`` only when no sentinel
-    # was declared.
+    # Apply the VRT-specific masking step. The shared helper's
+    # ``_apply_eager_nodata_mask`` is single-sentinel, but the VRT
+    # multi-band case masks each band against its own ``<NoDataValue>``,
+    # so we run the VRT-aware helper here and feed the post-mask buffer
+    # to ``_finalize_lazy_read_attrs``. This is documented divergence
+    # tied to the per-band selection above.
     nodata_pixels_present: bool | None = None
     if mask_nodata:
         arr, nodata_pixels_present = _vrt_mask_with_presence(arr, vrt, band)
@@ -461,8 +483,8 @@ def read_vrt(source: str, *,
 
     # Capture pre-cast dtype: ``_vrt._read_data`` NaN-masks float source
     # arrays (and int sources feeding a float VRT dataType) inline, and
-    # ``_vrt_apply_integer_sentinel_mask`` above promotes int-with-sentinel
-    # to float64 with NaNs written in place. Any of those paths yield a
+    # ``_vrt_mask_with_presence`` above promotes int-with-sentinel to
+    # float64 with NaNs written in place. Any of those paths yield a
     # float pre-cast dtype; an int pre-cast dtype means literal sentinels
     # are still in the buffer. The optional user dtype cast below may
     # promote int -> float without masking, so reading dtype after the
@@ -506,47 +528,64 @@ def read_vrt(source: str, *,
             # back to the helper's answer rather than raising mid-read.
             pass
 
-    # Surface the source GeoTransform in the same rasterio ordering used
-    # by open_geotiff: (pixel_width, 0, origin_x, 0, pixel_height, origin_y).
-    # vrt.geo_transform is GDAL ordering, so reorder. For a windowed read
-    # the origin shifts by (col_offset * res_x, row_offset * res_y).
-    # Rotated VRTs (allow_rotated=True opt-in) intentionally skip the
-    # transform attr because the axis-aligned 6-tuple would silently drop
-    # the rotation terms and downstream code that branches on
-    # ``'transform' in attrs`` would treat the array as projected (#2122).
-    if gt is not None and not _vrt_is_rotated:
-        if window is not None:
-            tt_window = (max(0, window[0]), max(0, window[1]), 0, 0)
-        else:
-            tt_window = None
-        attrs['transform'] = _transform_tuple_from_pixel_geometry(
-            origin_x, origin_y, res_x, res_y, window=tt_window,
-        )
-
-    # Transfer to GPU if requested
+    # Transfer to GPU if requested. The dtype cast lands after the lift
+    # so ``cupy.ndarray.astype`` runs on the device.
     if gpu:
         import cupy
         arr = cupy.asarray(arr)
 
-    dtype_cast_attr: str | None = None
     if dtype is not None:
         target = np.dtype(dtype)
         _validate_dtype_cast(np.dtype(str(arr.dtype)), target)
         arr = arr.astype(target)
-        dtype_cast_attr = target.name
 
-    # ``masked`` follows the contract documented on ``_set_nodata_attrs``:
-    # ``mask_nodata and final_dtype.kind == 'f'``. The ``mask_nodata=False``
-    # arm fix from #2158 leaves float source buffers untouched, so
-    # ``pre_cast_dtype.kind == 'f'`` alone would now stamp
-    # ``masked_nodata=True`` on a buffer that still carries literal
-    # sentinel values. AND-ing the kwarg in keeps the attr honest (#2159).
-    _set_nodata_attrs(
-        attrs, nodata,
-        masked=(mask_nodata and pre_cast_dtype.kind == 'f'),
-        pixels_present=nodata_pixels_present,
-        dtype_cast=dtype_cast_attr,
+    # Wave 3 of #2162: route attrs assembly through
+    # ``_finalize_lazy_read_attrs`` so the VRT eager path shares the
+    # validate-then-populate-then-stamp block with the eager numpy,
+    # eager GPU, and dask backends. ``geo_info`` is a synthesised
+    # ``GeoInfo`` carrying only the fields the VRT path owns; the
+    # helper handles ``georef_status`` / ``rotated_affine`` / no-georef
+    # marker emission via the same ``geo_info_to_metadata`` ->
+    # ``metadata_to_attrs`` pipeline.
+    #
+    # ``dtype`` is the **pre-cast** dtype so ``masked_nodata`` reflects
+    # whether VRT-side masking actually ran (an int -> float caller
+    # cast must not flip the attr; see #2092 follow-up). The helper's
+    # ``nodata_dtype_cast`` is overwritten via ``_apply_caller_dtype_cast``
+    # so the attr records the caller's ``dtype=`` kwarg, not the
+    # masking-induced graph dtype.
+    #
+    # Documented divergence from the eager helper:
+    #
+    # * ``vrt_holes`` is VRT-specific and ``GeoInfo`` has no slot for it.
+    #   The seed dict carries the value through ``attrs_in`` so the
+    #   helper's ``attrs.update`` leaves it intact; the helper's own
+    #   metadata copy does not emit ``vrt_holes`` for a synthetic
+    #   GeoInfo.
+    # * Per-band nodata selection happens above this call, not inside
+    #   the helper. ``_apply_eager_nodata_mask`` is single-sentinel.
+    # * ``nodata_pixels_present`` is computed above (VRT-aware scan)
+    #   and stamped post-helper because ``_finalize_lazy_read_attrs``
+    #   passes ``pixels_present=None`` unconditionally.
+    synth_geo_info = _vrt_to_synthetic_geo_info(vrt)
+    attrs_seed: dict = {}
+    if vrt.holes:
+        attrs_seed['vrt_holes'] = list(vrt.holes)
+    attrs = _finalize_lazy_read_attrs(
+        geo_info=synth_geo_info,
+        nodata=nodata,
+        mask_nodata=mask_nodata,
+        dtype=pre_cast_dtype,
+        window=window,
+        allow_rotated=allow_rotated,
+        allow_unparseable_crs=allow_unparseable_crs,
+        attrs_in=attrs_seed,
     )
+    _apply_caller_dtype_cast(
+        attrs, caller_dtype=dtype, has_nodata=nodata is not None,
+    )
+    if nodata is not None and nodata_pixels_present is not None:
+        attrs['nodata_pixels_present'] = bool(nodata_pixels_present)
 
     if arr.ndim == 3:
         dims = ['y', 'x', 'band']
@@ -877,16 +916,6 @@ def _read_vrt_chunked(source, *, window, band, name, chunks, gpu, dtype,
     # eager reads share the same x/y arrays.
     gt = vrt.geo_transform
     coords = {}
-    # Build attrs via :class:`GeoTIFFMetadata` to share the marshalling
-    # step with the eager VRT branch. See issue #2139.
-    #
-    # ``_vrt_is_rotated`` matches the eager VRT branch's gate (#2122):
-    # rotated VRTs read with ``allow_rotated=True`` opt out of the
-    # georef attrs (``crs`` / ``crs_wkt`` / ``transform``) so downstream
-    # code that branches on ``'crs' in attrs`` does not treat the pixel
-    # grid as projected. A VRT with no ``<GeoTransform>`` still
-    # surfaces CRS (mirroring the GeoTIFF writer's ``crs=`` kwarg
-    # path).
     _vrt_is_rotated = (
         gt is not None and (gt[2] != 0.0 or gt[4] != 0.0)
     )
@@ -904,49 +933,6 @@ def _read_vrt_chunked(source, *, window, band, name, chunks, gpu, dtype,
             window=coord_window,
             has_georef=not _vrt_is_rotated,
         )
-        # Rotated VRTs (#2122) drop the transform because it cannot
-        # round-trip as ``attrs['transform']``; ``_vrt_md.has_georef``
-        # gates this below so ``metadata_to_attrs`` emits the no-georef
-        # marker on the rotated path.
-        _vrt_transform = (
-            None if _vrt_is_rotated
-            else _transform_tuple_from_pixel_geometry(
-                origin_x, origin_y, res_x, res_y,
-                window=(win_r0, win_c0, 0, 0),
-            )
-        )
-    else:
-        _vrt_transform = None
-
-    # ``vrt.crs_wkt`` carries an empty string when the VRT XML has a
-    # ``<SRS>`` element but no recognised CRS body; treat empty as
-    # absent so ``metadata_to_attrs`` does not emit ``attrs['crs_wkt']=''``.
-    # Rotated VRTs drop CRS attrs alongside the transform (#2122).
-    _vrt_keep_crs = bool(vrt.crs_wkt) and not _vrt_is_rotated
-    _vrt_epsg = _wkt_to_epsg(vrt.crs_wkt) if _vrt_keep_crs else None
-    # See the eager VRT branch for the rationale; issue #2129 carries
-    # the rotated 6-tuple onto the chunked VRT path too so dask reads
-    # of rotated VRTs match the eager-VRT and non-VRT TIFF surface.
-    _vrt_rotated_affine = (
-        _gdal_geotransform_to_affine_tuple(gt) if _vrt_is_rotated else None
-    )
-    # ``georef_status`` (issue #2136). See the eager VRT branch above
-    # for the rationale; the rotated VRT path lands the array in the
-    # ``rotated_dropped`` bucket so consumers can branch on it.
-    _vrt_md = GeoTIFFMetadata(
-        transform=_vrt_transform,
-        crs_epsg=_vrt_epsg,
-        crs_wkt=vrt.crs_wkt if _vrt_keep_crs else None,
-        raster_type='point' if vrt.raster_type == 'point' else 'area',
-        has_georef=gt is not None and not _vrt_is_rotated,
-        georef_status=_compute_georef_status_from_parts(
-            has_transform=gt is not None and not _vrt_is_rotated,
-            has_crs=vrt.crs_wkt is not None and not _vrt_is_rotated,
-            rotated_dropped=_vrt_is_rotated,
-        ),
-        rotated_affine=_vrt_rotated_affine,
-    )
-    attrs = metadata_to_attrs(_vrt_md)
 
     # Surface the nodata sentinel for the selected band. The chunked
     # path declares ``float64`` up front whenever any selected band has
@@ -955,35 +941,15 @@ def _read_vrt_chunked(source, *, window, band, name, chunks, gpu, dtype,
     # ``masked_nodata`` (issue #1988). ``final_dtype`` is the post-cast
     # dtype the dask array was reshaped to above, which is what the
     # caller will see on the returned DataArray.
+    #
+    # Documented divergence (see ``_finalize_lazy_read_attrs`` call): the
+    # synthesised ``GeoInfo`` does not model per-band nodata, so the
+    # caller picks the right band's sentinel here and forwards it via
+    # the helper's ``nodata`` kwarg.
     nodata_meta = None
     if vrt.bands:
         band_idx_for_nodata = band if band is not None else 0
         nodata_meta = vrt.bands[band_idx_for_nodata].nodata
-    # VRT chunked path: ``declared_dtype`` is promoted to float64 only
-    # when ``mask_nodata`` is on and an integer band has a representable
-    # sentinel (see the ``declared_dtype`` block earlier in this
-    # function). A user-supplied ``dtype=`` cast happens on top of the
-    # lazy graph above (see ``final_dtype`` block) and must not flip
-    # this attr, so we read the pre-cast ``declared_dtype`` here rather
-    # than ``final_dtype`` (#2092 follow-up).
-    # ``nodata_pixels_present`` is intentionally left unset on the
-    # chunked VRT path: a per-chunk reduction would force eager
-    # ``.compute()`` (matches the dask backend's policy for issue
-    # #2135). ``dtype_cast`` records the caller-supplied ``dtype=``
-    # kwarg when present so downstream can tell float-by-cast apart
-    # from float-by-masking even on the lazy output.
-    # ``masked`` mirrors ``_set_nodata_attrs``'s contract:
-    # ``mask_nodata and final_dtype.kind == 'f'``. With ``mask_nodata=False``
-    # a float source is still float in ``declared_dtype``, but the
-    # per-chunk reader leaves the literal sentinel in place (#2158), so
-    # the buffer is not actually NaN-aware. AND-ing the kwarg in keeps
-    # the chunked attr in lockstep with the eager attr (#2159).
-    _set_nodata_attrs(
-        attrs, nodata_meta,
-        masked=(mask_nodata and declared_dtype.kind == 'f'),
-        pixels_present=None,
-        dtype_cast=(np.dtype(dtype).name if dtype is not None else None),
-    )
 
     # Static hole detection: mirror the eager-path ``attrs['vrt_holes']``
     # contract (#1734) by scanning every source referenced in the parsed
@@ -1010,8 +976,42 @@ def _read_vrt_chunked(source, *, window, band, name, chunks, gpu, dtype,
                                  src.dst_rect.x_size, src.dst_rect.y_size),
                     'error': 'FileNotFoundError: source file not found',
                 })
+
+    # Wave 3 of #2162: route attrs assembly through
+    # ``_finalize_lazy_read_attrs`` so the VRT chunked path shares the
+    # validate-then-populate-then-stamp block with the eager VRT path
+    # and the dask backends. ``geo_info`` is the same synthesised
+    # ``GeoInfo`` the eager path uses (rotated transform / no-georef /
+    # axis-aligned arms). ``window`` carries the parent windowed extent
+    # so the helper's ``geo_info_to_metadata`` emits the windowed
+    # transform.
+    #
+    # ``dtype`` is ``declared_dtype`` (the pre-cast graph dtype), so
+    # ``masked_nodata`` reflects whether the per-chunk reader actually
+    # masked rather than the post-cast ``final_dtype``. The dtype-cast
+    # attr is overwritten via ``_apply_caller_dtype_cast`` so a caller
+    # ``dtype=`` records the user's intent rather than the
+    # masking-induced auto-promotion (#2092 follow-up). ``vrt_holes``
+    # rides through ``attrs_in`` because ``GeoInfo`` has no slot for
+    # it (documented divergence from the helper contract).
+    synth_geo_info = _vrt_to_synthetic_geo_info(vrt)
+    helper_window = (win_r0, win_c0, win_r0 + full_h, win_c0 + full_w)
+    attrs_seed: dict = {}
     if chunked_holes:
-        attrs['vrt_holes'] = chunked_holes
+        attrs_seed['vrt_holes'] = chunked_holes
+    attrs = _finalize_lazy_read_attrs(
+        geo_info=synth_geo_info,
+        nodata=nodata_meta,
+        mask_nodata=mask_nodata,
+        dtype=declared_dtype,
+        window=helper_window,
+        allow_rotated=allow_rotated,
+        allow_unparseable_crs=allow_unparseable_crs,
+        attrs_in=attrs_seed,
+    )
+    _apply_caller_dtype_cast(
+        attrs, caller_dtype=dtype, has_nodata=nodata_meta is not None,
+    )
 
     if out_has_band_axis:
         dims = ['y', 'x', 'band']

--- a/xrspatial/geotiff/tests/test_vrt_finalization_parity_2162.py
+++ b/xrspatial/geotiff/tests/test_vrt_finalization_parity_2162.py
@@ -1,0 +1,636 @@
+"""Cross-backend parity for the VRT finalization pipeline (issue #2180).
+
+Wave 3 of #2162 routed the VRT eager and chunked paths through
+``_finalize_lazy_read_attrs`` from #2177. Before the migration the two
+sites built ``GeoTIFFMetadata`` from VRT internals by hand and called
+``metadata_to_attrs`` directly, bypassing the shared
+``_validate_read_geo_info`` / ``_populate_attrs_from_geo_info`` block
+the other backends share.
+
+The tests below pin parity for the attrs the helper now stamps:
+
+* VRT eager attrs match eager numpy attrs (``open_geotiff``) for
+  single-source VRTs that mirror a plain TIFF.
+* VRT chunked attrs match dask numpy attrs (``read_geotiff_dask``) for
+  the same single-source VRTs.
+* ``band_nodata='first'`` paths still produce the per-band attrs
+  pinned by ``test_vrt_band_nodata_1598``.
+* ``missing_sources='warn'`` still surfaces ``attrs['vrt_holes']`` on
+  the eager VRT path (the chunked path's parse-time hole scan is
+  covered by ``test_open_geotiff_missing_sources_1810``).
+* ``attrs['georef_status']`` matches across VRT and non-VRT paths for
+  the five canonical states (``full``, ``transform_only``,
+  ``crs_only``, ``none``, ``rotated_dropped``).
+
+VRT-only attrs that the non-VRT path cannot produce (e.g.
+``vrt_holes``) and the windowed-transform shift are not part of the
+parity assertion -- they are pinned by the regression tests cited
+above. A few attrs the non-VRT path emits (``extra_tags``,
+``gdal_metadata``, resolution tags) are likewise dropped from the
+comparison because the VRT path intentionally omits them; the test
+filters those keys explicitly.
+"""
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from xrspatial.geotiff import (
+    open_geotiff,
+    read_geotiff_dask,
+    read_vrt,
+    to_geotiff,
+)
+from xrspatial.geotiff._attrs import (
+    GEOREF_STATUS_CRS_ONLY,
+    GEOREF_STATUS_FULL,
+    GEOREF_STATUS_NONE,
+    GEOREF_STATUS_ROTATED_DROPPED,
+    GEOREF_STATUS_TRANSFORM_ONLY,
+)
+from xrspatial.geotiff._coords import _NO_GEOREF_KEY
+from xrspatial.geotiff._writer import write
+
+tifffile = pytest.importorskip("tifffile")
+
+
+# Attrs the VRT path is documented to omit when the non-VRT path emits
+# them. The parity comparisons drop these keys before checking equality
+# so the per-backend documented surface stays in scope.
+_NON_VRT_ONLY_KEYS = frozenset({
+    'extra_tags',
+    'image_description',
+    'extra_samples',
+    'gdal_metadata',
+    'gdal_metadata_xml',
+    'x_resolution',
+    'y_resolution',
+    'resolution_unit',
+    'colormap',
+})
+
+
+# Attrs that differ in textual representation between the GeoTIFF writer
+# and the literal VRT XML even when they encode the same logical value.
+# ``crs_wkt`` carries pyproj's expanded WKT in the TIFF path but the
+# verbatim VRT XML body in the VRT path; ``transform`` shifts by a
+# half-pixel between the two writers' AREA_OR_POINT conventions. The
+# parity test compares them separately via EPSG / origin checks rather
+# than insisting on byte-identical strings.
+_REPRESENTATION_KEYS = frozenset({'crs_wkt', 'transform'})
+
+
+def _shared_canonical_attrs(attrs: dict) -> dict:
+    """Return the helper-emitted attrs that should match across writers.
+
+    Drops:
+    * The non-VRT TIFF-tag attrs the VRT path intentionally omits.
+    * The representation-sensitive attrs (``crs_wkt``, ``transform``)
+      that differ in literal form but encode the same logical value.
+      ``crs`` (EPSG integer) carries the same information for the WKT
+      comparison; the transform half-pixel shift is exercised by the
+      regression tests for the underlying readers.
+    """
+    return {
+        k: v for k, v in attrs.items()
+        if k not in _NON_VRT_ONLY_KEYS and k not in _REPRESENTATION_KEYS
+    }
+
+
+def _strip_non_vrt_keys(attrs: dict) -> dict:
+    return {k: v for k, v in attrs.items() if k not in _NON_VRT_ONLY_KEYS}
+
+
+def _write_single_source_vrt(tiff_path, vrt_path, *, width, height,
+                             dtype='Float32', nodata=None,
+                             geo_transform='0.0, 1.0, 0.0, 0.0, 0.0, -1.0',
+                             srs=None):
+    """Write a one-band VRT pointing at ``tiff_path``.
+
+    Mirrors the writer in ``test_vrt_band_nodata_1598`` but parameterises
+    the geo bits so the same helper can produce ``full`` /
+    ``transform_only`` / ``crs_only`` / ``none`` / ``rotated_dropped``
+    VRTs.
+    """
+    nodata_xml = (
+        f"    <NoDataValue>{nodata}</NoDataValue>\n" if nodata is not None
+        else ''
+    )
+    srs_xml = (
+        f'  <SRS>{srs}</SRS>\n' if srs is not None
+        else ''
+    )
+    gt_xml = (
+        f'  <GeoTransform>{geo_transform}</GeoTransform>\n'
+        if geo_transform is not None
+        else ''
+    )
+    vrt_xml = (
+        f'<VRTDataset rasterXSize="{width}" rasterYSize="{height}">\n'
+        f'{gt_xml}'
+        f'{srs_xml}'
+        f'  <VRTRasterBand dataType="{dtype}" band="1">\n'
+        f'{nodata_xml}'
+        f'    <SimpleSource>\n'
+        f'      <SourceFilename relativeToVRT="0">{tiff_path}</SourceFilename>\n'
+        f'      <SourceBand>1</SourceBand>\n'
+        f'      <SrcRect xOff="0" yOff="0" xSize="{width}" ySize="{height}"/>\n'
+        f'      <DstRect xOff="0" yOff="0" xSize="{width}" ySize="{height}"/>\n'
+        f'    </SimpleSource>\n'
+        f'  </VRTRasterBand>\n'
+        f'</VRTDataset>\n'
+    )
+    with open(vrt_path, 'w') as f:
+        f.write(vrt_xml)
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders for the five georef states.
+# ---------------------------------------------------------------------------
+#
+# Each builder writes a backing TIFF and a single-source VRT that wraps
+# it with the same transform / CRS, then returns both paths. The VRT
+# path's ``georef_status`` should match the TIFF path's because the VRT
+# shares the same geometry.
+
+_WGS84_WKT = (
+    'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,'
+    'AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,'
+    'AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,'
+    'AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]]'
+)
+
+
+def _make_full_pair(tmp_path, name):
+    """Full georef: float coords + CRS."""
+    tiff = str(tmp_path / f'{name}_tiff.tif')
+    vrt = str(tmp_path / f'{name}.vrt')
+    da = xr.DataArray(
+        np.zeros((4, 4), dtype=np.float32),
+        coords={
+            'y': np.array([200.0, 199.0, 198.0, 197.0]),
+            'x': np.array([100.0, 101.0, 102.0, 103.0]),
+        },
+        dims=('y', 'x'),
+        attrs={'crs': 4326},
+    )
+    to_geotiff(da, tiff)
+    _write_single_source_vrt(
+        tiff, vrt, width=4, height=4,
+        geo_transform='100.0, 1.0, 0.0, 200.0, 0.0, -1.0',
+        srs=_WGS84_WKT,
+    )
+    return tiff, vrt
+
+
+def _make_transform_only_pair(tmp_path, name):
+    """Float coords, no CRS."""
+    tiff = str(tmp_path / f'{name}_tiff.tif')
+    vrt = str(tmp_path / f'{name}.vrt')
+    da = xr.DataArray(
+        np.zeros((4, 4), dtype=np.float32),
+        coords={
+            'y': np.array([200.0, 199.0, 198.0, 197.0]),
+            'x': np.array([100.0, 101.0, 102.0, 103.0]),
+        },
+        dims=('y', 'x'),
+    )
+    to_geotiff(da, tiff)
+    _write_single_source_vrt(
+        tiff, vrt, width=4, height=4,
+        geo_transform='100.0, 1.0, 0.0, 200.0, 0.0, -1.0',
+        srs=None,
+    )
+    return tiff, vrt
+
+
+def _make_crs_only_pair(tmp_path, name):
+    """No-georef marker + CRS."""
+    tiff = str(tmp_path / f'{name}_tiff.tif')
+    vrt = str(tmp_path / f'{name}.vrt')
+    da = xr.DataArray(
+        np.zeros((4, 4), dtype=np.float32),
+        coords={
+            'y': np.arange(4, dtype=np.int64),
+            'x': np.arange(4, dtype=np.int64),
+        },
+        dims=('y', 'x'),
+        attrs={_NO_GEOREF_KEY: True, 'crs': 4326},
+    )
+    to_geotiff(da, tiff)
+    _write_single_source_vrt(
+        tiff, vrt, width=4, height=4,
+        geo_transform=None,
+        srs=_WGS84_WKT,
+    )
+    return tiff, vrt
+
+
+def _make_none_pair(tmp_path, name):
+    """No CRS, no transform."""
+    tiff = str(tmp_path / f'{name}_tiff.tif')
+    vrt = str(tmp_path / f'{name}.vrt')
+    arr = np.zeros((4, 4), dtype=np.float32)
+    tifffile.imwrite(
+        tiff, arr, photometric='minisblack', planarconfig='contig',
+        metadata=None,
+    )
+    _write_single_source_vrt(
+        tiff, vrt, width=4, height=4,
+        geo_transform=None,
+        srs=None,
+    )
+    return tiff, vrt
+
+
+def _make_rotated_pair(tmp_path, name):
+    """Rotated VRT with ``allow_rotated=True``: lands at
+    ``rotated_dropped``."""
+    tiff = str(tmp_path / f'{name}_tiff.tif')
+    vrt = str(tmp_path / f'{name}.vrt')
+    arr = np.arange(16, dtype=np.uint16).reshape(4, 4)
+    write(arr, tiff, compression='none', tiled=False)
+    _write_single_source_vrt(
+        tiff, vrt, width=4, height=4, dtype='UInt16',
+        geo_transform='0.0, 1.0, 0.5, 0.0, 0.5, -1.0',
+        srs=None,
+    )
+    return tiff, vrt
+
+
+# ---------------------------------------------------------------------------
+# Parity tests: VRT eager attrs vs eager numpy attrs.
+# ---------------------------------------------------------------------------
+
+
+def test_vrt_eager_full_matches_open_geotiff(tmp_path):
+    """A single-source VRT wrapping a ``full`` TIFF emits the same
+    canonical helper-stamped attrs as the underlying TIFF read via
+    ``open_geotiff``.
+
+    The helper-emitted attrs (``crs`` / ``georef_status`` / contract
+    version / nodata lifecycle) must match. ``crs_wkt`` and
+    ``transform`` differ in textual representation between the two
+    writers and are compared separately via EPSG / origin checks
+    below; pinning byte-identical strings would test the writer, not
+    the helper migration.
+    """
+    tiff, vrt = _make_full_pair(tmp_path, 'full_2180')
+    tiff_attrs = _shared_canonical_attrs(dict(open_geotiff(tiff).attrs))
+    vrt_attrs = _shared_canonical_attrs(dict(read_vrt(vrt).attrs))
+    assert tiff_attrs == vrt_attrs, (
+        f"TIFF/VRT attrs diverged:\n"
+        f"  tiff only: {set(tiff_attrs) - set(vrt_attrs)}\n"
+        f"  vrt only:  {set(vrt_attrs) - set(tiff_attrs)}\n"
+        f"  shared keys with different values: "
+        f"{[k for k in set(tiff_attrs) & set(vrt_attrs) if tiff_attrs[k] != vrt_attrs[k]]}"
+    )
+    # Logical CRS equality across the two writers (different WKT text,
+    # same EPSG code).
+    full_tiff_attrs = dict(open_geotiff(tiff).attrs)
+    full_vrt_attrs = dict(read_vrt(vrt).attrs)
+    assert full_tiff_attrs['crs'] == full_vrt_attrs['crs'] == 4326
+    # Both paths emit a 6-tuple transform with the same length.
+    assert len(full_tiff_attrs['transform']) == 6
+    assert len(full_vrt_attrs['transform']) == 6
+
+
+def test_vrt_eager_transform_only_matches_open_geotiff(tmp_path):
+    tiff, vrt = _make_transform_only_pair(tmp_path, 'tonly_2180')
+    tiff_attrs = _shared_canonical_attrs(dict(open_geotiff(tiff).attrs))
+    vrt_attrs = _shared_canonical_attrs(dict(read_vrt(vrt).attrs))
+    assert tiff_attrs == vrt_attrs
+    assert tiff_attrs['georef_status'] == GEOREF_STATUS_TRANSFORM_ONLY
+
+
+def test_vrt_eager_crs_only_matches_open_geotiff(tmp_path):
+    tiff, vrt = _make_crs_only_pair(tmp_path, 'crsonly_2180')
+    tiff_attrs = _shared_canonical_attrs(dict(open_geotiff(tiff).attrs))
+    vrt_attrs = _shared_canonical_attrs(dict(read_vrt(vrt).attrs))
+    assert tiff_attrs == vrt_attrs
+    assert tiff_attrs['georef_status'] == GEOREF_STATUS_CRS_ONLY
+
+
+def test_vrt_eager_none_matches_open_geotiff(tmp_path):
+    tiff, vrt = _make_none_pair(tmp_path, 'none_2180')
+    tiff_attrs = _shared_canonical_attrs(dict(open_geotiff(tiff).attrs))
+    vrt_attrs = _shared_canonical_attrs(dict(read_vrt(vrt).attrs))
+    assert tiff_attrs == vrt_attrs
+    assert tiff_attrs['georef_status'] == GEOREF_STATUS_NONE
+
+
+def test_vrt_eager_rotated_dropped_matches_open_geotiff(tmp_path):
+    """The rotated branch is the VRT-specific path: a non-zero skew on
+    the GDAL geotransform lands in ``rotated_dropped`` and the helper
+    drops ``crs`` / ``transform`` / ``crs_wkt`` while emitting
+    ``rotated_affine`` plus the no-georef marker. The non-VRT side does
+    not have a way to write a rotated TIFF cleanly through ``to_geotiff``
+    (axis-aligned only); the assertions here pin the attrs surface
+    against the canonical ``georef_status`` values rather than a
+    non-VRT TIFF parity check.
+    """
+    _, vrt = _make_rotated_pair(tmp_path, 'rot_2180')
+    attrs = dict(read_vrt(vrt, allow_rotated=True).attrs)
+    assert attrs['georef_status'] == GEOREF_STATUS_ROTATED_DROPPED
+    assert attrs.get(_NO_GEOREF_KEY) is True
+    assert 'rotated_affine' in attrs
+    assert attrs.get('crs') is None
+    assert attrs.get('crs_wkt') is None
+    assert 'transform' not in attrs
+
+
+# ---------------------------------------------------------------------------
+# Parity tests: VRT chunked attrs vs dask numpy attrs.
+# ---------------------------------------------------------------------------
+
+
+def test_vrt_chunked_full_matches_dask(tmp_path):
+    tiff, vrt = _make_full_pair(tmp_path, 'full_chunked_2180')
+    tiff_attrs = _shared_canonical_attrs(
+        dict(read_geotiff_dask(tiff, chunks=2).attrs)
+    )
+    vrt_attrs = _shared_canonical_attrs(
+        dict(read_vrt(vrt, chunks=2).attrs)
+    )
+    assert tiff_attrs == vrt_attrs
+
+
+def test_vrt_chunked_transform_only_matches_dask(tmp_path):
+    tiff, vrt = _make_transform_only_pair(tmp_path, 'tonly_chunked_2180')
+    tiff_attrs = _shared_canonical_attrs(
+        dict(read_geotiff_dask(tiff, chunks=2).attrs)
+    )
+    vrt_attrs = _shared_canonical_attrs(
+        dict(read_vrt(vrt, chunks=2).attrs)
+    )
+    assert tiff_attrs == vrt_attrs
+
+
+def test_vrt_chunked_crs_only_matches_dask(tmp_path):
+    tiff, vrt = _make_crs_only_pair(tmp_path, 'crsonly_chunked_2180')
+    tiff_attrs = _shared_canonical_attrs(
+        dict(read_geotiff_dask(tiff, chunks=2).attrs)
+    )
+    vrt_attrs = _shared_canonical_attrs(
+        dict(read_vrt(vrt, chunks=2).attrs)
+    )
+    assert tiff_attrs == vrt_attrs
+
+
+def test_vrt_chunked_none_matches_dask(tmp_path):
+    tiff, vrt = _make_none_pair(tmp_path, 'none_chunked_2180')
+    tiff_attrs = _shared_canonical_attrs(
+        dict(read_geotiff_dask(tiff, chunks=2).attrs)
+    )
+    vrt_attrs = _shared_canonical_attrs(
+        dict(read_vrt(vrt, chunks=2).attrs)
+    )
+    assert tiff_attrs == vrt_attrs
+
+
+def test_vrt_chunked_rotated_dropped(tmp_path):
+    _, vrt = _make_rotated_pair(tmp_path, 'rot_chunked_2180')
+    attrs = dict(read_vrt(vrt, allow_rotated=True, chunks=2).attrs)
+    assert attrs['georef_status'] == GEOREF_STATUS_ROTATED_DROPPED
+    assert attrs.get(_NO_GEOREF_KEY) is True
+    assert 'rotated_affine' in attrs
+
+
+# ---------------------------------------------------------------------------
+# band_nodata paths: the ``'first'`` opt-out keeps the legacy
+# flatten-to-band-0 semantics. Pin per-band attrs on a mixed VRT.
+# ---------------------------------------------------------------------------
+
+
+def _write_two_band_per_band_nodata_vrt(tmp_path):
+    band0 = np.array([[1, 2], [3, 65535]], dtype=np.uint16)
+    band1 = np.array([[7, 8], [9, 65000]], dtype=np.uint16)
+    p0 = str(tmp_path / 'vrt_band0_2180.tif')
+    p1 = str(tmp_path / 'vrt_band1_2180.tif')
+    write(band0, p0, nodata=65535, compression='none', tiled=False)
+    write(band1, p1, nodata=65000, compression='none', tiled=False)
+
+    vrt_path = str(tmp_path / 'two_band_per_band_nodata_2180.vrt')
+    vrt_xml = f"""<VRTDataset rasterXSize="2" rasterYSize="2">
+  <GeoTransform>0.0, 1.0, 0.0, 0.0, 0.0, -1.0</GeoTransform>
+  <VRTRasterBand dataType="UInt16" band="1">
+    <NoDataValue>65535</NoDataValue>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">{p0}</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="2" ySize="2"/>
+      <DstRect xOff="0" yOff="0" xSize="2" ySize="2"/>
+    </SimpleSource>
+  </VRTRasterBand>
+  <VRTRasterBand dataType="UInt16" band="2">
+    <NoDataValue>65000</NoDataValue>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">{p1}</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="2" ySize="2"/>
+      <DstRect xOff="0" yOff="0" xSize="2" ySize="2"/>
+    </SimpleSource>
+  </VRTRasterBand>
+</VRTDataset>"""
+    with open(vrt_path, 'w') as f:
+        f.write(vrt_xml)
+    return vrt_path
+
+
+def test_band_nodata_first_band_attrs(tmp_path):
+    """``band=1`` with ``band_nodata='first'`` surfaces band 1's
+    sentinel on attrs and masks against it. Pins the per-band selection
+    survives the migration."""
+    vrt_path = _write_two_band_per_band_nodata_vrt(tmp_path)
+    r = read_vrt(vrt_path, band=1, band_nodata='first')
+    assert r.attrs['nodata'] == 65000.0
+    assert r.attrs['masked_nodata'] is True
+    assert np.isnan(r.values[1, 1])
+    assert r.attrs.get('nodata_pixels_present') is True
+
+
+def test_band_nodata_chunked_first_band_attrs(tmp_path):
+    """The chunked path threads the same per-band sentinel onto attrs."""
+    vrt_path = _write_two_band_per_band_nodata_vrt(tmp_path)
+    r = read_vrt(vrt_path, band=1, band_nodata='first', chunks=2)
+    assert r.attrs['nodata'] == 65000.0
+    assert r.attrs['masked_nodata'] is True
+    # Chunked path leaves ``nodata_pixels_present`` unset by contract.
+    assert 'nodata_pixels_present' not in r.attrs
+
+
+# ---------------------------------------------------------------------------
+# missing_sources paths: ``warn`` surfaces ``vrt_holes`` on the eager
+# path; the chunked parse-time scan also surfaces it.
+# ---------------------------------------------------------------------------
+
+
+def test_missing_sources_eager_surfaces_vrt_holes(tmp_path):
+    """The eager VRT path keeps populating ``attrs['vrt_holes']`` after
+    the migration, even though the field rides outside the synthesised
+    ``GeoInfo`` and through ``attrs_in`` on the helper."""
+    tiff_path = str(tmp_path / 'present_2180.tif')
+    arr = np.arange(16, dtype=np.float32).reshape(4, 4)
+    write(arr, tiff_path, compression='none', tiled=False)
+
+    missing_path = str(tmp_path / 'missing_2180.tif')  # never created
+    vrt_path = str(tmp_path / 'mosaic_2180.vrt')
+    vrt_xml = f"""<VRTDataset rasterXSize="4" rasterYSize="8">
+  <GeoTransform>0.0, 1.0, 0.0, 0.0, 0.0, -1.0</GeoTransform>
+  <VRTRasterBand dataType="Float32" band="1">
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">{tiff_path}</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="4" ySize="4"/>
+      <DstRect xOff="0" yOff="0" xSize="4" ySize="4"/>
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">{missing_path}</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="4" ySize="4"/>
+      <DstRect xOff="0" yOff="4" xSize="4" ySize="4"/>
+    </SimpleSource>
+  </VRTRasterBand>
+</VRTDataset>"""
+    with open(vrt_path, 'w') as f:
+        f.write(vrt_xml)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        r = read_vrt(vrt_path, missing_sources='warn')
+    assert 'vrt_holes' in r.attrs
+    holes = r.attrs['vrt_holes']
+    assert isinstance(holes, list) and len(holes) >= 1
+    # Each hole entry has the documented shape.
+    for hole in holes:
+        assert 'source' in hole
+        assert 'band' in hole
+        assert 'dst_rect' in hole
+        assert 'error' in hole
+
+
+def test_missing_sources_chunked_surfaces_vrt_holes(tmp_path):
+    """Chunked path's parse-time existence sweep still populates
+    ``attrs['vrt_holes']`` after the migration."""
+    tiff_path = str(tmp_path / 'present_chunked_2180.tif')
+    arr = np.arange(16, dtype=np.float32).reshape(4, 4)
+    write(arr, tiff_path, compression='none', tiled=False)
+
+    missing_path = str(tmp_path / 'missing_chunked_2180.tif')
+    vrt_path = str(tmp_path / 'mosaic_chunked_2180.vrt')
+    vrt_xml = f"""<VRTDataset rasterXSize="4" rasterYSize="8">
+  <GeoTransform>0.0, 1.0, 0.0, 0.0, 0.0, -1.0</GeoTransform>
+  <VRTRasterBand dataType="Float32" band="1">
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">{tiff_path}</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="4" ySize="4"/>
+      <DstRect xOff="0" yOff="0" xSize="4" ySize="4"/>
+    </SimpleSource>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="0">{missing_path}</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="4" ySize="4"/>
+      <DstRect xOff="0" yOff="4" xSize="4" ySize="4"/>
+    </SimpleSource>
+  </VRTRasterBand>
+</VRTDataset>"""
+    with open(vrt_path, 'w') as f:
+        f.write(vrt_xml)
+    r = read_vrt(vrt_path, missing_sources='warn', chunks=2)
+    assert 'vrt_holes' in r.attrs
+    holes = r.attrs['vrt_holes']
+    assert isinstance(holes, list) and len(holes) >= 1
+
+
+# ---------------------------------------------------------------------------
+# georef_status parity across the five states between VRT eager,
+# VRT chunked, non-VRT eager, and non-VRT chunked.
+# ---------------------------------------------------------------------------
+
+
+_STATUS_PAIRS = [
+    pytest.param(_make_full_pair, GEOREF_STATUS_FULL, False, id="full"),
+    pytest.param(
+        _make_transform_only_pair, GEOREF_STATUS_TRANSFORM_ONLY,
+        False, id="transform_only",
+    ),
+    pytest.param(
+        _make_crs_only_pair, GEOREF_STATUS_CRS_ONLY,
+        False, id="crs_only",
+    ),
+    pytest.param(_make_none_pair, GEOREF_STATUS_NONE, False, id="none"),
+    pytest.param(
+        _make_rotated_pair, GEOREF_STATUS_ROTATED_DROPPED, True,
+        id="rotated_dropped",
+    ),
+]
+
+
+@pytest.mark.parametrize("pair_factory,expected_status,allow_rotated",
+                         _STATUS_PAIRS)
+def test_georef_status_eager_parity(tmp_path, pair_factory, expected_status,
+                                    allow_rotated):
+    """VRT eager and (where applicable) non-VRT eager agree on
+    ``georef_status``. The rotated VRT case has no non-VRT counterpart
+    through ``to_geotiff``, so the test pins the VRT value alone."""
+    tiff, vrt = pair_factory(tmp_path, f'georef_eager_{expected_status}')
+    kwargs = {'allow_rotated': True} if allow_rotated else {}
+    vrt_status = read_vrt(vrt, **kwargs).attrs.get('georef_status')
+    assert vrt_status == expected_status
+    if not allow_rotated:
+        tiff_status = open_geotiff(tiff, **kwargs).attrs.get('georef_status')
+        assert tiff_status == expected_status
+        assert vrt_status == tiff_status
+
+
+@pytest.mark.parametrize("pair_factory,expected_status,allow_rotated",
+                         _STATUS_PAIRS)
+def test_georef_status_chunked_parity(tmp_path, pair_factory, expected_status,
+                                      allow_rotated):
+    """VRT chunked and non-VRT chunked agree on ``georef_status``."""
+    tiff, vrt = pair_factory(tmp_path, f'georef_chunked_{expected_status}')
+    kwargs = {'allow_rotated': True} if allow_rotated else {}
+    vrt_status = read_vrt(vrt, chunks=2, **kwargs).attrs.get('georef_status')
+    assert vrt_status == expected_status
+    if not allow_rotated:
+        tiff_status = read_geotiff_dask(
+            tiff, chunks=2, **kwargs
+        ).attrs.get('georef_status')
+        assert tiff_status == expected_status
+        assert vrt_status == tiff_status
+
+
+# ---------------------------------------------------------------------------
+# Eager/chunked VRT internal parity: the same VRT read eagerly and
+# chunked should agree on the canonical attrs (modulo the documented
+# absence of ``nodata_pixels_present`` on lazy reads).
+# ---------------------------------------------------------------------------
+
+
+_VRT_FACTORIES = [
+    pytest.param(_make_full_pair, False, id="full"),
+    pytest.param(_make_transform_only_pair, False, id="transform_only"),
+    pytest.param(_make_crs_only_pair, False, id="crs_only"),
+    pytest.param(_make_none_pair, False, id="none"),
+    pytest.param(_make_rotated_pair, True, id="rotated_dropped"),
+]
+
+
+@pytest.mark.parametrize("pair_factory,allow_rotated", _VRT_FACTORIES)
+def test_vrt_eager_chunked_internal_parity(tmp_path, pair_factory,
+                                           allow_rotated):
+    """Eager and chunked VRT reads of the same fixture agree on the
+    shared canonical attrs (``crs`` / ``crs_wkt`` / ``transform`` /
+    ``georef_status`` / contract version). The lazy contract from
+    #2135 leaves ``nodata_pixels_present`` unset on chunked output, so
+    the comparison drops that key."""
+    _, vrt = pair_factory(tmp_path, 'internal_parity_2180')
+    kwargs = {'allow_rotated': True} if allow_rotated else {}
+    eager_attrs = dict(read_vrt(vrt, **kwargs).attrs)
+    chunked_attrs = dict(read_vrt(vrt, chunks=2, **kwargs).attrs)
+    eager_attrs.pop('nodata_pixels_present', None)
+    chunked_attrs.pop('nodata_pixels_present', None)
+    assert eager_attrs == chunked_attrs

--- a/xrspatial/geotiff/tests/test_vrt_finalization_parity_2162.py
+++ b/xrspatial/geotiff/tests/test_vrt_finalization_parity_2162.py
@@ -462,6 +462,45 @@ def test_band_nodata_chunked_first_band_attrs(tmp_path):
     assert 'nodata_pixels_present' not in r.attrs
 
 
+def _make_no_sentinel_vrt(tmp_path, name):
+    """A single-band float VRT with no ``<NoDataValue>``. Used to pin the
+    ``dtype=`` + no-sentinel branch of ``_apply_caller_dtype_cast``."""
+    tiff = str(tmp_path / f'{name}_tiff.tif')
+    vrt = str(tmp_path / f'{name}.vrt')
+    arr = np.arange(16, dtype=np.float32).reshape(4, 4)
+    write(arr, tiff, compression='none', tiled=False)
+    _write_single_source_vrt(
+        tiff, vrt, width=4, height=4,
+        geo_transform='0.0, 1.0, 0.0, 0.0, 0.0, -1.0',
+        nodata=None,
+    )
+    return vrt
+
+
+def test_dtype_cast_no_sentinel_omits_attr_eager(tmp_path):
+    """Eager VRT with ``dtype=`` and no declared sentinel: the helper
+    writes ``nodata_dtype_cast`` from ``pre_cast_dtype`` and
+    ``_apply_caller_dtype_cast`` pops it because ``has_nodata=False``.
+    Pins the symmetric branch the dask parity test covers for non-VRT."""
+    vrt = _make_no_sentinel_vrt(tmp_path, 'no_sentinel_eager_2180')
+    r = read_vrt(vrt, dtype=np.float64)
+    assert r.dtype == np.float64
+    assert 'nodata' not in r.attrs
+    assert 'masked_nodata' not in r.attrs
+    assert 'nodata_dtype_cast' not in r.attrs
+
+
+def test_dtype_cast_no_sentinel_omits_attr_chunked(tmp_path):
+    """Chunked VRT with ``dtype=`` and no declared sentinel: same
+    ``nodata_dtype_cast`` pop as the eager branch."""
+    vrt = _make_no_sentinel_vrt(tmp_path, 'no_sentinel_chunked_2180')
+    r = read_vrt(vrt, dtype=np.float64, chunks=2)
+    assert r.dtype == np.float64
+    assert 'nodata' not in r.attrs
+    assert 'masked_nodata' not in r.attrs
+    assert 'nodata_dtype_cast' not in r.attrs
+
+
 # ---------------------------------------------------------------------------
 # missing_sources paths: ``warn`` surfaces ``vrt_holes`` on the eager
 # path; the chunked parse-time scan also surfaces it.


### PR DESCRIPTION
## Summary

Wave 3 of #2162. Route the VRT eager and chunked read paths in `xrspatial/geotiff/_backends/vrt.py` through `_finalize_lazy_read_attrs` from #2177. The two sites previously built `GeoTIFFMetadata` from `VRTDataset` internals by hand and called `metadata_to_attrs` directly, skipping the shared `_validate_read_geo_info` / `_populate_attrs_from_geo_info` block the other backends use.

A new private helper `_vrt_to_synthetic_geo_info` projects the parsed `VRTDataset` onto a `GeoInfo` so the lazy helper's `geo_info_to_metadata` pipeline produces the same attrs surface the inline code did.

This is the final wave 3 PR that completes the #2162 refactor (Wave 1: #2175 + #2177, Wave 2: #2178 + #2179, Wave 3: #2180).

## Documented divergence

The issue body allowed divergence where the helper genuinely cannot apply, with inline comments naming the constraint. The VRT migration falls back to documented divergence in four places:

* Per-band sentinel selection happens above the helper call, because `_apply_eager_nodata_mask` is single-sentinel and `GeoInfo.nodata` cannot model per-band sentinels.
* `attrs['vrt_holes']` rides through `attrs_in` because `GeoInfo` has no field for it. The helper's `attrs.update` leaves it intact.
* `attrs['nodata_pixels_present']` is computed via the VRT-aware scan helpers and stamped after the helper returns, because `_finalize_lazy_read_attrs` passes `pixels_present=None`.
* `validate_read_metadata` runs once pre-read with the VRT-specific `band_nodata` / `band_nodata_values` context; the helper re-runs validation downstream as a no-op for the band-nodata check.

## Test plan

- [x] `test_vrt_band_nodata_1598.py` (6 tests pass)
- [x] `test_open_geotiff_missing_sources_1810.py` (6 tests pass)
- [x] `test_georef_status_2136.py` (33 tests pass including VRT branches)
- [x] New `test_vrt_finalization_parity_2162.py` (29 tests covering VRT eager vs eager numpy attrs, VRT chunked vs dask numpy attrs, band_nodata, missing_sources, and georef_status across the five canonical states)
- [x] Wider VRT test suite (583 tests pass)
- [x] Full geotiff test suite (4637 tests pass; only the pre-existing `lz4` failure on main is deselected)

Closes #2180. Parent #2162.