### PR TITLE
zonal: fix trim() default NaN sentinel on numpy and cupy backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@
 
 #### Fixed
 
+- `zonal.trim()` with the default `values=(np.nan,)` (or any NaN
+  sentinel) now trims a NaN-framed raster on the numpy and cupy
+  backends, matching the existing dask behaviour. The numba kernel
+  `_trim` matched sentinels with `e == val` and `NaN == NaN` is False,
+  so NaN borders were silently ignored on those backends. NaN matching
+  is now handled in a numpy bounds helper that mirrors the dask
+  reduction. Behaviour for finite sentinels (zero, integer zone ids,
+  etc.) is unchanged. (#2559)
+
 - `polygonize` now auto-detects the raster's affine transform from
   `attrs['transform']` (xrspatial.geotiff convention) or
   `rio.transform()` (rioxarray) when the caller did not pass an

--- a/xrspatial/tests/test_zonal_backend_coverage_2026_05_27.py
+++ b/xrspatial/tests/test_zonal_backend_coverage_2026_05_27.py
@@ -334,12 +334,12 @@ def test_trim_dask_cupy_matches_numpy(trim_input):
 
 @dask_required
 def test_trim_dask_nan_values(trim_input):
-    """Cat 2 HIGH: dask trim with default NaN sentinel.
+    """trim with a NaN sentinel agrees across numpy and dask backends.
 
-    The dask branch ``_trim_bounds_dask`` has a dedicated ``isnan`` path
-    (zonal.py:2287) that the numpy backend lacks: numpy's ``_trim`` uses
-    a plain equality check, which never matches NaN. This test pins the
-    backend asymmetry so any future change is visible as a diff.
+    Originally pinned a numpy/dask asymmetry: ``_trim``'s ``e == val``
+    check never matched NaN, so the numpy path left a NaN-framed
+    raster unchanged while dask trimmed it. Fixed in #2559 by routing
+    NaN sentinels through ``_trim_bounds_numpy`` in the wrapper.
     """
     arr_with_nan = np.where(trim_input == 0, np.nan, trim_input)
 
@@ -348,22 +348,20 @@ def test_trim_dask_nan_values(trim_input):
         da.from_array(arr_with_nan, chunks=(3, 2)), dims=['y', 'x'],
     )
 
-    # Dask path trims the all-NaN frame to the bounding box of finite
-    # data.  Interior NaNs (the original 0 in the middle of row 1) are
+    # Bounding box covers rows 1-3, cols 1-2 of the input.
+    # Interior NaNs (the original 0 in the middle of row 1) are
     # preserved.
-    out_da = trim(arr_da, values=(np.nan,))
-    out_da_np = _to_numpy(out_da)
-    assert out_da_np.shape == (3, 2)
-    # bounding box covers rows 1-3, cols 1-2 of the input
     expected = np.array([[4.0, np.nan],
                          [4.0, 4.0],
                          [1.0, 1.0]])
-    np.testing.assert_array_equal(out_da_np, expected)
 
-    # numpy path doesn't match NaN with equality, so the result is
-    # unchanged.  Pin this asymmetry so a future change is visible.
-    out_np_nan = trim(arr_np, values=(np.nan,))
-    assert out_np_nan.shape == arr_np.shape
+    out_da = _to_numpy(trim(arr_da, values=(np.nan,)))
+    out_np = _to_numpy(trim(arr_np, values=(np.nan,)))
+
+    assert out_da.shape == (3, 2)
+    assert out_np.shape == (3, 2)
+    np.testing.assert_array_equal(out_da, expected)
+    np.testing.assert_array_equal(out_np, expected)
 
 
 def test_trim_preserves_name_attribute():
@@ -378,6 +376,151 @@ def test_trim_preserves_name_attribute():
     # attrs propagated from input
     assert out.attrs.get('res') == (1.0, 1.0)
     assert out.attrs.get('crs') == 'EPSG:4326'
+
+
+# ---------------------------------------------------------------------------
+# trim() with default NaN sentinel -- cross-backend agreement (#2559)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def trim_nan_input():
+    return np.array(
+        [[np.nan, np.nan, np.nan, np.nan],
+         [np.nan, 4.0,    np.nan, np.nan],
+         [np.nan, 4.0,    4.0,    np.nan],
+         [np.nan, 1.0,    1.0,    np.nan],
+         [np.nan, np.nan, np.nan, np.nan]],
+        dtype=np.float64,
+    )
+
+
+def test_trim_numpy_default_nan(trim_nan_input):
+    """Default values=(np.nan,) trims a NaN-framed numpy raster (#2559).
+
+    Pre-fix this returned the input unchanged because ``_trim`` matched
+    sentinels with ``e == val`` and ``NaN == NaN`` is False.
+    """
+    arr = xr.DataArray(trim_nan_input, dims=['y', 'x'])
+
+    out = trim(arr)  # default values=(np.nan,)
+    out_np = _to_numpy(out)
+
+    expected = np.array([[4.0, np.nan],
+                         [4.0, 4.0],
+                         [1.0, 1.0]])
+    assert out_np.shape == (3, 2)
+    np.testing.assert_array_equal(out_np, expected)
+
+
+def test_trim_numpy_explicit_nan_matches_default(trim_nan_input):
+    """Passing values=(np.nan,) explicitly matches the default (#2559)."""
+    arr = xr.DataArray(trim_nan_input, dims=['y', 'x'])
+
+    out_default = _to_numpy(trim(arr))
+    out_explicit = _to_numpy(trim(arr, values=(np.nan,)))
+
+    np.testing.assert_array_equal(out_default, out_explicit)
+
+
+@cuda_and_cupy_available
+def test_trim_cupy_default_nan_matches_numpy(trim_nan_input):
+    """cupy backend trims a NaN-framed raster identically to numpy (#2559)."""
+    import cupy as cp
+
+    arr_np = xr.DataArray(trim_nan_input, dims=['y', 'x'])
+    arr_cp = xr.DataArray(cp.asarray(trim_nan_input), dims=['y', 'x'])
+
+    out_np = _to_numpy(trim(arr_np))
+    out_cp = _to_numpy(trim(arr_cp))
+
+    assert out_cp.shape == out_np.shape == (3, 2)
+    np.testing.assert_array_equal(out_cp, out_np)
+
+
+@dask_required
+def test_trim_dask_numpy_default_nan_matches_numpy(trim_nan_input):
+    """dask+numpy backend trims a NaN-framed raster identically to numpy (#2559)."""
+    arr_np = xr.DataArray(trim_nan_input, dims=['y', 'x'])
+    arr_da = xr.DataArray(
+        da.from_array(trim_nan_input, chunks=(3, 2)), dims=['y', 'x'],
+    )
+
+    out_np = _to_numpy(trim(arr_np))
+    out_da = _to_numpy(trim(arr_da))
+
+    assert out_da.shape == out_np.shape == (3, 2)
+    np.testing.assert_array_equal(out_da, out_np)
+
+
+@cuda_and_cupy_available
+@dask_required
+def test_trim_dask_cupy_default_nan_matches_numpy(trim_nan_input):
+    """dask+cupy backend trims a NaN-framed raster identically to numpy (#2559)."""
+    import cupy as cp
+
+    arr_np = xr.DataArray(trim_nan_input, dims=['y', 'x'])
+    arr_dc = xr.DataArray(
+        da.from_array(cp.asarray(trim_nan_input), chunks=(3, 2)),
+        dims=['y', 'x'],
+    )
+
+    out_np = _to_numpy(trim(arr_np))
+    out_dc = _to_numpy(trim(arr_dc))
+
+    assert out_dc.shape == out_np.shape == (3, 2)
+    np.testing.assert_array_equal(out_dc, out_np)
+
+
+def test_trim_numpy_mixed_nan_and_finite_sentinels():
+    """Passing both NaN and a finite sentinel trims either kind of border (#2559)."""
+    data = np.array(
+        [[0.0,    0.0, 0.0,    0.0],
+         [0.0,    5.0, np.nan, 0.0],
+         [np.nan, 5.0, 5.0,    np.nan],
+         [0.0,    0.0, 0.0,    0.0]],
+        dtype=np.float64,
+    )
+    arr = xr.DataArray(data, dims=['y', 'x'])
+
+    out = _to_numpy(trim(arr, values=(0.0, np.nan)))
+
+    # Rows 0 and 3 are all-zero -> trimmed.
+    # Row 1 col 2 is NaN, row 2 cols 0 and 3 are NaN -> all trimmable
+    # via the mixed-sentinel rule. The first non-trimmable row is 1
+    # (because of the 5.0), last is 2. Same for cols (1, 2).
+    expected = np.array([[5.0, np.nan],
+                         [5.0, 5.0]])
+    assert out.shape == (2, 2)
+    np.testing.assert_array_equal(out, expected)
+
+
+def test_trim_numpy_integer_dtype_non_nan_sentinel_still_works():
+    """Integer-dtype input with a non-NaN sentinel goes through the numba
+    kernel and trims correctly (#2559 regression guard)."""
+    data = np.array(
+        [[0, 0, 0, 0, 0],
+         [0, 0, 7, 0, 0],
+         [0, 0, 7, 7, 0],
+         [0, 0, 0, 0, 0]],
+        dtype=np.int32,
+    )
+    arr = xr.DataArray(data, dims=['y', 'x'])
+
+    out = _to_numpy(trim(arr, values=(0,)))
+
+    expected = np.array([[7, 0],
+                         [7, 7]], dtype=np.int32)
+    assert out.shape == (2, 2)
+    np.testing.assert_array_equal(out, expected)
+
+
+def test_trim_numpy_all_nan_input():
+    """trim() of an all-NaN raster returns an empty slice on numpy (#2559)."""
+    arr = xr.DataArray(np.full((4, 4), np.nan), dims=['y', 'x'])
+
+    out = _to_numpy(trim(arr))
+
+    assert out.size == 0
 
 
 # ---------------------------------------------------------------------------

--- a/xrspatial/zonal.py
+++ b/xrspatial/zonal.py
@@ -2374,6 +2374,47 @@ def _trim_bounds_dask(data, excludes):
             int(data_cols[0]), int(data_cols[-1]))
 
 
+def _split_nan_excludes(values):
+    """Return (finite_excludes_array, has_nan).
+
+    NaN sentinels cannot be matched by the numba kernel's ``e == val``
+    test (``NaN == NaN`` is False) and ``np.isnan`` is not callable on
+    integer dtypes inside numba, so NaN matching is handled in the
+    wrapper instead of inside ``_trim``.
+    """
+    has_nan = False
+    finite = []
+    for v in values:
+        if isinstance(v, float) and np.isnan(v):
+            has_nan = True
+        else:
+            finite.append(v)
+    return np.asarray(finite), has_nan
+
+
+def _trim_bounds_numpy(data, excludes):
+    """Find trim bounds using a numpy row/col reduction (handles NaN)."""
+    finite, has_nan = _split_nan_excludes(excludes)
+
+    excluded = np.zeros(data.shape, dtype=bool)
+    if has_nan and np.issubdtype(data.dtype, np.floating):
+        excluded |= np.isnan(data)
+    for v in finite:
+        excluded |= (data == v)
+
+    all_excl_rows = excluded.all(axis=1)
+    all_excl_cols = excluded.all(axis=0)
+
+    data_rows = np.where(~all_excl_rows)[0]
+    data_cols = np.where(~all_excl_cols)[0]
+
+    if len(data_rows) == 0 or len(data_cols) == 0:
+        return 0, -1, 0, -1  # empty slice
+
+    return (int(data_rows[0]), int(data_rows[-1]),
+            int(data_cols[0]), int(data_cols[-1]))
+
+
 def trim(
     raster: xr.DataArray,
     values: Union[list, tuple] = (np.nan,),
@@ -2487,7 +2528,14 @@ def trim(
     else:
         if is_cupy_array(data):
             data = data.get()
-        top, bottom, left, right = _trim(data, np.asarray(values))
+        finite, has_nan = _split_nan_excludes(values)
+        # NaN sentinels cannot be matched by the numba kernel
+        # (NaN == NaN is False). Route to the numpy bounds helper
+        # whenever NaN matching is needed.
+        if has_nan:
+            top, bottom, left, right = _trim_bounds_numpy(data, values)
+        else:
+            top, bottom, left, right = _trim(data, finite)
 
     arr = raster[top: bottom + 1, left: right + 1]
     arr.name = name


### PR DESCRIPTION
Closes #2559.

## Summary

- Fix `zonal.trim()` so the default `values=(np.nan,)` actually trims
  a NaN-framed raster on the numpy and cupy backends. The numba kernel
  `_trim` matched sentinels with `e == val`, and `NaN == NaN` is
  False, so NaN borders were silently ignored. The dask branch
  already handled NaN via `da.isnan`, so the same input behaved
  differently across backends.
- Add `_trim_bounds_numpy` (a row/col `.all()` reduction on a
  NaN-aware mask, mirroring `_trim_bounds_dask`) and route NaN
  sentinels through it from the `trim()` wrapper. Finite sentinels
  still go through the existing numba kernel; `_trim` is unchanged.
- Update the pre-existing asymmetry-pin test in
  `test_zonal_backend_coverage_2026_05_27.py` and add cross-backend
  tests covering numpy / cupy / dask+numpy / dask+cupy with a NaN
  sentinel, plus mixed NaN+finite sentinels, integer-dtype regression,
  and all-NaN input.

## Backend coverage

- numpy: fixed, new tests
- cupy: fixed (routes through the same wrapper), new tests
  (skipped without CUDA)
- dask+numpy: unchanged behaviour, new parity test
- dask+cupy: unchanged behaviour, new parity test
  (skipped without CUDA)

## Test plan

- [x] `pytest xrspatial/tests/test_zonal.py -k trim`
- [x] `pytest xrspatial/tests/test_zonal_backend_coverage_2026_05_27.py -k trim`
- [x] `pytest xrspatial/tests/test_zonal.py xrspatial/tests/test_zonal_backend_coverage_2026_05_27.py xrspatial/tests/test_dask_cupy_gaps.py`
- [x] Repro snippet in the issue now returns shape (1, 1) on numpy