### PR TITLE
resample: validate target_resolution and scale_factor up front (#2574)

### DIFF
--- a/xrspatial/resample.py
+++ b/xrspatial/resample.py
@@ -165,7 +165,8 @@ def _validate_resample_scalar_or_pair(value, param_name):
     positive. Raises ``ValueError`` with a message naming the parameter
     and the offending value.
     """
-    if isinstance(value, (tuple, list)):
+    is_pair = isinstance(value, (tuple, list))
+    if is_pair:
         if len(value) != 2:
             raise ValueError(
                 f"{param_name} must have length 2, got length {len(value)}"
@@ -174,21 +175,25 @@ def _validate_resample_scalar_or_pair(value, param_name):
     else:
         components = (value,)
 
-    for comp in components:
+    for i, comp in enumerate(components):
+        # Suffix points at the bad slot when the input was a pair, so
+        # `(0.0, 1.0)` reports "got 0.0 at index 0 of (0.0, 1.0)"
+        # instead of dumping the whole tuple.
+        where = f"{comp!r} at index {i} of {value!r}" if is_pair else f"{value!r}"
         try:
             f = float(comp)
         except (TypeError, ValueError):
             raise ValueError(
                 f"{param_name} must be a finite positive number "
-                f"(or length-2 sequence of them), got {value!r}"
-            )
+                f"(or length-2 sequence of them), got {where}"
+            ) from None
         if not np.isfinite(f):
             raise ValueError(
-                f"{param_name} must be finite and > 0, got {value!r}"
+                f"{param_name} must be finite and > 0, got {where}"
             )
         if f <= 0:
             raise ValueError(
-                f"{param_name} must be > 0, got {value!r}"
+                f"{param_name} must be > 0, got {where}"
             )
 
 
@@ -1257,6 +1262,14 @@ def resample(
         Output dtype matches the input float dtype (float32 or float64);
         integer inputs return float32 since NaN-sentinel resampling
         requires a float type.
+
+    Raises
+    ------
+    ValueError
+        If neither or both of ``scale_factor`` and ``target_resolution``
+        are given; if either is a sequence whose length is not 2; if any
+        component is zero, negative, NaN, or infinite; or if ``method``
+        is not in :data:`ALL_METHODS`.
     """
     _validate_raster(agg, func_name='resample', name='agg', ndim=(2, 3))
 
@@ -1300,6 +1313,11 @@ def resample(
     else:
         scale_y = scale_x = float(scale_factor)
 
+    # Defence-in-depth: the public inputs were already validated above
+    # by ``_validate_resample_scalar_or_pair``, so on the scale_factor
+    # path this branch is unreachable. It still fires on the
+    # target_resolution path if ``calc_res(agg)`` returns zero from a
+    # degenerate coord array.
     if scale_y <= 0 or scale_x <= 0:
         raise ValueError(
             f"Scale factors must be positive, got ({scale_y}, {scale_x})"

--- a/xrspatial/resample.py
+++ b/xrspatial/resample.py
@@ -155,6 +155,43 @@ def _check_resample_gpu_memory(out_h, out_w):
         )
 
 
+# -- Input-validation helpers ------------------------------------------------
+
+def _validate_resample_scalar_or_pair(value, param_name):
+    """Validate a scalar-or-2-tuple resolution / scale parameter.
+
+    Accepts either a real scalar or a length-2 tuple/list of scalars.
+    Each component must be finite (not NaN, not inf) and strictly
+    positive. Raises ``ValueError`` with a message naming the parameter
+    and the offending value.
+    """
+    if isinstance(value, (tuple, list)):
+        if len(value) != 2:
+            raise ValueError(
+                f"{param_name} must have length 2, got length {len(value)}"
+            )
+        components = value
+    else:
+        components = (value,)
+
+    for comp in components:
+        try:
+            f = float(comp)
+        except (TypeError, ValueError):
+            raise ValueError(
+                f"{param_name} must be a finite positive number "
+                f"(or length-2 sequence of them), got {value!r}"
+            )
+        if not np.isfinite(f):
+            raise ValueError(
+                f"{param_name} must be finite and > 0, got {value!r}"
+            )
+        if f <= 0:
+            raise ValueError(
+                f"{param_name} must be > 0, got {value!r}"
+            )
+
+
 # -- Output-geometry helpers -------------------------------------------------
 
 def _output_shape(in_h, in_w, scale_y, scale_x):
@@ -1233,6 +1270,18 @@ def resample(
         raise ValueError(
             "Exactly one of scale_factor or target_resolution must be given"
         )
+
+    # Validate shape, finiteness, and positivity of whichever input was
+    # supplied. Fails fast with a parameter-named message before any
+    # geometry math runs, so overlong/short tuples, zero, and NaN/inf
+    # do not surface later as IndexError / ZeroDivisionError / opaque
+    # numpy conversion errors.
+    if target_resolution is not None:
+        _validate_resample_scalar_or_pair(
+            target_resolution, 'target_resolution'
+        )
+    else:
+        _validate_resample_scalar_or_pair(scale_factor, 'scale_factor')
 
     if target_resolution is not None:
         if agg.shape[-2] < 2 or agg.shape[-1] < 2:

--- a/xrspatial/tests/test_resample.py
+++ b/xrspatial/tests/test_resample.py
@@ -61,7 +61,7 @@ class TestResampleAPI:
             resample(grid_4x4, scale_factor=0.5, target_resolution=2.0)
 
     def test_negative_scale(self, grid_4x4):
-        with pytest.raises(ValueError, match="positive"):
+        with pytest.raises(ValueError, match="scale_factor must be > 0"):
             resample(grid_4x4, scale_factor=-1.0)
 
     def test_aggregate_upsample_rejected(self, grid_4x4):

--- a/xrspatial/tests/test_resample_input_validation_2574.py
+++ b/xrspatial/tests/test_resample_input_validation_2574.py
@@ -1,0 +1,147 @@
+"""Input-validation tests for xrspatial.resample (issue #2574).
+
+`target_resolution` and `scale_factor` must fail fast with a clear
+``ValueError`` for:
+  * overlong tuples (length > 2)
+  * short tuples (length < 2)
+  * zero / negative components
+  * non-finite values (NaN, inf)
+
+These used to surface deep inside the function as IndexError /
+ZeroDivisionError / opaque numpy conversion errors.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from xrspatial.resample import resample
+from xrspatial.tests.general_checks import create_test_raster
+
+
+@pytest.fixture
+def grid_4x4():
+    data = np.arange(1, 17, dtype=np.float32).reshape(4, 4)
+    return create_test_raster(
+        data, backend='numpy', attrs={'res': (1.0, 1.0)},
+    )
+
+
+# ---------------------------------------------------------------------------
+# target_resolution
+# ---------------------------------------------------------------------------
+
+class TestTargetResolutionValidation:
+    def test_overlong_tuple(self, grid_4x4):
+        with pytest.raises(
+            ValueError,
+            match=r"target_resolution must have length 2, got length 3",
+        ):
+            resample(grid_4x4, target_resolution=(1.0, 1.0, 1.0))
+
+    def test_short_tuple(self, grid_4x4):
+        with pytest.raises(
+            ValueError,
+            match=r"target_resolution must have length 2, got length 1",
+        ):
+            resample(grid_4x4, target_resolution=(1.0,))
+
+    def test_zero_scalar(self, grid_4x4):
+        with pytest.raises(
+            ValueError, match=r"target_resolution must be > 0, got 0",
+        ):
+            resample(grid_4x4, target_resolution=0)
+
+    def test_zero_component(self, grid_4x4):
+        with pytest.raises(
+            ValueError, match=r"target_resolution must be > 0",
+        ):
+            resample(grid_4x4, target_resolution=(0.0, 1.0))
+
+    def test_negative_scalar(self, grid_4x4):
+        with pytest.raises(
+            ValueError, match=r"target_resolution must be > 0, got -2.0",
+        ):
+            resample(grid_4x4, target_resolution=-2.0)
+
+    def test_nan_scalar(self, grid_4x4):
+        with pytest.raises(
+            ValueError,
+            match=r"target_resolution must be finite and > 0, got nan",
+        ):
+            resample(grid_4x4, target_resolution=float('nan'))
+
+    def test_inf_scalar(self, grid_4x4):
+        with pytest.raises(
+            ValueError,
+            match=r"target_resolution must be finite and > 0, got inf",
+        ):
+            resample(grid_4x4, target_resolution=float('inf'))
+
+
+# ---------------------------------------------------------------------------
+# scale_factor
+# ---------------------------------------------------------------------------
+
+class TestScaleFactorValidation:
+    def test_overlong_tuple(self, grid_4x4):
+        with pytest.raises(
+            ValueError,
+            match=r"scale_factor must have length 2, got length 3",
+        ):
+            resample(grid_4x4, scale_factor=(2.0, 2.0, 2.0))
+
+    def test_short_tuple(self, grid_4x4):
+        with pytest.raises(
+            ValueError,
+            match=r"scale_factor must have length 2, got length 1",
+        ):
+            resample(grid_4x4, scale_factor=(2.0,))
+
+    def test_zero_scalar(self, grid_4x4):
+        with pytest.raises(
+            ValueError, match=r"scale_factor must be > 0, got 0",
+        ):
+            resample(grid_4x4, scale_factor=0)
+
+    def test_zero_component(self, grid_4x4):
+        with pytest.raises(
+            ValueError, match=r"scale_factor must be > 0",
+        ):
+            resample(grid_4x4, scale_factor=(0.0, 2.0))
+
+    def test_nan_scalar(self, grid_4x4):
+        with pytest.raises(
+            ValueError,
+            match=r"scale_factor must be finite and > 0, got nan",
+        ):
+            resample(grid_4x4, scale_factor=float('nan'))
+
+    def test_inf_scalar(self, grid_4x4):
+        with pytest.raises(
+            ValueError,
+            match=r"scale_factor must be finite and > 0, got inf",
+        ):
+            resample(grid_4x4, scale_factor=float('inf'))
+
+
+# ---------------------------------------------------------------------------
+# Valid inputs still work (regression guard)
+# ---------------------------------------------------------------------------
+
+class TestValidInputsStillWork:
+    def test_scalar_scale_factor(self, grid_4x4):
+        out = resample(grid_4x4, scale_factor=2.0)
+        assert out.shape == (8, 8)
+
+    def test_tuple_scale_factor(self, grid_4x4):
+        out = resample(grid_4x4, scale_factor=(0.5, 0.5))
+        assert out.shape == (2, 2)
+
+    def test_scalar_target_resolution(self, grid_4x4):
+        out = resample(grid_4x4, target_resolution=0.5)
+        assert out.shape == (8, 8)
+
+    def test_tuple_target_resolution(self, grid_4x4):
+        out = resample(grid_4x4, target_resolution=(0.5, 0.5))
+        assert out.shape == (8, 8)

--- a/xrspatial/tests/test_resample_input_validation_2574.py
+++ b/xrspatial/tests/test_resample_input_validation_2574.py
@@ -53,8 +53,10 @@ class TestTargetResolutionValidation:
             resample(grid_4x4, target_resolution=0)
 
     def test_zero_component(self, grid_4x4):
+        # Pair errors point at the failing index.
         with pytest.raises(
-            ValueError, match=r"target_resolution must be > 0",
+            ValueError,
+            match=r"target_resolution must be > 0, got 0.0 at index 0 of",
         ):
             resample(grid_4x4, target_resolution=(0.0, 1.0))
 
@@ -105,8 +107,10 @@ class TestScaleFactorValidation:
             resample(grid_4x4, scale_factor=0)
 
     def test_zero_component(self, grid_4x4):
+        # Pair errors point at the failing index.
         with pytest.raises(
-            ValueError, match=r"scale_factor must be > 0",
+            ValueError,
+            match=r"scale_factor must be > 0, got 0.0 at index 0 of",
         ):
             resample(grid_4x4, scale_factor=(0.0, 2.0))
 


### PR DESCRIPTION
Closes #2574.

## Summary

- Add `_validate_resample_scalar_or_pair` and call it at the top of `resample()`, right after the `(scale_factor XOR target_resolution)` check.
- The four leaky cases now raise `ValueError` with a message that names the parameter and shows the offending value, before any geometry math runs:
  - overlong tuple -> `target_resolution must have length 2, got length 3`
  - short tuple -> `scale_factor must have length 2, got length 1`
  - zero or negative -> `target_resolution must be > 0, got 0`
  - NaN / inf -> `scale_factor must be finite and > 0, got nan`
- Existing defence-in-depth `scale_y <= 0 or scale_x <= 0` check stays, but it is no longer the first thing the user sees.

## Backend coverage

Pure CPython input validation at the public boundary. No backend code touched. The helper runs once before dispatch, so numpy / cupy / dask+numpy / dask+cupy all behave the same.

## Test plan

- [x] New `xrspatial/tests/test_resample_input_validation_2574.py` with 17 cases (overlong, short, zero scalar, zero component, negative, NaN, inf for each of the two params, plus a regression block confirming valid scalar and tuple inputs still produce the expected output shape).
- [x] Update one existing `test_negative_scale` to match the new wording.
- [x] Full `test_resample*.py` suite: 249 passed, 2 skipped (pre-existing skips).