### PR TITLE
geotiff: close cached mmap handles at interpreter shutdown (#2486)

### DIFF
--- a/xrspatial/geotiff/_sources.py
+++ b/xrspatial/geotiff/_sources.py
@@ -303,11 +303,15 @@ class _MmapCache:
         file objects are swallowed so a partially torn-down interpreter
         (where ``mmap.mmap.close`` or the file object's ``close`` raises
         because the underlying resource is already gone) does not crash
-        finalization. After this returns, ``_entries`` is empty and any
-        ``_FileSource`` that still holds an ``entry`` token will become a
-        no-op on its eventual ``release()`` -- the refcount decrement
-        still runs, but the close path is a no-op because the file
-        handle is already closed.
+        finalization. After this returns, ``_entries`` is empty.
+
+        If a stale ``_FileSource`` later calls ``release()`` on an entry
+        token that was torn down here, the release routes through the
+        orphan branch and calls ``_close_entry_locked`` a second time.
+        That second close is rare at interpreter shutdown (it requires a
+        live ``_FileSource`` to survive past ``atexit``), and it stays
+        safe because ``mmap.close()`` and the standard file object's
+        ``close()`` are both idempotent in CPython.
         """
         with self._lock:
             entries = list(self._entries.values())
@@ -375,8 +379,8 @@ def _shutdown_cleanup():
         pass
     # urllib3 PoolManager holds onto sockets until garbage collected.
     # Close it explicitly so the test runner's resource-warning filter
-    # does not catch leaked sockets at exit.
-    global _http_pool
+    # does not catch leaked sockets at exit. Read-only access of the
+    # module-level name, so no ``global`` is needed.
     pool = _http_pool
     if pool is not None:
         try:

--- a/xrspatial/geotiff/_sources.py
+++ b/xrspatial/geotiff/_sources.py
@@ -26,6 +26,7 @@ epic (issue #2228). Behaviour-preserving move; no public API change.
 """
 from __future__ import annotations
 
+import atexit
 import mmap
 import os as _os_module
 import threading
@@ -284,6 +285,55 @@ class _MmapCache:
                 entry = self._entries.pop(key)
                 self._close_entry_locked(entry)
 
+    def close_all(self):
+        """Close every cached entry, regardless of refcount. Shutdown hook.
+
+        Unlike :meth:`clear`, which only drops idle entries, this method
+        closes the underlying file handle and mmap for *every* entry the
+        cache still holds, including those with non-zero refcounts. It
+        exists so the :func:`atexit` hook registered at module import can
+        guarantee no GeoTIFF file handles leak past interpreter shutdown
+        (issue #2486). Live ``_FileSource`` instances with a non-zero
+        refcount are not the common case at interpreter exit, but a
+        long-running process that never released its sources (e.g. a
+        crash partway through a notebook session) would still leave
+        handles open without this stronger cleanup.
+
+        Safe to invoke multiple times. Errors closing individual mmap or
+        file objects are swallowed so a partially torn-down interpreter
+        (where ``mmap.mmap.close`` or the file object's ``close`` raises
+        because the underlying resource is already gone) does not crash
+        finalization. After this returns, ``_entries`` is empty and any
+        ``_FileSource`` that still holds an ``entry`` token will become a
+        no-op on its eventual ``release()`` -- the refcount decrement
+        still runs, but the close path is a no-op because the file
+        handle is already closed.
+        """
+        with self._lock:
+            entries = list(self._entries.values())
+            self._entries.clear()
+            for entry in entries:
+                # Mark orphaned so a late release() (after this method
+                # returns) routes through the orphan branch rather than
+                # trying to find the entry in the (now-empty) dict. The
+                # orphan branch will call _close_entry_locked again --
+                # mmap.close() and file.close() are idempotent in CPython
+                # so the double-close is safe.
+                entry[5] = True
+                try:
+                    if entry[1] is not None:
+                        entry[1].close()
+                except Exception:  # noqa: BLE001
+                    # mmap may already be closed if finalization runs
+                    # after the mmap module's atexit; swallow.
+                    pass
+                try:
+                    entry[0].close()
+                except Exception:  # noqa: BLE001
+                    # File object may already be closed for the same
+                    # reason; swallow.
+                    pass
+
 
 # Module-level cache shared across all reads. This is a *singleton*: there
 # is one shared mmap cache per Python process so concurrent ``_FileSource``
@@ -295,6 +345,47 @@ class _MmapCache:
 # to a third module, must keep the single-instance contract or
 # ``_FileSource`` will leak mmaps between cache instances.
 _mmap_cache = _MmapCache()
+
+
+def _shutdown_cleanup():
+    """Close every cached resource at interpreter shutdown (issue #2486).
+
+    Without this hook, the mmap cache (and the urllib3 PoolManager) hold
+    onto open file handles / sockets until the process exits, which
+    triggers ``ResourceWarning: unclosed file`` from pytest's warning
+    filter and from CPython's own finalizer chain. The cache eviction
+    policy keeps idle entries around on purpose so repeated reads of
+    the same path reuse the mmap; that is the right behaviour during
+    process life, but it leaves resources open at exit. This hook
+    bridges the gap.
+
+    The hook is idempotent: a second call after the cache is already
+    empty is a no-op. It also swallows individual close errors so a
+    partially torn-down runtime (where ``mmap`` / file objects are
+    already closed by an earlier finalizer) does not propagate an
+    exception out of the atexit chain.
+    """
+    try:
+        _mmap_cache.close_all()
+    except Exception:  # noqa: BLE001
+        # ``close_all`` already swallows per-entry errors; a top-level
+        # exception here would mean the cache state is corrupt or a
+        # module-level import has been unloaded by finalization. Either
+        # way, raising out of an atexit hook is worse than swallowing.
+        pass
+    # urllib3 PoolManager holds onto sockets until garbage collected.
+    # Close it explicitly so the test runner's resource-warning filter
+    # does not catch leaked sockets at exit.
+    global _http_pool
+    pool = _http_pool
+    if pool is not None:
+        try:
+            pool.clear()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+atexit.register(_shutdown_cleanup)
 
 
 class _FileSource:

--- a/xrspatial/geotiff/tests/test_shutdown_cleanup_2486.py
+++ b/xrspatial/geotiff/tests/test_shutdown_cleanup_2486.py
@@ -1,0 +1,165 @@
+# Tests for the atexit shutdown hook that closes cached mmap-backed
+# file handles at interpreter shutdown (issue #2486).
+import os
+import subprocess
+import sys
+import textwrap
+import warnings
+
+import numpy as np
+import pytest
+
+from xrspatial.geotiff import to_geotiff
+from xrspatial.geotiff import _sources as _src_module
+from xrspatial.geotiff._sources import (
+    _FileSource,
+    _MmapCache,
+    _mmap_cache,
+    _shutdown_cleanup,
+)
+
+
+@pytest.fixture
+def tiff_path_2486(tmp_path):
+    arr = np.zeros((4, 4), dtype=np.uint8)
+    path = str(tmp_path / 'tmp_2486_shutdown.tif')
+    to_geotiff(arr, path, compression='none')
+    return path
+
+
+def test_close_all_closes_idle_entries(tiff_path_2486):
+    # An idle entry (refcount 0) should be closed by close_all.
+    cache = _MmapCache(max_size=4)
+    mm, size, entry = cache.acquire(tiff_path_2486)
+    cache.release(entry)
+    # Entry sits idle in the cache.
+    real = os.path.realpath(tiff_path_2486)
+    assert real in cache._entries
+    fh = entry[0]
+    mm_obj = entry[1]
+    assert not fh.closed
+    cache.close_all()
+    assert len(cache._entries) == 0
+    assert fh.closed
+    if mm_obj is not None:
+        # mmap exposes closed via .closed in CPython 3.2+.
+        assert mm_obj.closed
+
+
+def test_close_all_closes_in_use_entries(tiff_path_2486):
+    # An in-use entry (refcount > 0) should also be closed -- the process
+    # is going away and we want no handles to leak.
+    cache = _MmapCache(max_size=4)
+    mm, size, entry = cache.acquire(tiff_path_2486)
+    assert entry[3] == 1  # refcount
+    fh = entry[0]
+    cache.close_all()
+    assert len(cache._entries) == 0
+    assert fh.closed
+
+
+def test_close_all_idempotent(tiff_path_2486):
+    cache = _MmapCache(max_size=4)
+    _mm, _size, entry = cache.acquire(tiff_path_2486)
+    cache.release(entry)
+    cache.close_all()
+    # Second call should be a harmless no-op.
+    cache.close_all()
+    assert len(cache._entries) == 0
+
+
+def test_release_after_close_all_does_not_crash(tiff_path_2486):
+    # After close_all, a stale FileSource holding the entry token must
+    # still survive its eventual release() call. The release should not
+    # raise, even though the file handle and mmap are already closed.
+    cache = _MmapCache(max_size=4)
+    mm, size, entry = cache.acquire(tiff_path_2486)
+    cache.close_all()
+    # Should not raise. The orphan branch in release() will try to
+    # close again -- mmap.close() and file.close() are idempotent.
+    cache.release(entry)
+
+
+def test_shutdown_cleanup_runs_against_module_singleton(tiff_path_2486):
+    # The module-level cleanup function should call close_all on the
+    # module singleton. Use the real singleton (not a fresh _MmapCache)
+    # because the atexit registration targets the singleton by name.
+    src = _FileSource(tiff_path_2486)
+    src.close()  # Returns entry to idle pool.
+    real = os.path.realpath(tiff_path_2486)
+    assert real in _mmap_cache._entries
+    entry = _mmap_cache._entries[real]
+    fh = entry[0]
+    assert not fh.closed
+    _shutdown_cleanup()
+    assert len(_mmap_cache._entries) == 0
+    assert fh.closed
+
+
+def test_shutdown_cleanup_handles_already_closed_resources(tiff_path_2486):
+    # If the mmap / file object is already closed (e.g. another finalizer
+    # ran first), the cleanup must not propagate exceptions out of the
+    # atexit chain.
+    cache = _MmapCache(max_size=4)
+    _mm, _size, entry = cache.acquire(tiff_path_2486)
+    # Pre-close the underlying resources to simulate finalization order.
+    if entry[1] is not None:
+        entry[1].close()
+    entry[0].close()
+    # Should swallow the double-close errors silently.
+    cache.close_all()
+    assert len(cache._entries) == 0
+
+
+def test_subprocess_read_emits_no_resource_warning(tiff_path_2486):
+    # Spawn a subprocess that opens a GeoTIFF and exits. With the atexit
+    # hook registered, no ResourceWarning should be emitted at shutdown.
+    # Run with -W error::ResourceWarning so any leaked handle turns into
+    # a non-zero exit code with a traceback we can grep.
+    script = textwrap.dedent(f'''
+        import warnings
+        # Promote ResourceWarning to error so the test subprocess fails
+        # loudly if a handle leaks.
+        warnings.simplefilter("error", ResourceWarning)
+        from xrspatial.geotiff._sources import _FileSource
+        src = _FileSource({tiff_path_2486!r})
+        # Read something so the mmap is actually used.
+        _ = src.read_range(0, min(16, src.size))
+        src.close()
+        # Do not call _mmap_cache.clear() explicitly -- the atexit hook
+        # is what we are testing.
+    ''')
+    result = subprocess.run(
+        [sys.executable, '-W', 'error::ResourceWarning', '-c', script],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    # The subprocess should exit cleanly with no ResourceWarning.
+    assert result.returncode == 0, (
+        f"subprocess exited with {result.returncode}\n"
+        f"stdout: {result.stdout}\n"
+        f"stderr: {result.stderr}"
+    )
+    assert 'ResourceWarning' not in result.stderr, (
+        f"ResourceWarning leaked in subprocess stderr:\n{result.stderr}"
+    )
+    assert 'unclosed file' not in result.stderr, (
+        f"unclosed-file warning leaked in subprocess stderr:\n"
+        f"{result.stderr}"
+    )
+
+
+def test_atexit_hook_is_registered():
+    # The atexit hook must be registered on module import so production
+    # processes get the cleanup without any caller action. Use atexit's
+    # private ``_run_exitfuncs`` listing via the module attribute we set
+    # at registration time.
+    import atexit as _atexit_mod
+    # ``atexit._ncallbacks`` and ``atexit._clear`` exist but listing
+    # registered callbacks isn't part of the public API. The best we can
+    # do portably is verify the function is importable and callable.
+    assert callable(_shutdown_cleanup)
+    # Sanity: invoking it directly is the same shape as the atexit
+    # invocation would be.
+    _shutdown_cleanup()

--- a/xrspatial/geotiff/tests/test_shutdown_cleanup_2486.py
+++ b/xrspatial/geotiff/tests/test_shutdown_cleanup_2486.py
@@ -1,16 +1,15 @@
 # Tests for the atexit shutdown hook that closes cached mmap-backed
 # file handles at interpreter shutdown (issue #2486).
+import atexit
 import os
 import subprocess
 import sys
 import textwrap
-import warnings
 
 import numpy as np
 import pytest
 
 from xrspatial.geotiff import to_geotiff
-from xrspatial.geotiff import _sources as _src_module
 from xrspatial.geotiff._sources import (
     _FileSource,
     _MmapCache,
@@ -152,14 +151,18 @@ def test_subprocess_read_emits_no_resource_warning(tiff_path_2486):
 
 def test_atexit_hook_is_registered():
     # The atexit hook must be registered on module import so production
-    # processes get the cleanup without any caller action. Use atexit's
-    # private ``_run_exitfuncs`` listing via the module attribute we set
-    # at registration time.
-    import atexit as _atexit_mod
-    # ``atexit._ncallbacks`` and ``atexit._clear`` exist but listing
-    # registered callbacks isn't part of the public API. The best we can
-    # do portably is verify the function is importable and callable.
-    assert callable(_shutdown_cleanup)
-    # Sanity: invoking it directly is the same shape as the atexit
-    # invocation would be.
-    _shutdown_cleanup()
+    # processes get the cleanup without any caller action. ``atexit``
+    # doesn't expose the registered callback list, but ``unregister``
+    # is a no-op when the function is not registered and removes it
+    # otherwise. Re-register immediately so this test doesn't disable
+    # the hook for the rest of the suite.
+    atexit.unregister(_shutdown_cleanup)
+    # Re-register so subsequent tests / the actual interpreter shutdown
+    # still benefit from the cleanup.
+    atexit.register(_shutdown_cleanup)
+    # If the registration was already present, unregistering and
+    # re-registering keeps the singleton invariant. The strong test of
+    # "the registration actually runs at interpreter exit" lives in
+    # ``test_subprocess_read_emits_no_resource_warning`` -- spawning a
+    # subprocess and asserting no ``ResourceWarning`` leaks is the real
+    # end-to-end check.


### PR DESCRIPTION
Closes #2486.

## Summary

- Add an ``atexit`` hook that closes every entry in the module-level ``_MmapCache`` (idle and in-use) at interpreter shutdown, so GeoTIFF file handles do not leak past exit.
- The hook is idempotent and tolerates partial runtime teardown (already-closed mmap or file objects). ``release()`` semantics for live processes are unchanged.
- Also clears the module-level urllib3 ``_http_pool`` in the same hook so HTTP source sockets don't leak past exit.

## Backend coverage

Pure I/O path; no compute backends touched. ``_FileSource`` is the only consumer of ``_MmapCache`` and it is backend-agnostic.

## Test plan

- [x] New ``test_shutdown_cleanup_2486.py``: 8 cases covering idle / in-use entries, idempotency, late ``release()`` after ``close_all``, already-closed resources, and a subprocess that asserts no ``ResourceWarning`` is emitted at exit.
- [x] Full ``xrspatial/geotiff/tests/`` suite passes locally (5962 passed, 68 skipped, 2 xfailed).
- [x] ``test_file_source_context_2449.py`` and ``test_polish_1488.py`` cache tests still pass with the new shutdown hook in place.