### PR TITLE
geotiff: enforce mixed-band dtype rejection in VRT reader

### DIFF
--- a/xrspatial/geotiff/_backends/vrt.py
+++ b/xrspatial/geotiff/_backends/vrt.py
@@ -1018,7 +1018,8 @@ def _read_vrt_chunked(source, *, window, band, name, chunks, gpu, dtype,
     #     source integer dtype (handled by the ``promotes is False``
     #     fall-through below).
     # See also Copilot review on PR #1822.
-    declared_dtype = _effective_dtype_for_bands(selected_bands)
+    declared_dtype = _effective_dtype_for_bands(
+        selected_bands, source=source)
 
     if mask_nodata and declared_dtype.kind in ('u', 'i'):
         promotes = False

--- a/xrspatial/geotiff/_vrt.py
+++ b/xrspatial/geotiff/_vrt.py
@@ -966,7 +966,7 @@ def _sentinel_for_dtype(nodata_val, dtype):
     return dtype.type(int(nodata_f))
 
 
-def _effective_dtype_for_bands(selected_bands) -> np.dtype:
+def _effective_dtype_for_bands(selected_bands, *, source=None) -> np.dtype:
     """Return the output buffer dtype shared by every selected band.
 
     Each band's effective dtype is the declared ``<VRTRasterBand>``
@@ -990,6 +990,16 @@ def _effective_dtype_for_bands(selected_bands) -> np.dtype:
     truncation. When every selected band declares the same ``dataType``,
     a ``ComplexSource``-driven widening on any band promotes the shared
     output buffer to ``float64``.
+
+    Parameters
+    ----------
+    selected_bands
+        The ``VRTRasterBand`` entries to validate.
+    source
+        Optional path / identifier of the VRT being read. When provided,
+        the ``MixedBandMetadataError`` message includes it so the caller
+        can locate the file from the traceback without re-parsing the
+        VRT XML.
     """
     if not selected_bands:
         raise ValueError(
@@ -1008,11 +1018,13 @@ def _effective_dtype_for_bands(selected_bands) -> np.dtype:
         band_descs = ", ".join(
             f"band {i + 1}: {d}" for i, d in enumerate(declared_dtypes)
         )
+        source_clause = f"VRT '{source}': " if source else ""
         raise MixedBandMetadataError(
-            "VRT bands declare conflicting dtypes; expected a single "
-            "declared dataType across all <VRTRasterBand> elements but "
-            f"saw {band_descs}. The VRT support matrix rejects mixed "
-            "band dtypes rather than widening via np.result_type."
+            f"{source_clause}VRT bands declare conflicting dtypes; "
+            "expected a single declared dataType across all "
+            f"<VRTRasterBand> elements but saw {band_descs}. The VRT "
+            "support matrix rejects mixed band dtypes rather than "
+            "widening via np.result_type."
         )
     # All declared dtypes agree. A single band's ``ComplexSource``
     # ``ScaleRatio`` / ``ScaleOffset`` still promotes the shared buffer
@@ -1406,7 +1418,7 @@ def read_vrt(vrt_path: str, *, window=None,
     # "at least one array or dtype is required" message that gives the
     # caller no hint about the underlying cause. The helper raises
     # ``ValueError`` for the empty case with that explicit message.
-    dtype = _effective_dtype_for_bands(selected_bands)
+    dtype = _effective_dtype_for_bands(selected_bands, source=vrt_path)
     fill = np.nan if dtype.kind in ('f', 'c') else 0
     if len(selected_bands) == 1:
         result = np.full((out_h, out_w), fill, dtype=dtype)

--- a/xrspatial/geotiff/_vrt.py
+++ b/xrspatial/geotiff/_vrt.py
@@ -17,7 +17,7 @@ from xml.sax.saxutils import quoteattr as _xml_quoteattr
 
 import numpy as np
 
-from ._errors import UnsupportedGeoTIFFFeatureError
+from ._errors import MixedBandMetadataError, UnsupportedGeoTIFFFeatureError
 from ._safe_xml import safe_fromstring
 
 
@@ -967,31 +967,65 @@ def _sentinel_for_dtype(nodata_val, dtype):
 
 
 def _effective_dtype_for_bands(selected_bands) -> np.dtype:
-    """Return the output buffer dtype that holds every selected band losslessly.
+    """Return the output buffer dtype shared by every selected band.
 
-    Computes ``np.result_type`` over each band's effective dtype, where
-    each band's effective dtype is widened to ``float64`` if any of its
-    ``ComplexSource`` declarations apply a non-identity ``ScaleRatio``
-    (``scale``) or ``ScaleOffset`` (``offset``). Mirrors the historic
-    inline computation in :func:`read_vrt` and matches the parse-time
-    declared dtype the chunked path emits up front. Issue #1825.
+    Each band's effective dtype is the declared ``<VRTRasterBand>``
+    ``dataType``, widened to ``float64`` if any of its ``ComplexSource``
+    declarations apply a non-identity ``ScaleRatio`` (``scale``) or
+    ``ScaleOffset`` (``offset``). Mirrors the historic inline computation
+    in :func:`read_vrt` and matches the parse-time declared dtype the
+    chunked path emits up front. Issue #1825.
+
+    All selected bands must share the same declared ``dataType``. The
+    VRT support matrix documented at ``xrspatial.geotiff._backends.vrt``
+    requires this: per-band dtype mismatch raises rather than silently
+    flattening to a common output dtype. A disagreement raises
+    :class:`MixedBandMetadataError` naming the offending bands. Issue
+    #2485.
+
+    Per-band widening to ``float64`` driven by a ``ComplexSource``
+    ``ScaleRatio`` / ``ScaleOffset`` is not a cross-band dtype mismatch
+    because it does not change the declared band ``dataType`` -- it just
+    promotes that one band's buffer to hold the scaled values without
+    truncation. When every selected band declares the same ``dataType``,
+    a ``ComplexSource``-driven widening on any band promotes the shared
+    output buffer to ``float64``.
     """
     if not selected_bands:
         raise ValueError(
             "VRT has no <VRTRasterBand> elements; cannot determine "
             "output dtype"
         )
-    effective_dtypes = []
+    declared_dtypes = [vrt_band.dtype for vrt_band in selected_bands]
+    # Contract from xrspatial.geotiff._backends.vrt: per-band declared
+    # dtype mismatch raises rather than flattening via ``np.result_type``.
+    # ``np.result_type`` would happily widen ``UInt16`` + ``Float32`` to
+    # ``Float32`` and silently change downstream dtype semantics
+    # (categorical values, integer extremes, nodata sentinels). Issue
+    # #2485.
+    first_declared = declared_dtypes[0]
+    if any(d != first_declared for d in declared_dtypes[1:]):
+        band_descs = ", ".join(
+            f"band {i + 1}: {d}" for i, d in enumerate(declared_dtypes)
+        )
+        raise MixedBandMetadataError(
+            "VRT bands declare conflicting dtypes; expected a single "
+            "declared dataType across all <VRTRasterBand> elements but "
+            f"saw {band_descs}. The VRT support matrix rejects mixed "
+            "band dtypes rather than widening via np.result_type."
+        )
+    # All declared dtypes agree. A single band's ``ComplexSource``
+    # ``ScaleRatio`` / ``ScaleOffset`` still promotes the shared buffer
+    # to ``float64`` so the scaled values survive without truncation.
+    # This preserves the issue #1696 / #1825 behaviour for matching-
+    # dtype bands.
     for vrt_band in selected_bands:
-        eff = vrt_band.dtype
         for src in vrt_band.sources:
             scaled = src.scale is not None and src.scale != 1.0
             offset = src.offset is not None and src.offset != 0.0
             if scaled or offset:
-                eff = np.dtype(np.float64)
-                break
-        effective_dtypes.append(eff)
-    return np.result_type(*effective_dtypes)
+                return np.dtype(np.float64)
+    return first_declared
 
 
 def _apply_integer_sentinel_mask(arr, vrt, band):

--- a/xrspatial/geotiff/tests/vrt/test_dtype_conversion.py
+++ b/xrspatial/geotiff/tests/vrt/test_dtype_conversion.py
@@ -26,7 +26,10 @@ import pytest
 import uuid
 import xarray as xr
 from xrspatial.geotiff import read_vrt, to_geotiff
-from xrspatial.geotiff._errors import VRTUnsupportedError
+from xrspatial.geotiff._errors import (
+    MixedBandMetadataError,
+    VRTUnsupportedError,
+)
 from xrspatial.geotiff._vrt import (
     _NP_TO_VRT_DTYPE,
     _parse_band_nodata,
@@ -655,10 +658,14 @@ def _multiband_dtype_build_complex_source_vrt(tmp_path, *, dtype_str, src_path, 
     return str(p)
 
 
-def test_mixed_byte_and_float32_bands_preserve_fractional(tmp_path):
-    """``Byte`` band 0 + ``Float32`` band 1: band 1's fractional values
-    must survive the read. Before the fix the buffer was allocated as
-    uint8 and ``1.5, 2.5, 3.5, 4.5`` truncated to ``1, 2, 3, 4``.
+def test_mixed_byte_and_float32_bands_raise(tmp_path):
+    """``Byte`` band 0 + ``Float32`` band 1 must raise rather than widen.
+
+    The original #1696 fix widened the output buffer so band 1's
+    fractional values survived. The VRT support matrix at
+    ``_backends/vrt.py`` later tightened the contract: per-band dtype
+    mismatch is a documented error condition, not a silent widening.
+    Issue #2485 flipped the behaviour from widening to raising.
     """
     b0 = np.array([[10, 11], [12, 13]], dtype=np.uint8)
     b1 = np.array([[1.5, 2.5], [3.5, 4.5]], dtype=np.float32)
@@ -667,10 +674,10 @@ def test_mixed_byte_and_float32_bands_preserve_fractional(tmp_path):
     _multiband_dtype_write(b0, p0)
     _multiband_dtype_write(b1, p1)
     vrt_path = _multiband_dtype_build_two_band_vrt(tmp_path, b0_dtype_str='Byte', b0_path=str(p0), b1_dtype_str='Float32', b1_path=str(p1))
-    r = read_vrt(vrt_path)
-    assert r.dtype.kind == 'f', f'Mixed Byte+Float32 must widen to float; got {r.dtype}'
-    np.testing.assert_allclose(r.values[..., 1], b1.astype(r.dtype))
-    np.testing.assert_array_equal(r.values[..., 0], b0.astype(r.dtype))
+    with pytest.raises(MixedBandMetadataError) as excinfo:
+        read_vrt(vrt_path)
+    msg = str(excinfo.value).lower()
+    assert 'band 1' in msg and 'band 2' in msg
 
 
 def test_complex_source_scale_promotes_buffer_to_float(tmp_path):
@@ -733,11 +740,15 @@ def test_complex_source_scale_and_offset_preserve_precision(tmp_path):
     np.testing.assert_allclose(r.values[..., 1], expected)
 
 
-def test_nodata_round_trip_through_widened_int_dtype(tmp_path):
-    """Band 0 = uint8 with NoData=255; band 1 = int16 with NoData=-9999.
-    ``np.result_type(uint8, int16) = int16``. Band 0's value 255 is
-    representable as int16 so the nodata fast-path still fires; the
-    surviving values must be preserved through the wider buffer.
+def test_mixed_byte_and_int16_bands_raise(tmp_path):
+    """``Byte`` band 0 + ``Int16`` band 1 must raise rather than widen.
+
+    Previously the reader widened via ``np.result_type(uint8, int16)``
+    and round-tripped the nodata sentinels through the wider buffer.
+    The #2485 contract rejects this kind of cross-band dtype mismatch
+    rather than silently flattening; callers that genuinely want the
+    widened behaviour must rebuild their VRT with a single declared
+    dataType.
     """
     b0 = np.array([[1, 2], [3, 255]], dtype=np.uint8)
     b1 = np.array([[100, 200], [300, -9999]], dtype=np.int16)
@@ -748,18 +759,10 @@ def test_nodata_round_trip_through_widened_int_dtype(tmp_path):
     vrt_path = f'<VRTDataset rasterXSize="2" rasterYSize="2">\n  <GeoTransform>0.0, 1.0, 0.0, 0.0, 0.0, -1.0</GeoTransform>\n  <VRTRasterBand dataType="Byte" band="1">\n    <NoDataValue>255</NoDataValue>\n    <SimpleSource>\n      <SourceFilename relativeToVRT="0">{p0}</SourceFilename>\n      <SourceBand>1</SourceBand>\n      <SrcRect xOff="0" yOff="0" xSize="2" ySize="2"/>\n      <DstRect xOff="0" yOff="0" xSize="2" ySize="2"/>\n    </SimpleSource>\n  </VRTRasterBand>\n  <VRTRasterBand dataType="Int16" band="2">\n    <NoDataValue>-9999</NoDataValue>\n    <SimpleSource>\n      <SourceFilename relativeToVRT="0">{p1}</SourceFilename>\n      <SourceBand>1</SourceBand>\n      <SrcRect xOff="0" yOff="0" xSize="2" ySize="2"/>\n      <DstRect xOff="0" yOff="0" xSize="2" ySize="2"/>\n    </SimpleSource>\n  </VRTRasterBand>\n</VRTDataset>'
     out = tmp_path / 'mixed.vrt'
     out.write_text(vrt_path)
-    r = read_vrt(str(out), band_nodata='first')
-    if r.dtype.kind == 'f':
-        assert r.values[0, 0, 0] == 1
-        assert r.values[0, 1, 0] == 2
-        assert r.values[1, 0, 0] == 3
-        assert np.isnan(r.values[1, 1, 0])
-        assert np.isnan(r.values[1, 1, 1])
-        assert r.values[0, 0, 1] == 100
-    else:
-        assert r.dtype == np.int16
-        assert r.values[0, 0, 0] == 1
-        assert r.values[0, 0, 1] == 100
+    with pytest.raises(MixedBandMetadataError) as excinfo:
+        read_vrt(str(out), band_nodata='first')
+    msg = str(excinfo.value).lower()
+    assert 'band 1' in msg and 'band 2' in msg
 
 
 def test_single_band_complex_source_scale_widens_buffer(tmp_path):

--- a/xrspatial/geotiff/tests/vrt/test_validation.py
+++ b/xrspatial/geotiff/tests/vrt/test_validation.py
@@ -1036,15 +1036,28 @@ def test_mixed_source_crs_no_vrt_srs_rejects(tmp_path):
     assert src_3857 in str(excinfo.value)
 
 
+_VRT_TO_NP_DTYPE = {
+    "Byte": np.uint8,
+    "UInt16": np.uint16,
+    "Int16": np.int16,
+    "UInt32": np.uint32,
+    "Int32": np.int32,
+    "Float32": np.float32,
+    "Float64": np.float64,
+}
+
+
 @pytest.mark.parametrize(
-    "dtype_a, dtype_b, name_a, name_b",
+    "name_a, name_b",
     [
-        (np.uint16, np.float32, "UInt16", "Float32"),
-        (np.int32, np.float64, "Int32", "Float64"),
+        ("UInt16", "Float32"),
+        ("Int32", "Float64"),
     ],
+    ids=lambda n: n,
 )
+@pytest.mark.parametrize("chunks", [None, 2], ids=["eager", "chunked"])
 def test_mixed_source_dtype_ambiguous_widening_rejected(
-        tmp_path, dtype_a, dtype_b, name_a, name_b):
+        tmp_path, name_a, name_b, chunks):
     """Bands declaring incompatible dtypes must raise rather than
     silently widen via ``np.result_type``.
 
@@ -1052,10 +1065,16 @@ def test_mixed_source_dtype_ambiguous_widening_rejected(
     per-band dtype mismatches surface as ``MixedBandMetadataError``.
     Covers both the original ``UInt16`` + ``Float32`` case and an
     integer-floating combo at higher precision (``Int32`` + ``Float64``)
-    so the rule is enforced generally. Issue #2485.
+    so the rule is enforced generally. Parametrising over
+    ``chunks=None`` (eager) and ``chunks=2`` (dask) pins the same
+    behaviour on both reader paths so a future change that detours
+    around ``_effective_dtype_for_bands`` in the chunked path cannot
+    regress this silently. Issue #2485.
     """
-    src_a = _write_src_float32_geotiff(tmp_path, dtype=dtype_a)
-    src_b = _write_src_float32_geotiff(tmp_path, dtype=dtype_b)
+    src_a = _write_src_float32_geotiff(
+        tmp_path, dtype=_VRT_TO_NP_DTYPE[name_a])
+    src_b = _write_src_float32_geotiff(
+        tmp_path, dtype=_VRT_TO_NP_DTYPE[name_b])
     body_b1 = _simple_source_xml(src_a)
     body_b2 = _simple_source_xml(src_b)
     xml = f"""<VRTDataset rasterXSize="4" rasterYSize="4">
@@ -1071,13 +1090,19 @@ def test_mixed_source_dtype_ambiguous_widening_rejected(
     vrt_path = _write_vrt(tmp_path, xml)
 
     with pytest.raises(MixedBandMetadataError) as excinfo:
-        _package_read_vrt(vrt_path)
+        if chunks is None:
+            _package_read_vrt(vrt_path)
+        else:
+            _package_read_vrt(vrt_path, chunks=chunks)
     msg = str(excinfo.value).lower()
     assert any(k in msg for k in ('dtype', 'datatype', 'mixed'))
     # Message should name both conflicting bands so the caller can
     # locate the disagreement without reading the VRT XML by hand.
     assert 'band 1' in msg
     assert 'band 2' in msg
+    # And the VRT path so callers can locate the file from the
+    # traceback without re-parsing the XML.
+    assert vrt_path in str(excinfo.value)
 
 
 def test_supported_simple_vrt_round_trips_via_open_geotiff(tmp_path):

--- a/xrspatial/geotiff/tests/vrt/test_validation.py
+++ b/xrspatial/geotiff/tests/vrt/test_validation.py
@@ -1036,36 +1036,48 @@ def test_mixed_source_crs_no_vrt_srs_rejects(tmp_path):
     assert src_3857 in str(excinfo.value)
 
 
-@pytest.mark.xfail(
-    reason="mixed band dtype rejection still silently widens to a "
-           "common dtype; the validator needs to honour the contract",
-    strict=False,
+@pytest.mark.parametrize(
+    "dtype_a, dtype_b, name_a, name_b",
+    [
+        (np.uint16, np.float32, "UInt16", "Float32"),
+        (np.int32, np.float64, "Int32", "Float64"),
+    ],
 )
-def test_mixed_source_dtype_ambiguous_widening_rejected(tmp_path):
-    """Two bands declaring incompatible dtypes (``UInt16`` and
-    ``Float32``) silently widen the output buffer today. The contract
-    for the release is to reject mixed band dtypes unless the user opts
-    in."""
-    src_u16 = _write_src_float32_geotiff(tmp_path, dtype=np.uint16)
-    src_f32 = _write_src_float32_geotiff(tmp_path, dtype=np.float32)
-    body_b1 = _simple_source_xml(src_u16)
-    body_b2 = _simple_source_xml(src_f32)
+def test_mixed_source_dtype_ambiguous_widening_rejected(
+        tmp_path, dtype_a, dtype_b, name_a, name_b):
+    """Bands declaring incompatible dtypes must raise rather than
+    silently widen via ``np.result_type``.
+
+    The VRT support matrix at ``_backends/vrt.py`` requires that
+    per-band dtype mismatches surface as ``MixedBandMetadataError``.
+    Covers both the original ``UInt16`` + ``Float32`` case and an
+    integer-floating combo at higher precision (``Int32`` + ``Float64``)
+    so the rule is enforced generally. Issue #2485.
+    """
+    src_a = _write_src_float32_geotiff(tmp_path, dtype=dtype_a)
+    src_b = _write_src_float32_geotiff(tmp_path, dtype=dtype_b)
+    body_b1 = _simple_source_xml(src_a)
+    body_b2 = _simple_source_xml(src_b)
     xml = f"""<VRTDataset rasterXSize="4" rasterYSize="4">
   <SRS>EPSG:4326</SRS>
   <GeoTransform>0.0, 1.0, 0.0, 0.0, 0.0, -1.0</GeoTransform>
-  <VRTRasterBand dataType="UInt16" band="1">
+  <VRTRasterBand dataType="{name_a}" band="1">
 {body_b1}
   </VRTRasterBand>
-  <VRTRasterBand dataType="Float32" band="2">
+  <VRTRasterBand dataType="{name_b}" band="2">
 {body_b2}
   </VRTRasterBand>
 </VRTDataset>"""
     vrt_path = _write_vrt(tmp_path, xml)
 
-    with pytest.raises((ValueError, NotImplementedError)) as excinfo:
+    with pytest.raises(MixedBandMetadataError) as excinfo:
         _package_read_vrt(vrt_path)
     msg = str(excinfo.value).lower()
     assert any(k in msg for k in ('dtype', 'datatype', 'mixed'))
+    # Message should name both conflicting bands so the caller can
+    # locate the disagreement without reading the VRT XML by hand.
+    assert 'band 1' in msg
+    assert 'band 2' in msg
 
 
 def test_supported_simple_vrt_round_trips_via_open_geotiff(tmp_path):


### PR DESCRIPTION
## Summary

- Tightens `_effective_dtype_for_bands` in `xrspatial/geotiff/_vrt.py` to honour the contract at `_backends/vrt.py:158`: per-band declared dtype mismatch raises `MixedBandMetadataError` instead of silently widening through `np.result_type`.
- ComplexSource `ScaleRatio` / `ScaleOffset` widening still works when every band declares the same `dataType` (matching-dtype intra-band widening stays supported).
- Closes #2485.

## Backend coverage

Pure parse-time / reader logic, no kernel changes. Behaviour applies on every read path (numpy, dask).

## Test plan

- `xrspatial/geotiff/tests/vrt/test_validation.py::test_mixed_source_dtype_ambiguous_widening_rejected` is now a strict, parametrised test (`UInt16+Float32`, `Int32+Float64`) -- passes.
- `test_dtype_conversion.py::test_mixed_byte_and_float32_bands_raise` and `test_mixed_byte_and_int16_bands_raise` flipped from widening-expectation to raise-expectation -- pass.
- ScaleRatio / ScaleOffset tests (same declared dtype, intra-band widening) still pass.
- Full geotiff suite: 5956 passed, 68 skipped, 1 xfailed.