### PR TITLE
Drop lz4 from byte-parity sweep, gated as experimental (#2268)

### DIFF
--- a/xrspatial/geotiff/tests/test_lowlevel_write_pushdown_2138.py
+++ b/xrspatial/geotiff/tests/test_lowlevel_write_pushdown_2138.py
@@ -266,16 +266,18 @@ class TestDtypePromotionPushdown:
 
 # JPEG omitted from the byte-parity sweep on purpose: it requires the
 # opt-in, which the wrapper emits a runtime warning for, and JPEG is
-# lossy so trivial seed changes can shift bytes. ``_write`` is exercised
-# elsewhere; the parity sweep covers the lossless codec set that direct
-# callers reach for first.
+# lossy so trivial seed changes can shift bytes. The experimental codecs
+# (``lerc``, ``jpeg2000`` / ``j2k``, ``lz4``) are gated behind
+# ``allow_experimental_codecs=True`` (issue #2137) and are likewise
+# excluded from this sweep. ``_write`` is exercised elsewhere; the
+# parity sweep covers the stable lossless codec set that direct callers
+# reach for first.
 _PARITY_CODECS = (
     "none",
     "deflate",
     "lzw",
     "packbits",
     "zstd",
-    "lz4",
 )
 
 


### PR DESCRIPTION
## Summary

- `xrspatial/geotiff/tests/test_lowlevel_write_pushdown_2138.py::test_write_vs_to_geotiff_byte_parity_uint8[lz4]` was failing because `_write` / `to_geotiff` now reject `lz4` at the experimental-codec gate from #2137 unless the caller passes `allow_experimental_codecs=True`.
- Remove `lz4` from `_PARITY_CODECS`. The other experimental codecs (`lerc`, `jpeg2000`, `j2k`) were never in the tuple, so the result matches the docstring's "stable lossless codec set" framing.
- Note the experimental-codec exclusion in the tuple's leading comment so the next maintainer to add a codec sees the gate up front.

Closes #2268.

## Test plan

- [x] `pytest xrspatial/geotiff/tests/test_lowlevel_write_pushdown_2138.py -v` -- 26 passed (was 26 passed, 1 failed before the change)