### PR TITLE
geotiff: surface sidecar parse error on explicit overview_level>=1

### DIFF
--- a/xrspatial/geotiff/__init__.py
+++ b/xrspatial/geotiff/__init__.py
@@ -296,7 +296,8 @@ def _read_geo_info(source, *, overview_level: int | None = None,
         # behaviour with a warning. Mirrors the eager CPU path in
         # ``_reader._read_to_array`` and the dask metadata helper
         # ``_sidecar.discover_remote_sidecar``. Issue #2416.
-        from ._sidecar import attach_sidecar_origin, find_sidecar, load_sidecar
+        from ._sidecar import (attach_sidecar_origin, find_sidecar,
+                                handle_sidecar_parse_failure, load_sidecar)
         sidecar_origin: dict[int, tuple] = {}
         sidecar_path = find_sidecar(source)
         if sidecar_path is not None:
@@ -313,31 +314,14 @@ def _read_geo_info(source, *, overview_level: int | None = None,
                 # patch routes a cloud-source path through here.
                 raise
             except Exception as exc:
-                # Explicit ``overview_level >= 1`` is a request for the
-                # external sidecar surface. The release contract
-                # (``geotiff_release_contract.md`` row
-                # ``reader.sidecar_ovr``) and the fallback warning
-                # text below both promise that this case surfaces the
-                # underlying parse error rather than silently degrading
-                # to base-only and then raising a misleading "out of
-                # range" from ``select_overview_ifd``. Chain via
-                # ``raise ... from exc`` so the traceback carries the
-                # concrete parse failure. Mirrors the eager CPU path
-                # in ``_reader._read_to_array``. Issue #2484.
-                if overview_level is not None and overview_level >= 1:
-                    raise ValueError(
-                        f"Cannot read overview_level={overview_level} "
-                        f"from external sidecar {sidecar_path!r}: "
-                        f"sidecar parse failed with "
-                        f"{type(exc).__name__}: {exc}"
-                    ) from exc
-                warnings.warn(
-                    f"Ignoring unreadable sidecar {sidecar_path!r}: "
-                    f"{type(exc).__name__}: {exc}. Falling back to "
-                    f"base-file-only read. Delete the .ovr file or pass "
-                    f"overview_level>=1 to surface the parse error.",
-                    RuntimeWarning,
-                    stacklevel=3,
+                # Shared policy: surface the parse error when the
+                # caller asked for a level the base file alone cannot
+                # serve; warn and fall back otherwise. See
+                # ``_sidecar.handle_sidecar_parse_failure`` for the
+                # rationale. Issue #2484.
+                handle_sidecar_parse_failure(
+                    exc, sidecar_path, overview_level,
+                    base_ifd_count=len(ifds),
                 )
                 sidecar = None
             if sidecar is not None:

--- a/xrspatial/geotiff/__init__.py
+++ b/xrspatial/geotiff/__init__.py
@@ -313,6 +313,24 @@ def _read_geo_info(source, *, overview_level: int | None = None,
                 # patch routes a cloud-source path through here.
                 raise
             except Exception as exc:
+                # Explicit ``overview_level >= 1`` is a request for the
+                # external sidecar surface. The release contract
+                # (``geotiff_release_contract.md`` row
+                # ``reader.sidecar_ovr``) and the fallback warning
+                # text below both promise that this case surfaces the
+                # underlying parse error rather than silently degrading
+                # to base-only and then raising a misleading "out of
+                # range" from ``select_overview_ifd``. Chain via
+                # ``raise ... from exc`` so the traceback carries the
+                # concrete parse failure. Mirrors the eager CPU path
+                # in ``_reader._read_to_array``. Issue #2484.
+                if overview_level is not None and overview_level >= 1:
+                    raise ValueError(
+                        f"Cannot read overview_level={overview_level} "
+                        f"from external sidecar {sidecar_path!r}: "
+                        f"sidecar parse failed with "
+                        f"{type(exc).__name__}: {exc}"
+                    ) from exc
                 warnings.warn(
                     f"Ignoring unreadable sidecar {sidecar_path!r}: "
                     f"{type(exc).__name__}: {exc}. Falling back to "

--- a/xrspatial/geotiff/_backends/gpu.py
+++ b/xrspatial/geotiff/_backends/gpu.py
@@ -438,7 +438,9 @@ def read_geotiff_gpu(source: str, *,
         # and ``reader.sidecar_ovr`` at advanced; matches the eager CPU
         # path in ``_reader._read_to_array`` and the dask metadata
         # helper ``_sidecar.discover_remote_sidecar``. Issue #2416.
-        from .._sidecar import attach_sidecar_origin, close_sidecar, find_sidecar, load_sidecar
+        from .._sidecar import (attach_sidecar_origin, close_sidecar,
+                                 find_sidecar, handle_sidecar_parse_failure,
+                                 load_sidecar)
         sidecar_origin: dict[int, tuple] = {}
         sidecar_path = find_sidecar(source)
         if sidecar_path is not None:
@@ -453,30 +455,14 @@ def read_geotiff_gpu(source: str, *,
                 # patch routes a cloud-source path through here.
                 raise
             except Exception as exc:
-                # Explicit ``overview_level >= 1`` is a request for the
-                # external sidecar surface. The release contract
-                # (``geotiff_release_contract.md`` row
-                # ``reader.sidecar_ovr``) promises that this surfaces
-                # the underlying parse error rather than degrading to a
-                # misleading "out of range" raise from
-                # ``select_overview_ifd``. Chain via
-                # ``raise ... from exc`` so the traceback carries the
-                # concrete parse failure. Mirrors the eager CPU path
-                # in ``_reader._read_to_array``. Issue #2484.
-                if overview_level is not None and overview_level >= 1:
-                    raise ValueError(
-                        f"Cannot read overview_level={overview_level} "
-                        f"from external sidecar {sidecar_path!r}: "
-                        f"sidecar parse failed with "
-                        f"{type(exc).__name__}: {exc}"
-                    ) from exc
-                warnings.warn(
-                    f"Ignoring unreadable sidecar {sidecar_path!r}: "
-                    f"{type(exc).__name__}: {exc}. Falling back to "
-                    f"base-file-only read. Delete the .ovr file or pass "
-                    f"overview_level>=1 to surface the parse error.",
-                    RuntimeWarning,
-                    stacklevel=3,
+                # Shared policy: surface the parse error when the
+                # caller asked for a level the base file alone cannot
+                # serve; warn and fall back otherwise. See
+                # ``_sidecar.handle_sidecar_parse_failure`` for the
+                # rationale. Issue #2484.
+                handle_sidecar_parse_failure(
+                    exc, sidecar_path, overview_level,
+                    base_ifd_count=len(ifds),
                 )
                 sidecar = None
             if sidecar is not None:

--- a/xrspatial/geotiff/_backends/gpu.py
+++ b/xrspatial/geotiff/_backends/gpu.py
@@ -453,6 +453,23 @@ def read_geotiff_gpu(source: str, *,
                 # patch routes a cloud-source path through here.
                 raise
             except Exception as exc:
+                # Explicit ``overview_level >= 1`` is a request for the
+                # external sidecar surface. The release contract
+                # (``geotiff_release_contract.md`` row
+                # ``reader.sidecar_ovr``) promises that this surfaces
+                # the underlying parse error rather than degrading to a
+                # misleading "out of range" raise from
+                # ``select_overview_ifd``. Chain via
+                # ``raise ... from exc`` so the traceback carries the
+                # concrete parse failure. Mirrors the eager CPU path
+                # in ``_reader._read_to_array``. Issue #2484.
+                if overview_level is not None and overview_level >= 1:
+                    raise ValueError(
+                        f"Cannot read overview_level={overview_level} "
+                        f"from external sidecar {sidecar_path!r}: "
+                        f"sidecar parse failed with "
+                        f"{type(exc).__name__}: {exc}"
+                    ) from exc
                 warnings.warn(
                     f"Ignoring unreadable sidecar {sidecar_path!r}: "
                     f"{type(exc).__name__}: {exc}. Falling back to "

--- a/xrspatial/geotiff/_reader.py
+++ b/xrspatial/geotiff/_reader.py
@@ -246,6 +246,26 @@ def _read_to_array(source, *, window=None, overview_level: int | None = None,
             except CloudSizeLimitError:
                 raise
             except Exception as exc:
+                # An explicit ``overview_level >= 1`` is a request for
+                # the external/sidecar surface. The release contract
+                # (``geotiff_release_contract.md`` row
+                # ``reader.sidecar_ovr``) and the fallback warning text
+                # below both promise that this case surfaces the
+                # underlying parse error; silently falling back would
+                # only hide what went wrong and force the user to
+                # diagnose from a misleading "out of range" raised by
+                # ``select_overview_ifd``. Chain the original exception
+                # via ``raise ... from exc`` so the traceback carries
+                # both the high-level reason ("you asked for level N
+                # which lives in the sidecar") and the concrete parse
+                # failure. Issue #2484.
+                if overview_level is not None and overview_level >= 1:
+                    raise ValueError(
+                        f"Cannot read overview_level={overview_level} "
+                        f"from external sidecar {sidecar_path!r}: "
+                        f"sidecar parse failed with "
+                        f"{type(exc).__name__}: {exc}"
+                    ) from exc
                 warnings.warn(
                     f"Ignoring unreadable sidecar {sidecar_path!r}: "
                     f"{type(exc).__name__}: {exc}. Falling back to "

--- a/xrspatial/geotiff/_reader.py
+++ b/xrspatial/geotiff/_reader.py
@@ -236,7 +236,8 @@ def _read_to_array(source, *, window=None, overview_level: int | None = None,
         # the user can still investigate. Mirrors the contract that
         # ``discover_remote_sidecar`` already uses on the dask metadata
         # path. Issue #2416.
-        from ._sidecar import attach_sidecar_origin, find_sidecar, load_sidecar
+        from ._sidecar import (attach_sidecar_origin, find_sidecar,
+                                handle_sidecar_parse_failure, load_sidecar)
         sidecar_origin: dict[int, tuple] = {}
         sidecar_path = find_sidecar(source)
         if sidecar_path is not None:
@@ -246,33 +247,19 @@ def _read_to_array(source, *, window=None, overview_level: int | None = None,
             except CloudSizeLimitError:
                 raise
             except Exception as exc:
-                # An explicit ``overview_level >= 1`` is a request for
-                # the external/sidecar surface. The release contract
-                # (``geotiff_release_contract.md`` row
-                # ``reader.sidecar_ovr``) and the fallback warning text
-                # below both promise that this case surfaces the
-                # underlying parse error; silently falling back would
-                # only hide what went wrong and force the user to
-                # diagnose from a misleading "out of range" raised by
-                # ``select_overview_ifd``. Chain the original exception
-                # via ``raise ... from exc`` so the traceback carries
-                # both the high-level reason ("you asked for level N
-                # which lives in the sidecar") and the concrete parse
-                # failure. Issue #2484.
-                if overview_level is not None and overview_level >= 1:
-                    raise ValueError(
-                        f"Cannot read overview_level={overview_level} "
-                        f"from external sidecar {sidecar_path!r}: "
-                        f"sidecar parse failed with "
-                        f"{type(exc).__name__}: {exc}"
-                    ) from exc
-                warnings.warn(
-                    f"Ignoring unreadable sidecar {sidecar_path!r}: "
-                    f"{type(exc).__name__}: {exc}. Falling back to "
-                    f"base-file-only read. Delete the .ovr file or pass "
-                    f"overview_level>=1 to surface the parse error.",
-                    RuntimeWarning,
-                    stacklevel=3,
+                # Shared policy across eager CPU, eager GPU, and the
+                # metadata-only path: an explicit request for a level
+                # the base file alone cannot serve surfaces the
+                # underlying parse error (release contract row
+                # ``reader.sidecar_ovr``); otherwise we warn and fall
+                # back. The gate uses ``base_ifd_count`` rather than a
+                # bare ``>= 1`` because a base TIFF with internal
+                # overview IFDs can satisfy ``level=1`` without the
+                # sidecar, and forcing a raise in that case would deny
+                # a valid read. Issue #2484.
+                handle_sidecar_parse_failure(
+                    exc, sidecar_path, overview_level,
+                    base_ifd_count=len(ifds),
                 )
                 sidecar = None
             if sidecar is not None:

--- a/xrspatial/geotiff/_sidecar.py
+++ b/xrspatial/geotiff/_sidecar.py
@@ -365,3 +365,72 @@ def discover_remote_sidecar(
     merged = list(base_ifds) + list(sidecar.ifds)
     sidecar_ifd_ids = {id(ifd) for ifd in sidecar.ifds}
     return merged, sidecar, sidecar_ifd_ids
+
+
+def handle_sidecar_parse_failure(
+    exc: BaseException,
+    sidecar_path: str,
+    overview_level: int | None,
+    base_ifd_count: int,
+) -> None:
+    """React to a sidecar load/parse failure consistently across readers.
+
+    Called by the eager CPU, eager GPU, and metadata-only paths after
+    catching a non-:class:`CloudSizeLimitError` exception from
+    :func:`load_sidecar`. The shared policy is:
+
+    * If the caller explicitly requested a level the base file alone
+      cannot serve (``overview_level >= base_ifd_count``), raise a
+      ``ValueError`` chained from ``exc`` so the traceback shows the
+      real sidecar parse failure. The release contract
+      (``geotiff_release_contract.md`` row ``reader.sidecar_ovr``) and
+      the in-tree warning text both promise this case surfaces the
+      cause rather than degrading to a misleading "out of range" raise
+      from :func:`select_overview_ifd`. Issue #2484.
+
+    * Otherwise (``None``, ``0``, or any level the base IFD chain can
+      serve), emit a ``RuntimeWarning`` and return so the caller can
+      fall back to base-only behaviour.
+
+    Gating on ``len(base_ifd_count)`` rather than the cruder
+    ``overview_level >= 1`` matters when the base TIFF carries
+    internal overview IFDs of its own: a request for ``level=1`` is
+    reachable from the base file in that case, and forcing a raise
+    just because a sibling sidecar happens to be corrupt would deny
+    the user a perfectly valid read.
+
+    Parameters
+    ----------
+    exc
+        The exception raised by :func:`load_sidecar`.
+    sidecar_path
+        Path or URL of the sidecar that failed to parse. Embedded in
+        both the raised error message and the fallback warning so the
+        user can find the offending file.
+    overview_level
+        The caller's requested overview level. ``None`` and ``0`` map
+        to silent-fallback. Higher values trigger the raise only when
+        they exceed ``base_ifd_count``.
+    base_ifd_count
+        Number of IFDs already parsed from the base file's pyramid.
+        A request inside ``[0, base_ifd_count)`` is satisfiable without
+        the sidecar and so does not trigger the raise.
+    """
+    if (
+        overview_level is not None
+        and overview_level >= base_ifd_count
+    ):
+        raise ValueError(
+            f"Cannot read overview_level={overview_level} from "
+            f"external sidecar {sidecar_path!r}: sidecar parse failed "
+            f"with {type(exc).__name__}: {exc}"
+        ) from exc
+    import warnings
+    warnings.warn(
+        f"Ignoring unreadable sidecar {sidecar_path!r}: "
+        f"{type(exc).__name__}: {exc}. Falling back to "
+        f"base-file-only read. Delete the .ovr file or pass "
+        f"overview_level>=1 to surface the parse error.",
+        RuntimeWarning,
+        stacklevel=3,
+    )

--- a/xrspatial/geotiff/tests/integration/test_sidecar.py
+++ b/xrspatial/geotiff/tests/integration/test_sidecar.py
@@ -1040,22 +1040,76 @@ def test_open_geotiff_base_read_survives_various_sidecar_payloads(
 
 
 # ---------------------------------------------------------------------------
-# Explicit external-overview requests still surface the error.
+# Explicit external-overview requests surface the underlying parse error.
+#
+# The release contract (``reader.sidecar_ovr`` row in
+# ``docs/source/reference/geotiff_release_contract.md``) and the
+# silent-fallback warning text both promise that ``overview_level >= 1``
+# exposes the actual sidecar parse failure rather than a generic "out of
+# range" from ``select_overview_ifd``. Issue #2484.
 # ---------------------------------------------------------------------------
-def test_open_geotiff_requesting_sidecar_level_still_raises(tmp_path):
-    """Asking for ``overview_level=1`` is asking for the sidecar surface;
-    a parse failure on that surface should not be silently swallowed."""
+def test_open_geotiff_requesting_sidecar_level_surfaces_parse_error(tmp_path):
+    """``overview_level=1`` against a corrupt sidecar must surface the
+    sidecar parse failure, not a misleading "out of range" raised after
+    silent fallback to base-only IFDs (#2484)."""
     path, _ = _make_base_2416(tmp_path)
     _make_corrupt_sidecar_2416(path, b"not a tiff")
 
-    # The base IFD list has length 1, sidecar is unreadable -> level 1
-    # falls outside the merged list. The reader's ``select_overview_ifd``
-    # raises ``ValueError`` for an out-of-range level. The point is that
-    # the error surfaces (warning + then explicit raise) rather than the
-    # base read silently failing.
+    # No silent fallback warning -- the explicit level request short-
+    # circuits the warn-and-fall-through branch and raises directly.
+    with pytest.raises(ValueError, match="external sidecar") as excinfo:
+        open_geotiff(str(path), overview_level=1)
+
+    # The underlying parse exception is chained via ``__cause__`` so the
+    # traceback shows what actually went wrong. The outer message must
+    # not be the generic "overview_level out of range" string that the
+    # pre-fix behaviour produced via ``select_overview_ifd``.
+    assert "out of range" not in str(excinfo.value)
+    assert excinfo.value.__cause__ is not None
+    cause_blob = (
+        f"{type(excinfo.value.__cause__).__name__}: "
+        f"{excinfo.value.__cause__}"
+    )
+    # The chained cause type / message also surface on the outer message
+    # so callers reading only ``str(exc)`` still see the real reason.
+    assert cause_blob in str(excinfo.value)
+
+
+def test_open_geotiff_overview_level_two_surfaces_parse_error(tmp_path):
+    """Any ``overview_level >= 1`` triggers the surface-the-cause path,
+    not just level 1. The level value is reflected in the message."""
+    path, _ = _make_base_2416(tmp_path)
+    _make_corrupt_sidecar_2416(path, b"not a tiff")
+
+    with pytest.raises(ValueError, match="overview_level=2") as excinfo:
+        open_geotiff(str(path), overview_level=2)
+
+    assert excinfo.value.__cause__ is not None
+
+
+def test_open_geotiff_overview_level_none_silently_falls_back(tmp_path):
+    """Contrast case: implicit / auto overview discovery
+    (``overview_level=None``) keeps the documented silent-fallback
+    behaviour. A corrupt sidecar must not break the base read."""
+    path, expected = _make_base_2416(tmp_path)
+    _make_corrupt_sidecar_2416(path, b"not a tiff")
+
     with pytest.warns(RuntimeWarning, match="Ignoring unreadable sidecar"):
-        with pytest.raises(ValueError, match="out of range"):
-            open_geotiff(str(path), overview_level=1)
+        da = open_geotiff(str(path), overview_level=None)
+
+    np.testing.assert_array_equal(da.values, expected)
+
+
+def test_open_geotiff_overview_level_zero_silently_falls_back(tmp_path):
+    """``overview_level=0`` is the base IFD, not a sidecar request, so
+    it follows the same silent-fallback rule as ``None``."""
+    path, expected = _make_base_2416(tmp_path)
+    _make_corrupt_sidecar_2416(path, b"not a tiff")
+
+    with pytest.warns(RuntimeWarning, match="Ignoring unreadable sidecar"):
+        da = open_geotiff(str(path), overview_level=0)
+
+    np.testing.assert_array_equal(da.values, expected)
 
 
 # ---------------------------------------------------------------------------
@@ -1124,6 +1178,35 @@ def test_open_geotiff_gpu_base_read_survives_unreadable_sidecar(tmp_path):
         gpu_da = open_geotiff(str(path), gpu=True)
 
     np.testing.assert_array_equal(gpu_da.data.get(), expected)
+
+
+def test_read_geo_info_requesting_sidecar_level_surfaces_parse_error(tmp_path):
+    """Metadata-only helper mirrors the eager CPU contract: an explicit
+    ``overview_level >= 1`` request against a corrupt sidecar must
+    surface the underlying parse error (#2484)."""
+    path, _ = _make_base_2416(tmp_path)
+    _make_corrupt_sidecar_2416(path, b"not a tiff")
+
+    with pytest.raises(ValueError, match="external sidecar") as excinfo:
+        _read_geo_info(str(path), overview_level=1)
+
+    assert "out of range" not in str(excinfo.value)
+    assert excinfo.value.__cause__ is not None
+
+
+@requires_gpu
+def test_open_geotiff_gpu_requesting_sidecar_level_surfaces_parse_error(
+    tmp_path,
+):
+    """GPU eager path mirrors the CPU contract for explicit external-
+    overview requests (#2484)."""
+    path, _ = _make_base_2416(tmp_path)
+    _make_corrupt_sidecar_2416(path, b"not a tiff")
+
+    with pytest.raises(ValueError, match="external sidecar") as excinfo:
+        open_geotiff(str(path), gpu=True, overview_level=1)
+
+    assert excinfo.value.__cause__ is not None
 
 
 # ============================================================================

--- a/xrspatial/geotiff/tests/integration/test_sidecar.py
+++ b/xrspatial/geotiff/tests/integration/test_sidecar.py
@@ -1076,14 +1076,54 @@ def test_open_geotiff_requesting_sidecar_level_surfaces_parse_error(tmp_path):
 
 
 def test_open_geotiff_overview_level_two_surfaces_parse_error(tmp_path):
-    """Any ``overview_level >= 1`` triggers the surface-the-cause path,
-    not just level 1. The level value is reflected in the message."""
+    """Any level the base file alone cannot serve triggers the
+    surface-the-cause path. With ``_make_base_2416`` writing a single
+    IFD, that includes level 2 -- the sidecar would have to supply it,
+    so the corrupt-sidecar branch surfaces the parse failure rather
+    than letting ``select_overview_ifd`` raise a generic "out of
+    range"."""
     path, _ = _make_base_2416(tmp_path)
     _make_corrupt_sidecar_2416(path, b"not a tiff")
 
     with pytest.raises(ValueError, match="overview_level=2") as excinfo:
         open_geotiff(str(path), overview_level=2)
 
+    assert excinfo.value.__cause__ is not None
+
+
+def test_open_geotiff_internal_overview_level_silent_on_bad_sidecar(
+    tmp_path,
+):
+    """A TIFF carrying its own internal overview IFDs can satisfy
+    ``overview_level=1`` from the base file alone. A sibling corrupt
+    sidecar must not turn that valid read into a raise (#2484
+    follow-up): the warn-and-fall-back branch handles it, the request
+    is reachable from the base IFD chain, and the user gets the
+    overview they asked for."""
+    # Write a base TIFF with one internal overview level so the IFD
+    # chain has length 2 (level 0 + level 1) before any sidecar.
+    arr = np.arange(64, dtype=np.uint16).reshape(8, 8)
+    xs = np.arange(8) + 0.5
+    ys = np.arange(8) + 0.5
+    da = xr.DataArray(arr, dims=("y", "x"), coords={"y": ys, "x": xs})
+    da.attrs["crs"] = 4326
+    path = tmp_path / "internal_ovr_2484.tif"
+    to_geotiff(da, str(path), cog=True, compression="none",
+               overview_levels=[2])
+
+    _make_corrupt_sidecar_2416(path, b"not a tiff")
+
+    # Level 1 is the internal overview; reachable without the sidecar.
+    # Expect a warning (sidecar still tried + fell back), no raise.
+    with pytest.warns(RuntimeWarning, match="Ignoring unreadable sidecar"):
+        da_lvl1 = open_geotiff(str(path), overview_level=1)
+    # Internal overview is a 4x4 reduction of the 8x8 base.
+    assert da_lvl1.shape == (4, 4)
+
+    # Level 2 is beyond the base IFD chain -- now the sidecar is
+    # required, so the parse error surfaces.
+    with pytest.raises(ValueError, match="external sidecar") as excinfo:
+        open_geotiff(str(path), overview_level=2)
     assert excinfo.value.__cause__ is not None
 
 


### PR DESCRIPTION
Closes #2484.

## Summary

- The release contract for `reader.sidecar_ovr` says "Requesting a specific external level surfaces the underlying parse error." The eager CPU, eager GPU, and metadata paths were silently swallowing the sidecar exception, so a caller asking for `overview_level=1` against a corrupt `.tif.ovr` got a misleading `ValueError("overview_level=1 out of range")` from `select_overview_ifd` instead of the real parse failure.
- For `overview_level >= 1`, chain the parse exception via `raise ... from exc` so the traceback shows what actually went wrong.
- `overview_level=None` / `0` keep the documented silent-fallback behaviour. `CloudSizeLimitError` still propagates either way.

## Backend coverage

- numpy (eager CPU): fixed in `_reader._read_to_array`.
- cupy (eager GPU): fixed in `_backends/gpu` for symmetry with the contract.
- metadata path used by the dask graph builder: fixed in `__init__._read_geo_info`.
- HTTP / fsspec dask path goes through `discover_remote_sidecar`, which has its own carve-out and is out of scope for this finding.

## Test plan

- [x] `test_open_geotiff_requesting_sidecar_level_surfaces_parse_error` (rewritten from the test that pinned the broken behaviour)
- [x] `test_open_geotiff_overview_level_two_surfaces_parse_error`
- [x] `test_open_geotiff_overview_level_none_silently_falls_back`
- [x] `test_open_geotiff_overview_level_zero_silently_falls_back`
- [x] `test_read_geo_info_requesting_sidecar_level_surfaces_parse_error`
- [x] `test_open_geotiff_gpu_requesting_sidecar_level_surfaces_parse_error` (gated on GPU)
- [x] All 88 tests in `xrspatial/geotiff/tests/integration/test_sidecar.py` pass locally.