### PR TITLE
Release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Unreleased
 
+
+### Version 0.10.0 - 2026-05-27
+
 #### GeoTIFF release contract
 
 Tiers what the public GeoTIFF and COG surface promises for this release.


### PR DESCRIPTION
Stamps the curated Unreleased section of CHANGELOG.md as v0.10.0 (2026-05-27) and opens a fresh Unreleased section for the next cycle. Minor bump: this release adds user-facing features (reproject bounds_policy, polygonize/rasterize additions) and the GeoTIFF stable release contract, on top of extensive GeoTIFF hardening and test work.