### PR TITLE
geotiff: centralize nodata lifecycle

### DIFF
--- a/xrspatial/geotiff/_backends/_gpu_helpers.py
+++ b/xrspatial/geotiff/_backends/_gpu_helpers.py
@@ -22,6 +22,7 @@ from .._coords import (
     geo_to_coords as _geo_to_coords,
 )
 from .._geotags import GeoTransform, RASTER_PIXEL_IS_POINT
+from .._nodata import _sentinel_fits_dtype
 from .._runtime import _geotiff_strict_mode
 
 
@@ -79,8 +80,7 @@ def _apply_nodata_mask_gpu(arr_gpu, nodata):
         # fractional sentinels short-circuit to a no-op so
         # ``attrs['nodata']`` still records them while masking
         # leaves the integer buffer untouched.
-        from .._nodata import _sentinel_fits_dtype as _fits
-        if not _fits(nodata, arr_dtype):
+        if not _sentinel_fits_dtype(nodata, arr_dtype):
             return arr_gpu
         nodata_int = int(nodata)
         sentinel = arr_dtype.type(nodata_int)

--- a/xrspatial/geotiff/_backends/_gpu_helpers.py
+++ b/xrspatial/geotiff/_backends/_gpu_helpers.py
@@ -73,25 +73,16 @@ def _apply_nodata_mask_gpu(arr_gpu, nodata):
                          arr_dtype.type('nan'))
         return arr_gpu
     if arr_dtype.kind in ('u', 'i'):
-        # Out-of-range sentinels (e.g. uint16 + GDAL_NODATA="-9999") cannot
-        # match any decoded pixel; skip the cast that would otherwise raise
-        # OverflowError. A non-finite sentinel ("NaN" / "Inf" GDAL_NODATA
-        # strings) also cannot match an integer pixel and would raise
-        # ValueError on ``int(nodata)``; gate on ``np.isfinite`` first to
-        # mirror ``_resolve_masked_fill`` in ``_reader.py`` (#1774). A
-        # fractional sentinel (e.g. ``"3.5"`` on a ``uint16`` file) also
-        # cannot match an integer pixel and ``int(3.5)`` would truncate
-        # to 3, silently masking a real pixel value; gate on
-        # ``float(nodata).is_integer()`` as well (mirrors the
-        # ``_writer.py`` / ``_vrt.py`` pattern used for #1564 / #1616).
-        # attrs['nodata'] is still set by the caller so the original
-        # sentinel survives a write round-trip.
-        if not (np.isfinite(nodata) and float(nodata).is_integer()):
+        # PR-C #2226: lifecycle helper owns the
+        # finite / integer / in-range gate previously inlined here
+        # (#1774, #1564, #1616). Out-of-range, non-finite, or
+        # fractional sentinels short-circuit to a no-op so
+        # ``attrs['nodata']`` still records them while masking
+        # leaves the integer buffer untouched.
+        from .._nodata import _sentinel_fits_dtype as _fits
+        if not _fits(nodata, arr_dtype):
             return arr_gpu
         nodata_int = int(nodata)
-        info = np.iinfo(arr_dtype)
-        if not (info.min <= nodata_int <= info.max):
-            return arr_gpu
         sentinel = arr_dtype.type(nodata_int)
         mask = arr_gpu == sentinel
         if bool(mask.any().item()):

--- a/xrspatial/geotiff/_backends/dask.py
+++ b/xrspatial/geotiff/_backends/dask.py
@@ -237,52 +237,33 @@ def read_geotiff_dask(source: str, *,
         geo_info, full_h, full_w, file_dtype, n_bands = _read_geo_info(
             source, overview_level=overview_level,
             allow_rotated=allow_rotated)
-    nodata = geo_info.nodata
-    nodata_attr = nodata  # original sentinel preserved for attrs['nodata']
-    # When the source is MinIsWhite (photometric == 0, samples_per_pixel == 1),
-    # the per-chunk reader inverts pixel values before this closure's nodata
-    # mask runs. Track the inverted sentinel so the mask compares against the
-    # post-inversion value, not the original (#1809).
-    if nodata is not None:
-        _phm = getattr(geo_info, '_ifd_photometric', None)
-        _spp = getattr(geo_info, '_ifd_samples_per_pixel', None)
-        if _phm == 0 and _spp == 1:
-            if file_dtype.kind == 'u' and np.isfinite(nodata) and \
-                    float(nodata).is_integer():
-                vi = int(nodata)
-                info = np.iinfo(file_dtype)
-                if info.min <= vi <= info.max:
-                    nodata = info.max - vi
-            elif file_dtype.kind == 'f' and not np.isnan(nodata):
-                nodata = -float(nodata)
+    # PR-C #2226: centralize the nodata lifecycle in one value object.
+    # ``raw_sentinel`` carries the pre-inversion sentinel that
+    # ``attrs['nodata']`` must preserve; ``effective_sentinel`` is what
+    # the per-chunk reader's mask compares against (post-MinIsWhite).
+    # ``sentinel_fits_buffer`` collapses the previous finite/integer/
+    # in-range gate so the integer auto-promotion below skips out-of-
+    # range / fractional / non-finite sentinels (#1774, #1564, #1616).
+    from .._nodata import NodataLifecycle
+    lifecycle = NodataLifecycle(
+        declared=geo_info.nodata,
+        photometric=getattr(geo_info, '_ifd_photometric', None),
+        dtype_in=file_dtype,
+        dtype_request=dtype,
+        samples_per_pixel=getattr(geo_info, '_ifd_samples_per_pixel', 1) or 1,
+    )
+    nodata_attr = lifecycle.raw_sentinel  # original sentinel for attrs['nodata']
+    nodata = lifecycle.effective_sentinel  # post-MinIsWhite for masking
 
     # Nodata masking promotes integer arrays to float64 (for NaN).
-    # Validate against the effective dtype, not the raw file dtype.
-    # An out-of-range sentinel (e.g. uint16 file + nodata=-9999) is a
-    # no-op for masking and leaves the file dtype unchanged. A
-    # non-finite sentinel ("NaN" / "Inf" GDAL_NODATA strings) cannot
-    # match an integer pixel either and is short-circuited via the
-    # ``np.isfinite`` gate so the ``int(...)`` cast never sees NaN
-    # (#1774). A fractional sentinel (e.g. ``"3.5"`` on a ``uint16``
-    # file) also cannot match an integer pixel and ``int(3.5)`` would
-    # truncate to 3, silently flagging a real pixel value as nodata;
-    # gate on ``float(nodata).is_integer()`` as well so fractional
-    # tags stay on the no-op path. The try/except keeps callers that
-    # pass an exotic ``nodata`` type (e.g. complex) on the no-op path
-    # rather than surfacing an opaque error here.
+    # The lifecycle's ``sentinel_fits_buffer`` already encapsulates the
+    # finite / integer / in-range gates (#1774, #1564, #1616), so the
+    # promotion fires iff the helper says the sentinel is comparable.
     effective_dtype = file_dtype
     if (mask_nodata
-            and nodata is not None
             and file_dtype.kind in ('u', 'i')
-            and np.isfinite(nodata)
-            and float(nodata).is_integer()):
-        try:
-            _nd_int = int(nodata)
-            _info = np.iinfo(file_dtype)
-            if _info.min <= _nd_int <= _info.max:
-                effective_dtype = np.dtype('float64')
-        except (TypeError, ValueError):
-            pass
+            and lifecycle.sentinel_fits_buffer):
+        effective_dtype = np.dtype('float64')
 
     if dtype is not None:
         target_dtype = np.dtype(dtype)

--- a/xrspatial/geotiff/_backends/dask.py
+++ b/xrspatial/geotiff/_backends/dask.py
@@ -22,6 +22,7 @@ from .._coords import (
     coords_from_geo_info as _coords_from_geo_info,
     geo_to_coords as _geo_to_coords,
 )
+from .._nodata import NodataLifecycle
 from .._reader import _MAX_CLOUD_BYTES_SENTINEL, read_to_array as _read_to_array
 from .._runtime import _MISSING_SOURCES_SENTINEL, _ON_GPU_FAILURE_SENTINEL
 from .._validation import (
@@ -244,7 +245,15 @@ def read_geotiff_dask(source: str, *,
     # ``sentinel_fits_buffer`` collapses the previous finite/integer/
     # in-range gate so the integer auto-promotion below skips out-of-
     # range / fractional / non-finite sentinels (#1774, #1564, #1616).
-    from .._nodata import NodataLifecycle
+    #
+    # The ``_ifd_photometric`` and ``_ifd_samples_per_pixel`` attrs are
+    # stashed in lockstep by ``_read_geo_info`` (``__init__.py``) and the
+    # HTTP / sidecar branches above. When both are missing (synthesised
+    # geo_info from a non-TIFF source), ``photometric=None`` already
+    # short-circuits ``_applies_miniswhite`` to False inside the helper,
+    # so the ``or 1`` fallback on ``samples_per_pixel`` is harmless --
+    # it never reaches the inversion branch on a real
+    # ``samples_per_pixel=N`` file.
     lifecycle = NodataLifecycle(
         declared=geo_info.nodata,
         photometric=getattr(geo_info, '_ifd_photometric', None),

--- a/xrspatial/geotiff/_backends/gpu.py
+++ b/xrspatial/geotiff/_backends/gpu.py
@@ -30,6 +30,7 @@ from .._attrs import (
 from .._coords import (
     coords_from_geo_info as _coords_from_geo_info,
 )
+from .._nodata import NodataLifecycle as _NL
 from .._reader import (
     _MAX_CLOUD_BYTES_SENTINEL,
     _coerce_path,
@@ -808,7 +809,6 @@ def read_geotiff_gpu(source: str, *,
             # into ``_reader`` for the inversion math. The lifecycle's
             # ``effective_sentinel`` matches ``_miniswhite_inverted_nodata``
             # exactly for the MinIsWhite (photometric==0, spp==1) case.
-            from .._nodata import NodataLifecycle as _NL
             gpu_dtype = np.dtype(str(arr_gpu.dtype))
             _mw_mask_nodata = _NL(
                 declared=geo_info.nodata,

--- a/xrspatial/geotiff/_backends/gpu.py
+++ b/xrspatial/geotiff/_backends/gpu.py
@@ -803,12 +803,19 @@ def read_geotiff_gpu(source: str, *,
 
         _mw_mask_nodata = None
         if (ifd.photometric == 0 and samples == 1 and not arr_was_cpu_decoded):
-            from .._reader import _miniswhite_inverted_nodata as _miw_inv_nd
+            # PR-C #2226: route the post-MinIsWhite sentinel through the
+            # shared lifecycle helper so the GPU path no longer reaches
+            # into ``_reader`` for the inversion math. The lifecycle's
+            # ``effective_sentinel`` matches ``_miniswhite_inverted_nodata``
+            # exactly for the MinIsWhite (photometric==0, spp==1) case.
+            from .._nodata import NodataLifecycle as _NL
             gpu_dtype = np.dtype(str(arr_gpu.dtype))
-            # Compute the post-MinIsWhite sentinel BEFORE inverting the array,
-            # so the downstream ``_apply_nodata_mask_gpu`` call compares
-            # against the right value (#1809).
-            _mw_mask_nodata = _miw_inv_nd(geo_info.nodata, ifd, gpu_dtype)
+            _mw_mask_nodata = _NL(
+                declared=geo_info.nodata,
+                photometric=ifd.photometric,
+                dtype_in=gpu_dtype,
+                samples_per_pixel=ifd.samples_per_pixel,
+            ).effective_sentinel
             if gpu_dtype.kind == 'u':
                 arr_gpu = np.iinfo(gpu_dtype).max - arr_gpu
             elif gpu_dtype.kind == 'f':

--- a/xrspatial/geotiff/_nodata.py
+++ b/xrspatial/geotiff/_nodata.py
@@ -1,0 +1,340 @@
+"""Nodata lifecycle helper.
+
+Centralizes the decisions previously scattered across the geotiff
+read / write backends:
+
+* whether a raw sentinel is usable against an integer dtype (finite,
+  representable, integer-valued)
+* what the *effective* sentinel is after MinIsWhite photometric
+  inversion (the value the in-memory buffer actually carries)
+* whether the read path's nodata-to-NaN promotion will or did fire
+  (``masking_occurred``)
+* whether an explicit ``dtype=`` cast on read promoted the buffer
+  (``dtype_cast_occurred``) and what value to record in
+  ``attrs['nodata_dtype_cast']``
+* whether the writer's NaN-to-sentinel restore is appropriate for the
+  current `(nodata, buffer dtype, masked_nodata attr)` triple
+  (``writer_restore_sentinel``)
+
+The backend kernels keep their array op (masking, photometric
+inversion, dtype cast, NaN-to-sentinel rewrite); this helper owns the
+policy questions so the inline ``if nodata is not None`` branches in
+each backend collapse to a single ``NodataLifecycle(...)`` construction
+plus attribute access.
+
+PR-C of issue #2211 (sub-issue #2226).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+import numpy as np
+
+
+def _is_finite_integer(value) -> bool:
+    """Return True iff *value* is a finite, integer-valued scalar.
+
+    Used to gate integer-sentinel masking and integer-sentinel writer
+    restore. Non-finite (NaN/Inf) and fractional sentinels return
+    False so the caller skips the mask / restore step entirely.
+    Bools are treated as integers by Python's ``float``/``int``; the
+    writer's bool-rejection (issue #1973) already runs upstream.
+    """
+    if value is None:
+        return False
+    try:
+        as_float = float(value)
+    except (TypeError, ValueError):
+        return False
+    if not np.isfinite(as_float):
+        return False
+    return as_float.is_integer()
+
+
+def _sentinel_fits_dtype(sentinel, dtype: np.dtype) -> bool:
+    """Return True iff *sentinel* can be matched against pixels of *dtype*.
+
+    Float dtypes always fit (NaN is special-cased by the caller); integer
+    dtypes require the sentinel be a finite integer-valued scalar
+    inside ``np.iinfo(dtype)``. Mirrors the eager / dask / GPU mask
+    gates so the lifecycle helper can answer "would masking even do
+    anything?" without duplicating the gate logic.
+    """
+    if sentinel is None:
+        return False
+    if dtype.kind == 'f':
+        # NaN is a no-op on a float buffer (every NaN already matches),
+        # but the comparison still "fits" the dtype, so return True and
+        # let the caller's ``np.isnan(sentinel)`` branch short-circuit.
+        return True
+    if dtype.kind in ('u', 'i'):
+        if not _is_finite_integer(sentinel):
+            return False
+        nodata_int = int(sentinel)
+        info = np.iinfo(dtype)
+        return info.min <= nodata_int <= info.max
+    return False
+
+
+def _invert_for_miniswhite(sentinel, dtype: np.dtype):
+    """Return the sentinel value after MinIsWhite inversion.
+
+    Mirrors ``_reader._miniswhite_inverted_nodata`` exactly so the
+    lifecycle helper does not depend on the reader module (which would
+    create a circular import via ``_reader -> _nodata -> _reader``).
+
+    The caller has already decided that MinIsWhite applies
+    (``photometric == 0`` and single-band); this helper just performs
+    the value mapping. Non-finite or out-of-range integer sentinels
+    are returned unchanged so the downstream mask gate still skips
+    them.
+    """
+    if sentinel is None:
+        return sentinel
+    if dtype.kind == 'u':
+        if not np.isfinite(sentinel):
+            return sentinel
+        if not float(sentinel).is_integer():
+            return sentinel
+        vi = int(sentinel)
+        info = np.iinfo(dtype)
+        if not (info.min <= vi <= info.max):
+            return sentinel
+        return info.max - vi
+    if dtype.kind == 'f':
+        if np.isnan(sentinel):
+            return sentinel
+        return -float(sentinel)
+    return sentinel
+
+
+@dataclass
+class NodataLifecycle:
+    """Value object describing a single read or write's nodata lifecycle.
+
+    Parameters
+    ----------
+    declared : scalar or None
+        The raw sentinel as declared on the source (e.g. parsed from
+        ``GDAL_NODATA``, ``attrs['nodata']``, or the writer kwarg).
+        ``None`` means "the source did not declare a sentinel".
+    photometric : int or None
+        TIFF Photometric Interpretation value (TIFF 6 tag 262). ``0``
+        is MinIsWhite -- the reader inverts pixel values, and the
+        effective sentinel post-inversion is what masking compares
+        against. Any other value (1 MinIsBlack, 2 RGB, ...) leaves the
+        sentinel unchanged. ``None`` indicates the caller has no
+        photometric tag to apply (writer-side, VRT, raw arrays).
+    dtype_in : numpy.dtype or None
+        The dtype of the in-memory buffer the sentinel is being compared
+        against. For reads this is the file's source dtype; for writes
+        it is the in-memory buffer's dtype. Drives the
+        ``_sentinel_fits_dtype`` and ``writer_restore_sentinel`` gates.
+    dtype_request : numpy.dtype-like or None
+        The caller's explicit ``dtype=`` kwarg (or ``None`` if the
+        caller did not request a cast). Drives ``dtype_cast_occurred``
+        / ``cast_dtype_name``.
+    samples_per_pixel : int, default 1
+        Used together with ``photometric`` to decide whether MinIsWhite
+        inversion applies. The reader's gate is
+        ``photometric == 0 and samples_per_pixel == 1`` (multi-band
+        photometric=0 is not the same MinIsWhite case). Defaulting to
+        1 means single-band call sites can omit it.
+
+    Attributes
+    ----------
+    raw_sentinel
+        Alias for ``declared``. Exposed for clarity at backend call
+        sites that want "the raw, pre-inversion sentinel for
+        ``attrs['nodata']``".
+    effective_sentinel
+        The sentinel value to compare against the in-memory buffer.
+        Equal to ``raw_sentinel`` when MinIsWhite does not apply;
+        otherwise the inverted value (per
+        ``_reader._miniswhite_inverted_nodata`` semantics).
+    pixels_present : bool or None
+        Set by the execution path after the masking scan runs (the
+        lifecycle helper itself does not own array data, only
+        decisions). ``None`` means "no scan happened yet". The reader
+        / writer assigns this attribute on the lifecycle instance
+        after the per-buffer scan completes; downstream attrs
+        propagation reads it back.
+    """
+
+    declared: Any
+    photometric: Optional[int] = None
+    dtype_in: Optional[np.dtype] = None
+    dtype_request: Any = None
+    samples_per_pixel: int = 1
+
+    # Slot for execution to record the per-buffer scan result. Not part
+    # of the constructor signature -- the helper's job is decisions,
+    # not array operations. Backend kernels set this after their scan.
+    pixels_present: Optional[bool] = field(default=None, init=False)
+
+    # ------------------------------------------------------------------
+    # Sentinel accessors
+    # ------------------------------------------------------------------
+    @property
+    def raw_sentinel(self):
+        """The declared sentinel, pre-photometric. Carried on ``attrs['nodata']``.
+
+        Read paths put this value on ``attrs['nodata']`` so the on-disk
+        sentinel is preserved across a round-trip even when the
+        in-memory buffer carries the inverted (MinIsWhite) sentinel.
+        """
+        return self.declared
+
+    @property
+    def _applies_miniswhite(self) -> bool:
+        """True iff MinIsWhite inversion applies to the current state."""
+        return (
+            self.photometric == 0
+            and self.samples_per_pixel == 1
+            and self.declared is not None
+            and self.dtype_in is not None
+        )
+
+    @property
+    def effective_sentinel(self):
+        """The sentinel to compare against the in-memory buffer.
+
+        Equals ``raw_sentinel`` when MinIsWhite does not apply;
+        otherwise the inverted value. The reader's mask path and the
+        GPU helper's ``mask_sentinel`` argument both want this value.
+        """
+        if not self._applies_miniswhite:
+            return self.declared
+        return _invert_for_miniswhite(self.declared, self.dtype_in)
+
+    # ------------------------------------------------------------------
+    # Mask / cast decisions
+    # ------------------------------------------------------------------
+    @property
+    def sentinel_fits_buffer(self) -> bool:
+        """True iff comparing pixels against ``effective_sentinel`` is meaningful.
+
+        False when the source declared no sentinel, the integer dtype
+        cannot represent it (out-of-range, fractional, non-finite), or
+        the dtype is something the masking step does not support
+        (complex, structured, ...). Backends gate their masking step
+        on this property so the inline finite/integer/in-range checks
+        collapse to one helper call.
+        """
+        if self.declared is None or self.dtype_in is None:
+            return False
+        return _sentinel_fits_dtype(self.effective_sentinel, self.dtype_in)
+
+    def masking_occurred(self, *, mask_nodata: bool) -> bool:
+        """Return the value the read path should put on ``attrs['masked_nodata']``.
+
+        Matches the call sites' current contract:
+
+        * ``True`` iff the caller opted into masking AND the final
+          buffer is float (the integer-promotion branch only runs
+          when the sentinel actually matches a pixel; an integer
+          buffer surviving means "no pixels were masked").
+        * ``False`` when the caller passed ``mask_nodata=False``
+          (buffer keeps the literal sentinel) or when there is no
+          declared sentinel.
+
+        The ``final_dtype`` is taken from ``dtype_request`` when a
+        caller cast was requested (the cast lands AFTER masking, so
+        the final dtype is the request), otherwise from
+        ``dtype_in``. This mirrors the eager finalizer ordering in
+        ``_finalize_eager_read``.
+        """
+        if self.declared is None or not mask_nodata:
+            return False
+        final_dtype = self._final_dtype()
+        if final_dtype is None:
+            return False
+        return final_dtype.kind == 'f'
+
+    def _final_dtype(self) -> Optional[np.dtype]:
+        """The dtype the buffer will have at the end of read finalization.
+
+        Caller cast wins (it runs after masking). Otherwise the masking
+        step may promote integer -> float64 when the sentinel matches a
+        pixel; we cannot answer that without scanning, so the helper
+        approximates with the input dtype. ``masking_occurred`` checks
+        for ``kind == 'f'`` which is True iff (a) caller cast to a float
+        dtype, (b) the source was already float, or (c) the integer
+        promotion path actually fired. Returning the input dtype keeps
+        the gate consistent with the existing call sites.
+        """
+        if self.dtype_request is not None:
+            return np.dtype(self.dtype_request)
+        if self.dtype_in is None:
+            return None
+        return np.dtype(self.dtype_in)
+
+    @property
+    def dtype_cast_occurred(self) -> bool:
+        """True iff the caller requested an explicit dtype cast on read.
+
+        Used to populate ``attrs['nodata_dtype_cast']`` (#2135). The
+        attr is omitted when False.
+        """
+        return self.dtype_request is not None
+
+    @property
+    def cast_dtype_name(self) -> Optional[str]:
+        """The string dtype name to record on ``attrs['nodata_dtype_cast']``.
+
+        ``None`` when no caller cast happened; otherwise the canonical
+        dtype name (e.g. ``"float64"``). Pairs with
+        ``dtype_cast_occurred`` -- when that is False, this is None.
+        """
+        if self.dtype_request is None:
+            return None
+        return np.dtype(self.dtype_request).name
+
+    # ------------------------------------------------------------------
+    # Writer-side decision
+    # ------------------------------------------------------------------
+    def writer_restore_sentinel(
+        self,
+        *,
+        buffer_dtype: np.dtype,
+        masked_nodata_attr: Optional[bool] = None,
+    ) -> bool:
+        """Return True iff the writer should NaN-to-sentinel rewrite.
+
+        Mirrors ``_attrs._should_restore_nan_sentinel`` plus the
+        per-writer dtype/finite gates so the inline check in the
+        writer collapses to one helper call:
+
+        * No declared sentinel -> False (nothing to restore).
+        * Buffer dtype not float -> False (no NaN to convert).
+        * Sentinel itself is NaN -> False (NaN -> NaN is a no-op
+          and the dtype.type(NaN) cast on integer fallbacks is
+          undefined; the current writer's ``not np.isnan(nodata)``
+          gate matches this).
+        * ``masked_nodata`` attr explicitly ``False`` -> False
+          (issue #1988: the read path did NOT mask, so any NaN in
+          the buffer was put there by the user for other reasons;
+          rewriting would corrupt their data).
+        * Otherwise True (pre-#1988 default).
+
+        ``masked_nodata_attr`` is the value read off
+        ``attrs['masked_nodata']`` by the caller. ``None`` means the
+        attr was absent (the pre-#1988 default applies). Pass ``False``
+        explicitly only when the attr was literal ``False`` -- truthy
+        values and absence both collapse to the True default.
+        """
+        if self.declared is None:
+            return False
+        if buffer_dtype is None or np.dtype(buffer_dtype).kind != 'f':
+            return False
+        # NaN sentinel: no rewrite needed (NaN already matches NaN).
+        try:
+            if np.isnan(self.declared):
+                return False
+        except TypeError:
+            # Non-numeric sentinel (defensive; validators reject this
+            # upstream). Treat as "do not restore" rather than crash.
+            return False
+        return masked_nodata_attr is not False

--- a/xrspatial/geotiff/_nodata.py
+++ b/xrspatial/geotiff/_nodata.py
@@ -161,6 +161,23 @@ class NodataLifecycle:
         / writer assigns this attribute on the lifecycle instance
         after the per-buffer scan completes; downstream attrs
         propagation reads it back.
+
+    Notes
+    -----
+    The ``pixels_present`` slot is reserved for callers that want a
+    single lifecycle instance to thread the scan result through to the
+    attrs-stamping step. The current backends still read the value off
+    a per-call ``nodata_pixels_present`` local because the helper
+    arrived after the existing scan plumbing was in place; the slot is
+    available for sites that migrate to the lifecycle-owned shape in
+    follow-up work.
+
+    ``masking_occurred`` cannot tell "int promoted to float by masking"
+    from "still int because the sentinel never matched a pixel" --
+    decisions live on the helper, not pixel data. The eager finalizer
+    side-steps this by computing its ``masked_nodata`` attr from the
+    final buffer dtype after masking ran; treat ``masking_occurred`` as
+    a pre-execution policy answer, not a post-execution oracle.
     """
 
     declared: Any
@@ -300,6 +317,7 @@ class NodataLifecycle:
         *,
         buffer_dtype: np.dtype,
         masked_nodata_attr: Optional[bool] = None,
+        restore_sentinel: bool = True,
     ) -> bool:
         """Return True iff the writer should NaN-to-sentinel rewrite.
 
@@ -307,6 +325,11 @@ class NodataLifecycle:
         per-writer dtype/finite gates so the inline check in the
         writer collapses to one helper call:
 
+        * ``restore_sentinel`` False -> False. The caller already
+          resolved the ``attrs['masked_nodata']`` gate upstream and
+          cached the result in a local. Pass it through directly to
+          short-circuit; the writer call sites keep one bool rather
+          than reverse-encoding it back into ``masked_nodata_attr``.
         * No declared sentinel -> False (nothing to restore).
         * Buffer dtype not float -> False (no NaN to convert).
         * Sentinel itself is NaN -> False (NaN -> NaN is a no-op
@@ -323,8 +346,13 @@ class NodataLifecycle:
         ``attrs['masked_nodata']`` by the caller. ``None`` means the
         attr was absent (the pre-#1988 default applies). Pass ``False``
         explicitly only when the attr was literal ``False`` -- truthy
-        values and absence both collapse to the True default.
+        values and absence both collapse to the True default. Callers
+        that already collapsed the attr via
+        ``_should_restore_nan_sentinel`` should use the
+        ``restore_sentinel`` kwarg instead of reconstructing the attr.
         """
+        if not restore_sentinel:
+            return False
         if self.declared is None:
             return False
         if buffer_dtype is None or np.dtype(buffer_dtype).kind != 'f':

--- a/xrspatial/geotiff/_writers/eager.py
+++ b/xrspatial/geotiff/_writers/eager.py
@@ -856,8 +856,19 @@ def to_geotiff(data: xr.DataArray | np.ndarray,
     # ``np.asarray(raw)`` of a caller-owned numpy DataArray (a view,
     # not a copy) or ``np.moveaxis(arr, 0, -1)`` of one (also a view).
     # Mutating without a copy would corrupt the user's input buffer.
-    if (nodata is not None and arr.dtype.kind == 'f'
-            and not np.isnan(nodata) and restore_sentinel):
+    #
+    # PR-C #2226: ``NodataLifecycle.writer_restore_sentinel`` owns the
+    # "should we restore?" decision (no declared sentinel, non-float
+    # buffer, NaN sentinel all collapse to False there). The
+    # ``restore_sentinel`` local was resolved upstream from
+    # ``attrs['masked_nodata']`` (issue #1988); passing it as the
+    # ``masked_nodata_attr`` keeps the lifecycle helper authoritative
+    # for the whole gate.
+    from .._nodata import NodataLifecycle as _NL
+    if _NL(declared=nodata, dtype_in=arr.dtype).writer_restore_sentinel(
+            buffer_dtype=arr.dtype,
+            masked_nodata_attr=False if not restore_sentinel else None,
+    ):
         nan_mask = np.isnan(arr)
         if nan_mask.any():
             arr = arr.copy()
@@ -953,8 +964,14 @@ def _write_single_tile(chunk_data, path, geo_transform, epsg, wkt,
     # from ``np.asarray(chunk_data)`` where ``chunk_data`` may be a
     # caller-owned numpy buffer. Mutating without a copy would corrupt
     # the user's input.
-    if (nodata is not None and arr.dtype.kind == 'f'
-            and not np.isnan(nodata) and restore_sentinel):
+    #
+    # PR-C #2226: ``NodataLifecycle.writer_restore_sentinel`` owns the
+    # gate; see the matching block in ``to_geotiff`` above.
+    from .._nodata import NodataLifecycle as _NL
+    if _NL(declared=nodata, dtype_in=arr.dtype).writer_restore_sentinel(
+            buffer_dtype=arr.dtype,
+            masked_nodata_attr=False if not restore_sentinel else None,
+    ):
         nan_mask = np.isnan(arr)
         if nan_mask.any():
             arr = arr.copy()

--- a/xrspatial/geotiff/_writers/eager.py
+++ b/xrspatial/geotiff/_writers/eager.py
@@ -39,6 +39,7 @@ from .._coords import (
 )
 from .._crs import _validate_crs_arg, _validate_crs_fallback, _wkt_to_epsg
 from .._geotags import GeoTransform, RASTER_PIXEL_IS_AREA
+from .._nodata import NodataLifecycle as _NL
 from .._runtime import (
     GeoTIFFFallbackWarning,
     _geotiff_strict_mode,
@@ -861,13 +862,11 @@ def to_geotiff(data: xr.DataArray | np.ndarray,
     # "should we restore?" decision (no declared sentinel, non-float
     # buffer, NaN sentinel all collapse to False there). The
     # ``restore_sentinel`` local was resolved upstream from
-    # ``attrs['masked_nodata']`` (issue #1988); passing it as the
-    # ``masked_nodata_attr`` keeps the lifecycle helper authoritative
-    # for the whole gate.
-    from .._nodata import NodataLifecycle as _NL
+    # ``attrs['masked_nodata']`` (issue #1988) and is passed through
+    # the helper's ``restore_sentinel=`` kwarg as a single bool.
     if _NL(declared=nodata, dtype_in=arr.dtype).writer_restore_sentinel(
             buffer_dtype=arr.dtype,
-            masked_nodata_attr=False if not restore_sentinel else None,
+            restore_sentinel=restore_sentinel,
     ):
         nan_mask = np.isnan(arr)
         if nan_mask.any():
@@ -967,10 +966,9 @@ def _write_single_tile(chunk_data, path, geo_transform, epsg, wkt,
     #
     # PR-C #2226: ``NodataLifecycle.writer_restore_sentinel`` owns the
     # gate; see the matching block in ``to_geotiff`` above.
-    from .._nodata import NodataLifecycle as _NL
     if _NL(declared=nodata, dtype_in=arr.dtype).writer_restore_sentinel(
             buffer_dtype=arr.dtype,
-            masked_nodata_attr=False if not restore_sentinel else None,
+            restore_sentinel=restore_sentinel,
     ):
         nan_mask = np.isnan(arr)
         if nan_mask.any():

--- a/xrspatial/geotiff/_writers/gpu.py
+++ b/xrspatial/geotiff/_writers/gpu.py
@@ -31,6 +31,7 @@ from .._coords import (
     transform_from_attr as _transform_from_attr,
 )
 from .._crs import _validate_crs_arg, _validate_crs_fallback, _wkt_to_epsg
+from .._nodata import NodataLifecycle as _NL
 from .._runtime import GeoTIFFFallbackWarning, _resolve_spatial_coords
 from .._validation import (
     _validate_3d_writer_dims,
@@ -578,10 +579,9 @@ def write_geotiff_gpu(data: xr.DataArray | cupy.ndarray | np.ndarray,
     # path, and it guarantees the CPU writer's defensive-copy semantics
     # in every case.
     # PR-C #2226: shared NodataLifecycle gate for NaN->sentinel restore.
-    from .._nodata import NodataLifecycle as _NL
     if _NL(declared=nodata, dtype_in=np_dtype).writer_restore_sentinel(
             buffer_dtype=np_dtype,
-            masked_nodata_attr=False if not restore_sentinel else None,
+            restore_sentinel=restore_sentinel,
     ):
         nan_mask = cupy.isnan(arr)
         if bool(nan_mask.any()):
@@ -666,7 +666,7 @@ def write_geotiff_gpu(data: xr.DataArray | cupy.ndarray | np.ndarray,
             declared=nodata, dtype_in=np_dtype,
         ).writer_restore_sentinel(
             buffer_dtype=np_dtype,
-            masked_nodata_attr=False if not restore_sentinel else None,
+            restore_sentinel=restore_sentinel,
         )
         sentinel_scalar = (
             np_dtype.type(nodata) if rewrite_nodata else None

--- a/xrspatial/geotiff/_writers/gpu.py
+++ b/xrspatial/geotiff/_writers/gpu.py
@@ -577,10 +577,12 @@ def write_geotiff_gpu(data: xr.DataArray | cupy.ndarray | np.ndarray,
     # the cost is one GPU array allocation, only on the NaN-present
     # path, and it guarantees the CPU writer's defensive-copy semantics
     # in every case.
-    if (nodata is not None
-            and np_dtype.kind == 'f'
-            and not np.isnan(float(nodata))
-            and restore_sentinel):
+    # PR-C #2226: shared NodataLifecycle gate for NaN->sentinel restore.
+    from .._nodata import NodataLifecycle as _NL
+    if _NL(declared=nodata, dtype_in=np_dtype).writer_restore_sentinel(
+            buffer_dtype=np_dtype,
+            masked_nodata_attr=False if not restore_sentinel else None,
+    ):
         nan_mask = cupy.isnan(arr)
         if bool(nan_mask.any()):
             arr = arr.copy()
@@ -657,11 +659,14 @@ def write_geotiff_gpu(data: xr.DataArray | cupy.ndarray | np.ndarray,
         # ``make_overview_gpu`` preserves dtype, so the sentinel cast is
         # loop-invariant. Hoist it (and the float/finite gate) out of the
         # inner ``while`` to skip redundant per-level scalar work.
-        rewrite_nodata = (
-            nodata is not None
-            and np_dtype.kind == 'f'
-            and not np.isnan(float(nodata))
-            and restore_sentinel
+        # PR-C #2226: lifecycle's writer_restore_sentinel mirrors the
+        # gate used for the full-resolution rewrite above so the
+        # overview loop stays in sync with the base rewrite.
+        rewrite_nodata = _NL(
+            declared=nodata, dtype_in=np_dtype,
+        ).writer_restore_sentinel(
+            buffer_dtype=np_dtype,
+            masked_nodata_attr=False if not restore_sentinel else None,
         )
         sentinel_scalar = (
             np_dtype.type(nodata) if rewrite_nodata else None

--- a/xrspatial/geotiff/tests/test_nodata_lifecycle_parity_2211.py
+++ b/xrspatial/geotiff/tests/test_nodata_lifecycle_parity_2211.py
@@ -281,6 +281,70 @@ class TestWriterRestoreSentinelDecision:
             masked_nodata_attr=None,
         ) is True
 
+    def test_restore_sentinel_false_short_circuits(self):
+        # ``restore_sentinel=False`` caller opt-out (the cached attr
+        # answer from ``_should_restore_nan_sentinel``) must win over
+        # the otherwise-True default path.
+        lc = NodataLifecycle(declared=-9999.0, dtype_in=np.dtype("float32"))
+        assert lc.writer_restore_sentinel(
+            buffer_dtype=np.dtype("float32"),
+            restore_sentinel=False,
+        ) is False
+
+    def test_restore_sentinel_true_is_default(self):
+        lc = NodataLifecycle(declared=-9999.0, dtype_in=np.dtype("float32"))
+        # Explicit True matches the default (kwarg omitted).
+        assert lc.writer_restore_sentinel(
+            buffer_dtype=np.dtype("float32"),
+            restore_sentinel=True,
+        ) is True
+
+
+class TestInvertForMinIsWhiteLockstep:
+    """``_invert_for_miniswhite`` mirrors ``_reader._miniswhite_inverted_nodata``.
+
+    The two functions intentionally duplicate the inversion math so the
+    lifecycle helper does not pull ``_reader`` into its dependency
+    graph. Sweep a wide sentinel / dtype grid here so drift between the
+    two surfaces fast.
+    """
+
+    def test_grid_matches_reader_helper(self):
+        from xrspatial.geotiff._nodata import _invert_for_miniswhite
+        from xrspatial.geotiff._reader import _miniswhite_inverted_nodata
+
+        class _IFDStub:
+            photometric = 0
+            samples_per_pixel = 1
+
+        sentinels = [
+            0, 1, 10, 127, 128, 255,        # uint8 range
+            256, 1000, 32767, 65535,        # uint16 range
+            -1, -9999,                      # out of unsigned range
+            0.0, 1.5, 3.5, -3.5,            # float values
+            float("nan"), float("inf"),     # non-finite
+        ]
+        dtypes = [
+            np.dtype("uint8"),
+            np.dtype("uint16"),
+            np.dtype("uint32"),
+            np.dtype("int16"),
+            np.dtype("float32"),
+            np.dtype("float64"),
+        ]
+        for s in sentinels:
+            for d in dtypes:
+                ref = _miniswhite_inverted_nodata(s, _IFDStub, d)
+                got = _invert_for_miniswhite(s, d)
+                if isinstance(ref, float) and np.isnan(ref):
+                    assert isinstance(got, float) and np.isnan(got), (
+                        f"sentinel={s} dtype={d}: ref=NaN, got={got!r}"
+                    )
+                else:
+                    assert ref == got, (
+                        f"sentinel={s} dtype={d}: ref={ref!r}, got={got!r}"
+                    )
+
 
 class TestPixelsPresentSlot:
     """``pixels_present`` is a settable slot; constructor leaves it None."""
@@ -651,6 +715,7 @@ class TestExplicitDtypeRequestParity:
 @pytest.fixture
 def simple_vrt(tmp_path):
     """A trivial VRT wrapping a single GeoTIFF with a -9999 sentinel."""
+    import os
     import xarray as xr
 
     from xrspatial.geotiff import to_geotiff
@@ -673,7 +738,7 @@ def simple_vrt(tmp_path):
   <VRTRasterBand dataType="Float32" band="1">
     <NoDataValue>-9999</NoDataValue>
     <SimpleSource>
-      <SourceFilename relativeToVRT="1">{src.rsplit("/", 1)[-1]}</SourceFilename>
+      <SourceFilename relativeToVRT="1">{os.path.basename(src)}</SourceFilename>
       <SourceBand>1</SourceBand>
       <SrcRect xOff="0" yOff="0" xSize="3" ySize="2"/>
       <DstRect xOff="0" yOff="0" xSize="3" ySize="2"/>

--- a/xrspatial/geotiff/tests/test_nodata_lifecycle_parity_2211.py
+++ b/xrspatial/geotiff/tests/test_nodata_lifecycle_parity_2211.py
@@ -1,0 +1,789 @@
+"""Cross-backend parity tests for the centralized NodataLifecycle (#2226).
+
+PR-C of epic #2211. The lifecycle helper in ``xrspatial.geotiff._nodata``
+owns the decisions (raw sentinel, post-MinIsWhite effective sentinel,
+``sentinel_fits_buffer``, ``masking_occurred``, ``dtype_cast_occurred``,
+``writer_restore_sentinel``) previously inlined across the geotiff
+backends. These tests pin the decision contract directly AND check the
+public read/write paths produce the same lifecycle attrs across eager
+NumPy, Dask, GPU (skip if no CUDA), and VRT eager backends.
+
+Covers:
+* integer sentinel
+* float sentinel
+* NaN sentinel
+* out-of-range sentinel (uint16 + -9999)
+* MinIsWhite photometric inversion (single-band, photometric=0)
+* ``mask_nodata=False``
+* explicit ``dtype=`` kwarg
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import numpy as np
+import pytest
+
+from xrspatial.geotiff._nodata import NodataLifecycle
+
+
+# ---------------------------------------------------------------------------
+# Skip helpers (loud, not silent: a missing-cupy test reports the skip reason)
+# ---------------------------------------------------------------------------
+
+def _gpu_available() -> bool:
+    if importlib.util.find_spec("cupy") is None:
+        return False
+    try:
+        import cupy
+
+        return bool(cupy.cuda.is_available())
+    except Exception:
+        return False
+
+
+_HAS_GPU = _gpu_available()
+_gpu_only = pytest.mark.skipif(
+    not _HAS_GPU,
+    reason="cupy + CUDA required for NodataLifecycle GPU parity (PR-C #2226)",
+)
+
+
+# ===========================================================================
+# Direct unit tests on NodataLifecycle's decisions
+# ===========================================================================
+
+class TestRawSentinelExposure:
+    """``raw_sentinel`` is the declared value, not the inverted one."""
+
+    def test_returns_declared_when_no_photometric(self):
+        lc = NodataLifecycle(declared=-9999, dtype_in=np.dtype("int16"))
+        assert lc.raw_sentinel == -9999
+
+    def test_returns_declared_under_miniswhite(self):
+        # Even when MinIsWhite would invert the effective sentinel, the
+        # raw sentinel must remain the original (so attrs['nodata']
+        # preserves the on-disk value for write round-trip).
+        lc = NodataLifecycle(
+            declared=10,
+            photometric=0,
+            dtype_in=np.dtype("uint8"),
+            samples_per_pixel=1,
+        )
+        assert lc.raw_sentinel == 10
+
+    def test_none_passes_through(self):
+        lc = NodataLifecycle(declared=None, dtype_in=np.dtype("float32"))
+        assert lc.raw_sentinel is None
+
+
+class TestEffectiveSentinelUnderMinIsWhite:
+    """``effective_sentinel`` mirrors ``_reader._miniswhite_inverted_nodata``."""
+
+    def test_uint_inverts_to_iinfo_max_minus_value(self):
+        lc = NodataLifecycle(
+            declared=10,
+            photometric=0,
+            dtype_in=np.dtype("uint8"),
+            samples_per_pixel=1,
+        )
+        # 255 - 10 = 245 (TIFF6 MinIsWhite semantics)
+        assert lc.effective_sentinel == 245
+
+    def test_float_inverts_to_negation(self):
+        lc = NodataLifecycle(
+            declared=3.5,
+            photometric=0,
+            dtype_in=np.dtype("float32"),
+            samples_per_pixel=1,
+        )
+        assert lc.effective_sentinel == -3.5
+
+    def test_nan_passes_unchanged(self):
+        lc = NodataLifecycle(
+            declared=float("nan"),
+            photometric=0,
+            dtype_in=np.dtype("float32"),
+            samples_per_pixel=1,
+        )
+        assert np.isnan(lc.effective_sentinel)
+
+    def test_multiband_photometric_zero_is_not_miniswhite(self):
+        # Multi-band photometric=0 is a different TIFF case from
+        # single-band MinIsWhite; the reader's gate is
+        # ``photometric == 0 AND samples_per_pixel == 1``.
+        lc = NodataLifecycle(
+            declared=10,
+            photometric=0,
+            dtype_in=np.dtype("uint8"),
+            samples_per_pixel=3,
+        )
+        assert lc.effective_sentinel == 10
+
+    def test_photometric_one_minisblack_no_inversion(self):
+        lc = NodataLifecycle(
+            declared=10,
+            photometric=1,
+            dtype_in=np.dtype("uint8"),
+            samples_per_pixel=1,
+        )
+        assert lc.effective_sentinel == 10
+
+    def test_out_of_range_sentinel_stays_unchanged(self):
+        # uint16 + nodata=-9999: cannot be represented, mirror reader.
+        lc = NodataLifecycle(
+            declared=-9999,
+            photometric=0,
+            dtype_in=np.dtype("uint16"),
+            samples_per_pixel=1,
+        )
+        assert lc.effective_sentinel == -9999
+
+
+class TestSentinelFitsBuffer:
+    """``sentinel_fits_buffer`` collapses finite + integer + in-range gates."""
+
+    def test_int_in_range(self):
+        lc = NodataLifecycle(declared=0, dtype_in=np.dtype("uint8"))
+        assert lc.sentinel_fits_buffer is True
+
+    def test_int_out_of_range(self):
+        # uint16 + -9999: cannot match.
+        lc = NodataLifecycle(declared=-9999, dtype_in=np.dtype("uint16"))
+        assert lc.sentinel_fits_buffer is False
+
+    def test_int_fractional(self):
+        # 3.5 on uint16 -> int(3.5) would truncate to 3 and false-flag
+        # a real pixel value; helper must reject it.
+        lc = NodataLifecycle(declared=3.5, dtype_in=np.dtype("uint16"))
+        assert lc.sentinel_fits_buffer is False
+
+    def test_int_non_finite(self):
+        lc = NodataLifecycle(declared=float("nan"), dtype_in=np.dtype("uint8"))
+        assert lc.sentinel_fits_buffer is False
+        lc2 = NodataLifecycle(declared=float("inf"), dtype_in=np.dtype("uint8"))
+        assert lc2.sentinel_fits_buffer is False
+
+    def test_float_dtype_always_fits(self):
+        lc = NodataLifecycle(declared=-9999.0, dtype_in=np.dtype("float32"))
+        assert lc.sentinel_fits_buffer is True
+        lc2 = NodataLifecycle(
+            declared=float("nan"), dtype_in=np.dtype("float32"),
+        )
+        assert lc2.sentinel_fits_buffer is True
+
+    def test_none_does_not_fit(self):
+        lc = NodataLifecycle(declared=None, dtype_in=np.dtype("uint8"))
+        assert lc.sentinel_fits_buffer is False
+
+
+class TestMaskingOccurredDecision:
+    """``masking_occurred`` mirrors the call sites' attr-stamping rule."""
+
+    def test_no_sentinel_returns_false(self):
+        lc = NodataLifecycle(declared=None, dtype_in=np.dtype("float32"))
+        assert lc.masking_occurred(mask_nodata=True) is False
+
+    def test_mask_nodata_false_returns_false(self):
+        lc = NodataLifecycle(declared=-9999.0, dtype_in=np.dtype("float32"))
+        assert lc.masking_occurred(mask_nodata=False) is False
+
+    def test_float_buffer_with_sentinel_returns_true(self):
+        lc = NodataLifecycle(declared=-9999.0, dtype_in=np.dtype("float32"))
+        assert lc.masking_occurred(mask_nodata=True) is True
+
+    def test_integer_buffer_returns_false(self):
+        # Integer buffer surviving means no promotion -> no pixels masked.
+        lc = NodataLifecycle(declared=0, dtype_in=np.dtype("uint8"))
+        assert lc.masking_occurred(mask_nodata=True) is False
+
+    def test_explicit_float_cast_returns_true(self):
+        # Caller cast to float, so the final buffer is float and the
+        # mask-occurred attr stays True.
+        lc = NodataLifecycle(
+            declared=0,
+            dtype_in=np.dtype("uint8"),
+            dtype_request=np.dtype("float64"),
+        )
+        assert lc.masking_occurred(mask_nodata=True) is True
+
+
+class TestDtypeCastDecision:
+    """``dtype_cast_occurred`` / ``cast_dtype_name`` reflect caller intent."""
+
+    def test_no_request_returns_false(self):
+        lc = NodataLifecycle(declared=0, dtype_in=np.dtype("uint8"))
+        assert lc.dtype_cast_occurred is False
+        assert lc.cast_dtype_name is None
+
+    def test_request_records_name(self):
+        lc = NodataLifecycle(
+            declared=0,
+            dtype_in=np.dtype("uint8"),
+            dtype_request="float64",
+        )
+        assert lc.dtype_cast_occurred is True
+        assert lc.cast_dtype_name == "float64"
+
+
+class TestWriterRestoreSentinelDecision:
+    """``writer_restore_sentinel`` mirrors the in-line write-side gate."""
+
+    def test_no_declared_returns_false(self):
+        lc = NodataLifecycle(declared=None, dtype_in=np.dtype("float32"))
+        assert lc.writer_restore_sentinel(
+            buffer_dtype=np.dtype("float32"),
+        ) is False
+
+    def test_non_float_buffer_returns_false(self):
+        lc = NodataLifecycle(declared=0, dtype_in=np.dtype("uint8"))
+        assert lc.writer_restore_sentinel(
+            buffer_dtype=np.dtype("uint8"),
+        ) is False
+
+    def test_nan_sentinel_returns_false(self):
+        lc = NodataLifecycle(
+            declared=float("nan"), dtype_in=np.dtype("float32"),
+        )
+        assert lc.writer_restore_sentinel(
+            buffer_dtype=np.dtype("float32"),
+        ) is False
+
+    def test_finite_float_sentinel_returns_true(self):
+        lc = NodataLifecycle(declared=-9999.0, dtype_in=np.dtype("float32"))
+        assert lc.writer_restore_sentinel(
+            buffer_dtype=np.dtype("float32"),
+        ) is True
+
+    def test_masked_nodata_attr_false_returns_false(self):
+        # Mirrors issue #1988: literal False on attrs['masked_nodata']
+        # tells the writer the read path did NOT mask, so the in-buffer
+        # NaN must NOT be rewritten to the sentinel.
+        lc = NodataLifecycle(declared=-9999.0, dtype_in=np.dtype("float32"))
+        assert lc.writer_restore_sentinel(
+            buffer_dtype=np.dtype("float32"),
+            masked_nodata_attr=False,
+        ) is False
+
+    def test_masked_nodata_attr_true_returns_true(self):
+        lc = NodataLifecycle(declared=-9999.0, dtype_in=np.dtype("float32"))
+        assert lc.writer_restore_sentinel(
+            buffer_dtype=np.dtype("float32"),
+            masked_nodata_attr=True,
+        ) is True
+
+    def test_masked_nodata_attr_none_defaults_true(self):
+        # Attr absent -> pre-#1988 default (True).
+        lc = NodataLifecycle(declared=-9999.0, dtype_in=np.dtype("float32"))
+        assert lc.writer_restore_sentinel(
+            buffer_dtype=np.dtype("float32"),
+            masked_nodata_attr=None,
+        ) is True
+
+
+class TestPixelsPresentSlot:
+    """``pixels_present`` is a settable slot; constructor leaves it None."""
+
+    def test_default_none(self):
+        lc = NodataLifecycle(declared=0, dtype_in=np.dtype("uint8"))
+        assert lc.pixels_present is None
+
+    def test_settable(self):
+        lc = NodataLifecycle(declared=0, dtype_in=np.dtype("uint8"))
+        lc.pixels_present = True
+        assert lc.pixels_present is True
+        lc.pixels_present = False
+        assert lc.pixels_present is False
+
+
+# ===========================================================================
+# Cross-backend parity through the public API
+# ===========================================================================
+
+# Helpers borrowed in spirit from test_nodata_lifecycle_attrs_2135.py:
+# build small rasters and compare the post-read lifecycle attrs across
+# the eager / dask / GPU / VRT-eager paths.
+
+def _make_int_raster(path, sentinel=255, dtype=np.uint8, plant=True):
+    """2x3 uint raster with the sentinel planted at (0, 2) when ``plant``."""
+    import xarray as xr
+
+    if plant:
+        data = np.array(
+            [[1, 2, sentinel], [4, 5, 6]], dtype=dtype,
+        )
+    else:
+        data = np.array(
+            [[1, 2, 3], [4, 5, 6]], dtype=dtype,
+        )
+    da = xr.DataArray(
+        data,
+        coords={"y": np.array([0.5, 1.5]), "x": np.array([0.5, 1.5, 2.5])},
+        dims=("y", "x"),
+        attrs={"nodata": sentinel},
+    )
+    from xrspatial.geotiff import to_geotiff
+
+    to_geotiff(da, path, nodata=sentinel)
+    return path
+
+
+def _make_float_raster(path, sentinel=-9999.0, plant=True):
+    import xarray as xr
+
+    if plant:
+        data = np.array(
+            [[1.0, 2.0, sentinel], [4.0, 5.0, 6.0]], dtype=np.float32,
+        )
+    else:
+        data = np.array(
+            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=np.float32,
+        )
+    da = xr.DataArray(
+        data,
+        coords={"y": np.array([0.5, 1.5]), "x": np.array([0.5, 1.5, 2.5])},
+        dims=("y", "x"),
+        attrs={"nodata": sentinel},
+    )
+    from xrspatial.geotiff import to_geotiff
+
+    to_geotiff(da, path, nodata=sentinel)
+    return path
+
+
+@pytest.fixture
+def int_tif(tmp_path):
+    return _make_int_raster(str(tmp_path / "int_sentinel_2226.tif"))
+
+
+@pytest.fixture
+def float_tif(tmp_path):
+    return _make_float_raster(str(tmp_path / "float_sentinel_2226.tif"))
+
+
+@pytest.fixture
+def nan_tif(tmp_path):
+    return _make_float_raster(
+        str(tmp_path / "nan_sentinel_2226.tif"),
+        sentinel=float("nan"),
+        plant=False,
+    )
+
+
+@pytest.fixture
+def oor_tif(tmp_path):
+    # uint16 + -9999: classic out-of-range sentinel that cannot match
+    # any pixel; the reader still surfaces it on attrs['nodata'].
+    path = str(tmp_path / "uint16_oor_2226.tif")
+    return _make_int_raster(
+        path, sentinel=-9999, dtype=np.uint16, plant=False,
+    )
+
+
+# ----------------------- integer sentinel -----------------------
+
+class TestIntegerSentinelParity:
+    def test_eager_masks_int_sentinel_to_nan(self, int_tif):
+        from xrspatial.geotiff import open_geotiff
+
+        da = open_geotiff(int_tif)
+        # int sentinel auto-promotes to float when at least one pixel
+        # matches, leaving NaN where the sentinel was.
+        assert da.dtype.kind == "f"
+        assert np.isnan(da.data[0, 2])
+        assert da.attrs["nodata"] == 255
+        assert da.attrs["masked_nodata"] is True
+
+    def test_dask_matches_eager(self, int_tif):
+        from xrspatial.geotiff import open_geotiff, read_geotiff_dask
+
+        eager = open_geotiff(int_tif)
+        lazy = read_geotiff_dask(int_tif, chunks=2)
+        # Same on-disk sentinel propagated.
+        assert lazy.attrs["nodata"] == eager.attrs["nodata"]
+        # Same lifecycle decision: dask graph promoted to float64.
+        assert lazy.dtype.kind == "f"
+        np.testing.assert_array_equal(
+            np.isnan(eager.data), np.isnan(lazy.compute().data),
+        )
+
+    @_gpu_only
+    def test_gpu_matches_eager(self, int_tif):
+        from xrspatial.geotiff import open_geotiff, read_geotiff_gpu
+
+        eager = open_geotiff(int_tif)
+        gpu = read_geotiff_gpu(int_tif)
+        assert gpu.attrs["nodata"] == eager.attrs["nodata"]
+        np.testing.assert_array_equal(
+            np.isnan(eager.data), np.isnan(gpu.data.get()),
+        )
+
+
+# ----------------------- float sentinel -----------------------
+
+class TestFloatSentinelParity:
+    def test_eager(self, float_tif):
+        from xrspatial.geotiff import open_geotiff
+
+        da = open_geotiff(float_tif)
+        assert da.dtype == np.float32
+        assert np.isnan(da.data[0, 2])
+        assert da.attrs["nodata"] == -9999.0
+        assert da.attrs["masked_nodata"] is True
+
+    def test_dask(self, float_tif):
+        from xrspatial.geotiff import open_geotiff, read_geotiff_dask
+
+        eager = open_geotiff(float_tif)
+        lazy = read_geotiff_dask(float_tif, chunks=2)
+        np.testing.assert_array_equal(
+            np.isnan(eager.data), np.isnan(lazy.compute().data),
+        )
+        assert lazy.attrs["nodata"] == eager.attrs["nodata"]
+
+    @_gpu_only
+    def test_gpu(self, float_tif):
+        from xrspatial.geotiff import open_geotiff, read_geotiff_gpu
+
+        eager = open_geotiff(float_tif)
+        gpu = read_geotiff_gpu(float_tif)
+        np.testing.assert_array_equal(
+            np.isnan(eager.data), np.isnan(gpu.data.get()),
+        )
+
+
+# ----------------------- NaN sentinel -----------------------
+
+class TestNaNSentinelParity:
+    def test_eager(self, nan_tif):
+        from xrspatial.geotiff import open_geotiff
+
+        da = open_geotiff(nan_tif)
+        # NaN sentinel: float buffer keeps NaN as the sentinel; no
+        # integer-to-float promotion because the source was already
+        # float, and mask sees no literal pixel match.
+        assert da.dtype == np.float32
+        assert np.isnan(da.attrs["nodata"])
+
+    def test_dask_matches(self, nan_tif):
+        from xrspatial.geotiff import read_geotiff_dask
+
+        lazy = read_geotiff_dask(nan_tif, chunks=2)
+        out = lazy.compute()
+        # Source had no NaN pixels planted, so the float buffer carries
+        # the original values.
+        assert out.dtype == np.float32
+        assert np.isnan(out.attrs["nodata"])
+
+
+# ----------------------- out-of-range integer sentinel -----------------------
+
+class TestOutOfRangeSentinelParity:
+    def test_eager_keeps_int_dtype_and_records_sentinel(self, oor_tif):
+        from xrspatial.geotiff import open_geotiff
+
+        da = open_geotiff(oor_tif)
+        # uint16 + -9999 cannot match any pixel; buffer stays integer.
+        assert da.dtype == np.uint16
+        # Sentinel still recorded for write round-trip.
+        assert int(da.attrs["nodata"]) == -9999
+
+    def test_dask_matches(self, oor_tif):
+        from xrspatial.geotiff import open_geotiff, read_geotiff_dask
+
+        eager = open_geotiff(oor_tif)
+        lazy = read_geotiff_dask(oor_tif, chunks=2)
+        assert lazy.dtype == eager.dtype
+        np.testing.assert_array_equal(
+            eager.data, lazy.compute().data,
+        )
+        assert int(lazy.attrs["nodata"]) == int(eager.attrs["nodata"])
+
+
+# ----------------------- MinIsWhite photometric -----------------------
+
+class TestMinIsWhiteSentinelInversion:
+    """Direct lifecycle check + downstream usage on a hand-built file.
+
+    Building a real MinIsWhite file through ``to_geotiff`` is supported
+    (``photometric='miniswhite'``); we use that to drive an end-to-end
+    parity check across eager + dask. The lifecycle helper's
+    ``effective_sentinel`` is what the per-chunk masking compares
+    against, so a planted sentinel pixel must mask correctly after
+    inversion.
+    """
+
+    def _build(self, path, sentinel=10):
+        import xarray as xr
+
+        from xrspatial.geotiff import to_geotiff
+
+        data = np.array(
+            [[1, 2, sentinel], [4, 5, 6]], dtype=np.uint8,
+        )
+        da = xr.DataArray(
+            data,
+            coords={
+                "y": np.array([0.5, 1.5]),
+                "x": np.array([0.5, 1.5, 2.5]),
+            },
+            dims=("y", "x"),
+            attrs={"nodata": sentinel},
+        )
+        to_geotiff(da, path, nodata=sentinel, photometric="miniswhite")
+
+    def test_eager_masks_inverted_sentinel(self, tmp_path):
+        from xrspatial.geotiff import open_geotiff
+
+        path = str(tmp_path / "miw_2226.tif")
+        self._build(path)
+        da = open_geotiff(path)
+        # The MinIsWhite writer pre-inverts both pixels AND the sentinel
+        # (see ``_writer._invert_nodata_for_miniswhite``), so the on-disk
+        # GDAL_NODATA tag stores 245 = 255 - 10. The reader's MinIsWhite
+        # inversion runs on read; the reader's downstream mask compares
+        # against the post-inversion sentinel (10 again) and rewrites the
+        # planted pixel to NaN. The lifecycle helper's contract requires
+        # the same effective_sentinel resolution.
+        assert np.isnan(da.data[0, 2])
+        # attrs['nodata'] carries the on-disk value (inverted by the
+        # writer); this is the documented round-trip behaviour (#1809).
+        assert int(da.attrs["nodata"]) == 245
+
+    def test_dask_matches_eager(self, tmp_path):
+        from xrspatial.geotiff import open_geotiff, read_geotiff_dask
+
+        path = str(tmp_path / "miw_dask_2226.tif")
+        self._build(path)
+        eager = open_geotiff(path)
+        lazy = read_geotiff_dask(path, chunks=2)
+        np.testing.assert_array_equal(
+            np.isnan(eager.data), np.isnan(lazy.compute().data),
+        )
+        assert lazy.attrs["nodata"] == eager.attrs["nodata"]
+
+    def test_lifecycle_effective_sentinel_matches_reader_helper(self):
+        from xrspatial.geotiff._reader import _miniswhite_inverted_nodata
+
+        # Synthesize an IFD-like object for the legacy helper. Only
+        # ``photometric`` and ``samples_per_pixel`` are read; build a
+        # minimal stand-in rather than constructing a real IFD.
+        class _IFDStub:
+            photometric = 0
+            samples_per_pixel = 1
+
+        for sentinel, dtype in [
+            (10, np.dtype("uint8")),
+            (-9999, np.dtype("uint16")),  # out of range -> unchanged
+            (3.5, np.dtype("float32")),
+            (float("nan"), np.dtype("float32")),
+        ]:
+            ref = _miniswhite_inverted_nodata(sentinel, _IFDStub, dtype)
+            lc = NodataLifecycle(
+                declared=sentinel,
+                photometric=0,
+                dtype_in=dtype,
+                samples_per_pixel=1,
+            )
+            if isinstance(ref, float) and np.isnan(ref):
+                assert np.isnan(lc.effective_sentinel)
+            else:
+                assert lc.effective_sentinel == ref, (
+                    f"sentinel={sentinel} dtype={dtype}: ref={ref}, "
+                    f"lifecycle={lc.effective_sentinel}"
+                )
+
+
+# ----------------------- mask_nodata=False -----------------------
+
+class TestMaskNodataFalseParity:
+    def test_eager_keeps_literal_sentinel(self, int_tif):
+        from xrspatial.geotiff import open_geotiff
+
+        da = open_geotiff(int_tif, mask_nodata=False)
+        # Buffer keeps integer dtype + literal sentinel pixel (255).
+        assert da.dtype == np.uint8
+        assert int(da.data[0, 2]) == 255
+        # Lifecycle attr says masking did NOT occur.
+        assert da.attrs["masked_nodata"] is False
+
+    def test_dask_keeps_literal_sentinel(self, int_tif):
+        from xrspatial.geotiff import read_geotiff_dask
+
+        lazy = read_geotiff_dask(int_tif, chunks=2, mask_nodata=False)
+        out = lazy.compute()
+        assert out.dtype == np.uint8
+        assert int(out.data[0, 2]) == 255
+        assert lazy.attrs["masked_nodata"] is False
+
+    @_gpu_only
+    def test_gpu_keeps_literal_sentinel(self, int_tif):
+        from xrspatial.geotiff import read_geotiff_gpu
+
+        gpu = read_geotiff_gpu(int_tif, mask_nodata=False)
+        host = gpu.data.get()
+        assert host.dtype == np.uint8
+        assert int(host[0, 2]) == 255
+        assert gpu.attrs["masked_nodata"] is False
+
+
+# ----------------------- explicit dtype= -----------------------
+
+class TestExplicitDtypeRequestParity:
+    def test_eager_records_dtype_cast(self, int_tif):
+        from xrspatial.geotiff import open_geotiff
+
+        da = open_geotiff(int_tif, dtype="float64")
+        assert da.dtype == np.float64
+        assert da.attrs.get("nodata_dtype_cast") == "float64"
+
+    def test_dask_records_dtype_cast(self, int_tif):
+        from xrspatial.geotiff import read_geotiff_dask
+
+        lazy = read_geotiff_dask(int_tif, chunks=2, dtype="float64")
+        assert lazy.dtype == np.float64
+        assert lazy.attrs.get("nodata_dtype_cast") == "float64"
+
+
+# ----------------------- VRT eager -----------------------
+
+@pytest.fixture
+def simple_vrt(tmp_path):
+    """A trivial VRT wrapping a single GeoTIFF with a -9999 sentinel."""
+    import xarray as xr
+
+    from xrspatial.geotiff import to_geotiff
+
+    src = str(tmp_path / "vrt_src_2226.tif")
+    data = np.array(
+        [[1.0, 2.0, -9999.0], [4.0, 5.0, 6.0]], dtype=np.float32,
+    )
+    da = xr.DataArray(
+        data,
+        coords={"y": np.array([0.5, 1.5]), "x": np.array([0.5, 1.5, 2.5])},
+        dims=("y", "x"),
+        attrs={"nodata": -9999.0},
+    )
+    to_geotiff(da, src, nodata=-9999.0)
+
+    vrt = str(tmp_path / "vrt_eager_2226.vrt")
+    xml = f"""<VRTDataset rasterXSize="3" rasterYSize="2">
+  <GeoTransform>  0.0,  1.0,  0.0,  0.0,  0.0, 1.0</GeoTransform>
+  <VRTRasterBand dataType="Float32" band="1">
+    <NoDataValue>-9999</NoDataValue>
+    <SimpleSource>
+      <SourceFilename relativeToVRT="1">{src.rsplit("/", 1)[-1]}</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <SrcRect xOff="0" yOff="0" xSize="3" ySize="2"/>
+      <DstRect xOff="0" yOff="0" xSize="3" ySize="2"/>
+    </SimpleSource>
+  </VRTRasterBand>
+</VRTDataset>
+"""
+    with open(vrt, "w") as f:
+        f.write(xml)
+    return vrt
+
+
+class TestVRTEagerParity:
+    def test_vrt_masks_sentinel_to_nan(self, simple_vrt):
+        from xrspatial.geotiff import read_vrt
+
+        da = read_vrt(simple_vrt)
+        assert da.dtype.kind == "f"
+        assert np.isnan(da.data[0, 2])
+
+    def test_vrt_mask_nodata_false_keeps_literal(self, simple_vrt):
+        from xrspatial.geotiff import read_vrt
+
+        da = read_vrt(simple_vrt, mask_nodata=False)
+        # Literal -9999 survives in the float buffer.
+        assert da.data[0, 2] == -9999.0
+        assert da.attrs.get("masked_nodata") is False
+
+
+# ===========================================================================
+# Writer-side restore decision parity
+# ===========================================================================
+
+class TestWriterRestoreParity:
+    """Round-trip a float raster with NaN pixels through the writer.
+
+    The lifecycle's ``writer_restore_sentinel`` controls whether NaN
+    pixels are rewritten to the integer / float sentinel on disk. The
+    eager and (when available) GPU writer must agree.
+    """
+
+    def test_eager_restores_nan_to_sentinel(self, tmp_path):
+        import xarray as xr
+
+        from xrspatial.geotiff import open_geotiff, to_geotiff
+
+        path = str(tmp_path / "restore_eager_2226.tif")
+        data = np.array(
+            [[1.0, np.nan, 3.0], [4.0, 5.0, 6.0]], dtype=np.float32,
+        )
+        da = xr.DataArray(
+            data,
+            coords={
+                "y": np.array([0.5, 1.5]),
+                "x": np.array([0.5, 1.5, 2.5]),
+            },
+            dims=("y", "x"),
+        )
+        to_geotiff(da, path, nodata=-9999.0)
+        # Read back with mask_nodata=False so we can see the literal
+        # on-disk byte value the restore step planted.
+        readback = open_geotiff(path, mask_nodata=False)
+        assert readback.data[0, 1] == -9999.0
+
+    def test_masked_nodata_false_attr_blocks_restore(self, tmp_path):
+        # Issue #1988: the reader stores masked_nodata=False to opt out
+        # of the writer's NaN->sentinel rewrite. The lifecycle's
+        # writer_restore_sentinel reads this through the
+        # ``restore_sentinel`` kwarg the writer threads in.
+        import xarray as xr
+
+        from xrspatial.geotiff import open_geotiff, to_geotiff
+
+        path = str(tmp_path / "no_restore_2226.tif")
+        data = np.array(
+            [[1.0, np.nan, 3.0], [4.0, 5.0, 6.0]], dtype=np.float32,
+        )
+        da = xr.DataArray(
+            data,
+            coords={
+                "y": np.array([0.5, 1.5]),
+                "x": np.array([0.5, 1.5, 2.5]),
+            },
+            dims=("y", "x"),
+            attrs={"nodata": -9999.0, "masked_nodata": False},
+        )
+        to_geotiff(da, path)
+        readback = open_geotiff(path, mask_nodata=False)
+        # Restore step skipped, so the NaN survives as on-disk NaN.
+        assert np.isnan(readback.data[0, 1])
+
+    @_gpu_only
+    def test_gpu_writer_matches_eager(self, tmp_path):
+        import xarray as xr
+        import cupy
+
+        from xrspatial.geotiff import open_geotiff, to_geotiff
+
+        path = str(tmp_path / "restore_gpu_2226.tif")
+        data = cupy.asarray(np.array(
+            [[1.0, np.nan, 3.0], [4.0, 5.0, 6.0]], dtype=np.float32,
+        ))
+        da = xr.DataArray(
+            data,
+            coords={
+                "y": np.array([0.5, 1.5]),
+                "x": np.array([0.5, 1.5, 2.5]),
+            },
+            dims=("y", "x"),
+        )
+        to_geotiff(da, path, nodata=-9999.0, gpu=True)
+        readback = open_geotiff(path, mask_nodata=False)
+        assert readback.data[0, 1] == -9999.0


### PR DESCRIPTION
## Summary

Adds `xrspatial/geotiff/_nodata.py` housing `NodataLifecycle`, a value
object that captures the nodata-related decisions the read and write
backends were each making inline:

- `raw_sentinel` and `effective_sentinel` (post-MinIsWhite inversion)
- `sentinel_fits_buffer` (finite + integer + in-range gate for integer dtypes)
- `masking_occurred` (the value `attrs['masked_nodata']` should carry)
- `dtype_cast_occurred` / `cast_dtype_name` (the `attrs['nodata_dtype_cast']` signal)
- `writer_restore_sentinel` (gates the writer's NaN-to-sentinel rewrite, including the `masked_nodata=False` opt-out from #1988)
- `pixels_present` slot (set by execution after the per-buffer scan)

The backends keep their array operations; the helper owns the
decisions. Affected sites:

- `_backends/dask.py`: the MinIsWhite-inversion block and the integer
  auto-promotion gate collapse to `effective_sentinel` and
  `sentinel_fits_buffer`.
- `_backends/gpu.py`: the post-MinIsWhite sentinel resolution moves
  to `effective_sentinel` instead of reaching into `_reader`.
- `_backends/_gpu_helpers.py`: `_apply_nodata_mask_gpu` uses the
  shared `_sentinel_fits_dtype` gate.
- `_writers/eager.py` and `_writers/gpu.py`: the NaN-to-sentinel
  rewrite gate (none / non-float / NaN sentinel / `masked_nodata=False`)
  routes through `writer_restore_sentinel`.

No public API change. The existing regression tests
(`test_nodata_lifecycle_attrs_2135.py`, `test_nodata_semantics_split_1988.py`,
`test_apply_nodata_mask_gpu_inplace_1934.py`) keep passing.

`_reader.py` and `_vrt.py` are left untouched in this PR to keep
PR-E (#2228, sources extraction) rebasing cheaply: those modules
already use `_miniswhite_inverted_nodata` and per-band sentinel
helpers respectively, and the lifecycle value object mirrors the
same math without forcing those large files into the diff.

## Tests

Adds `test_nodata_lifecycle_parity_2211.py` (54 cases):

- direct unit tests against every `NodataLifecycle` property and decision
- cross-backend parity for integer / float / NaN / out-of-range
  sentinels through eager NumPy, Dask, GPU (skip if no CUDA), and
  VRT eager
- MinIsWhite photometric inversion end-to-end, plus a
  property-equivalence check against `_reader._miniswhite_inverted_nodata`
- `mask_nodata=False` parity across eager / Dask / GPU
- explicit `dtype=` kwarg parity across eager / Dask
- writer-side restore: NaN restored to sentinel by default, opt-out
  via `attrs['masked_nodata']=False` honoured, GPU writer matches

GPU skips report the explicit reason (`cupy + CUDA required for
NodataLifecycle GPU parity (PR-C #2226)`) so a missing CUDA
environment is visible rather than silently passing.

## Test plan

- [x] `pytest xrspatial/geotiff/tests/test_nodata_lifecycle_parity_2211.py` (54 pass)
- [x] `pytest xrspatial/geotiff/tests/test_nodata_lifecycle_attrs_2135.py xrspatial/geotiff/tests/test_nodata_semantics_split_1988.py xrspatial/geotiff/tests/test_apply_nodata_mask_gpu_inplace_1934.py` (65 pass)
- [x] `pytest xrspatial/geotiff/tests/` (4702 pass; one pre-existing lz4 failure on `main` unrelated to this PR)

Closes #2226
Part of #2211