### PR TITLE
zonal: fix cupy backend dropping all-NaN zones and desyncing zone_ids (#2562)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 #### Fixed
 
+- `zonal.stats` on the cupy backend now agrees with the numpy and dask
+  backends on two edge cases. A zone whose values are all NaN (or all
+  equal to `nodata_values`) is preserved in the output with NaN stats
+  instead of being dropped. When `zone_ids` contains IDs that do not
+  appear in the zones raster, the missing IDs are filtered out so the
+  zone column and stats columns stay aligned (previously the cupy path
+  could silently desynchronize the rows). (#2562)
+
 - `polygonize` now auto-detects the raster's affine transform from
   `attrs['transform']` (xrspatial.geotiff convention) or
   `rio.transform()` (rioxarray) when the caller did not pass an

--- a/xrspatial/tests/test_zonal.py
+++ b/xrspatial/tests/test_zonal.py
@@ -620,6 +620,7 @@ def test_stats_all_nan_zone_preserved(backend):
         zones=zones, values=values, stats_funcs=['min', 'max', 'mean', 'count']
     )
 
+    assert list(df_result.columns) == ['zone', 'min', 'max', 'mean', 'count']
     expected_result = {
         'zone': [1, 2, 3, 5],
         'min': [1.0, 3.0, 9.0, np.nan],
@@ -658,6 +659,7 @@ def test_stats_zone_ids_missing_from_raster(backend):
         stats_funcs=['min', 'max', 'sum', 'count']
     )
 
+    assert list(df_result.columns) == ['zone', 'min', 'max', 'sum', 'count']
     expected_result = {
         'zone': [1],
         'min': [10.0],
@@ -666,6 +668,23 @@ def test_stats_zone_ids_missing_from_raster(backend):
         'count': [4],
     }
     check_results(backend, df_result, expected_result)
+
+    # Also verify that zone_ids passed in reverse order (or with duplicates)
+    # produces the same numpy-style ordering: np.unique sorts ascending and
+    # dedupes, so [3, 1, 1] becomes [1, 3]. This pins the cupy path's
+    # np.unique normalization that matches the numpy backend.
+    df_result_reversed = stats(
+        zones=zones, values=values, zone_ids=[3, 1, 1],
+        stats_funcs=['min', 'max', 'sum', 'count'],
+    )
+    expected_reversed = {
+        'zone': [1, 3],
+        'min': [10.0, 100.0],
+        'max': [40.0, 100.0],
+        'sum': [100.0, 400.0],
+        'count': [4, 4],
+    }
+    check_results(backend, df_result_reversed, expected_reversed)
 
 
 @pytest.mark.filterwarnings("ignore:All-NaN slice encountered:RuntimeWarning")

--- a/xrspatial/tests/test_zonal.py
+++ b/xrspatial/tests/test_zonal.py
@@ -590,6 +590,137 @@ def test_majority_with_ties(backend):
     check_results(backend, df_result, expected_result)
 
 
+# Regression tests for issue #2562: cupy backend used to drop all-NaN zones
+# and could desync the zone/stats alignment when zone_ids contained IDs that
+# don't appear in the raster.
+
+@pytest.mark.filterwarnings("ignore:All-NaN slice encountered:RuntimeWarning")
+@pytest.mark.filterwarnings("ignore:Mean of empty slice:RuntimeWarning")
+@pytest.mark.filterwarnings("ignore:Degrees of freedom <= 0 for slice:RuntimeWarning")
+@pytest.mark.filterwarnings("ignore:invalid value encountered in.*:RuntimeWarning")
+@pytest.mark.parametrize("backend", ['numpy', 'cupy'])
+def test_stats_all_nan_zone_preserved(backend):
+    # Zone 5 exists in the zones raster but every value at zone 5 is NaN.
+    # The numpy path returns zone 5 with NaN stats; the cupy path used to
+    # drop the row entirely. After the fix both backends should agree.
+    if backend == 'cupy' and not has_cuda_and_cupy():
+        pytest.skip("Requires CUDA and CuPy")
+
+    zones_data = np.array([[1, 1, 2, 2],
+                           [1, 5, 2, 5],
+                           [3, 3, 5, 5]], dtype=np.float64)
+    values_data = np.array([[1.0, 2.0, 3.0, 4.0],
+                            [5.0, np.nan, 7.0, np.nan],
+                            [9.0, 10.0, np.nan, np.nan]])
+
+    zones = create_test_raster(zones_data, backend)
+    values = create_test_raster(values_data, backend)
+
+    df_result = stats(
+        zones=zones, values=values, stats_funcs=['min', 'max', 'mean', 'count']
+    )
+
+    expected_result = {
+        'zone': [1, 2, 3, 5],
+        'min': [1.0, 3.0, 9.0, np.nan],
+        'max': [5.0, 7.0, 10.0, np.nan],
+        'mean': [(1.0 + 2.0 + 5.0) / 3, (3.0 + 4.0 + 7.0) / 3, 9.5, np.nan],
+        # numpy's _calc_stats leaves an all-NaN zone at NaN for every stat,
+        # including count (the func is only called when len(zone_values) > 0).
+        'count': [3, 3, 2, np.nan],
+    }
+    check_results(backend, df_result, expected_result)
+
+
+@pytest.mark.filterwarnings("ignore:All-NaN slice encountered:RuntimeWarning")
+@pytest.mark.filterwarnings("ignore:Mean of empty slice:RuntimeWarning")
+@pytest.mark.parametrize("backend", ['numpy', 'cupy'])
+def test_stats_zone_ids_missing_from_raster(backend):
+    # zone_ids contains 999 which does not appear in the zones raster.
+    # The numpy path drops missing IDs so the result lists only zone 1.
+    # The cupy path used to keep 999 in the zone column while indexing
+    # into a found-only counts/index list, which desynced the rows.
+    if backend == 'cupy' and not has_cuda_and_cupy():
+        pytest.skip("Requires CUDA and CuPy")
+
+    zones_data = np.array([[1, 1, 2, 2],
+                           [1, 1, 2, 2],
+                           [3, 3, 3, 3]], dtype=np.float64)
+    values_data = np.array([[10.0, 20.0, 1.0, 2.0],
+                            [30.0, 40.0, 3.0, 4.0],
+                            [100.0, 100.0, 100.0, 100.0]])
+
+    zones = create_test_raster(zones_data, backend)
+    values = create_test_raster(values_data, backend)
+
+    df_result = stats(
+        zones=zones, values=values, zone_ids=[1, 999],
+        stats_funcs=['min', 'max', 'sum', 'count']
+    )
+
+    expected_result = {
+        'zone': [1],
+        'min': [10.0],
+        'max': [40.0],
+        'sum': [100.0],
+        'count': [4],
+    }
+    check_results(backend, df_result, expected_result)
+
+
+@pytest.mark.filterwarnings("ignore:All-NaN slice encountered:RuntimeWarning")
+@pytest.mark.filterwarnings("ignore:Mean of empty slice:RuntimeWarning")
+@pytest.mark.filterwarnings("ignore:Degrees of freedom <= 0 for slice:RuntimeWarning")
+@pytest.mark.filterwarnings("ignore:invalid value encountered in.*:RuntimeWarning")
+def test_stats_cupy_matches_numpy_row_for_row():
+    # Cross-backend parity check. Run numpy and cupy with the same inputs
+    # (all-NaN zone + zone_ids containing a missing ID) and assert the
+    # resulting DataFrames match row-for-row.
+    if not has_cuda_and_cupy():
+        pytest.skip("Requires CUDA and CuPy")
+
+    zones_data = np.array([[1, 1, 2, 2, 5],
+                           [1, 5, 2, 5, 5],
+                           [3, 3, 5, 5, 4]], dtype=np.float64)
+    values_data = np.array([[1.0, 2.0, 3.0, 4.0, np.nan],
+                            [5.0, np.nan, 7.0, np.nan, np.nan],
+                            [9.0, 10.0, np.nan, np.nan, 42.0]])
+
+    zones_np = create_test_raster(zones_data, 'numpy')
+    values_np = create_test_raster(values_data, 'numpy')
+    zones_cp = create_test_raster(zones_data, 'cupy')
+    values_cp = create_test_raster(values_data, 'cupy')
+
+    stats_funcs = ['min', 'max', 'mean', 'sum', 'count']
+
+    df_np = stats(zones=zones_np, values=values_np, stats_funcs=stats_funcs)
+    df_cp = stats(zones=zones_cp, values=values_cp, stats_funcs=stats_funcs)
+
+    assert list(df_np.columns) == list(df_cp.columns)
+    assert (df_np['zone'].to_numpy() == df_cp['zone'].to_numpy()).all()
+    for col in df_np.columns[1:]:
+        np.testing.assert_allclose(
+            df_np[col].to_numpy(), df_cp[col].to_numpy(),
+            rtol=1e-05, atol=1e-07, equal_nan=True,
+        )
+
+    # And again with zone_ids requesting a zone that doesn't exist.
+    df_np2 = stats(
+        zones=zones_np, values=values_np, zone_ids=[1, 5, 999],
+        stats_funcs=stats_funcs,
+    )
+    df_cp2 = stats(
+        zones=zones_cp, values=values_cp, zone_ids=[1, 5, 999],
+        stats_funcs=stats_funcs,
+    )
+    assert (df_np2['zone'].to_numpy() == df_cp2['zone'].to_numpy()).all()
+    for col in df_np2.columns[1:]:
+        np.testing.assert_allclose(
+            df_np2[col].to_numpy(), df_cp2[col].to_numpy(),
+            rtol=1e-05, atol=1e-07, equal_nan=True,
+        )
+
+
 @pytest.mark.parametrize("stats_funcs, expected_cols", [
     (['min', 'max'], ['zone', 'min', 'max']),
     (['mean'], ['zone', 'mean']),
@@ -650,9 +781,9 @@ def test_zonal_stats_against_qgis(elevation_raster_no_nans, raster, qgis_zonal_s
 def test_stats_all_nan_zone(backend):
     """Zone where every value is NaN should not crash.
 
-    Backend quirks: numpy keeps the empty zone with all-NaN stats; the dask
-    path uses nansum for count/sum so those become 0; cupy drops the empty
-    zone from the result entirely.
+    All backends now agree: the empty zone stays in the output with NaN
+    stats. The cupy path used to drop the zone (issue #2562) — that is
+    now fixed and the per-backend branching is gone.
     """
     if 'cupy' in backend and not has_cuda_and_cupy():
         pytest.skip("Requires CUDA and CuPy")
@@ -670,26 +801,14 @@ def test_stats_all_nan_zone(backend):
     funcs = ['mean', 'max', 'min', 'sum', 'count']
     df_result = stats(zones=zones, values=values, stats_funcs=funcs)
 
-    if 'cupy' in backend and 'dask' not in backend:
-        # cupy drops zones with no valid values
-        expected = {
-            'zone':  [2],
-            'mean':  [6.0],
-            'max':   [7.0],
-            'min':   [5.0],
-            'sum':   [12.0],
-            'count': [2],
-        }
-    else:
-        # numpy and dask both return NaN for all-NaN zones
-        expected = {
-            'zone':  [1, 2],
-            'mean':  [np.nan, 6.0],
-            'max':   [np.nan, 7.0],
-            'min':   [np.nan, 5.0],
-            'sum':   [np.nan, 12.0],
-            'count': [np.nan, 2],
-        }
+    expected = {
+        'zone':  [1, 2],
+        'mean':  [np.nan, 6.0],
+        'max':   [np.nan, 7.0],
+        'min':   [np.nan, 5.0],
+        'sum':   [np.nan, 12.0],
+        'count': [np.nan, 2],
+    }
     check_results(backend, df_result, expected)
 
 
@@ -761,7 +880,7 @@ def test_stats_negative_zone_ids(backend):
 def test_stats_nodata_wipes_zone(backend):
     """When nodata_values filters out every finite value in a zone, stats are NaN.
 
-    Same per-backend quirks as test_stats_all_nan_zone.
+    All backends now agree after the issue #2562 fix.
     """
     if 'cupy' in backend and not has_cuda_and_cupy():
         pytest.skip("Requires CUDA and CuPy")
@@ -779,25 +898,14 @@ def test_stats_nodata_wipes_zone(backend):
     funcs = ['mean', 'max', 'min', 'sum', 'count']
     df_result = stats(zones=zones, values=values, stats_funcs=funcs, nodata_values=5)
 
-    if 'cupy' in backend and 'dask' not in backend:
-        expected = {
-            'zone':  [2],
-            'mean':  [5.0],
-            'max':   [7.0],
-            'min':   [3.0],
-            'sum':   [10.0],
-            'count': [2],
-        }
-    else:
-        # numpy and dask both return NaN for zones with no valid values
-        expected = {
-            'zone':  [1, 2],
-            'mean':  [np.nan, 5.0],
-            'max':   [np.nan, 7.0],
-            'min':   [np.nan, 3.0],
-            'sum':   [np.nan, 10.0],
-            'count': [np.nan, 2],
-        }
+    expected = {
+        'zone':  [1, 2],
+        'mean':  [np.nan, 5.0],
+        'max':   [np.nan, 7.0],
+        'min':   [np.nan, 3.0],
+        'sum':   [np.nan, 10.0],
+        'count': [np.nan, 2],
+    }
     check_results(backend, df_result, expected)
 
 

--- a/xrspatial/zonal.py
+++ b/xrspatial/zonal.py
@@ -569,8 +569,10 @@ def _stats_cupy(
     unique_zones = unique_zones.get()
 
     if zone_ids is not None:
-        # Match the numpy path: drop zone_ids that don't exist in the
-        # raster so the zone column and stats columns stay aligned.
+        # Match the numpy path: deduplicate / sort with np.unique and drop
+        # zone_ids that don't exist in the raster so the zone column and
+        # stats columns stay aligned and the row order matches numpy.
+        zone_ids = np.unique(zone_ids)
         unique_index_lst = []
         unique_counts_lst = []
         kept_zones = []
@@ -609,14 +611,16 @@ def _stats_cupy(
             zone_mask = zone_mask & (zone_values != nodata_values)
         zone_values = zone_values[zone_mask]
 
+        if zone_values.size == 0:
+            for stats in stats_funcs:
+                stats_dict[stats].append(float('nan'))
+            continue
+
         # apply stats on the zone data
         for j, stats in enumerate(stats_funcs):
             stats_func = stats_funcs.get(stats)
             if not callable(stats_func):
                 raise ValueError(stats)
-            if zone_values.size == 0:
-                stats_dict[stats].append(float('nan'))
-                continue
             result = stats_func(zone_values)
 
             assert (len(result.shape) == 0)

--- a/xrspatial/zonal.py
+++ b/xrspatial/zonal.py
@@ -548,23 +548,18 @@ def _stats_cupy(
     zones = cupy.ravel(orig_zones)
     values = cupy.ravel(orig_values)
 
+    # Sort by zone so each zone's values occupy a contiguous range. Build
+    # unique_zones from the raw zones array (finite zone IDs only) BEFORE
+    # filtering values: a zone whose values are all NaN or all nodata must
+    # still appear in the output with NaN stats, matching the numpy path.
     sorted_indices = cupy.argsort(zones)
-
     sorted_zones = zones[sorted_indices]
     values_by_zone = values[sorted_indices]
 
-    # filter out values that are non-finite or values equal to nodata_values
-    # Note: use `is not None` instead of truthiness so that nodata_values=0
-    # (a common sentinel) still triggers the filter, matching the numpy path.
-    if nodata_values is not None:
-        filter_values = cupy.isfinite(values_by_zone) & (
-            values_by_zone != nodata_values)
-    else:
-        filter_values = cupy.isfinite(values_by_zone)
-    values_by_zone = values_by_zone[filter_values]
-    sorted_zones = sorted_zones[filter_values]
+    finite_zone_mask = cupy.isfinite(sorted_zones)
+    sorted_zones = sorted_zones[finite_zone_mask]
+    values_by_zone = values_by_zone[finite_zone_mask]
 
-    # Now I need to find the unique zones, and zone breaks
     unique_zones, unique_index, unique_counts = cupy.unique(
         sorted_zones, return_index=True, return_counts=True)
 
@@ -574,19 +569,21 @@ def _stats_cupy(
     unique_zones = unique_zones.get()
 
     if zone_ids is not None:
-        # We need to extract the index and element count
-        # only for the elements in zone_ids
+        # Match the numpy path: drop zone_ids that don't exist in the
+        # raster so the zone column and stats columns stay aligned.
         unique_index_lst = []
         unique_counts_lst = []
-        unique_zones = list(unique_zones)
+        kept_zones = []
+        unique_zones_lst = list(unique_zones)
         for z in zone_ids:
             try:
-                idx = unique_zones.index(z)
-                unique_index_lst.append(unique_index[idx])
-                unique_counts_lst.append(unique_counts[idx])
+                idx = unique_zones_lst.index(z)
             except ValueError:
                 continue
-        unique_zones = zone_ids
+            kept_zones.append(z)
+            unique_index_lst.append(unique_index[idx])
+            unique_counts_lst.append(unique_counts[idx])
+        unique_zones = kept_zones
         unique_counts = unique_counts_lst
         unique_index = unique_index_lst
 
@@ -603,14 +600,23 @@ def _stats_cupy(
 
         stats_dict['zone'].append(zone_id)
 
-        # extract zone_values
+        # extract zone_values, then filter per-zone for non-finite values
+        # and the nodata sentinel. If the zone has no valid values left,
+        # emit NaN for every stat instead of dropping the zone.
         zone_values = values_by_zone[unique_index[i]:unique_index[i]+unique_counts[i]]
+        zone_mask = cupy.isfinite(zone_values)
+        if nodata_values is not None:
+            zone_mask = zone_mask & (zone_values != nodata_values)
+        zone_values = zone_values[zone_mask]
 
         # apply stats on the zone data
         for j, stats in enumerate(stats_funcs):
             stats_func = stats_funcs.get(stats)
             if not callable(stats_func):
                 raise ValueError(stats)
+            if zone_values.size == 0:
+                stats_dict[stats].append(float('nan'))
+                continue
             result = stats_func(zone_values)
 
             assert (len(result.shape) == 0)


### PR DESCRIPTION
## Summary

- Fix `_stats_cupy()` dropping zones whose values are entirely NaN or all equal to `nodata_values`. The cupy path now returns a row with NaN stats, matching numpy and dask.
- Fix `_stats_cupy()` desyncing the zone column from per-zone stats when `zone_ids` contains IDs that don't appear in the raster. Missing IDs are filtered out, matching numpy and dask.
- Add cross-backend regression tests for both cases plus a row-for-row numpy/cupy parity check. The pre-existing `test_stats_all_nan_zone` and `test_stats_nodata_wipes_zone` had per-backend branches that pinned the buggy cupy behavior; those branches are gone.

Closes #2562

## Backend coverage

- numpy: unchanged (already correct)
- cupy: fixed
- dask+numpy: unchanged (already correct)
- dask+cupy: unchanged (delegates to dask+numpy via `_stats_dask_cupy`)

## Test plan

- [x] `pytest xrspatial/tests/test_zonal.py` (141 passed)
- [x] New regression tests run on numpy and cupy backends
- [x] Updated `test_stats_all_nan_zone` and `test_stats_nodata_wipes_zone` no longer carry a cupy-specific branch