### PR TITLE
geotiff: fix CI by renaming stale dtype= kwarg in test_helper_band_nodata_2210

### DIFF
--- a/xrspatial/geotiff/tests/test_helper_band_nodata_2210.py
+++ b/xrspatial/geotiff/tests/test_helper_band_nodata_2210.py
@@ -125,7 +125,7 @@ def test_lazy_finalize_routes_band_nodata_through_validator():
             geo_info=gi,
             nodata=None,
             mask_nodata=False,
-            dtype='float64',
+            graph_dtype='float64',
             window=None,
             band_nodata=None,
             band_nodata_values=[-9999.0, 0.0],
@@ -141,7 +141,7 @@ def test_lazy_finalize_band_nodata_first_opts_out():
         geo_info=gi,
         nodata=-9999,
         mask_nodata=True,
-        dtype='float64',
+        graph_dtype='float64',
         window=None,
         band_nodata='first',
         band_nodata_values=[-9999.0, 0.0],
@@ -158,7 +158,7 @@ def test_lazy_finalize_without_band_kwargs_unchanged():
         geo_info=gi,
         nodata=-9999,
         mask_nodata=True,
-        dtype='float64',
+        graph_dtype='float64',
         window=None,
     )
     assert attrs['georef_status'] == 'full'


### PR DESCRIPTION
## Summary

CI is failing on `main` with three `TypeError` failures in
`test_helper_band_nodata_2210.py`:

```
TypeError: _finalize_lazy_read_attrs() got an unexpected keyword argument 'dtype'
```

PR #2206 (e74a1b7) split `_finalize_lazy_read_attrs`'s `dtype` parameter
into `graph_dtype` + `caller_dtype`. PR #2210 (6bc0502) landed after
that with three test call sites still passing the pre-split `dtype=`
name. The signatures diverged at merge time and the tests started
failing on `main`.

This PR renames the three test call sites to `graph_dtype=` to match
the current signature. `graph_dtype` is the right replacement here:
the original `dtype` arg drove the float-dtype masking decision, which
is exactly what `graph_dtype` now controls (per the docstring at
`_attrs.py:1382-1393`).

## Test plan

- [x] `pytest xrspatial/geotiff/tests/test_helper_band_nodata_2210.py` — 9 passed
- [x] `pytest xrspatial/geotiff/tests/test_{finalization_helpers,vrt_finalization_parity,eager_finalization_parity}_2162.py xrspatial/geotiff/tests/test_helper_band_nodata_2210.py` — 73 passed
- [ ] CI on this PR is green