### PR TITLE
geotiff: skip LERC golden-corpus fixture when lerc package is missing

### DIFF
--- a/xrspatial/geotiff/tests/golden_corpus/_marks.py
+++ b/xrspatial/geotiff/tests/golden_corpus/_marks.py
@@ -32,11 +32,22 @@ is just a ``list(...) + [extra_mark]`` away.
 """
 from __future__ import annotations
 
+from importlib.util import find_spec
 from typing import Any
 
 import pytest
 
 _FAST_TAG = "fast"
+
+# Optional Python packages required to decode specific TIFF compressions.
+# Fixtures using these codecs must be skipped when the package is not
+# importable; otherwise the read-path raises ``ImportError`` and the
+# parity test fails for an environmental reason rather than a real bug.
+# Keep this list in sync with the optional codec imports in
+# ``xrspatial.geotiff._compression``.
+_COMPRESSION_OPTIONAL_DEPS: dict[str, str] = {
+    "lerc": "lerc",
+}
 
 
 def is_fast(entry: dict[str, Any]) -> bool:
@@ -59,3 +70,29 @@ def fast_slow_marks_for(entry: dict[str, Any]) -> list[pytest.MarkDecorator]:
     without an empty-mark guard or a generator-to-list conversion.
     """
     return [pytest.mark.slow] if not is_fast(entry) else []
+
+
+def optional_dep_marks_for(entry: dict[str, Any]) -> list[pytest.MarkDecorator]:
+    """Return a skipif mark when the fixture's codec needs a missing dep.
+
+    Some compressions (currently LERC) rely on a Python package that is
+    not a hard dependency of xrspatial. On a host without that package
+    the read-path raises ``ImportError``; the parity test would then
+    fail for an environmental reason rather than a real bug. This helper
+    yields a ``pytest.mark.skipif`` mark in that case so the run stays
+    green on minimal envs. Returns ``[]`` when the codec has no optional
+    dep or when the dep is importable.
+    """
+    codec = entry.get("compression")
+    dep = _COMPRESSION_OPTIONAL_DEPS.get(codec)
+    if dep is None or find_spec(dep) is not None:
+        return []
+    return [
+        pytest.mark.skipif(
+            True,
+            reason=(
+                f"{dep!r} is not installed; fixture {entry['id']!r} uses "
+                f"the {codec!r} codec which requires it"
+            ),
+        )
+    ]

--- a/xrspatial/geotiff/tests/golden_corpus/test_dask_numpy.py
+++ b/xrspatial/geotiff/tests/golden_corpus/test_dask_numpy.py
@@ -48,7 +48,10 @@ from xrspatial.geotiff import open_geotiff  # noqa: E402
 _OPTIN = {"allow_experimental_codecs": True, "allow_internal_only_jpeg": True}
 
 from xrspatial.geotiff.tests.golden_corpus import generate  # noqa: E402
-from xrspatial.geotiff.tests.golden_corpus._marks import fast_slow_marks_for  # noqa: E402
+from xrspatial.geotiff.tests.golden_corpus._marks import (  # noqa: E402
+    fast_slow_marks_for,
+    optional_dep_marks_for,
+)
 from xrspatial.geotiff.tests.golden_corpus._oracle import compare_to_oracle  # noqa: E402
 
 FIXTURES_DIR = (
@@ -120,7 +123,7 @@ def _build_param(entry: dict) -> pytest.param:
     job has no filter and exercises every fixture.
     """
     fid = entry["id"]
-    marks = list(fast_slow_marks_for(entry))
+    marks = list(fast_slow_marks_for(entry)) + list(optional_dep_marks_for(entry))
     if fid in _PARITY_GAPS:
         marks.append(
             pytest.mark.xfail(reason=_PARITY_GAPS[fid], strict=True)

--- a/xrspatial/geotiff/tests/golden_corpus/test_eager_numpy.py
+++ b/xrspatial/geotiff/tests/golden_corpus/test_eager_numpy.py
@@ -76,7 +76,10 @@ from xrspatial.geotiff import open_geotiff  # noqa: E402
 _OPTIN = {"allow_experimental_codecs": True, "allow_internal_only_jpeg": True}
 
 from xrspatial.geotiff.tests.golden_corpus import generate  # noqa: E402
-from xrspatial.geotiff.tests.golden_corpus._marks import fast_slow_marks_for  # noqa: E402
+from xrspatial.geotiff.tests.golden_corpus._marks import (  # noqa: E402
+    fast_slow_marks_for,
+    optional_dep_marks_for,
+)
 from xrspatial.geotiff.tests.golden_corpus._oracle import compare_to_oracle  # noqa: E402
 
 FIXTURES_DIR = (
@@ -130,7 +133,7 @@ def _build_param(entry: dict) -> pytest.param:
     pick up ``pytest.mark.slow`` from the corpus helper.
     """
     fid = entry["id"]
-    marks = list(fast_slow_marks_for(entry))
+    marks = list(fast_slow_marks_for(entry)) + list(optional_dep_marks_for(entry))
     if fid in _PARITY_GAPS:
         marks.append(
             pytest.mark.xfail(reason=_PARITY_GAPS[fid], strict=True)

--- a/xrspatial/geotiff/tests/golden_corpus/test_fsspec.py
+++ b/xrspatial/geotiff/tests/golden_corpus/test_fsspec.py
@@ -65,7 +65,10 @@ from xrspatial.geotiff import open_geotiff  # noqa: E402
 _OPTIN = {"allow_experimental_codecs": True, "allow_internal_only_jpeg": True}
 
 from xrspatial.geotiff.tests.golden_corpus import generate  # noqa: E402
-from xrspatial.geotiff.tests.golden_corpus._marks import fast_slow_marks_for  # noqa: E402
+from xrspatial.geotiff.tests.golden_corpus._marks import (  # noqa: E402
+    fast_slow_marks_for,
+    optional_dep_marks_for,
+)
 from xrspatial.geotiff.tests.golden_corpus._oracle import compare_to_oracle  # noqa: E402
 
 FIXTURES_DIR = (
@@ -129,7 +132,7 @@ def _build_param(entry: dict) -> pytest.param:
     split (#2062) cooperates.
     """
     fid = entry["id"]
-    marks = list(fast_slow_marks_for(entry))
+    marks = list(fast_slow_marks_for(entry)) + list(optional_dep_marks_for(entry))
     if fid in _PARITY_GAPS:
         marks.append(
             pytest.mark.xfail(reason=_PARITY_GAPS[fid], strict=True)


### PR DESCRIPTION
## Summary
- The push-to-main and nightly runs of `pytest-geotiff-corpus` exercise the full fixture matrix (no `-m "not slow"` filter) on Ubuntu, macOS, and Windows. The conda env those jobs install (`rasterio gdal pyyaml tifffile`) does not ship the Python `lerc` binding, so the LERC-compressed parity cell raises `ImportError` and three tests fail for an environmental reason rather than a real bug. See the failed pytest-geotiff-corpus run on commit 6401e0dc.
- Adds an `optional_dep_marks_for(entry)` helper next to `fast_slow_marks_for` in `_marks.py`. It returns a `pytest.mark.skipif` mark when the fixture's compression codec requires a Python package that is not importable. Wires it into the eager, dask+numpy, and fsspec backend modules.
- Mirrors the `LERC_AVAILABLE` skip the unit tests at `xrspatial/geotiff/tests/unit/test_codec_roundtrip.py` already use, so `lerc` stays truly optional for both CI and local dev environments.

## Test plan
- [x] `python -m pytest xrspatial/geotiff/tests/golden_corpus/test_dask_numpy.py xrspatial/geotiff/tests/golden_corpus/test_eager_numpy.py xrspatial/geotiff/tests/golden_corpus/test_fsspec.py` passes locally with `lerc` installed (95 passed, 6 pre-existing intentional skips).
- [x] Helper unit-verified: returns the skip mark when `find_spec('lerc')` returns `None`, and `[]` otherwise.
- [ ] pytest-geotiff-corpus on this PR (Ubuntu fast lane).
- [ ] Confirm the next nightly / push-to-main run on `main` goes green after merge (full matrix, including macOS + Windows).