### PR TITLE
zonal: fix flake8 F401, E501 + isort drift

### DIFF
--- a/.claude/sweep-style-state.csv
+++ b/.claude/sweep-style-state.csv
@@ -1,3 +1,4 @@
 module,last_inspected,issue,severity_max,categories_found,notes
 geotiff,2026-05-27,2481,HIGH,1;3;4,"Bundled 387 flake8 + ~30 isort fixes since #2285/#2430. F401 x9, F811 x6, F841 x3. E501 x250 (mostly wrapped, 3 file-scope imports keep noqa: E402+E501). E252 x62, blank-line cluster, E128/E127 indents. importorskip imports use # noqa: E402. Cat 5 grep clean."
 rasterize,2026-05-27,2503,HIGH,1;3,F401 line 15 + F811 line 1193 (paired: local import warnings shadowed unused module-level import); E306 line 1775 (nested @cuda.jit). isort clean. Cat 5 grep clean. Fix in PR #2507.
+zonal,2026-05-27,2522,HIGH,1;3;4,"F401 not_implemented_func (line 42, only present on import line). E501 line 455 (dd.concat one-liner, 117 chars) wrapped across 3 lines. isort: consolidated xrspatial.utils block (merged has_dask_array, dropped not_implemented_func, alphabetised, trimmed extra blank line). Cat 5 grep clean. 125 zonal tests pass."

--- a/xrspatial/zonal.py
+++ b/xrspatial/zonal.py
@@ -5,7 +5,6 @@ import copy
 from math import sqrt
 from typing import Callable, Dict, List, Optional, Union
 
-
 # 3rd-party
 try:
     import dask
@@ -36,12 +35,9 @@ except ImportError:
         ndarray = False
 
 # local modules
-from xrspatial.utils import (
-    ArrayTypeFunctionMapping, _validate_raster, cuda_args, has_cuda_and_cupy,
-    is_cupy_array, is_dask_cupy,
-    ngjit, not_implemented_func, validate_arrays,
-)
-from xrspatial.utils import has_dask_array
+from xrspatial.utils import (ArrayTypeFunctionMapping, _validate_raster, cuda_args,
+                             has_cuda_and_cupy, has_dask_array, is_cupy_array, is_dask_cupy, ngjit,
+                             validate_arrays)
 
 TOTAL_COUNT = '_total_count'
 
@@ -452,7 +448,10 @@ def _stats_dask_numpy(
             )
 
     # generate dask dataframe
-    stats_df = dd.concat([dd.from_dask_array(s) for s in stats_dict.values()], axis=1, ignore_unknown_divisions=True)
+    stats_df = dd.concat(
+        [dd.from_dask_array(s) for s in stats_dict.values()],
+        axis=1, ignore_unknown_divisions=True,
+    )
     # name columns
     stats_df.columns = stats_dict.keys()
     # select columns (only include stats that were actually computed)


### PR DESCRIPTION
Closes #2522.

## Summary

- Drop unused `not_implemented_func` import (F401, Cat 3).
- Wrap the 117-char `dd.concat` one-liner at line 455 (E501, Cat 1).
- Consolidate the `xrspatial.utils` import block — merge the trailing
  `has_dask_array`, alphabetise, trim the extra blank line above
  `# 3rd-party` (Cat 4, isort).

No behavioural change. `not_implemented_func` was only on the import
line; there are no call sites.

## Test plan

- [x] `flake8 xrspatial/zonal.py` clean
- [x] `isort --check-only xrspatial/zonal.py` clean
- [x] `pytest xrspatial/tests/test_zonal.py -x` — 125 passed