### PR TITLE
Audit GeoTIFF example notebooks for tier wording (#2345 PR 4, closes #2382)

### DIFF
--- a/examples/user_guide/25_GLCM_Texture.ipynb
+++ b/examples/user_guide/25_GLCM_Texture.ipynb
@@ -12,6 +12,17 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Tier note\n",
+    "\n",
+    "The classification section reads a Sentinel-2 Cloud-Optimized GeoTIFF over HTTPS with `open_geotiff`. The HTTP COG reader sits at the `advanced` tier in `xrspatial.geotiff.SUPPORTED_FEATURES` (`reader.http_cog`): range fetching, redirect handling, and cache behaviour are not contracted at the stable bar. Local COG reads (`reader.local_cog`) and the GLCM kernel itself are unrelated to that caveat -- swap the URL for a local path and the rest of the notebook stays inside the stable surface.\n",
+    "\n",
+    "**See also:** the GeoTIFF / COG reference page at `docs/source/reference/geotiff.rst` lists every feature in `xrspatial.geotiff.SUPPORTED_FEATURES` against its tier (`stable`, `advanced`, `experimental`, `internal_only`) and links the release gate that locks each promise.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "7yishbzt21d",
    "metadata": {},
    "source": [

--- a/examples/user_guide/29_Preview.ipynb
+++ b/examples/user_guide/29_Preview.ipynb
@@ -12,6 +12,15 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### See also\n",
+    "\n",
+    "This notebook is about lazy downsampling, not GeoTIFF I/O. If you do feed `preview` data loaded via `open_geotiff`, the GeoTIFF / COG reference page (`docs/source/reference/geotiff.rst`) records which reader paths sit at the `stable` versus `advanced` / `experimental` tier in `xrspatial.geotiff.SUPPORTED_FEATURES`.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "x11ktiuo2cf",
    "metadata": {},
    "source": [

--- a/examples/user_guide/29_Preview.ipynb
+++ b/examples/user_guide/29_Preview.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "### See also\n",
     "\n",
-    "This notebook is about lazy downsampling, not GeoTIFF I/O. If you do feed `preview` data loaded via `open_geotiff`, the GeoTIFF / COG reference page (`docs/source/reference/geotiff.rst`) records which reader paths sit at the `stable` versus `advanced` / `experimental` tier in `xrspatial.geotiff.SUPPORTED_FEATURES`.\n"
+    "If you feed `preview` data loaded via `open_geotiff`, `docs/source/reference/geotiff.rst` records which reader paths are `stable`, `advanced`, or `experimental` in `xrspatial.geotiff.SUPPORTED_FEATURES`.\n"
    ]
   },
   {

--- a/examples/user_guide/39_GeoTIFF_IO.ipynb
+++ b/examples/user_guide/39_GeoTIFF_IO.ipynb
@@ -15,7 +15,7 @@
    "source": [
     "### Tier note\n",
     "\n",
-    "`open_geotiff` and `to_geotiff` against local files, the lossless codecs (`none`, `deflate`, `lzw`, `zstd`, `packbits`), axis-aligned 2D / 3D rasters, and dask reads / writes are tagged `stable` in `xrspatial.geotiff.SUPPORTED_FEATURES`. The VRT mosaic section at the bottom exercises `write_vrt` / `read_vrt`, which sit at the `advanced` tier (`reader.vrt`): the supported subset is a flat mosaic of compatible GeoTIFF tiles, not the full GDAL VRT spec.\n",
+    "`open_geotiff` and `to_geotiff` against local files, the lossless codecs (`none`, `deflate`, `lzw`, `zstd`, `packbits`), and axis-aligned 2D / 3D rasters are tagged `stable` in `xrspatial.geotiff.SUPPORTED_FEATURES`. Dask reads (`reader.dask`) and dask streaming writes (covered by `writer.local_file`) are stable too. The VRT mosaic section at the bottom exercises `write_vrt` / `read_vrt`, which sit at the `advanced` tier (`reader.vrt`): the supported subset is a flat mosaic of compatible GeoTIFF tiles, not the full GDAL VRT spec.\n",
     "\n",
     "**See also:** the GeoTIFF / COG reference page at `docs/source/reference/geotiff.rst` lists every feature in `xrspatial.geotiff.SUPPORTED_FEATURES` against its tier (`stable`, `advanced`, `experimental`, `internal_only`) and links the release gate that locks each promise.\n"
    ]

--- a/examples/user_guide/39_GeoTIFF_IO.ipynb
+++ b/examples/user_guide/39_GeoTIFF_IO.ipynb
@@ -13,6 +13,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Tier note\n",
+    "\n",
+    "`open_geotiff` and `to_geotiff` against local files, the lossless codecs (`none`, `deflate`, `lzw`, `zstd`, `packbits`), axis-aligned 2D / 3D rasters, and dask reads / writes are tagged `stable` in `xrspatial.geotiff.SUPPORTED_FEATURES`. The VRT mosaic section at the bottom exercises `write_vrt` / `read_vrt`, which sit at the `advanced` tier (`reader.vrt`): the supported subset is a flat mosaic of compatible GeoTIFF tiles, not the full GDAL VRT spec.\n",
+    "\n",
+    "**See also:** the GeoTIFF / COG reference page at `docs/source/reference/geotiff.rst` lists every feature in `xrspatial.geotiff.SUPPORTED_FEATURES` against its tier (`stable`, `advanced`, `experimental`, `internal_only`) and links the release gate that locks each promise.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### What you'll build\n",
     "\n",
     "1. [Write and read back a GeoTIFF](#Write-and-read-back) with `to_geotiff` and `open_geotiff`\n",

--- a/examples/user_guide/40_JPEG2000_Compression.ipynb
+++ b/examples/user_guide/40_JPEG2000_Compression.ipynb
@@ -12,7 +12,7 @@
    "source": [
     "### Experimental tier callout\n",
     "\n",
-    "The `jpeg2000` / `j2k` codec is tagged `experimental` in `xrspatial.geotiff.SUPPORTED_FEATURES` (`codec.jpeg2000`, `codec.j2k`). Cross-backend numerical parity, external GDAL / libtiff interop, and round-trip stability across releases are not contracted yet. Writers require the explicit `allow_experimental_codecs=True` opt-in. The GPU path (`reader.gpu` / `writer.gpu`) is also `experimental` and depends on nvJPEG2000 being available at import time.\n",
+    "The `jpeg2000` / `j2k` codec is tagged `experimental` in `xrspatial.geotiff.SUPPORTED_FEATURES` (`codec.jpeg2000`, `codec.j2k`). Cross-backend numerical parity, external GDAL / libtiff interop, and round-trip stability across releases are not contracted yet. Writers require the explicit `allow_experimental_codecs=True` opt-in. The GPU path (`reader.gpu` / `writer.gpu`) is also `experimental` and probes for nvJPEG2000 lazily on the first GPU call -- if `libnvjpeg2k.so` is not on the loader path, the GPU codec is unavailable and the call falls back or fails.\n",
     "\n",
     "Treat the recipes below as a working reference for the current code, not a stable API surface. If you need a contracted lossless codec, use `deflate`, `lzw`, `zstd`, or `packbits` from the stable tier instead.\n",
     "\n",

--- a/examples/user_guide/40_JPEG2000_Compression.ipynb
+++ b/examples/user_guide/40_JPEG2000_Compression.ipynb
@@ -8,6 +8,19 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Experimental tier callout\n",
+    "\n",
+    "The `jpeg2000` / `j2k` codec is tagged `experimental` in `xrspatial.geotiff.SUPPORTED_FEATURES` (`codec.jpeg2000`, `codec.j2k`). Cross-backend numerical parity, external GDAL / libtiff interop, and round-trip stability across releases are not contracted yet. Writers require the explicit `allow_experimental_codecs=True` opt-in. The GPU path (`reader.gpu` / `writer.gpu`) is also `experimental` and depends on nvJPEG2000 being available at import time.\n",
+    "\n",
+    "Treat the recipes below as a working reference for the current code, not a stable API surface. If you need a contracted lossless codec, use `deflate`, `lzw`, `zstd`, or `packbits` from the stable tier instead.\n",
+    "\n",
+    "**See also:** the GeoTIFF / COG reference page at `docs/source/reference/geotiff.rst` lists every feature in `xrspatial.geotiff.SUPPORTED_FEATURES` against its tier (`stable`, `advanced`, `experimental`, `internal_only`) and links the release gate that locks each promise.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "46a72497",
    "source": "### What you'll build\n\n1. [Generate synthetic elevation data](#data)\n2. [Write with JPEG 2000 lossless compression](#write-j2k)\n3. [Read back and verify the roundtrip](#read-verify)\n4. [Compress a multi-band RGB image](#multi-band)\n5. [GPU acceleration notes](#gpu)\n\n![preview](images/40_jpeg2000_compression.png)",
    "metadata": {}

--- a/examples/user_guide/46_GeoTIFF_Performance.ipynb
+++ b/examples/user_guide/46_GeoTIFF_Performance.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "### Tier note\n",
     "\n",
-    "The `dtype` and `compression_level` techniques below ride on the stable local read / write paths (`reader.local_file`, `writer.local_file`) and the stable lossless codecs. The third section (\"VRT tiled output\") drives `to_geotiff(..., vrt=True)`, which sits at the `advanced` tier (`reader.vrt`): the writer emits a flat mosaic VRT pointing at sibling tiles, which is a subset of the full GDAL VRT spec.\n",
+    "The `dtype` and `compression_level` techniques below ride on the stable local read / write paths (`reader.local_file`, `writer.local_file`) and the stable lossless codecs. The third section (\"VRT tiled output\") drives `to_geotiff(..., vrt=True)`: each per-tile write itself rides on `writer.local_file` (stable), and the round-trip read through the VRT XML uses `reader.vrt`, which sits at the `advanced` tier. The supported VRT subset is a flat mosaic of compatible sibling tiles, not the full GDAL VRT spec.\n",
     "\n",
     "**See also:** the GeoTIFF / COG reference page at `docs/source/reference/geotiff.rst` lists every feature in `xrspatial.geotiff.SUPPORTED_FEATURES` against its tier (`stable`, `advanced`, `experimental`, `internal_only`) and links the release gate that locks each promise.\n"
    ]

--- a/examples/user_guide/46_GeoTIFF_Performance.ipynb
+++ b/examples/user_guide/46_GeoTIFF_Performance.ipynb
@@ -15,6 +15,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Tier note\n",
+    "\n",
+    "The `dtype` and `compression_level` techniques below ride on the stable local read / write paths (`reader.local_file`, `writer.local_file`) and the stable lossless codecs. The third section (\"VRT tiled output\") drives `to_geotiff(..., vrt=True)`, which sits at the `advanced` tier (`reader.vrt`): the writer emits a flat mosaic VRT pointing at sibling tiles, which is a subset of the full GDAL VRT spec.\n",
+    "\n",
+    "**See also:** the GeoTIFF / COG reference page at `docs/source/reference/geotiff.rst` lists every feature in `xrspatial.geotiff.SUPPORTED_FEATURES` against its tier (`stable`, `advanced`, `experimental`, `internal_only`) and links the release gate that locks each promise.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### What you'll build\n",
     "\n",
     "1. [dtype on read](#1.-dtype-on-read) - cast to a narrower type at load time to cut memory in half\n",

--- a/examples/user_guide/47_Streaming_GeoTIFF_Write.ipynb
+++ b/examples/user_guide/47_Streaming_GeoTIFF_Write.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "### Tier note\n",
     "\n",
-    "The streaming write path itself rides on `writer.local_file` (stable): a dask-backed `to_geotiff` call streams tile-row by tile-row out to a single TIFF using the stable lossless codecs. The \"Stream-write to a VRT mosaic\" section uses `to_geotiff(..., vrt=True)`, which sits at the `advanced` tier (`reader.vrt`): the VRT is a flat sibling-tile mosaic, not the full GDAL VRT spec.\n",
+    "The streaming write path itself rides on `writer.local_file` (stable): a dask-backed `to_geotiff` call streams tile-row by tile-row out to a single TIFF using the stable lossless codecs. The \"Stream-write to a VRT mosaic\" section also uses `writer.local_file` for the per-tile writes; the `advanced` tier (`reader.vrt`) only applies on the round-trip read through the VRT XML, where the supported subset is a flat sibling-tile mosaic rather than the full GDAL VRT spec.\n",
     "\n",
     "**See also:** the GeoTIFF / COG reference page at `docs/source/reference/geotiff.rst` lists every feature in `xrspatial.geotiff.SUPPORTED_FEATURES` against its tier (`stable`, `advanced`, `experimental`, `internal_only`) and links the release gate that locks each promise.\n"
    ]

--- a/examples/user_guide/47_Streaming_GeoTIFF_Write.ipynb
+++ b/examples/user_guide/47_Streaming_GeoTIFF_Write.ipynb
@@ -14,6 +14,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Tier note\n",
+    "\n",
+    "The streaming write path itself rides on `writer.local_file` (stable): a dask-backed `to_geotiff` call streams tile-row by tile-row out to a single TIFF using the stable lossless codecs. The \"Stream-write to a VRT mosaic\" section uses `to_geotiff(..., vrt=True)`, which sits at the `advanced` tier (`reader.vrt`): the VRT is a flat sibling-tile mosaic, not the full GDAL VRT spec.\n",
+    "\n",
+    "**See also:** the GeoTIFF / COG reference page at `docs/source/reference/geotiff.rst` lists every feature in `xrspatial.geotiff.SUPPORTED_FEATURES` against its tier (`stable`, `advanced`, `experimental`, `internal_only`) and links the release gate that locks each promise.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### What you'll build\n",
     "\n",
     "1. [Generate a chunked dask raster](#data)\n",

--- a/examples/user_guide/52_COG_Overview_Generation.ipynb
+++ b/examples/user_guide/52_COG_Overview_Generation.ipynb
@@ -14,7 +14,23 @@
   },
   {
    "cell_type": "markdown",
-   "source": "### Stable COG contract\n\nThe local COG writer and the local COG reader are tagged `stable` in `xrspatial.geotiff.SUPPORTED_FEATURES` (`writer.cog` and `reader.local_cog`). Axis-aligned 2D / 3D rasters, the lossless codecs (`none`, `deflate`, `lzw`, `zstd`, `packbits`), internal overviews, and normal CRS / transform / nodata round-trip are covered by the parity and compliance suites that gate every CI build, so the examples in this notebook all sit inside the stable contract.\n\nA few combinations stay outside the stable contract and keep their existing `advanced` or `experimental` tier:\n\n- The HTTP COG reader (`reader.http_cog`) -- range fetching, redirect handling, and cache behaviour are not contracted yet. Use with care.\n- GPU COG read / write.\n- Experimental codecs (`lerc`, `jpeg2000` / `j2k`, `lz4`) and the internal-only `jpeg` codec.\n- Rotated transforms, external `.tif.ovr` sidecars, file-like destinations with `cog=True`.\n- BigTIFF COG (tracked separately).\n\nSee the *Stable COG contract* section of the GeoTIFF / COG reference page for the full list.",
+   "source": [
+    "### Stable COG contract\n",
+    "\n",
+    "The local COG writer and the local COG reader are tagged `stable` in `xrspatial.geotiff.SUPPORTED_FEATURES` (`writer.cog` and `reader.local_cog`). Axis-aligned 2D / 3D rasters, the lossless codecs (`none`, `deflate`, `lzw`, `zstd`, `packbits`), internal overviews, and normal CRS / transform / nodata round-trip are covered by the parity and compliance suites that gate every CI build, so the examples in this notebook all sit inside the stable contract.\n",
+    "\n",
+    "A few combinations stay outside the stable contract and keep their existing `advanced` or `experimental` tier:\n",
+    "\n",
+    "- The HTTP COG reader (`reader.http_cog`) -- range fetching, redirect handling, and cache behaviour are not contracted yet. Use with care.\n",
+    "- GPU COG read / write.\n",
+    "- Experimental codecs (`lerc`, `jpeg2000` / `j2k`, `lz4`) and the internal-only `jpeg` codec.\n",
+    "- Rotated transforms, external `.tif.ovr` sidecars, file-like destinations with `cog=True`.\n",
+    "- BigTIFF COG (tracked separately).\n",
+    "\n",
+    "See the *Stable COG contract* section of the GeoTIFF / COG reference page for the full list.\n",
+    "\n",
+    "**See also:** the full feature / tier matrix lives in `docs/source/reference/geotiff.rst` and is sourced from `xrspatial.geotiff.SUPPORTED_FEATURES`.\n"
+   ],
    "metadata": {}
   },
   {

--- a/examples/user_guide/52_COG_Overview_Generation.ipynb
+++ b/examples/user_guide/52_COG_Overview_Generation.ipynb
@@ -27,9 +27,7 @@
     "- Rotated transforms, external `.tif.ovr` sidecars, file-like destinations with `cog=True`.\n",
     "- BigTIFF COG (tracked separately).\n",
     "\n",
-    "See the *Stable COG contract* section of the GeoTIFF / COG reference page for the full list.\n",
-    "\n",
-    "**See also:** the full feature / tier matrix lives in `docs/source/reference/geotiff.rst` and is sourced from `xrspatial.geotiff.SUPPORTED_FEATURES`.\n"
+    "See the *Stable COG contract* section of the GeoTIFF / COG reference page for the full list.\n"
    ],
    "metadata": {}
   },


### PR DESCRIPTION
## Summary

Adds a tier callout near the top of each GeoTIFF-touching example notebook so a reader can tell which sections sit on the stable contract and which exercise advanced or experimental paths. Each callout names the relevant `SUPPORTED_FEATURES` key (`codec.jpeg2000`, `reader.http_cog`, `reader.vrt`, etc.) and points to `docs/source/reference/geotiff.rst` for the full tier matrix. Markdown-only: no code cells, no narrative restructuring, no loaded data changed.

## Notebooks touched

- `25_GLCM_Texture.ipynb`: classification section pulls a Sentinel-2 COG over HTTPS (`reader.http_cog`, advanced).
- `29_Preview.ipynb`: no direct GeoTIFF call, just a see-also pointer.
- `39_GeoTIFF_IO.ipynb`: stable local read/write plus an advanced VRT mosaic section.
- `40_JPEG2000_Compression.ipynb`: experimental codec callout (`codec.jpeg2000` / `codec.j2k`).
- `46_GeoTIFF_Performance.ipynb`: stable dtype / compression_level plus advanced VRT tiled output.
- `47_Streaming_GeoTIFF_Write.ipynb`: stable streaming write plus advanced VRT mosaic.
- `52_COG_Overview_Generation.ipynb`: already had a stable COG callout, added a see-also pointer.

## Out of scope

Loaded data, narrative structure beyond the new callouts, and new notebooks.

## Test plan

- [x] All seven notebooks parse as valid `nbformat=4` JSON.
- [x] `git diff --stat` only touches the seven listed notebooks.
- [x] Notebooks aren't executed in CI on this repo (no `nbval` / `nbmake` / `ipynb` references in `.github/workflows/`), so end-to-end execution is unchanged by markdown-only edits.

Closes #2382. Part of epic #2345 (PR 4 of the audit slice).