### PR TITLE
geotiff: tighten 3D writer dim validator to reject non-band trailing dims (#2240)

### DIFF
--- a/xrspatial/geotiff/_validation.py
+++ b/xrspatial/geotiff/_validation.py
@@ -93,11 +93,14 @@ def _validate_3d_writer_dims(dims) -> None:
     if band_layout or yxb_layout:
         return
     # ``(y, x, *)`` with a non-band trailing dim. Temporal names get a
-    # dedicated friendly message (issue #1972); everything else
-    # (``z``, ``level``, ``scenario``, ``foo``, ...) is rejected with
-    # the generic ambiguous-dims wording below. Issue #2240 closes the
-    # escape hatch that previously let unknown trailing names through
-    # the band-position fallback.
+    # dedicated friendly message (issue #1972); every other non-band
+    # trailing name (``z``, ``level``, ``scenario``, ``foo``, ...) is
+    # rejected with the dedicated ``"non-band trailing dim"`` message
+    # immediately below. Issue #2240 closes the escape hatch that
+    # previously let unknown trailing names through the band-position
+    # fallback. The generic ``"ambiguous dims"`` message at the bottom
+    # of the function only fires for layouts that are neither
+    # ``(y, x, *)`` nor ``(_TIME_, y, x)`` (e.g. ``('foo', 'y', 'x')``).
     if d0 in _Y_DIM_NAMES and d1 in _X_DIM_NAMES:
         if _is_temporal_dim_name(d2):
             raise ValueError(
@@ -176,12 +179,13 @@ def _validate_writer_spatial_shape(shape, dims=None,
     collapse of the band axis.
 
     Note that this validator runs before ``_validate_3d_writer_dims``
-    (#1812 / #1972) in ``to_geotiff``. For an ambiguous-dim input like
-    ``(5, 5, 0)`` with dims ``('y', 'x', 'time')``, the band-last branch
-    sees ``bands == 0`` and the "no bands" error wins over the friendlier
-    ambiguous-dim message. Both errors name the right call to fix, so
-    the ordering is acceptable; reorder only if the ambiguous-dim
-    diagnostic becomes more important than the empty-axis one.
+    (#1812 / #1972 / #2240) in ``to_geotiff``. For an ambiguous-dim
+    input like ``(5, 5, 0)`` with dims ``('y', 'x', 'time')``, the
+    band-last branch sees ``bands == 0`` and the "no bands" error wins
+    over the friendlier ambiguous-dim message. Both errors name the
+    right call to fix, so the ordering is acceptable; reorder only if
+    the ambiguous-dim diagnostic becomes more important than the
+    empty-axis one.
     """
     if shape is None:
         return

--- a/xrspatial/geotiff/_validation.py
+++ b/xrspatial/geotiff/_validation.py
@@ -55,7 +55,7 @@ def _is_temporal_dim_name(name) -> bool:
 
 
 def _validate_3d_writer_dims(dims) -> None:
-    """Reject ambiguous 3D writer inputs (issue #1812).
+    """Reject ambiguous 3D writer inputs (issues #1812, #1972, #2240).
 
     The writer interprets a 3D DataArray as either ``(band, y, x)`` or
     ``(y, x, band)``. ``data.dims[0] in _BAND_DIM_NAMES`` decides which
@@ -64,6 +64,18 @@ def _validate_3d_writer_dims(dims) -> None:
     the spatial ``y`` axis and the result was a TIFF with the leading
     axis values laid out along ``y`` (silent data corruption -- on
     read-back the array round-tripped with a swapped shape).
+
+    DataArray dim contract (tightened in #2240): the trailing axis of a
+    ``(y, x, *)`` layout must be a recognized band alias
+    (``_BAND_DIM_NAMES``). Previously the validator silently accepted
+    any unknown trailing name (e.g. ``('y', 'x', 'z')``,
+    ``('lat', 'lon', 'scenario')``) and wrote those values as TIFF
+    bands. That escape hatch was a hold-over for raw-ndarray callers
+    that build band-last arrays without dim metadata; raw ndarrays
+    never flow through this DataArray-dim validator (callers gate the
+    call on ``isinstance(data, xr.DataArray)``), so removing it here
+    only tightens the DataArray contract and leaves the bare-ndarray
+    path unaffected.
 
     Refuse the ambiguous case at the entry point. The message tells the
     caller exactly how to fix the input (rename to one of
@@ -80,15 +92,12 @@ def _validate_3d_writer_dims(dims) -> None:
                   and d2 in _BAND_DIM_NAMES)
     if band_layout or yxb_layout:
         return
-    # Bare (y, x, *) where the third dim is unnamed but spatial -- the
-    # writer's old behaviour treats the non-spatial axis as bands.
-    # Accept that only when the unknown dim is in the band position
-    # (last), which matches how raw numpy callers typically build a
-    # band-last array. Refuse known *temporal* dim names so a
-    # ``(y, x, time)`` stack is rejected with a clear error instead of
-    # silently being written as a 3-band TIFF (issue #1972). The
-    # mirror case ``(time, y, x)`` was already caught -- this closes
-    # the asymmetry.
+    # ``(y, x, *)`` with a non-band trailing dim. Temporal names get a
+    # dedicated friendly message (issue #1972); everything else
+    # (``z``, ``level``, ``scenario``, ``foo``, ...) is rejected with
+    # the generic ambiguous-dims wording below. Issue #2240 closes the
+    # escape hatch that previously let unknown trailing names through
+    # the band-position fallback.
     if d0 in _Y_DIM_NAMES and d1 in _X_DIM_NAMES:
         if _is_temporal_dim_name(d2):
             raise ValueError(
@@ -100,7 +109,17 @@ def _validate_3d_writer_dims(dims) -> None:
                 f"{_BAND_DIM_NAMES} if you really intend the temporal "
                 f"axis to round-trip as TIFF bands (issue #1972)."
             )
-        return
+        raise ValueError(
+            f"3D writer input has non-band trailing dim {d2!r} in dims "
+            f"{dims!r}. The writer cannot infer that {d2!r} represents "
+            f"TIFF bands and used to silently write a multiband file "
+            f"with the {d2!r} axis stuffed into the band slot. Rename "
+            f"the trailing dim to one of {_BAND_DIM_NAMES}, reduce or "
+            f"select along it (e.g. ``data.isel({d2}=0)`` or "
+            f"``data.mean({d2!r})``), or pass a raw ndarray with "
+            f"shape ``(y, x, bands)`` if you really want the band-last "
+            f"layout written without a dim-name check (issue #2240)."
+        )
     # Symmetrise the friendly temporal message for the leading-dim case
     # ``(time, y, x)``. The generic ``ambiguous dims`` error below
     # already rejects this layout, but the temporal-specific message

--- a/xrspatial/geotiff/tests/test_temporal_3d_writer_rejection_1972.py
+++ b/xrspatial/geotiff/tests/test_temporal_3d_writer_rejection_1972.py
@@ -55,11 +55,15 @@ def test_validate_3d_still_accepts_yx_band():
     _validate_3d_writer_dims(('band', 'y', 'x'))
 
 
-def test_validate_3d_still_accepts_unknown_trailing_dim():
-    # The (y, x, *) fallback for raw numpy callers stays in place for
-    # genuinely unknown dim names; only known temporal names trip.
+def test_validate_3d_still_accepts_recognized_band_alias_trailing_dim():
+    # Recognized band aliases at the trailing position remain accepted.
+    # The loose ``(y, x, *)`` fallback for arbitrary unknown trailing
+    # names (``'foo'``, ``'z'``, ``'scenario'``) was removed in #2240
+    # because it silently wrote those values as TIFF bands. The
+    # regression coverage for the rejection lives in
+    # ``test_validate_3d_non_band_trailing_dim_2240.py``.
     _validate_3d_writer_dims(('y', 'x', 'channel'))
-    _validate_3d_writer_dims(('y', 'x', 'foo'))
+    _validate_3d_writer_dims(('y', 'x', 'bands'))
 
 
 def test_validate_3d_still_rejects_time_y_x():

--- a/xrspatial/geotiff/tests/test_validate_3d_non_band_trailing_dim_2240.py
+++ b/xrspatial/geotiff/tests/test_validate_3d_non_band_trailing_dim_2240.py
@@ -1,0 +1,215 @@
+"""Refuse ``(y, x, <non-band>)`` 3D writer inputs (#2240).
+
+``_validate_3d_writer_dims`` (introduced in #1812 and extended for the
+temporal case in #1972) used to accept any ``(y_alias, x_alias, *)``
+DataArray dim tuple whose trailing dim was not a recognized temporal
+name. That meant DataArrays with dims like ``('y', 'x', 'z')``,
+``('y', 'x', 'level')``, or ``('lat', 'lon', 'scenario')`` slipped
+through and were silently written as multiband TIFFs with the trailing
+axis stuffed into the band slot. #2240 closes that escape hatch.
+
+The intent of the original fallback was raw-ndarray callers building
+band-last arrays without dim metadata. Those callers never reach this
+validator (it is gated on ``isinstance(data, xr.DataArray)`` in every
+writer entry point), so the fallback's only effect was on DataArray
+inputs -- and there it was silent data corruption.
+"""
+from __future__ import annotations
+
+import io
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from xrspatial.geotiff import open_geotiff, to_geotiff
+from xrspatial.geotiff._validation import _validate_3d_writer_dims
+
+
+# --- Validator-level coverage ------------------------------------------------
+
+@pytest.mark.parametrize(
+    "trailing",
+    ['z', 'level', 'scenario', 'depth', 'member', 'realization',
+     'foo', 'bar', 'baz'],
+)
+def test_validate_3d_rejects_yx_non_band_trailing(trailing):
+    """``(y, x, <non-band, non-temporal>)`` now raises with a clear message."""
+    with pytest.raises(ValueError, match="non-band trailing dim"):
+        _validate_3d_writer_dims(('y', 'x', trailing))
+
+
+@pytest.mark.parametrize(
+    "yx",
+    [('y', 'x'), ('lat', 'lon'), ('latitude', 'longitude'), ('row', 'col')],
+)
+@pytest.mark.parametrize(
+    "trailing",
+    ['z', 'level', 'scenario'],
+)
+def test_validate_3d_rejects_yx_aliases_with_non_band_trailing(yx, trailing):
+    """Non-band trailing dim is rejected for every recognized y/x alias."""
+    with pytest.raises(ValueError, match="non-band trailing dim"):
+        _validate_3d_writer_dims((yx[0], yx[1], trailing))
+
+
+def test_validate_3d_still_accepts_band_alias_trailing():
+    """Recognized band aliases at the trailing position still succeed."""
+    _validate_3d_writer_dims(('y', 'x', 'band'))
+    _validate_3d_writer_dims(('y', 'x', 'bands'))
+    _validate_3d_writer_dims(('y', 'x', 'channel'))
+
+
+def test_validate_3d_still_accepts_band_alias_leading():
+    """``(band, y, x)`` and its aliases still succeed."""
+    _validate_3d_writer_dims(('band', 'y', 'x'))
+    _validate_3d_writer_dims(('bands', 'y', 'x'))
+    _validate_3d_writer_dims(('channel', 'y', 'x'))
+
+
+def test_validate_3d_still_routes_temporal_to_temporal_message():
+    """Temporal trailing dims still take the dedicated temporal error path.
+
+    The #1972 message gives more specific remediation (``isel`` /
+    ``mean`` along the time axis) than the #2240 generic non-band
+    message, so the temporal-name branch must fire first.
+    """
+    with pytest.raises(ValueError, match="temporal trailing dim"):
+        _validate_3d_writer_dims(('y', 'x', 'time'))
+    with pytest.raises(ValueError, match="temporal trailing dim"):
+        _validate_3d_writer_dims(('lat', 'lon', 'date'))
+
+
+def test_validate_3d_still_rejects_other_ambiguous_leading():
+    """Generic ambiguous-dim message still fires for non-y/x leading dims."""
+    with pytest.raises(ValueError, match="ambiguous dims"):
+        _validate_3d_writer_dims(('foo', 'y', 'x'))
+    with pytest.raises(ValueError, match="ambiguous dims"):
+        _validate_3d_writer_dims(('scenario', 'y', 'x'))
+
+
+def test_validate_3d_2d_dims_unchanged():
+    """2D dim tuples are still pass-through (validator only runs on 3D)."""
+    _validate_3d_writer_dims(('y', 'x'))
+    _validate_3d_writer_dims(('lat', 'lon'))
+
+
+# --- End-to-end writer coverage ----------------------------------------------
+
+def test_to_geotiff_rejects_yxz_dataarray():
+    """End-to-end: ``(y, x, z)`` DataArray writes are rejected."""
+    da = xr.DataArray(
+        np.zeros((4, 4, 3), dtype=np.float32),
+        coords={'y': np.arange(4.0), 'x': np.arange(4.0),
+                'z': np.arange(3)},
+        dims=('y', 'x', 'z'),
+    )
+    buf = io.BytesIO()
+    with pytest.raises(ValueError, match="non-band trailing dim"):
+        to_geotiff(da, buf)
+
+
+def test_to_geotiff_rejects_lat_lon_scenario_dataarray():
+    """End-to-end: ``(lat, lon, scenario)`` is rejected on the writer entry."""
+    da = xr.DataArray(
+        np.zeros((4, 4, 3), dtype=np.float32),
+        coords={'lat': np.arange(4.0), 'lon': np.arange(4.0),
+                'scenario': np.arange(3)},
+        dims=('lat', 'lon', 'scenario'),
+    )
+    buf = io.BytesIO()
+    with pytest.raises(ValueError, match="non-band trailing dim"):
+        to_geotiff(da, buf)
+
+
+def test_error_message_is_actionable():
+    """The error names the offending dim and points at fixes."""
+    da = xr.DataArray(
+        np.zeros((4, 4, 3), dtype=np.float32),
+        coords={'y': np.arange(4.0), 'x': np.arange(4.0),
+                'scenario': np.arange(3)},
+        dims=('y', 'x', 'scenario'),
+    )
+    buf = io.BytesIO()
+    with pytest.raises(ValueError) as excinfo:
+        to_geotiff(da, buf)
+    msg = str(excinfo.value)
+    # Names the offending dim
+    assert "'scenario'" in msg
+    # Mentions accepted band aliases
+    assert "band" in msg
+    # Points at concrete remediations
+    assert "isel(scenario=0)" in msg or "isel" in msg
+    assert "raw ndarray" in msg.lower() or "ndarray" in msg.lower()
+    # References the new issue
+    assert "#2240" in msg
+
+
+def test_to_geotiff_still_accepts_yx_band_dataarray(tmp_path):
+    """``(y, x, band)`` DataArrays still round-trip cleanly."""
+    arr = np.empty((4, 5, 3), dtype=np.uint8)
+    for k in range(3):
+        arr[:, :, k] = k + 1
+    da = xr.DataArray(arr, dims=('y', 'x', 'band'),
+                      attrs={'crs': 'EPSG:4326'})
+    out = tmp_path / 'tmp_2240_yx_band.tif'
+    to_geotiff(da, str(out), crs=4326)
+    rt = open_geotiff(str(out))
+    assert rt.shape == (4, 5, 3)
+    for k in range(3):
+        assert int(rt.values[:, :, k].sum()) == (k + 1) * 20
+
+
+def test_to_geotiff_still_accepts_band_yx_dataarray(tmp_path):
+    """``(band, y, x)`` DataArrays still round-trip cleanly."""
+    arr = np.empty((3, 4, 5), dtype=np.uint8)
+    for k in range(3):
+        arr[k] = k + 1
+    da = xr.DataArray(arr, dims=('band', 'y', 'x'),
+                      attrs={'crs': 'EPSG:4326'})
+    out = tmp_path / 'tmp_2240_band_yx.tif'
+    to_geotiff(da, str(out), crs=4326)
+    rt = open_geotiff(str(out))
+    assert rt.shape == (4, 5, 3)
+    for k in range(3):
+        assert int(rt.values[:, :, k].sum()) == (k + 1) * 20
+
+
+def test_raw_ndarray_band_last_still_writes(tmp_path):
+    """Raw ndarray inputs with band-last layout are unaffected by #2240.
+
+    The validator is only invoked from the ``isinstance(data, xr.DataArray)``
+    branch of every writer entry point, so a bare numpy array never goes
+    through the dim check. This regression guards the inspection-only
+    claim in the docstring that raw-ndarray band-last writes still work
+    after the tightening.
+    """
+    arr = np.empty((4, 5, 3), dtype=np.uint8)
+    for k in range(3):
+        arr[:, :, k] = k + 1
+    out = tmp_path / 'tmp_2240_raw_ndarray_band_last.tif'
+    to_geotiff(arr, str(out), crs=4326)
+    rt = open_geotiff(str(out))
+    assert rt.shape == (4, 5, 3)
+    for k in range(3):
+        assert int(rt.values[:, :, k].sum()) == (k + 1) * 20
+
+
+def test_raw_ndarray_unusual_third_axis_still_writes(tmp_path):
+    """Raw ndarray with no dim metadata is band-last by definition.
+
+    Even if a caller's mental model is ``(y, x, scenario)``, passing a
+    bare ndarray bypasses the DataArray dim contract entirely. The
+    writer treats the trailing axis as bands -- which is exactly what
+    the band-last raw-ndarray API has always done. The #2240
+    tightening only constrains DataArray inputs.
+    """
+    arr = np.empty((4, 5, 3), dtype=np.float32)
+    for k in range(3):
+        arr[:, :, k] = float(k + 1)
+    out = tmp_path / 'tmp_2240_raw_ndarray_band_last_floats.tif'
+    to_geotiff(arr, str(out), crs=4326)
+    rt = open_geotiff(str(out))
+    assert rt.shape == (4, 5, 3)
+    for k in range(3):
+        assert float(rt.values[:, :, k].sum()) == float(k + 1) * 20


### PR DESCRIPTION
## Summary

Closes #2240.

- Tighten `_validate_3d_writer_dims` so DataArray dim tuples with a non-band, non-temporal trailing axis raise `ValueError` instead of silently writing the trailing axis as TIFF bands. Examples that previously went through: `('y', 'x', 'z')`, `('y', 'x', 'level')`, `('lat', 'lon', 'scenario')`.
- The error names the offending dim and points the caller at the band aliases (`band`, `bands`, `channel`), an `isel`/`mean` reduction, or the raw-ndarray band-last escape.
- Raw ndarray inputs are unchanged. The validator is only invoked inside `isinstance(data, xr.DataArray)` branches in the eager, dask-streaming, and GPU writers, so bare numpy arrays never reach it. The audit is by inspection rather than by code motion.

Backend coverage: the validator is dispatch-agnostic and fires before any backend-specific work. The #1812 / #1972 regression matrix already exercises eager numpy, dask streaming, and GPU paths and continues to pass.

## Test plan

- [x] New validator-level tests reject `('y', 'x', 'z')`, `('y', 'x', 'level')`, `('y', 'x', 'scenario')`, and the y/x alias variants.
- [x] End-to-end `to_geotiff` rejects `('y', 'x', 'z')` and `('lat', 'lon', 'scenario')` DataArrays with the new message.
- [x] `('band', 'y', 'x')` and `('y', 'x', 'band')` still round-trip cleanly.
- [x] Temporal trailing/leading dims still route to the #1972 message branch.
- [x] Raw ndarray with band-last layout still writes correctly.
- [x] Full `xrspatial/geotiff/tests/` suite: 5011 passed (1 unrelated pre-existing lz4 failure on `main`).