### PR TITLE
CHANGELOG: clarify polygonize transform auto-detection covers all return types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,20 @@
 
 #### Fixed
 
-- `polygonize(return_type='geopandas')` now auto-detects the raster's
-  affine transform from `attrs['transform']` (xrspatial.geotiff
-  convention) or `rio.transform()` (rioxarray) when the caller did
-  not pass an explicit `transform=` argument. Previously the function
-  auto-detected `attrs['crs']` and stamped it on the `GeoDataFrame`
-  while leaving the geometries in pixel space, so the CRS attribute
-  claimed projected space but the coordinates did not match. Callers
-  who relied on the pre-fix behaviour and expected pixel-space
-  geometries from a rasterio-loaded raster should pass `transform=
-  np.array([1, 0, 0, 0, 1, 0])` explicitly, or strip the transform
-  attr before calling polygonize. (#2536)
+- `polygonize` now auto-detects the raster's affine transform from
+  `attrs['transform']` (xrspatial.geotiff convention) or
+  `rio.transform()` (rioxarray) when the caller did not pass an
+  explicit `transform=` argument. The auto-detected transform is
+  applied inside `_scan`, so it covers every `return_type` option
+  (`numpy`, `awkward`, `geopandas`, `spatialpandas`, `geojson`).
+  Previously `polygonize(return_type='geopandas')` auto-detected
+  `attrs['crs']` and stamped it on the `GeoDataFrame` while leaving
+  the geometries in pixel space, so the CRS attribute claimed
+  projected space but the coordinates did not match. Callers who
+  relied on the pre-fix behaviour and expected pixel-space geometries
+  from a rasterio-loaded raster should pass
+  `transform=np.array([1, 0, 0, 0, 1, 0])` explicitly, or strip the
+  transform attr before calling polygonize. (#2536)
 
 
 ### Version 0.10.0 - 2026-05-27


### PR DESCRIPTION
## Summary

Follow-up to PR #2541 (closes #2536). The CHANGELOG entry only mentioned `polygonize(return_type='geopandas')`, but the PR description and the implementation are broader: the auto-detected transform is applied inside `_scan`, so every `return_type` option (`numpy`, `awkward`, `geopandas`, `spatialpandas`, `geojson`) benefits.

This PR rewords the entry to match the PR description and the code, without changing any behaviour.

## Test plan

- [x] CHANGELOG-only change, no code or tests affected.
- [ ] CI green.