### PR TITLE
Fix hypsometric_integral dask+cupy backend (#2525)

### DIFF
--- a/xrspatial/tests/test_hypsometric_integral.py
+++ b/xrspatial/tests/test_hypsometric_integral.py
@@ -254,3 +254,66 @@ def test_hypsometric_integral_list_of_pairs_zones():
     result = hypsometric_integral(zones_pairs, values, nodata=0)
     assert isinstance(result, xr.DataArray)
     assert result.shape == values.shape
+
+
+# --- backend-consistency regression (#2525) ---------------------------------
+
+def _has_cuda_and_cupy():
+    try:
+        from numba import cuda
+        import cupy  # noqa: F401
+        return cuda.is_available()
+    except Exception:
+        return False
+
+
+@pytest.mark.parametrize("backend", ['numpy', 'cupy', 'dask+numpy', 'dask+cupy'])
+def test_hi_preserves_backend_2525(backend):
+    """Regression: output backend must match input backend.
+
+    Before the fix, `_hi_dask_cupy` converted chunks to numpy and called
+    `_hi_dask_numpy`, returning a dask+numpy array even when the input was
+    dask+cupy. Downstream dispatch via ArrayTypeFunctionMapping then routed
+    through the numpy path silently. See issue #2525.
+    """
+    if 'cupy' in backend and not _has_cuda_and_cupy():
+        pytest.skip("Requires CUDA and CuPy")
+    if 'dask' in backend and da is None:
+        pytest.skip("Requires Dask")
+
+    from xrspatial.zonal import hypsometric_integral
+    from xrspatial.utils import (
+        is_cupy_array, is_dask_cupy, has_dask_array,
+    )
+
+    zones_np = np.array([[1, 1, 2, 2],
+                         [1, 1, 2, 2]], dtype=np.int32)
+    values_np = np.array([[10.0, 20.0, 30.0, 40.0],
+                          [15.0, 25.0, 35.0, 45.0]])
+
+    zones = create_test_raster(zones_np, backend, dims=['y', 'x'],
+                               chunks=(2, 2))
+    values = create_test_raster(values_np, backend, dims=['y', 'x'],
+                                chunks=(2, 2))
+
+    result = hypsometric_integral(zones, values)
+    assert isinstance(result, xr.DataArray)
+    assert result.shape == values.shape
+
+    if backend == 'numpy':
+        assert isinstance(result.data, np.ndarray)
+    elif backend == 'cupy':
+        assert is_cupy_array(result.data)
+    elif backend == 'dask+numpy':
+        assert has_dask_array() and isinstance(result.data, da.Array)
+        assert not is_dask_cupy(result)
+        # confirm chunks are numpy
+        sample = result.data.blocks[0, 0].compute()
+        assert isinstance(sample, np.ndarray)
+    elif backend == 'dask+cupy':
+        assert is_dask_cupy(result), (
+            "dask+cupy input must produce dask+cupy output (#2525)"
+        )
+        # confirm chunks are cupy
+        sample = result.data.blocks[0, 0].compute()
+        assert is_cupy_array(sample)

--- a/xrspatial/tests/test_hypsometric_integral.py
+++ b/xrspatial/tests/test_hypsometric_integral.py
@@ -258,15 +258,6 @@ def test_hypsometric_integral_list_of_pairs_zones():
 
 # --- backend-consistency regression (#2525) ---------------------------------
 
-def _has_cuda_and_cupy():
-    try:
-        from numba import cuda
-        import cupy  # noqa: F401
-        return cuda.is_available()
-    except Exception:
-        return False
-
-
 @pytest.mark.parametrize("backend", ['numpy', 'cupy', 'dask+numpy', 'dask+cupy'])
 def test_hi_preserves_backend_2525(backend):
     """Regression: output backend must match input backend.
@@ -276,15 +267,17 @@ def test_hi_preserves_backend_2525(backend):
     dask+cupy. Downstream dispatch via ArrayTypeFunctionMapping then routed
     through the numpy path silently. See issue #2525.
     """
-    if 'cupy' in backend and not _has_cuda_and_cupy():
+    from xrspatial.utils import (
+        has_cuda_and_cupy, has_dask_array,
+        is_cupy_array, is_dask_cupy,
+    )
+
+    if 'cupy' in backend and not has_cuda_and_cupy():
         pytest.skip("Requires CUDA and CuPy")
-    if 'dask' in backend and da is None:
+    if 'dask' in backend and not has_dask_array():
         pytest.skip("Requires Dask")
 
     from xrspatial.zonal import hypsometric_integral
-    from xrspatial.utils import (
-        is_cupy_array, is_dask_cupy, has_dask_array,
-    )
 
     zones_np = np.array([[1, 1, 2, 2],
                          [1, 1, 2, 2]], dtype=np.int32)

--- a/xrspatial/zonal.py
+++ b/xrspatial/zonal.py
@@ -1538,14 +1538,24 @@ def _hi_dask_numpy(zones_data, values_data, nodata):
 
 
 def _hi_dask_cupy(zones_data, values_data, nodata):
-    """Dask+cupy backend: convert chunks to numpy, delegate."""
+    """Dask+cupy backend: convert chunks to numpy, delegate, then re-wrap as cupy.
+
+    The per-zone HI lookup table is a Python dict so the reduce step has to
+    pass through host memory. The painted output is wrapped back as cupy
+    chunks so the returned dask graph yields cupy arrays — keeping the
+    backend consistent with the dask+cupy input (issue #2525).
+    """
     zones_cpu = zones_data.map_blocks(
         lambda x: x.get(), dtype=zones_data.dtype, meta=np.array(()),
     )
     values_cpu = values_data.map_blocks(
         lambda x: x.get(), dtype=values_data.dtype, meta=np.array(()),
     )
-    return _hi_dask_numpy(zones_cpu, values_cpu, nodata)
+    result_cpu = _hi_dask_numpy(zones_cpu, values_cpu, nodata)
+    # Re-wrap each numpy chunk as cupy so dispatch downstream stays on GPU.
+    return result_cpu.map_blocks(
+        cupy.asarray, dtype=result_cpu.dtype, meta=cupy.array(()),
+    )
 
 
 def hypsometric_integral(

--- a/xrspatial/zonal.py
+++ b/xrspatial/zonal.py
@@ -1542,7 +1542,7 @@ def _hi_dask_cupy(zones_data, values_data, nodata):
 
     The per-zone HI lookup table is a Python dict so the reduce step has to
     pass through host memory. The painted output is wrapped back as cupy
-    chunks so the returned dask graph yields cupy arrays — keeping the
+    chunks so the returned dask graph yields cupy arrays, keeping the
     backend consistent with the dask+cupy input (issue #2525).
     """
     zones_cpu = zones_data.map_blocks(


### PR DESCRIPTION
Closes #2525.

## Summary

- `_hi_dask_cupy` previously converted cupy chunks to numpy and then called `_hi_dask_numpy`, returning a dask+numpy result for dask+cupy input. Downstream `ArrayTypeFunctionMapping` dispatch silently routed through the numpy path.
- After this change, the painted output is re-wrapped through `map_blocks(cupy.asarray, ...)` so each chunk lands back as a cupy array. The dask graph stays lazy and `is_dask_cupy(result)` is True for dask+cupy inputs.
- The numpy reduce in the middle is kept as-is. The per-zone HI lookup is a Python dict so the reduce must pass through host memory; only the painted output needs to match the input backend.

## Backend coverage

- numpy: unchanged, returns numpy ndarray
- cupy: unchanged, returns cupy ndarray
- dask+numpy: unchanged, returns dask Array with numpy chunks
- dask+cupy: now returns dask Array with cupy chunks (was: numpy chunks)

## Test plan

- [x] New parametrized regression test `test_hi_preserves_backend_2525` asserts the output backend matches the input across all four backends.
- [x] Existing `test_hypsometric_integral.py` suite still passes (33 tests).
- [x] Existing `test_zonal.py` suite still passes (125 tests).
- [x] Verified the new test fails with the fix reverted (confirms it catches the regression).

## Audit trail

Surfaced by `/sweep-metadata` on the zonal module, 2026-05-27. Cat 5 (backend-inconsistent metadata), severity MEDIUM.