### PR TITLE
zonal: fix crosstab cat_ids overcount when earlier categories are filtered out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 #### Fixed
 
+- `crosstab(cat_ids=[...])` no longer overcounts when `cat_ids` skips a
+  category that is present in the values raster. The 2D helper now
+  advances its cumulative cursor for every unique category instead of
+  only the selected ones, so each selected category's count starts from
+  the correct offset. All four backends (numpy, dask+numpy, cupy,
+  dask+cupy) share the helper and are fixed together. (#2560)
+
 - `polygonize` now auto-detects the raster's affine transform from
   `attrs['transform']` (xrspatial.geotiff convention) or
   `rio.transform()` (rioxarray) when the caller did not pass an

--- a/xrspatial/tests/test_zonal.py
+++ b/xrspatial/tests/test_zonal.py
@@ -1156,6 +1156,56 @@ def test_percentage_crosstab_2d(backend, data_zones, data_values_2d, result_perc
     assert_input_data_unmodified(data_values_2d, copied_data_values_2d)
 
 
+@pytest.mark.parametrize("backend", ['numpy', 'dask+numpy', 'cupy', 'dask+cupy'])
+def test_crosstab_2d_cat_ids_skips_earlier_category(backend, data_zones, data_values_2d):
+    """Regression test for issue #2560.
+
+    When cat_ids filters out a category that appears in the values raster,
+    the count for later selected categories must not be inflated by cells
+    that belong to the skipped category.
+
+    Zone 3 in the test fixture contains values [3, 3, 0, 3, 3] after nodata
+    filtering. Asking for cat_ids=[3] alone (skipping 0) should report 4
+    threes, not 5.
+    """
+    if 'cupy' in backend and not has_cuda_and_cupy():
+        pytest.skip("Requires CUDA and CuPy")
+    if 'dask' in backend and not dask_array_available():
+        pytest.skip("Requires Dask")
+
+    copied_data_zones = copy.deepcopy(data_zones)
+    copied_data_values_2d = copy.deepcopy(data_values_2d)
+
+    # cat_ids=[3] alone, with zone 3 containing 0s too. unique_cats is
+    # [0, 1, 2, 3]; the buggy code would let cat_start stay at the start
+    # of the sorted zone array and report 5 threes for zone 3.
+    df_result = crosstab(
+        zones=data_zones, values=data_values_2d,
+        zone_ids=[0, 1, 2, 3], cat_ids=[3],
+    )
+    expected = {
+        'zone': [0, 1, 2, 3],
+        3:      [0, 0, 0, 4],
+    }
+    check_results(backend, df_result, expected)
+
+    # cat_ids=[1, 3] skips category 2 between them. Zone 1 has six 1s
+    # and no 3s; zone 3 has zero 1s and four 3s.
+    df_result = crosstab(
+        zones=data_zones, values=data_values_2d,
+        zone_ids=[0, 1, 2, 3], cat_ids=[1, 3],
+    )
+    expected = {
+        'zone': [0, 1, 2, 3],
+        1:      [0, 6, 0, 0],
+        3:      [0, 0, 0, 4],
+    }
+    check_results(backend, df_result, expected)
+
+    assert_input_data_unmodified(data_zones, copied_data_zones)
+    assert_input_data_unmodified(data_values_2d, copied_data_values_2d)
+
+
 @pytest.mark.parametrize("backend", ['numpy', 'dask+numpy'])
 def test_crosstab_3d_count(backend, data_zones, data_values_3d, result_crosstab_3d):
 

--- a/xrspatial/zonal.py
+++ b/xrspatial/zonal.py
@@ -956,13 +956,17 @@ def _single_zone_crosstab_2d(
     sorted_zone_values = np.sort(zone_values)
     zone_cat_breaks = _strides(sorted_zone_values, unique_cats)
 
+    # cat_start must advance for every unique category, not only those
+    # in cat_ids. If we only advanced for selected categories, filtering
+    # out an earlier category would leave cat_start behind and inflate
+    # the next selected category's count. See issue #2560.
     cat_start = 0
 
     for j, cat in enumerate(unique_cats):
         if cat in cat_ids:
             count = zone_cat_breaks[j] - cat_start
             crosstab_dict[cat].append(count)
-            cat_start = zone_cat_breaks[j]
+        cat_start = zone_cat_breaks[j]
 
 
 def _single_zone_crosstab_3d(


### PR DESCRIPTION
## Summary

Closes #2560.

- Fixes the `_single_zone_crosstab_2d` helper in `xrspatial/zonal.py` so `cat_start` advances for every unique category, not only those selected via `cat_ids`. Previously, when `cat_ids` skipped a category that was present in the values raster, the cumulative cursor stayed behind and the next selected category's count absorbed the skipped cells.
- The helper is shared by all four backends (numpy, dask+numpy, cupy, dask+cupy), so the fix lands for every backend.
- Adds a cross-backend regression test `test_crosstab_2d_cat_ids_skips_earlier_category` covering both a single-cat selection that skips a leading category and a gapped selection that skips a middle category.

## Reproduction (before the fix)

```python
import numpy as np, xarray as xr
from xrspatial import zonal
zones = xr.DataArray(np.ones((2, 2), dtype=int))
values = xr.DataArray(np.array([[1, 2], [2, 3]]))
zonal.crosstab(zones=zones, values=values, cat_ids=[3])  # returned 4, should be 1
```

## Backend coverage

numpy / cupy / dask+numpy / dask+cupy. All four use the same `_single_zone_crosstab_2d` helper.

## Test plan

- [x] New regression test passes on all four backends locally
- [x] Existing crosstab tests still pass (16 selected, 16 passed)
- [ ] CI green