### PR TITLE
zonal: keep hypsometric_integral dask path fully lazy (#2563)

### DIFF
--- a/xrspatial/tests/test_hypsometric_integral.py
+++ b/xrspatial/tests/test_hypsometric_integral.py
@@ -230,7 +230,7 @@ def test_hypsometric_integral_accessor(backend, hi_zones, hi_values):
 # --- laziness (issue #2563) --------------------------------------------------
 
 @pytest.mark.skipif(da is None, reason="dask not installed")
-def test_hypsometric_integral_dask_returns_lazy():
+def test_hypsometric_integral_dask_returns_lazy(monkeypatch):
     """The dask backend must return a lazy graph — no eager compute on call."""
     import dask
     from xrspatial.zonal import hypsometric_integral
@@ -251,11 +251,9 @@ def test_hypsometric_integral_dask_returns_lazy():
         calls['n'] += 1
         return orig_compute(*args, **kwargs)
 
-    dask.compute = counting_compute
-    try:
-        result = hypsometric_integral(zones, values, nodata=None)
-    finally:
-        dask.compute = orig_compute
+    monkeypatch.setattr(dask, "compute", counting_compute)
+
+    result = hypsometric_integral(zones, values, nodata=None)
 
     assert isinstance(result.data, da.Array), \
         f"expected dask.Array, got {type(result.data).__name__}"
@@ -293,7 +291,7 @@ def test_hypsometric_integral_dask_matches_numpy():
 
 
 @pytest.mark.skipif(da is None, reason="dask not installed")
-def test_hypsometric_integral_dask_empty_lookup_is_lazy():
+def test_hypsometric_integral_dask_empty_lookup_is_lazy(monkeypatch):
     """When every zone is nodata, the result is still a lazy dask array of NaN."""
     import dask
     from xrspatial.zonal import hypsometric_integral
@@ -314,11 +312,9 @@ def test_hypsometric_integral_dask_empty_lookup_is_lazy():
         calls['n'] += 1
         return orig_compute(*args, **kwargs)
 
-    dask.compute = counting_compute
-    try:
-        result = hypsometric_integral(zones, values, nodata=0)
-    finally:
-        dask.compute = orig_compute
+    monkeypatch.setattr(dask, "compute", counting_compute)
+
+    result = hypsometric_integral(zones, values, nodata=0)
 
     assert isinstance(result.data, da.Array)
     assert calls['n'] == 0

--- a/xrspatial/tests/test_hypsometric_integral.py
+++ b/xrspatial/tests/test_hypsometric_integral.py
@@ -227,6 +227,105 @@ def test_hypsometric_integral_accessor(backend, hi_zones, hi_values):
     np.testing.assert_allclose(out[z1_mask], 0.5, rtol=1e-10)
 
 
+# --- laziness (issue #2563) --------------------------------------------------
+
+@pytest.mark.skipif(da is None, reason="dask not installed")
+def test_hypsometric_integral_dask_returns_lazy():
+    """The dask backend must return a lazy graph — no eager compute on call."""
+    import dask
+    from xrspatial.zonal import hypsometric_integral
+
+    zones = create_test_raster(
+        np.array([[1, 1, 2], [2, 2, 1]], dtype=np.float64),
+        backend='dask+numpy', chunks=(2, 2),
+    )
+    values = create_test_raster(
+        np.array([[10.0, 20, 5], [30, 40, 15]]),
+        backend='dask+numpy', chunks=(2, 2),
+    )
+
+    calls = {'n': 0}
+    orig_compute = dask.compute
+
+    def counting_compute(*args, **kwargs):
+        calls['n'] += 1
+        return orig_compute(*args, **kwargs)
+
+    dask.compute = counting_compute
+    try:
+        result = hypsometric_integral(zones, values, nodata=None)
+    finally:
+        dask.compute = orig_compute
+
+    assert isinstance(result.data, da.Array), \
+        f"expected dask.Array, got {type(result.data).__name__}"
+    assert calls['n'] == 0, \
+        f"hypsometric_integral fired dask.compute {calls['n']} times during construction"
+
+
+@pytest.mark.skipif(da is None, reason="dask not installed")
+def test_hypsometric_integral_dask_matches_numpy():
+    """Eager `.compute()` of the dask result must match the numpy backend exactly."""
+    from xrspatial.zonal import hypsometric_integral
+
+    zones_arr = np.array([
+        [0, 1, 1, 1],
+        [0, 1, 1, 2],
+        [0, 2, 2, 2],
+        [0, 2, 2, 0],
+    ], dtype=np.float64)
+    values_arr = np.array([
+        [999., 10., 20., 30.],
+        [999., 40., 50., 100.],
+        [999., 60., 70., 80.],
+        [999., 90., 95., 999.],
+    ], dtype=np.float64)
+
+    zones_np = create_test_raster(zones_arr, backend='numpy')
+    values_np = create_test_raster(values_arr, backend='numpy')
+    zones_d = create_test_raster(zones_arr, backend='dask+numpy', chunks=(2, 2))
+    values_d = create_test_raster(values_arr, backend='dask+numpy', chunks=(2, 2))
+
+    out_np = hypsometric_integral(zones_np, values_np).values
+    out_dask = hypsometric_integral(zones_d, values_d).compute().values
+
+    np.testing.assert_array_equal(out_np, out_dask)
+
+
+@pytest.mark.skipif(da is None, reason="dask not installed")
+def test_hypsometric_integral_dask_empty_lookup_is_lazy():
+    """When every zone is nodata, the result is still a lazy dask array of NaN."""
+    import dask
+    from xrspatial.zonal import hypsometric_integral
+
+    zones = create_test_raster(
+        np.array([[0, 0], [0, 0]], dtype=np.float64),
+        backend='dask+numpy', chunks=(2, 2),
+    )
+    values = create_test_raster(
+        np.array([[10.0, 20.0], [30.0, 40.0]]),
+        backend='dask+numpy', chunks=(2, 2),
+    )
+
+    calls = {'n': 0}
+    orig_compute = dask.compute
+
+    def counting_compute(*args, **kwargs):
+        calls['n'] += 1
+        return orig_compute(*args, **kwargs)
+
+    dask.compute = counting_compute
+    try:
+        result = hypsometric_integral(zones, values, nodata=0)
+    finally:
+        dask.compute = orig_compute
+
+    assert isinstance(result.data, da.Array)
+    assert calls['n'] == 0
+    out = result.compute().values
+    assert np.all(np.isnan(out))
+
+
 def test_hypsometric_integral_list_of_pairs_zones():
     """Vector zones via list of (geometry, value) pairs."""
     from shapely.geometry import box

--- a/xrspatial/zonal.py
+++ b/xrspatial/zonal.py
@@ -1563,7 +1563,8 @@ def _hi_dask_numpy(zones_data, values_data, nodata):
     )
 
     def _paint(zones_chunk, values_chunk, hi_map_arr):
-        hi_map = hi_map_arr[()] if hi_map_arr.shape == () else hi_map_arr.item()
+        # hi_map_arr is the 0-d object array carrying the lookup dict.
+        hi_map = hi_map_arr[()]
         out = np.full(zones_chunk.shape, np.nan, dtype=np.float64)
         for z, hi_val in hi_map.items():
             mask = (zones_chunk == z) & np.isfinite(values_chunk)

--- a/xrspatial/zonal.py
+++ b/xrspatial/zonal.py
@@ -1525,13 +1525,29 @@ def _hi_reduce(partials_list):
     return hi_lookup
 
 
+@delayed
+def _hi_lookup_as_object_array(hi_lookup):
+    """Wrap the HI lookup dict in a 0-d numpy object array.
+
+    `map_blocks` only threads dask-array positional args through the graph
+    lazily.  Wrapping the dict in a 0-d object array lets us hand the
+    delayed lookup to every paint chunk without computing it up front.
+    """
+    arr = np.empty((), dtype=object)
+    arr[()] = hi_lookup
+    return arr
+
+
 def _hi_dask_numpy(zones_data, values_data, nodata):
     """Dask+numpy backend for hypsometric integral.
 
     Single graph evaluation: each block computes its local (zone -> stats)
-    dict, then a streaming reduce merges them into a lookup table, then
+    dict, a streaming reduce merges them into a lookup table, and
     map_blocks paints the result.  No up-front `_unique_finite_zones`
     compute and no O(n_blocks * n_zones) scheduler-side stack.
+
+    The lookup table stays lazy (a 0-d dask object array) so the whole
+    pipeline is lazy: nothing runs until the caller computes the output.
     """
     zones_blocks = zones_data.to_delayed().ravel()
     values_blocks = values_data.to_delayed().ravel()
@@ -1541,13 +1557,13 @@ def _hi_dask_numpy(zones_data, values_data, nodata):
         for zb, vb in zip(zones_blocks, values_blocks)
     ]
 
-    hi_lookup = dask.compute(_hi_reduce(partials))[0]
+    hi_lookup_delayed = _hi_lookup_as_object_array(_hi_reduce(partials))
+    hi_lookup_arr = da.from_delayed(
+        hi_lookup_delayed, shape=(), dtype=object, meta=np.array((), dtype=object),
+    )
 
-    if not hi_lookup:
-        return da.full(values_data.shape, np.nan, dtype=np.float64,
-                       chunks=values_data.chunks)
-
-    def _paint(zones_chunk, values_chunk, hi_map):
+    def _paint(zones_chunk, values_chunk, hi_map_arr):
+        hi_map = hi_map_arr[()] if hi_map_arr.shape == () else hi_map_arr.item()
         out = np.full(zones_chunk.shape, np.nan, dtype=np.float64)
         for z, hi_val in hi_map.items():
             mask = (zones_chunk == z) & np.isfinite(values_chunk)
@@ -1555,7 +1571,7 @@ def _hi_dask_numpy(zones_data, values_data, nodata):
         return out
 
     return da.map_blocks(
-        _paint, zones_data, values_data, hi_map=hi_lookup,
+        _paint, zones_data, values_data, hi_lookup_arr,
         dtype=np.float64, meta=np.array(()),
     )
 


### PR DESCRIPTION
Closes #2563.

## Summary

- `_hi_dask_numpy` was calling `dask.compute()` inline on the per-zone reduce so it could pass the HI lookup dict to `map_blocks`. That broke the lazy convention for dask-backed results.
- Wrap the reduce in a 0-d dask object array (via `da.from_delayed`) and thread it through `map_blocks` as a positional dask arg. The lookup flows through the graph alongside the chunks; nothing computes until the caller asks for it.
- Drop the empty-lookup early return — painting over an empty dict already produces the all-NaN raster that case needs.
- The dask+cupy backend delegates to `_hi_dask_numpy`, so the same fix applies; the #2525 re-wrap step is preserved.

## Backend coverage

- numpy: unchanged
- cupy: unchanged
- dask+numpy: now returns a lazy dask graph
- dask+cupy: now returns a lazy dask graph (still cupy-typed chunks)

## Test plan

- [x] `pytest xrspatial/tests/test_hypsometric_integral.py` (36 passed locally, including 3 new laziness/parity tests)
- [x] `pytest xrspatial/tests/test_zonal.py xrspatial/tests/test_zonal_backend_coverage_2026_05_27.py xrspatial/tests/test_hypsometric_integral.py` (204 passed locally)
- [x] Manual: dask+cupy returns lazy graph and computes to the same values as numpy