### PR TITLE
reproject tests: gate GPU tests on has_cuda_and_cupy() runtime probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 #### Fixed
 
+- Reproject test suite now gates GPU tests on
+  `xrspatial.utils.has_cuda_and_cupy()` instead of an import-only
+  `try: import cupy` check. On hosts where `cupy` imports cleanly but
+  the CUDA driver is missing or too old, the GPU tests now skip with a
+  clear reason instead of erroring at allocation time with
+  `cudaErrorInsufficientDriver`. Affects `test_reproject.py` and
+  `test_reproject_coverage_2026_05_27.py`. (#2564)
+
 - `polygonize` now auto-detects the raster's affine transform from
   `attrs['transform']` (xrspatial.geotiff convention) or
   `rio.transform()` (rioxarray) when the caller did not pass an

--- a/xrspatial/tests/test_reproject.py
+++ b/xrspatial/tests/test_reproject.py
@@ -5,6 +5,8 @@ import numpy as np
 import pytest
 import xarray as xr
 
+from xrspatial.utils import has_cuda_and_cupy
+
 try:
     import pyproj
     HAS_PYPROJ = True
@@ -19,9 +21,13 @@ except ImportError:
 
 try:
     import cupy as cp
-    HAS_CUPY = True
 except ImportError:
-    HAS_CUPY = False
+    cp = None
+
+# Gate GPU tests on a real CUDA runtime probe, not just that ``cupy`` imports.
+# An import-only check leaves tests erroring with ``cudaErrorInsufficientDriver``
+# on hosts where ``cupy`` is installed but the driver is missing or too old.
+HAS_CUPY = has_cuda_and_cupy()
 
 pytestmark = pytest.mark.skipif(
     not HAS_PYPROJ, reason="pyproj required for reproject tests"

--- a/xrspatial/tests/test_reproject_coverage_2026_05_27.py
+++ b/xrspatial/tests/test_reproject_coverage_2026_05_27.py
@@ -31,6 +31,8 @@ import numpy as np
 import pytest
 import xarray as xr
 
+from xrspatial.utils import has_cuda_and_cupy
+
 try:
     import pyproj  # noqa: F401
     HAS_PYPROJ = True
@@ -45,9 +47,13 @@ except ImportError:
 
 try:
     import cupy as cp
-    HAS_CUPY = True
 except ImportError:
-    HAS_CUPY = False
+    cp = None
+
+# Gate GPU tests on a real CUDA runtime probe, not just that ``cupy`` imports.
+# An import-only check leaves tests erroring with ``cudaErrorInsufficientDriver``
+# on hosts where ``cupy`` is installed but the driver is missing or too old.
+HAS_CUPY = has_cuda_and_cupy()
 
 
 pytestmark = pytest.mark.skipif(

--- a/xrspatial/tests/test_reproject_cupy_gate_2564.py
+++ b/xrspatial/tests/test_reproject_cupy_gate_2564.py
@@ -14,6 +14,7 @@ the reproject test modules; the gate must follow.
 from __future__ import annotations
 
 import importlib
+import sys
 
 import pytest
 
@@ -31,7 +32,6 @@ def test_has_cupy_tracks_runtime_probe(module_name, monkeypatch):
     """``HAS_CUPY`` must reflect ``has_cuda_and_cupy()``, not just import."""
     monkeypatch.setattr(xu, "has_cuda_and_cupy", lambda: False)
 
-    import sys
     sys.modules.pop(module_name, None)
     module = importlib.import_module(module_name)
 

--- a/xrspatial/tests/test_reproject_cupy_gate_2564.py
+++ b/xrspatial/tests/test_reproject_cupy_gate_2564.py
@@ -1,0 +1,41 @@
+"""Regression test for #2564.
+
+The reproject test modules previously used an import-only ``HAS_CUPY``
+gate (``try: import cupy; HAS_CUPY = True``). On hosts where ``cupy``
+imports but the CUDA driver is missing or too old, every GPU-only test
+erred at allocation time with ``cudaErrorInsufficientDriver`` instead of
+skipping. The fix is to bind ``HAS_CUPY`` to ``has_cuda_and_cupy()``,
+which probes both ``cupy`` and a usable CUDA device.
+
+This test pins that the gate tracks the runtime probe by monkey-patching
+``xrspatial.utils.has_cuda_and_cupy`` to return ``False`` and reimporting
+the reproject test modules; the gate must follow.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from xrspatial import utils as xu
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "xrspatial.tests.test_reproject",
+        "xrspatial.tests.test_reproject_coverage_2026_05_27",
+    ],
+)
+def test_has_cupy_tracks_runtime_probe(module_name, monkeypatch):
+    """``HAS_CUPY`` must reflect ``has_cuda_and_cupy()``, not just import."""
+    monkeypatch.setattr(xu, "has_cuda_and_cupy", lambda: False)
+
+    import sys
+    sys.modules.pop(module_name, None)
+    module = importlib.import_module(module_name)
+
+    assert module.HAS_CUPY is False, (
+        f"{module_name}.HAS_CUPY should track the runtime CUDA probe, "
+        "not just whether ``import cupy`` succeeds."
+    )


### PR DESCRIPTION
## Summary

Closes #2564.

The reproject test suite used an import-only `HAS_CUPY` gate:

```python
try:
    import cupy as cp
    HAS_CUPY = True
except ImportError:
    HAS_CUPY = False
```

On hosts where `cupy` imports cleanly but the CUDA driver is missing or too old, every GPU-only test erred at allocation time with `cudaErrorInsufficientDriver` instead of skipping. The repo already has a runtime probe (`xrspatial.utils.has_cuda_and_cupy()`) and other suites use it directly or via the `cuda_and_cupy_available` decorator from `general_checks.py`.

This PR rebinds `HAS_CUPY` in both reproject test files to `has_cuda_and_cupy()`. The `cp` alias is preserved so tests can still reference `cp.asarray`, but the skip predicate now follows the runtime probe.

## Changes

- `xrspatial/tests/test_reproject.py`: bind `HAS_CUPY` to `has_cuda_and_cupy()`; keep `import cupy as cp` for the alias.
- `xrspatial/tests/test_reproject_coverage_2026_05_27.py`: same treatment.
- `xrspatial/tests/test_reproject_cupy_gate_2564.py`: new regression test that monkey-patches the probe to `False` and asserts both modules' `HAS_CUPY` follow.
- `CHANGELOG.md`: entry under Unreleased -> Fixed.

## Backend coverage

Tests-only change. No production code touched.

## Test plan

- [x] `pytest xrspatial/tests/test_reproject.py xrspatial/tests/test_reproject_coverage_2026_05_27.py` -> 364 passed locally with CUDA available.
- [x] With `has_cuda_and_cupy` forced to `False`, the same suite reports 328 passed + 36 skipped, 0 errors (previously 38 failures).
- [x] `pytest xrspatial/tests/test_reproject_cupy_gate_2564.py` -> 2 passed.

## Skipped rockout steps

- Step 6 (notebook): not applicable, pure bug fix.
- Step 7 (README matrix): not applicable, no new functions and no backend support change.