### PR TITLE
Drop xfail on test_external_cog_validator now that #2308 is fixed

### DIFF
--- a/xrspatial/geotiff/tests/test_cog_writer_compliance.py
+++ b/xrspatial/geotiff/tests/test_cog_writer_compliance.py
@@ -543,22 +543,6 @@ def test_layout_is_cog_shaped(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-# The writer currently emits overview tile blocks in the wrong order
-# (issue #2308 -- surfaced by this very gate). rio-cogeo reports:
-#   "The offset of the first block of overview of index 0 should be
-#    after the one of the overview of index 1"
-# The in-process round-trip and the local IFD-before-data layout
-# invariant both still pass; only the block ordering across overviews
-# trips external validators. xfail (strict=False) so the CI gate is
-# wired up and stays green for the rest of the suite. Drop this
-# marker once the writer fix lands.
-@pytest.mark.xfail(
-    reason=(
-        "writer emits overview tile blocks in wrong order; see #2308. "
-        "Remove xfail when the writer fix lands."
-    ),
-    strict=False,
-)
 def test_external_cog_validator(tmp_path):
     """Run rio-cogeo / GDAL's COG validator if available, else skip cleanly."""
     arr = _make_data(np.float32, bands=1, height=256, width=256)


### PR DESCRIPTION
Follow-up to #2304 and #2309.

#2304 wired up the rio-cogeo CI gate and marked `test_external_cog_validator` as xfail (strict=False) because the writer emitted overview tile blocks in the wrong order (#2308). #2309 fixed the writer, so the test now passes locally with `XRSPATIAL_REQUIRE_COG_VALIDATOR=1`. Drop the marker and the comment block that pointed at #2308.

Verified locally with rio-cogeo installed: the test goes from XPASS (silent under strict=False) to PASS. Final validation is the `run (3.12)` pytest-cog-validator job on this PR.

Diff is the decorator plus its preceding comment block, nothing else.