### PR TITLE
polygonize: fix flake8 F401, E127, and isort drift

### DIFF
--- a/.claude/sweep-style-state.csv
+++ b/.claude/sweep-style-state.csv
@@ -1,3 +1,4 @@
 module,last_inspected,issue,severity_max,categories_found,notes
 geotiff,2026-05-27,2481,HIGH,1;3;4,"Bundled 387 flake8 + ~30 isort fixes since #2285/#2430. F401 x9, F811 x6, F841 x3. E501 x250 (mostly wrapped, 3 file-scope imports keep noqa: E402+E501). E252 x62, blank-line cluster, E128/E127 indents. importorskip imports use # noqa: E402. Cat 5 grep clean."
+polygonize,2026-05-27,2534,HIGH,1;3;4,"F401 line 58 (is_cupy_array unused, not re-exported). E127 lines 83/88 (overload continuation indent in generated_jit). isort: 5-line .utils import block collapses to one line at 100-char limit. Cat 2 clean. Cat 5 grep clean."
 rasterize,2026-05-27,2503,HIGH,1;3,F401 line 15 + F811 line 1193 (paired: local import warnings shadowed unused module-level import); E306 line 1775 (nested @cuda.jit). isort clean. Cat 5 grep clean. Fix in PR #2507.

--- a/xrspatial/polygonize.py
+++ b/xrspatial/polygonize.py
@@ -52,12 +52,7 @@ try:
 except ImportError:
     cupy = None
 
-from .utils import (
-    ArrayTypeFunctionMapping,
-    _validate_raster,
-    is_cupy_array,
-    ngjit,
-)
+from .utils import ArrayTypeFunctionMapping, _validate_raster, ngjit
 
 _regions_dtype = np.uint32
 _visited_dtype = np.uint8
@@ -80,12 +75,12 @@ def generated_jit(function=None, cache=False,
 
     if function is not None:
         overload(function, jit_options=jit_options,
-                    strict=False)(function)
+                 strict=False)(function)
         return function
     else:
         def wrapper(func):
             overload(func, jit_options=jit_options,
-                        strict=False)(func)
+                     strict=False)(func)
             return func
         return wrapper
 


### PR DESCRIPTION
Closes #2534.

## Summary

- Drop the unused `is_cupy_array` import from `.utils` (F401). The symbol is not referenced anywhere in `polygonize.py` and the module has no `__all__`, so it was never re-exported either.
- Collapse the now-3-symbol `.utils` import to a single line. At 78 chars it fits within the configured 100-char `line_length`, so isort prefers the single-line form — same edit closes the isort diff.
- Pull the second argument of the two `overload(...)` calls in `generated_jit` back four columns so the continuation aligns with the opening paren (E127).

## Categories addressed

- Cat 1 (E127): 2 occurrences
- Cat 3 (F401): 1 occurrence
- Cat 4 (isort): import block reflow

No Cat 2 findings. Cat 5 grep clean (no bare `except`, no mutable default args, no shadowed builtins).

## Backend coverage

Style-only. No behavioural change. The fixes apply uniformly across the numpy / cupy / dask backends dispatched via `ArrayTypeFunctionMapping`.

## Test plan

- [x] `flake8 xrspatial/polygonize.py` is silent
- [x] `isort --check-only --diff xrspatial/polygonize.py` is silent
- [x] `pytest xrspatial/tests/test_polygonize*.py` -- 237 passed, 13 skipped