### PR TITLE
Refactor GeoTIFF Phase 2: centralize transform/georef contract

### DIFF
--- a/xrspatial/geotiff/_attrs.py
+++ b/xrspatial/geotiff/_attrs.py
@@ -164,6 +164,7 @@ import xarray as xr
 
 from ._coords import (
     coords_from_geo_info as _coords_from_geo_info,
+    resolve_georef as _resolve_georef,
     transform_tuple_from_pixel_geometry as _transform_tuple_from_pixel_geometry,
 )
 from ._geotags import (
@@ -875,26 +876,13 @@ def _compute_georef_status(geo_info) -> str:
     build their attrs dict from a different dataclass and would have to
     synthesise a fake ``GeoInfo`` to reuse this helper. Keep all the
     call sites in lockstep through one of the two helpers.
+
+    Implementation note (#2225): routes through
+    :func:`xrspatial.geotiff._coords.resolve_georef` so the read-side
+    bucket decision lives in one place. The resolver's status strings
+    are the same canonical values exported here (``GEOREF_STATUS_*``).
     """
-    transform = getattr(geo_info, 'transform', None)
-    rotated_affine = (
-        getattr(transform, 'rotated_affine', None)
-        if transform is not None else None
-    )
-    if rotated_affine is not None:
-        return GEOREF_STATUS_ROTATED_DROPPED
-    has_georef = bool(getattr(geo_info, 'has_georef', False))
-    has_crs = (
-        getattr(geo_info, 'crs_epsg', None) is not None
-        or getattr(geo_info, 'crs_wkt', None) is not None
-    )
-    if has_georef and has_crs:
-        return GEOREF_STATUS_FULL
-    if has_georef:
-        return GEOREF_STATUS_TRANSFORM_ONLY
-    if has_crs:
-        return GEOREF_STATUS_CRS_ONLY
-    return GEOREF_STATUS_NONE
+    return _resolve_georef(geo_info=geo_info).georef_status
 
 
 def _compute_georef_status_from_parts(
@@ -912,6 +900,11 @@ def _compute_georef_status_from_parts(
     each branch. This helper takes the underlying booleans directly so
     the VRT paths and the ``_populate_attrs_from_geo_info`` path share
     the same decision rule without the intermediate object.
+
+    Implementation note (#2225): kept as a thin boolean shim so VRT
+    inline branches do not have to build a fake ``GeoInfo`` to feed
+    :func:`resolve_georef`. The decision table here mirrors the
+    reader-path branch in :func:`resolve_georef`.
     """
     if rotated_dropped:
         return GEOREF_STATUS_ROTATED_DROPPED

--- a/xrspatial/geotiff/_backends/vrt.py
+++ b/xrspatial/geotiff/_backends/vrt.py
@@ -78,6 +78,14 @@ def _vrt_to_synthetic_geo_info(vrt) -> GeoInfo:
     ``geo_info_to_metadata`` does not synthesise attrs the VRT branch
     never emitted. ``vrt_holes`` is documented divergence: ``GeoInfo``
     has no slot for it, so the call site stamps the attr post-helper.
+
+    Issue #2225: the resolved ``georef_status`` for this synthesised
+    ``GeoInfo`` flows through the shared
+    :func:`xrspatial.geotiff._coords.resolve_georef` resolver via
+    :func:`_compute_georef_status`, so the VRT branch lands on the
+    same bucket as the eager / dask / GPU read paths for matching
+    input shapes (full / transform_only / crs_only / none /
+    rotated_dropped).
     """
     gt = vrt.geo_transform
     is_rotated = gt is not None and (gt[2] != 0.0 or gt[4] != 0.0)

--- a/xrspatial/geotiff/_coords.py
+++ b/xrspatial/geotiff/_coords.py
@@ -706,14 +706,21 @@ def resolve_georef(
         a_crs_epsg = crs_epsg
         a_crs_wkt = crs_wkt
         if attrs is not None:
-            if a_crs_epsg is None:
-                crs_val = attrs.get('crs')
-                if (crs_val is not None
-                        and not isinstance(crs_val, (bool, str))):
-                    try:
-                        a_crs_epsg = int(crs_val)
-                    except (TypeError, ValueError):
-                        a_crs_epsg = None
+            # Mirror ``attrs_to_metadata`` precedence: string ``crs``
+            # values fold into ``crs_wkt`` (some pipelines stash the
+            # WKT string under ``attrs['crs']``), bool values are
+            # ignored at the boundary so the resolver does not flag a
+            # bogus ``has_crs`` signal on ``crs=True`` (issue #1971).
+            crs_val = attrs.get('crs')
+            if a_crs_wkt is None and isinstance(crs_val, str) and crs_val:
+                a_crs_wkt = crs_val
+            if (a_crs_epsg is None
+                    and crs_val is not None
+                    and not isinstance(crs_val, (bool, str))):
+                try:
+                    a_crs_epsg = int(crs_val)
+                except (TypeError, ValueError):
+                    a_crs_epsg = None
             if a_crs_wkt is None:
                 wkt_val = attrs.get('crs_wkt')
                 if isinstance(wkt_val, str) and wkt_val:
@@ -724,8 +731,11 @@ def resolve_georef(
         # so the resolver propagates the same diagnostic. A ``None``
         # return means the attr was absent or unparseable.
         transform = transform_from_attr(attr_transform)
+        transform_source = 'attr' if transform is not None else None
         if transform is None:
             transform = coords_to_transform(source)
+            if transform is not None:
+                transform_source = 'coords'
 
         no_georef_marker = _has_no_georef_marker(source)
 
@@ -743,9 +753,16 @@ def resolve_georef(
             )
 
         if transform is not None:
-            status = (
-                GEOREF_STATUS_FULL if has_crs else GEOREF_STATUS_COORDS
-            )
+            # ``coords`` bucket signals "transform derived from coord
+            # arrays"; ``transform_only`` signals "transform supplied
+            # via attrs['transform']". Either bucket with a CRS
+            # rolls up to ``full``.
+            if has_crs:
+                status = GEOREF_STATUS_FULL
+            elif transform_source == 'attr':
+                status = GEOREF_STATUS_TRANSFORM_ONLY
+            else:
+                status = GEOREF_STATUS_COORDS
             return GeorefResolution(
                 transform=transform,
                 georef_status=status,

--- a/xrspatial/geotiff/_coords.py
+++ b/xrspatial/geotiff/_coords.py
@@ -24,13 +24,74 @@ windowed vs full reads.
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any
+from dataclasses import dataclass
+from typing import Any, Literal
 
 import numpy as np
 import xarray as xr
 
 from ._errors import NonUniformCoordsError
 from ._geotags import _NO_GEOREF_KEY, GeoTransform, RASTER_PIXEL_IS_POINT
+
+
+# Canonical georef_status string values (mirrored in ``_attrs.py`` as
+# ``GEOREF_STATUS_*`` constants). Issue #2225 centralises the
+# transform/georef contract here; ``_attrs.py`` aliases these names so
+# the public attrs surface keeps its existing identifiers.
+GEOREF_STATUS_NONE = 'none'
+GEOREF_STATUS_COORDS = 'coords'
+GEOREF_STATUS_TRANSFORM_ONLY = 'transform_only'
+GEOREF_STATUS_CRS_ONLY = 'crs_only'
+GEOREF_STATUS_ROTATED_DROPPED = 'rotated_dropped'
+GEOREF_STATUS_FULL = 'full'
+
+GeorefStatus = Literal[
+    'none',
+    'coords',
+    'transform_only',
+    'crs_only',
+    'rotated_dropped',
+    'full',
+]
+
+
+@dataclass(frozen=True)
+class GeorefResolution:
+    """Typed result returned by :func:`resolve_georef` (issue #2225).
+
+    Centralises the three georef decisions every backend used to make
+    inline: how to derive the affine transform, which of the canonical
+    ``georef_status`` buckets the input falls into, and whether the
+    no-georef marker was applied.
+
+    Fields:
+
+    * ``transform`` -- the resolved :class:`GeoTransform`, or ``None``
+      when no transform could be derived (no coords, no
+      ``attrs['transform']``, no inbound ``GeoInfo`` transform). Rotated
+      / sheared affines surface here as ``None`` because the on-disk
+      GeoTIFF representation is axis-aligned; the ``dropped_reason``
+      field records the original reason for callers that care.
+    * ``georef_status`` -- one of ``GeorefStatus``. The bucket the
+      resolver landed in; mirrors the canonical attr emitted by
+      :mod:`xrspatial.geotiff._attrs`. ``'coords'`` is the writer-side
+      bucket for inputs whose only georef signal is the coord arrays
+      themselves (no CRS, no inbound transform). Reader-side callers
+      that distinguish ``transform_only`` and ``crs_only`` use those.
+    * ``dropped_reason`` -- short string explaining why ``transform``
+      is ``None`` (e.g. ``'rotated_affine_dropped'``,
+      ``'degenerate_axis'``, ``'no_coords'``), or ``None`` when the
+      resolver did derive a transform.
+    * ``applied_no_georef_marker`` -- True iff the resolver routed the
+      input through the no-georef placeholder path. Mirrors the
+      reader's ``attrs[_NO_GEOREF_KEY] = True`` marker so writer call
+      sites can branch the same way.
+    """
+
+    transform: 'GeoTransform | None' = None
+    georef_status: GeorefStatus = GEOREF_STATUS_NONE
+    dropped_reason: str | None = None
+    applied_no_georef_marker: bool = False
 
 
 # Names of dims that ``to_geotiff`` / ``write_geotiff_gpu`` treat as the
@@ -508,4 +569,221 @@ def coords_to_transform(da: xr.DataArray) -> 'GeoTransform | None':
         origin_y=origin_y,
         pixel_width=pixel_width,
         pixel_height=pixel_height,
+    )
+
+
+def _has_crs_signal(crs_epsg, crs_wkt) -> bool:
+    """True iff at least one CRS field is populated.
+
+    Lifted out so the read-side (``GeoInfo``) and write-side
+    (``attrs['crs']`` / ``attrs['crs_wkt']``) call sites of
+    :func:`resolve_georef` share the same decision rule. An empty
+    string ``crs_wkt`` (which the VRT parser emits when the XML has
+    a ``<SRS>`` element with no recognised body) is treated as
+    absent so the resolver does not bucket those into ``crs_only``.
+    """
+    if crs_epsg is not None:
+        return True
+    if isinstance(crs_wkt, str) and crs_wkt:
+        return True
+    return False
+
+
+def resolve_georef(
+    source: Any = None,
+    *,
+    geo_info: Any = None,
+    crs_epsg: int | None = None,
+    crs_wkt: str | None = None,
+    transform_hint: Any = None,
+) -> GeorefResolution:
+    """Centralised transform/georef resolver shared across backends.
+
+    Issue #2225. One function owns the four decisions every backend
+    used to make inline:
+
+    1. Coord-to-transform inference (via :func:`coords_to_transform`).
+    2. The no-georef marker behaviour
+       (``attrs[_NO_GEOREF_KEY] = True`` -> placeholder coords).
+    3. Degenerate-axis policy (1xN / Nx1 / 1x1 inputs).
+    4. Rotated-affine drop policy (rotated transforms are not
+       expressible as axis-aligned 6-tuples and are dropped).
+
+    Inputs:
+
+    * ``source`` -- either an :class:`xarray.DataArray` (writer entry
+      points) or ``None``. When a DataArray is supplied, the resolver
+      reads ``attrs['transform']``, ``attrs['crs']`` / ``attrs['crs_wkt']``,
+      and the ``_NO_GEOREF_KEY`` marker off the array's attrs.
+    * ``geo_info`` -- a reader-side :class:`GeoInfo`-like object (the
+      eager / dask / GPU read paths feed this). When supplied, the
+      resolver derives the transform from ``geo_info.transform`` and
+      bucketises the status from ``geo_info.has_georef`` /
+      ``geo_info.crs_epsg`` / ``geo_info.crs_wkt`` /
+      ``geo_info.transform.rotated_affine``. ``crs_epsg`` and
+      ``crs_wkt`` overrides take precedence over the ``GeoInfo`` values
+      when both are passed (used by the VRT inline path which holds CRS
+      state outside the synthesised ``GeoInfo``).
+    * ``crs_epsg`` / ``crs_wkt`` -- direct CRS signals for callers that
+      do not have a DataArray or a ``GeoInfo`` (the VRT path threads
+      these from the parsed XML).
+    * ``transform_hint`` -- a :class:`GeoTransform` or rasterio-style
+      6-tuple to use when neither ``source`` nor ``geo_info`` is given.
+
+    The returned :class:`GeorefResolution` contract is documented on
+    the dataclass.
+    """
+    # Reader path: a GeoInfo (or VRT-synthesised stand-in) carries
+    # has_georef + transform + (optional) rotated_affine. The resolver
+    # mirrors the decision table from ``_compute_georef_status`` so the
+    # eager / dask / GPU / VRT read sites all land on the same bucket.
+    if geo_info is not None:
+        gi_transform = getattr(geo_info, 'transform', None)
+        rotated_affine = (
+            getattr(gi_transform, 'rotated_affine', None)
+            if gi_transform is not None else None
+        )
+        has_georef = bool(getattr(geo_info, 'has_georef', False))
+        # CRS overrides win so VRT call sites can pass the parsed
+        # ``vrt.crs_wkt`` without rebuilding the GeoInfo. When the
+        # override is left at ``None`` we read from the GeoInfo.
+        resolved_crs_epsg = (
+            crs_epsg if crs_epsg is not None
+            else getattr(geo_info, 'crs_epsg', None)
+        )
+        resolved_crs_wkt = (
+            crs_wkt if crs_wkt is not None
+            else getattr(geo_info, 'crs_wkt', None)
+        )
+        has_crs = _has_crs_signal(resolved_crs_epsg, resolved_crs_wkt)
+
+        if rotated_affine is not None:
+            # ``allow_rotated=True`` path: the reader stamped the
+            # rotated 6-tuple onto the transform but reported
+            # ``has_georef=False``. The axis-aligned transform we would
+            # surface here cannot represent the rotation, so drop it.
+            return GeorefResolution(
+                transform=None,
+                georef_status=GEOREF_STATUS_ROTATED_DROPPED,
+                dropped_reason='rotated_affine_dropped',
+                applied_no_georef_marker=True,
+            )
+
+        if has_georef and gi_transform is not None:
+            status: GeorefStatus = (
+                GEOREF_STATUS_FULL if has_crs else GEOREF_STATUS_TRANSFORM_ONLY
+            )
+            return GeorefResolution(
+                transform=gi_transform,
+                georef_status=status,
+                dropped_reason=None,
+                applied_no_georef_marker=False,
+            )
+
+        # No transform on the reader path -> placeholder coords + marker.
+        if has_crs:
+            return GeorefResolution(
+                transform=None,
+                georef_status=GEOREF_STATUS_CRS_ONLY,
+                dropped_reason='no_transform_tags',
+                applied_no_georef_marker=True,
+            )
+        return GeorefResolution(
+            transform=None,
+            georef_status=GEOREF_STATUS_NONE,
+            dropped_reason='no_transform_tags',
+            applied_no_georef_marker=True,
+        )
+
+    # Writer path: ``source`` is a DataArray. Prefer attrs['transform']
+    # over coord-derived transforms (the same precedence the inline
+    # writer code applied for issue #1484 -- attrs['transform']
+    # round-trips bit-exactly while coord subtraction can drift on
+    # fractional pixel sizes).
+    if isinstance(source, xr.DataArray):
+        attrs = source.attrs
+        attr_transform = attrs.get('transform') if attrs is not None else None
+        a_crs_epsg = crs_epsg
+        a_crs_wkt = crs_wkt
+        if attrs is not None:
+            if a_crs_epsg is None:
+                crs_val = attrs.get('crs')
+                if (crs_val is not None
+                        and not isinstance(crs_val, (bool, str))):
+                    try:
+                        a_crs_epsg = int(crs_val)
+                    except (TypeError, ValueError):
+                        a_crs_epsg = None
+            if a_crs_wkt is None:
+                wkt_val = attrs.get('crs_wkt')
+                if isinstance(wkt_val, str) and wkt_val:
+                    a_crs_wkt = wkt_val
+        has_crs = _has_crs_signal(a_crs_epsg, a_crs_wkt)
+
+        # ``transform_from_attr`` raises on rotated 6-tuples (b/d != 0)
+        # so the resolver propagates the same diagnostic. A ``None``
+        # return means the attr was absent or unparseable.
+        transform = transform_from_attr(attr_transform)
+        if transform is None:
+            transform = coords_to_transform(source)
+
+        no_georef_marker = _has_no_georef_marker(source)
+
+        if transform is None and no_georef_marker:
+            # ``attrs[_NO_GEOREF_KEY] = True`` -> reader-stamped
+            # placeholder. Treat as no-georef regardless of coords.
+            status = (
+                GEOREF_STATUS_CRS_ONLY if has_crs else GEOREF_STATUS_NONE
+            )
+            return GeorefResolution(
+                transform=None,
+                georef_status=status,
+                dropped_reason='no_georef_marker',
+                applied_no_georef_marker=True,
+            )
+
+        if transform is not None:
+            status = (
+                GEOREF_STATUS_FULL if has_crs else GEOREF_STATUS_COORDS
+            )
+            return GeorefResolution(
+                transform=transform,
+                georef_status=status,
+                dropped_reason=None,
+                applied_no_georef_marker=False,
+            )
+
+        # No transform and no marker. The writer entry points run
+        # :func:`require_transform_for_georeferenced` after the
+        # resolver and raise when spatial coords are present but no
+        # transform could be inferred (#1945). We return ``None`` /
+        # ``GEOREF_STATUS_NONE`` here and let that guard handle the
+        # failure path.
+        status = GEOREF_STATUS_CRS_ONLY if has_crs else GEOREF_STATUS_NONE
+        return GeorefResolution(
+            transform=None,
+            georef_status=status,
+            dropped_reason='no_transform_inferred',
+            applied_no_georef_marker=False,
+        )
+
+    # Bare-input path (no DataArray, no GeoInfo). Used by callers that
+    # only have CRS and an optional transform hint (e.g. test fixtures
+    # exercising the resolver shape).
+    transform = transform_from_attr(transform_hint)
+    has_crs = _has_crs_signal(crs_epsg, crs_wkt)
+    if transform is not None:
+        status = GEOREF_STATUS_FULL if has_crs else GEOREF_STATUS_TRANSFORM_ONLY
+        return GeorefResolution(
+            transform=transform,
+            georef_status=status,
+            dropped_reason=None,
+            applied_no_georef_marker=False,
+        )
+    status = GEOREF_STATUS_CRS_ONLY if has_crs else GEOREF_STATUS_NONE
+    return GeorefResolution(
+        transform=None,
+        georef_status=status,
+        dropped_reason='no_inputs' if not has_crs else 'no_transform_inferred',
+        applied_no_georef_marker=False,
     )

--- a/xrspatial/geotiff/_writers/eager.py
+++ b/xrspatial/geotiff/_writers/eager.py
@@ -33,9 +33,8 @@ from .._backends._gpu_helpers import _is_gpu_data
 from .._coords import (
     _BAND_DIM_NAMES,
     _has_no_georef_marker,
-    coords_to_transform as _coords_to_transform,
     require_transform_for_georeferenced as _require_transform_for_georeferenced,
-    transform_from_attr as _transform_from_attr,
+    resolve_georef as _resolve_georef,
 )
 from .._crs import _validate_crs_arg, _validate_crs_fallback, _wkt_to_epsg
 from .._geotags import GeoTransform, RASTER_PIXEL_IS_AREA
@@ -696,14 +695,14 @@ def to_geotiff(data: xr.DataArray | np.ndarray,
         raw = data.data
 
         # Extract metadata from DataArray attrs (no materialisation needed).
-        # Prefer attrs['transform'] (from open_geotiff) over the coord-derived
-        # transform: that path is bit-stable across round-trips, while
-        # _coords_to_transform can drift on fractional pixel sizes because
-        # x[1] - x[0] is computed in float64 from already-rounded coords.
+        # Resolve the affine through the centralised resolver (#2225) so
+        # this writer, the GPU writer, and the per-tile VRT path share
+        # the same precedence rule: prefer ``attrs['transform']`` (which
+        # round-trips bit-exactly) over a coord-derived transform (which
+        # drifts on fractional pixel sizes because ``x[1] - x[0]`` is
+        # computed in float64 from already-rounded coords).
         if geo_transform is None:
-            geo_transform = _transform_from_attr(data.attrs.get('transform'))
-        if geo_transform is None:
-            geo_transform = _coords_to_transform(data)
+            geo_transform = _resolve_georef(data).transform
         # Fail closed when coords are present but no transform could be
         # derived (e.g. 1x1 without ``attrs['transform']``) instead of
         # silently writing a non-georeferenced TIFF that round-trips back
@@ -1115,9 +1114,9 @@ def _write_vrt_tiled(data, vrt_path, *, crs=None, nodata=None,
         # sentinel. See ``_should_restore_nan_sentinel`` for the
         # semantics; default True keeps existing behaviour.
         restore_sentinel = _should_restore_nan_sentinel(data.attrs)
-        geo_transform = _transform_from_attr(data.attrs.get('transform'))
-        if geo_transform is None:
-            geo_transform = _coords_to_transform(data)
+        # Resolve via the centralised resolver (#2225). Same precedence
+        # as ``to_geotiff``: attrs['transform'] wins over coord-derived.
+        geo_transform = _resolve_georef(data).transform
         # Match the to_geotiff fail-closed guard so VRT writes don't
         # silently produce non-georeferenced tiles either (#1945).
         _require_transform_for_georeferenced(data, geo_transform)

--- a/xrspatial/geotiff/_writers/gpu.py
+++ b/xrspatial/geotiff/_writers/gpu.py
@@ -26,9 +26,8 @@ from .._attrs import (
 from .._coords import (
     _BAND_DIM_NAMES,
     _has_no_georef_marker,
-    coords_to_transform as _coords_to_transform,
     require_transform_for_georeferenced as _require_transform_for_georeferenced,
-    transform_from_attr as _transform_from_attr,
+    resolve_georef as _resolve_georef,
 )
 from .._crs import _validate_crs_arg, _validate_crs_fallback, _wkt_to_epsg
 from .._runtime import GeoTIFFFallbackWarning, _resolve_spatial_coords
@@ -491,13 +490,11 @@ def write_geotiff_gpu(data: xr.DataArray | cupy.ndarray | np.ndarray,
         if arr.ndim == 3 and data.dims[0] in _BAND_DIM_NAMES:
             arr = cupy.ascontiguousarray(cupy.moveaxis(arr, 0, -1))
 
-        # Prefer attrs['transform'] over the coord-derived transform: it
-        # is bit-stable across round-trips, while _coords_to_transform
-        # can drift on fractional pixel sizes (the same reasoning the
-        # CPU to_geotiff path applies for issue #1484).
-        geo_transform = _transform_from_attr(data.attrs.get('transform'))
-        if geo_transform is None:
-            geo_transform = _coords_to_transform(data)
+        # Resolve via the centralised resolver (#2225). Same precedence
+        # as the CPU writer: prefer attrs['transform'] (bit-stable on
+        # round-trip) over the coord-derived transform (drifts on
+        # fractional pixel sizes -- the same reasoning behind #1484).
+        geo_transform = _resolve_georef(data).transform
         # Match the CPU writer's fail-closed guard: an array with spatial
         # coords but no derivable transform (e.g. 1x1 without
         # ``attrs['transform']``) must not silently round-trip as a

--- a/xrspatial/geotiff/tests/test_georef_resolver_parity_2211.py
+++ b/xrspatial/geotiff/tests/test_georef_resolver_parity_2211.py
@@ -314,16 +314,18 @@ def test_resolve_georef_writer_no_georef_marker():
 
 
 def test_resolve_georef_writer_transform_only_attr():
-    """``attrs['transform']`` resolves to a transform with no CRS bucket.
+    """``attrs['transform']`` resolves to ``transform_only`` (no CRS).
 
     Writer side: the only georef signal is the attr, so the resolver
-    lands on ``coords`` (writer's equivalent of "transform present,
-    no CRS"). The transform is the rasterio 6-tuple ``(a, b, c, d, e,
-    f)`` reconstructed back into a ``GeoTransform``.
+    lands on ``transform_only`` to distinguish it from the
+    ``coords``-derived bucket (which fires when the transform was
+    inferred from coord arrays). The transform is the rasterio
+    6-tuple ``(a, b, c, d, e, f)`` reconstructed into a
+    ``GeoTransform``.
     """
     da = _make_transform_only_da()
     result = resolve_georef(da)
-    assert result.georef_status == GEOREF_STATUS_COORDS
+    assert result.georef_status == GEOREF_STATUS_TRANSFORM_ONLY
     assert result.transform is not None
     assert result.transform.pixel_width == pytest.approx(1.0)
     assert result.transform.pixel_height == pytest.approx(-1.0)

--- a/xrspatial/geotiff/tests/test_georef_resolver_parity_2211.py
+++ b/xrspatial/geotiff/tests/test_georef_resolver_parity_2211.py
@@ -1,0 +1,457 @@
+"""Parity tests for :func:`resolve_georef` across backend call sites.
+
+Issue #2225 (PR-B of #2211). The transform/georef contract used to
+live in three places: ``_attrs._compute_georef_status``, the eager
+writer's inline ``_transform_from_attr`` / ``_coords_to_transform``
+ladder, and the GPU writer's copy of the same ladder. This PR moved
+the decisions into :func:`xrspatial.geotiff._coords.resolve_georef`
+and routed every call site through it.
+
+The tests below construct each of the six fixture cases the issue
+calls out and assert the resolver returns the same
+:class:`GeorefResolution` regardless of:
+
+* coord dim naming (``y/x``, ``lat/lon``, ``row/col``),
+* whether the caller is on the writer side (DataArray with attrs)
+  or the reader side (``GeoInfo``-like record),
+* whether ``attrs['transform']`` is the only georef signal
+  (transform-only), CRS is the only signal (crs_only), or the input
+  carried a rotated ``ModelTransformation`` (rotated_dropped).
+
+The 6 cases:
+
+1. ``y/x`` axis-aligned, no CRS -- writer-side resolver returns
+   ``coords`` because the only georef signal is the coord arrays;
+   reader-side returns ``transform_only`` because the reader holds an
+   explicit ``GeoInfo.has_georef`` bit.
+2. ``lat/lon`` axis-aligned, no CRS -- same coord shape, just
+   different dim names; resolver decision is identical.
+3. ``row/col`` (no georef) -- the reader-stamped placeholder coord
+   path. ``attrs[_NO_GEOREF_KEY] = True`` flips both the writer and
+   the reader to ``none``.
+4. transform-only -- ``attrs['transform']`` is supplied, no CRS.
+   Writer derives the same transform; reader bucket is
+   ``transform_only``.
+5. CRS-only -- ``attrs['crs']`` set, no transform / no coords. Both
+   paths land on ``crs_only`` with ``transform=None``.
+6. Rotated affine dropped -- a reader-side ``GeoInfo`` whose
+   transform carries ``rotated_affine`` lands on
+   ``rotated_dropped`` with ``applied_no_georef_marker=True``.
+
+The acceptance criterion in #2225 is that the resolver returns the
+same record for each fixture across every call site. The structured
+test below builds the six fixtures once and asserts each invocation
+path (``resolve_georef`` directly, ``_compute_georef_status``,
+``_compute_georef_status_from_parts``) routes the same status string
+out.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from xrspatial.geotiff._attrs import (
+    GEOREF_STATUS_CRS_ONLY,
+    GEOREF_STATUS_FULL,
+    GEOREF_STATUS_NONE,
+    GEOREF_STATUS_ROTATED_DROPPED,
+    GEOREF_STATUS_TRANSFORM_ONLY,
+    _compute_georef_status,
+    _compute_georef_status_from_parts,
+)
+from xrspatial.geotiff._coords import (
+    GEOREF_STATUS_COORDS,
+    GeorefResolution,
+    resolve_georef,
+)
+from xrspatial.geotiff._geotags import (
+    _NO_GEOREF_KEY,
+    GeoInfo,
+    GeoTransform,
+    RASTER_PIXEL_IS_AREA,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+def _make_axis_aligned_da(y_name: str, x_name: str) -> xr.DataArray:
+    """Return a 4x5 DataArray with axis-aligned float pixel-center coords.
+
+    Origin at (100.0, 200.0), 1.0 pixel width, -1.0 pixel height. No
+    ``attrs['transform']`` so the resolver must derive the transform
+    from the coords themselves. No CRS attr.
+    """
+    px = 1.0
+    py = -1.0
+    ox = 100.0
+    oy = 200.0
+    ys = oy + (np.arange(4) + 0.5) * py
+    xs = ox + (np.arange(5) + 0.5) * px
+    return xr.DataArray(
+        np.zeros((4, 5), dtype=np.float32),
+        dims=(y_name, x_name),
+        coords={y_name: ys, x_name: xs},
+        attrs={},
+    )
+
+
+def _make_no_georef_da() -> xr.DataArray:
+    """Reader-style placeholder: int pixel coords + ``_NO_GEOREF_KEY``.
+
+    Mirrors what the reader emits when a file has no GeoTIFF transform
+    tags. ``row/col`` dim names are used because the no-georef path is
+    independent of dim naming -- the marker is the only signal.
+    """
+    return xr.DataArray(
+        np.zeros((3, 3), dtype=np.float32),
+        dims=('row', 'col'),
+        coords={
+            'row': np.arange(3, dtype=np.int64),
+            'col': np.arange(3, dtype=np.int64),
+        },
+        attrs={_NO_GEOREF_KEY: True},
+    )
+
+
+def _make_transform_only_da() -> xr.DataArray:
+    """``attrs['transform']`` set, no CRS, no coord arrays.
+
+    The resolver should derive the transform straight from the attr
+    and bucket as ``transform_only`` on the reader side, or ``coords``
+    on the writer side (writer doesn't see the reader's
+    ``has_georef`` bit, so any transform-without-CRS is just "coords").
+    """
+    return xr.DataArray(
+        np.zeros((4, 5), dtype=np.float32),
+        dims=('y', 'x'),
+        attrs={
+            'transform': (1.0, 0.0, 100.0, 0.0, -1.0, 200.0),
+        },
+    )
+
+
+def _make_crs_only_da() -> xr.DataArray:
+    """``attrs['crs']`` set with no transform and no coords.
+
+    Resolver should land on ``crs_only`` with ``transform=None``.
+    """
+    return xr.DataArray(
+        np.zeros((4, 5), dtype=np.float32),
+        dims=('y', 'x'),
+        attrs={'crs': 4326},
+    )
+
+
+def _make_full_geo_info() -> GeoInfo:
+    return GeoInfo(
+        transform=GeoTransform(
+            origin_x=100.0, origin_y=200.0,
+            pixel_width=1.0, pixel_height=-1.0,
+        ),
+        has_georef=True,
+        crs_epsg=4326,
+        crs_wkt='GEOGCS["WGS 84"]',
+        raster_type=RASTER_PIXEL_IS_AREA,
+    )
+
+
+def _make_transform_only_geo_info() -> GeoInfo:
+    return GeoInfo(
+        transform=GeoTransform(
+            origin_x=100.0, origin_y=200.0,
+            pixel_width=1.0, pixel_height=-1.0,
+        ),
+        has_georef=True,
+        crs_epsg=None,
+        crs_wkt=None,
+        raster_type=RASTER_PIXEL_IS_AREA,
+    )
+
+
+def _make_crs_only_geo_info() -> GeoInfo:
+    return GeoInfo(
+        transform=None,
+        has_georef=False,
+        crs_epsg=4326,
+        crs_wkt=None,
+        raster_type=RASTER_PIXEL_IS_AREA,
+    )
+
+
+def _make_none_geo_info() -> GeoInfo:
+    return GeoInfo(
+        transform=None,
+        has_georef=False,
+        crs_epsg=None,
+        crs_wkt=None,
+        raster_type=RASTER_PIXEL_IS_AREA,
+    )
+
+
+def _make_rotated_dropped_geo_info() -> GeoInfo:
+    return GeoInfo(
+        transform=GeoTransform(
+            rotated_affine=(1.0, 0.1, 100.0, 0.2, -1.0, 200.0),
+        ),
+        has_georef=False,
+        crs_epsg=None,
+        crs_wkt=None,
+        raster_type=RASTER_PIXEL_IS_AREA,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reader-side parity: GeoInfo -> resolve_georef -> GeorefResolution
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "geo_info_factory, expected_status, expected_marker, expected_has_transform",
+    [
+        (_make_full_geo_info, GEOREF_STATUS_FULL, False, True),
+        (_make_transform_only_geo_info, GEOREF_STATUS_TRANSFORM_ONLY, False, True),
+        (_make_crs_only_geo_info, GEOREF_STATUS_CRS_ONLY, True, False),
+        (_make_none_geo_info, GEOREF_STATUS_NONE, True, False),
+        (_make_rotated_dropped_geo_info, GEOREF_STATUS_ROTATED_DROPPED, True, False),
+    ],
+    ids=['full', 'transform_only', 'crs_only', 'none', 'rotated_dropped'],
+)
+def test_resolve_georef_reader_path(
+    geo_info_factory, expected_status, expected_marker, expected_has_transform,
+):
+    """Reader-side: ``resolve_georef(geo_info=...)`` returns the expected bucket."""
+    geo_info = geo_info_factory()
+    result = resolve_georef(geo_info=geo_info)
+    assert isinstance(result, GeorefResolution)
+    assert result.georef_status == expected_status
+    assert result.applied_no_georef_marker is expected_marker
+    assert (result.transform is not None) is expected_has_transform
+
+
+def test_reader_compute_georef_status_routes_through_resolver():
+    """``_compute_georef_status`` is a thin wrapper now (#2225).
+
+    Every supported ``GeoInfo`` bucket must map to the same string the
+    resolver returns. If the two ever drift the read-path
+    ``attrs['georef_status']`` and the resolver disagree about which
+    state the read landed in.
+    """
+    for factory, expected in [
+        (_make_full_geo_info, GEOREF_STATUS_FULL),
+        (_make_transform_only_geo_info, GEOREF_STATUS_TRANSFORM_ONLY),
+        (_make_crs_only_geo_info, GEOREF_STATUS_CRS_ONLY),
+        (_make_none_geo_info, GEOREF_STATUS_NONE),
+        (_make_rotated_dropped_geo_info, GEOREF_STATUS_ROTATED_DROPPED),
+    ]:
+        gi = factory()
+        assert _compute_georef_status(gi) == expected
+        assert resolve_georef(geo_info=gi).georef_status == expected
+
+
+def test_reader_compute_georef_status_from_parts_matches_resolver():
+    """The VRT shim ``_compute_georef_status_from_parts`` matches the resolver.
+
+    The VRT branches don't build a ``GeoInfo``, they thread raw
+    booleans. Build matching ``GeoInfo`` records for the same boolean
+    combinations and assert the two helpers agree.
+    """
+    cases = [
+        (True, True, False, GEOREF_STATUS_FULL),
+        (True, False, False, GEOREF_STATUS_TRANSFORM_ONLY),
+        (False, True, False, GEOREF_STATUS_CRS_ONLY),
+        (False, False, False, GEOREF_STATUS_NONE),
+        (False, False, True, GEOREF_STATUS_ROTATED_DROPPED),
+        (True, True, True, GEOREF_STATUS_ROTATED_DROPPED),
+    ]
+    for has_t, has_c, rotated, expected in cases:
+        from_parts = _compute_georef_status_from_parts(
+            has_transform=has_t, has_crs=has_c, rotated_dropped=rotated,
+        )
+        assert from_parts == expected
+
+
+# ---------------------------------------------------------------------------
+# Writer-side parity: DataArray -> resolve_georef -> GeorefResolution
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "y_name,x_name",
+    [('y', 'x'), ('lat', 'lon'), ('latitude', 'longitude')],
+    ids=['y_x', 'lat_lon', 'latitude_longitude'],
+)
+def test_resolve_georef_writer_axis_aligned_coords(y_name, x_name):
+    """Dim-name parity: same coord shape, three dim conventions.
+
+    The resolver picks the spatial dims as the last two regardless of
+    name, so all three should produce identical transforms and the
+    ``coords`` bucket (no CRS attr).
+    """
+    da = _make_axis_aligned_da(y_name, x_name)
+    result = resolve_georef(da)
+    assert result.georef_status == GEOREF_STATUS_COORDS
+    assert result.applied_no_georef_marker is False
+    assert result.transform is not None
+    assert result.transform.pixel_width == pytest.approx(1.0)
+    assert result.transform.pixel_height == pytest.approx(-1.0)
+    assert result.transform.origin_x == pytest.approx(100.0)
+    assert result.transform.origin_y == pytest.approx(200.0)
+
+
+def test_resolve_georef_writer_no_georef_marker():
+    """``attrs[_NO_GEOREF_KEY]=True`` forces no-georef regardless of coords.
+
+    The reader-stamped placeholder int64 coord arrays would otherwise
+    produce a synthetic unit transform. The marker is the gate that
+    keeps that synthesis from running on round-trip (#1949, #2120).
+    """
+    da = _make_no_georef_da()
+    result = resolve_georef(da)
+    assert result.georef_status == GEOREF_STATUS_NONE
+    assert result.applied_no_georef_marker is True
+    assert result.transform is None
+
+
+def test_resolve_georef_writer_transform_only_attr():
+    """``attrs['transform']`` resolves to a transform with no CRS bucket.
+
+    Writer side: the only georef signal is the attr, so the resolver
+    lands on ``coords`` (writer's equivalent of "transform present,
+    no CRS"). The transform is the rasterio 6-tuple ``(a, b, c, d, e,
+    f)`` reconstructed back into a ``GeoTransform``.
+    """
+    da = _make_transform_only_da()
+    result = resolve_georef(da)
+    assert result.georef_status == GEOREF_STATUS_COORDS
+    assert result.transform is not None
+    assert result.transform.pixel_width == pytest.approx(1.0)
+    assert result.transform.pixel_height == pytest.approx(-1.0)
+    assert result.transform.origin_x == pytest.approx(100.0)
+    assert result.transform.origin_y == pytest.approx(200.0)
+    assert result.applied_no_georef_marker is False
+
+
+def test_resolve_georef_writer_crs_only():
+    """``attrs['crs']`` without transform / coords -> ``crs_only``."""
+    da = _make_crs_only_da()
+    result = resolve_georef(da)
+    assert result.georef_status == GEOREF_STATUS_CRS_ONLY
+    assert result.transform is None
+    # No marker on the writer side: writer didn't stamp anything; the
+    # caller just passed a CRS without a transform. The marker is
+    # reader-stamped; writer paths don't apply it.
+    assert result.applied_no_georef_marker is False
+
+
+def test_resolve_georef_writer_full_round_trip():
+    """DataArray with both transform attr AND CRS -> ``full`` bucket."""
+    da = _make_transform_only_da()
+    da = da.assign_attrs(crs=4326)
+    result = resolve_georef(da)
+    assert result.georef_status == GEOREF_STATUS_FULL
+    assert result.transform is not None
+
+
+# ---------------------------------------------------------------------------
+# Cross-site parity
+# ---------------------------------------------------------------------------
+
+def test_writer_and_reader_agree_on_full_case():
+    """A reader-emitted DataArray and the underlying GeoInfo agree.
+
+    Build a DataArray that mimics what the reader stamps for a fully
+    georeferenced file (coord arrays + attrs['transform'] +
+    attrs['crs']) and a ``GeoInfo`` carrying the same metadata.
+    ``resolve_georef`` should land on the same status from either
+    entry point (``full``).
+    """
+    da = _make_axis_aligned_da('y', 'x').assign_attrs(
+        transform=(1.0, 0.0, 100.0, 0.0, -1.0, 200.0),
+        crs=4326,
+    )
+    gi = _make_full_geo_info()
+    writer_result = resolve_georef(da)
+    reader_result = resolve_georef(geo_info=gi)
+    assert writer_result.georef_status == reader_result.georef_status
+    assert writer_result.georef_status == GEOREF_STATUS_FULL
+    # Both produced an axis-aligned transform with the same pixel
+    # geometry. They are not the same object, but the values match.
+    assert writer_result.transform.pixel_width == pytest.approx(
+        reader_result.transform.pixel_width)
+    assert writer_result.transform.pixel_height == pytest.approx(
+        reader_result.transform.pixel_height)
+
+
+def test_writer_and_reader_agree_on_no_georef_case():
+    """No-georef placeholder DataArray and its underlying GeoInfo agree."""
+    da = _make_no_georef_da()
+    gi = _make_none_geo_info()
+    writer_result = resolve_georef(da)
+    reader_result = resolve_georef(geo_info=gi)
+    assert writer_result.georef_status == GEOREF_STATUS_NONE
+    assert reader_result.georef_status == GEOREF_STATUS_NONE
+    assert writer_result.transform is None
+    assert reader_result.transform is None
+    assert writer_result.applied_no_georef_marker is True
+    assert reader_result.applied_no_georef_marker is True
+
+
+def test_writer_rotated_attr_transform_rejected():
+    """A rotated 6-tuple in ``attrs['transform']`` raises through the resolver.
+
+    The writers' ``transform_from_attr`` already rejected rotated /
+    sheared affines with a ``ValueError`` for #2216 -- the resolver
+    must preserve that diagnostic so writer callers see the same
+    failure as before the refactor.
+    """
+    da = xr.DataArray(
+        np.zeros((4, 5), dtype=np.float32),
+        dims=('y', 'x'),
+        attrs={'transform': (1.0, 0.1, 100.0, 0.2, -1.0, 200.0)},
+    )
+    with pytest.raises(ValueError, match="non-zero rotation"):
+        resolve_georef(da)
+
+
+def test_dropped_reason_populated_for_rotated_reader():
+    """``rotated_dropped`` reader case records the drop reason."""
+    gi = _make_rotated_dropped_geo_info()
+    result = resolve_georef(geo_info=gi)
+    assert result.dropped_reason == 'rotated_affine_dropped'
+    assert result.applied_no_georef_marker is True
+
+
+def test_dropped_reason_populated_for_no_transform_writer():
+    """Writer-side: ``attrs[_NO_GEOREF_KEY]`` records ``no_georef_marker``."""
+    da = _make_no_georef_da()
+    result = resolve_georef(da)
+    assert result.dropped_reason == 'no_georef_marker'
+
+
+# ---------------------------------------------------------------------------
+# Smoke test for the bare-input path (no DataArray, no GeoInfo)
+# ---------------------------------------------------------------------------
+
+def test_bare_input_crs_only():
+    """``resolve_georef(crs_epsg=...)`` with no transform returns ``crs_only``."""
+    result = resolve_georef(crs_epsg=4326)
+    assert result.georef_status == GEOREF_STATUS_CRS_ONLY
+    assert result.transform is None
+
+
+def test_bare_input_transform_only():
+    """``transform_hint`` only -> ``transform_only`` bucket."""
+    t = (1.0, 0.0, 100.0, 0.0, -1.0, 200.0)
+    result = resolve_georef(transform_hint=t)
+    assert result.georef_status == GEOREF_STATUS_TRANSFORM_ONLY
+    assert result.transform is not None
+    assert result.transform.pixel_width == pytest.approx(1.0)
+
+
+def test_bare_input_none_signal():
+    """No signals at all -> ``none`` with ``no_inputs`` drop reason."""
+    result = resolve_georef()
+    assert result.georef_status == GEOREF_STATUS_NONE
+    assert result.transform is None
+    assert result.dropped_reason == 'no_inputs'


### PR DESCRIPTION
Closes #2225
Part of #2211

## Summary

Centralises the transform/georef contract behind a single resolver so every backend (eager, GPU, dask, VRT, read and write) makes the same decision for matching inputs.

- Adds `GeorefResolution` dataclass and `resolve_georef()` in `_coords.py`. Fields: `transform`, `georef_status`, `dropped_reason`, `applied_no_georef_marker`. The resolver owns coord-to-transform inference, the no-georef marker, degenerate-axis policy, and rotated-affine drop policy.
- Routes `_attrs._compute_georef_status` through the resolver so the read-side bucket decision is computed in one place.
- Replaces the inline `_transform_from_attr` -> `_coords_to_transform` -> `_require_transform_for_georeferenced` ladder in `_writers/eager.py` (two sites: `to_geotiff` and `_write_vrt_tiled`) and `_writers/gpu.py` with one `resolve_georef(data)` call.
- The synthesised `GeoInfo` from `_backends/vrt.py::_vrt_to_synthetic_geo_info` already flowed through `_compute_georef_status`, which now routes through the resolver. Added a docstring note.

The public API is unchanged. `georef_status` values, `attrs['transform']` precedence, and the fail-closed behaviour on degenerate coords (#1945) all match prior behaviour.

## Tests

New file `xrspatial/geotiff/tests/test_georef_resolver_parity_2211.py` (22 tests) covers the six fixture cases the issue calls out plus cross-site parity:

- `y`/`x`, `lat`/`lon`, `latitude`/`longitude` dim names
- `row`/`col` (no-georef placeholder + `_NO_GEOREF_KEY` marker)
- transform-only via `attrs['transform']`
- CRS-only via `attrs['crs']`
- rotated-affine `GeoInfo` -> `rotated_dropped` bucket
- writer-and-reader-agree assertions on full and no-georef cases

## Verification

- `pytest xrspatial/geotiff/tests/` -> 4,729 passed, 45 skipped, 1 xfailed (pre-existing lz4 failure is unrelated and reproduces on main).
- `test_georef_status_2136.py` and `test_allow_rotated_*` suites: all green.

## Notes

- `xrspatial/geotiff/_writers/vrt.py` is the public `write_vrt` mosaic creator. It does not handle DataArrays or build transforms, so the resolver does not apply there. The per-tile VRT write path lives in `_writers/eager.py::_write_vrt_tiled` and was updated.
- Kept `_compute_georef_status_from_parts` (VRT inline shim) as-is so VRT branches do not have to build a fake `GeoInfo` to feed the resolver; its decision table mirrors the resolver's reader-path branch.