### PR TITLE
reproject: fix vertical-datum shift crash on integer DEMs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@
 
 #### Fixed
 
+- `reproject` no longer crashes when the source raster is an integer
+  dtype and a vertical-datum shift is requested
+  (`src_vertical_crs` / `tgt_vertical_crs`). The shift path now
+  promotes integer inputs to `float32` (or to `float64` when the
+  source is already `float64`) before applying the geoid offset, and
+  refreshes `attrs['nodata']`, `attrs['_FillValue']`, and
+  `attrs['nodatavals']` to NaN so the sentinel matches the new dtype.
+  Integer nodata pixels propagate as NaN in the promoted output.
+  Affects the numpy, cupy, and dask+numpy backends. (#2565)
+
 - `polygonize` now auto-detects the raster's affine transform from
   `attrs['transform']` (xrspatial.geotiff convention) or
   `rio.transform()` (rioxarray) when the caller did not pass an

--- a/xrspatial/reproject/__init__.py
+++ b/xrspatial/reproject/__init__.py
@@ -1065,19 +1065,15 @@ def _promoted_vertical_dtype(src_dtype):
     """Return the float dtype to use when applying a geoid shift.
 
     The geoid offset is fractional metres, so any integer input has to
-    be promoted before we can add it. We pick ``float32`` for integer
-    and small-float inputs and only upgrade to ``float64`` when the
-    source is already ``float64``. Returns ``None`` when the input is
-    already a float dtype that does not need promotion.
+    be promoted before we can add it. Returns ``None`` when the input
+    is already a float dtype (including ``float64``) -- we leave its
+    precision alone. Returns ``np.float32`` for any non-float input;
+    that gives ~0.1 mm resolution in metres at altitudes up to ~10 km,
+    which is well below the accuracy of the geoid grids themselves.
     """
     src_dtype = np.dtype(src_dtype)
-    if src_dtype == np.float64:
-        return None
     if np.issubdtype(src_dtype, np.floating):
         return None
-    # Integer (or other non-float) input -> promote to float32. That
-    # gives ~0.1 mm precision in metres at altitudes up to ~10 km,
-    # which is well below the accuracy of the geoid grids themselves.
     return np.float32
 
 

--- a/xrspatial/reproject/__init__.py
+++ b/xrspatial/reproject/__init__.py
@@ -967,7 +967,7 @@ def reproject(
     # Vertical datum transformation (if requested)
     if src_vertical_crs is not None and tgt_vertical_crs is not None:
         if src_vertical_crs != tgt_vertical_crs:
-            result_data = _apply_vertical_shift(
+            result_data, nd = _apply_vertical_shift(
                 result_data, y_coords, x_coords,
                 src_vertical_crs, tgt_vertical_crs, nd,
                 tgt_crs_wkt=tgt_wkt,
@@ -1061,6 +1061,26 @@ def reproject(
     return result
 
 
+def _promoted_vertical_dtype(src_dtype):
+    """Return the float dtype to use when applying a geoid shift.
+
+    The geoid offset is fractional metres, so any integer input has to
+    be promoted before we can add it. We pick ``float32`` for integer
+    and small-float inputs and only upgrade to ``float64`` when the
+    source is already ``float64``. Returns ``None`` when the input is
+    already a float dtype that does not need promotion.
+    """
+    src_dtype = np.dtype(src_dtype)
+    if src_dtype == np.float64:
+        return None
+    if np.issubdtype(src_dtype, np.floating):
+        return None
+    # Integer (or other non-float) input -> promote to float32. That
+    # gives ~0.1 mm precision in metres at altitudes up to ~10 km,
+    # which is well below the accuracy of the geoid grids themselves.
+    return np.float32
+
+
 def _apply_vertical_shift(data, y_coords, x_coords,
                           src_vcrs, tgt_vcrs, nodata,
                           tgt_crs_wkt=None):
@@ -1085,6 +1105,16 @@ def _apply_vertical_shift(data, y_coords, x_coords,
       each chunk's slab is materialised, shifted, and returned in place.
     - For 3-D ``(y, x, band)`` results, the shift is applied per band
       because the geoid undulation depends only on horizontal position.
+
+    Returns
+    -------
+    (shifted, out_nodata) : tuple
+        ``shifted`` is the height-shifted array, possibly promoted to a
+        float dtype if the input was integer (see
+        ``_promoted_vertical_dtype``). ``out_nodata`` is the nodata
+        sentinel that matches the returned dtype -- ``NaN`` whenever a
+        promotion happened so the caller can rely on NaN semantics in
+        the float output.
     """
     # Direction (sign convention) is the same regardless of backend.
     geoid_models = []
@@ -1099,10 +1129,24 @@ def _apply_vertical_shift(data, y_coords, x_coords,
         geoid_models.extend([src_vcrs, tgt_vcrs])
         signs.extend([1.0, -1.0])  # H1 + N1 - N2
     else:
-        return data
+        return data, nodata
 
     x_arr = np.asarray(x_coords, dtype=np.float64)
     y_arr = np.asarray(y_coords, dtype=np.float64)
+
+    # Decide the output dtype once, here, so every backend agrees and
+    # the caller can update attrs['nodata'] etc. with the post-shift
+    # sentinel.
+    promoted = _promoted_vertical_dtype(data.dtype)
+    if promoted is None:
+        out_dtype = np.dtype(data.dtype)
+        out_nodata = nodata
+    else:
+        out_dtype = np.dtype(promoted)
+        # NaN is the natural sentinel in a float output. The numpy path
+        # below replaces any cells that matched the input integer
+        # ``nodata`` with NaN before applying the shift.
+        out_nodata = float('nan')
 
     # Dask backend: wrap the per-block computation. Each block sees its
     # own row slab of x/y coords, so we route through map_blocks and
@@ -1114,10 +1158,12 @@ def _apply_vertical_shift(data, y_coords, x_coords,
         is_dask = False
 
     if is_dask:
-        return _apply_vertical_shift_dask(
+        shifted = _apply_vertical_shift_dask(
             data, y_arr, x_arr,
             geoid_models, signs, nodata, tgt_crs_wkt,
+            out_dtype=out_dtype,
         )
+        return shifted, out_nodata
 
     # CuPy backend: round-trip via host. The geoid lookup is small
     # relative to the reprojection itself, and the CPU JIT path is
@@ -1133,22 +1179,33 @@ def _apply_vertical_shift(data, y_coords, x_coords,
         shifted = _apply_vertical_shift_numpy(
             host, y_arr, x_arr,
             geoid_models, signs, nodata, tgt_crs_wkt,
+            out_dtype=out_dtype,
         )
-        return cp.asarray(shifted)
+        return cp.asarray(shifted), out_nodata
 
-    return _apply_vertical_shift_numpy(
+    shifted = _apply_vertical_shift_numpy(
         np.asarray(data), y_arr, x_arr,
         geoid_models, signs, nodata, tgt_crs_wkt,
+        out_dtype=out_dtype,
     )
+    return shifted, out_nodata
 
 
 def _apply_vertical_shift_numpy(data, y_arr, x_arr,
-                                geoid_models, signs, nodata, tgt_crs_wkt):
+                                geoid_models, signs, nodata, tgt_crs_wkt,
+                                out_dtype=None):
     """Apply geoid shift on a numpy array.
 
     Handles both 2-D ``(H, W)`` and 3-D ``(H, W, B)`` shapes by looping
     over band slices; the geoid undulation depends only on horizontal
     position, so each band sees the same N(y, x) correction.
+
+    If ``out_dtype`` is given and differs from ``data.dtype`` (the
+    integer-DEM case), the input is cast to that float dtype before
+    the shift and the integer ``nodata`` sentinel is replaced with
+    NaN in the promoted output. When ``out_dtype`` is ``None`` (or
+    matches the input), the behaviour is in-place on a copy of the
+    input -- same as before this signature was added.
     """
     from ._vertical import _load_geoid, _interp_geoid_2d
 
@@ -1177,8 +1234,25 @@ def _apply_vertical_shift_numpy(data, y_arr, x_arr,
 
     # Process in row strips to bound memory in the numpy path; dask chunks
     # are usually smaller than one strip so this loop runs once per block.
-    result = data.copy()
-    is_nan_nodata = np.isnan(nodata) if isinstance(nodata, float) else False
+    # If the caller asked for dtype promotion (integer DEM -> float),
+    # build ``result`` in the new dtype and rewrite the input nodata
+    # sentinel to NaN so the rest of the loop can treat NaN as the
+    # missing-value marker uniformly.
+    promoted = (
+        out_dtype is not None and np.dtype(out_dtype) != np.dtype(data.dtype)
+    )
+    if promoted:
+        result = data.astype(out_dtype, copy=True)
+        # Map the source nodata (e.g. -32768 for int16) onto NaN before
+        # shifting so downstream consumers can use NaN semantics.
+        if isinstance(nodata, float) and np.isnan(nodata):
+            pass  # already NaN
+        else:
+            result[data == nodata] = np.nan
+        is_nan_nodata = True
+    else:
+        result = data.copy()
+        is_nan_nodata = np.isnan(nodata) if isinstance(nodata, float) else False
     strip = 128
 
     for r0 in range(0, out_h, strip):
@@ -1231,14 +1305,23 @@ def _apply_vertical_shift_numpy(data, y_arr, x_arr,
 
 
 def _apply_vertical_shift_dask(data, y_arr, x_arr,
-                               geoid_models, signs, nodata, tgt_crs_wkt):
+                               geoid_models, signs, nodata, tgt_crs_wkt,
+                               out_dtype=None):
     """Dask-backed geoid shift via ``map_blocks``.
 
     Each block receives only its row/column slab of the input. The block
     function recomputes per-block y/x slices from ``block_info`` and
     delegates to the numpy path so all backends share one implementation.
+
+    ``out_dtype`` is the (possibly promoted) dtype that
+    ``_apply_vertical_shift`` has decided for the whole array, and is
+    forwarded into every per-block call so the chunks return the same
+    promoted dtype the dask graph metadata advertises.
     """
     import dask.array as da
+
+    if out_dtype is None:
+        out_dtype = data.dtype
 
     # Note: blocks reaching this path are assumed to be numpy-backed.
     # dask-of-cupy is intentionally unreached today because
@@ -1253,12 +1336,13 @@ def _apply_vertical_shift_dask(data, y_arr, x_arr,
         return _apply_vertical_shift_numpy(
             block, y_slab, x_slab,
             geoid_models, signs, nodata, tgt_crs_wkt,
+            out_dtype=out_dtype,
         )
 
     # ``meta`` hardcodes a numpy template to match the assumption above
     # that incoming chunks are numpy-backed. Revisit if dask-of-cupy is
     # ever plumbed through.
-    return da.map_blocks(_block, data, dtype=data.dtype, meta=np.array((), dtype=data.dtype))
+    return da.map_blocks(_block, data, dtype=out_dtype, meta=np.array((), dtype=out_dtype))
 
 
 def _reproject_inmemory_numpy(

--- a/xrspatial/tests/test_reproject.py
+++ b/xrspatial/tests/test_reproject.py
@@ -2994,6 +2994,191 @@ class TestVerticalShift:
         )
 
 
+class TestVerticalShiftIntegerDtype:
+    """Vertical shift must work on integer DEMs by promoting to float (#2565).
+
+    Real-world DEM products (SRTM, ASTER GDEM, Copernicus DEM) ship as
+    int16, so the vertical-shift path used to crash with
+    ``UFuncTypeError`` when callers asked for a geoid -> ellipsoidal
+    transform. The fix promotes the array to a float dtype before the
+    shift and rewrites the integer nodata sentinel to NaN.
+    """
+
+    def _ny_raster_int(self, dtype, value, nodata, h=8, w=8):
+        # Same NY footprint as TestVerticalShift._ny_raster so the
+        # reference geoid undulation is known to be ~-33 m there.
+        y = np.linspace(41.1, 40.3, h)
+        x = np.linspace(-74.4, -73.6, w)
+        data = np.full((h, w), value, dtype=dtype)
+        return xr.DataArray(
+            data, dims=['y', 'x'],
+            coords={'y': y, 'x': x},
+            attrs={'crs': 'EPSG:4326', 'nodata': nodata},
+        )
+
+    def test_int16_promotes_to_float32(self):
+        """int16 DEM with EGM96 -> ellipsoidal shift returns float32."""
+        from xrspatial.reproject import reproject, geoid_height
+        raster = self._ny_raster_int(np.int16, 100, -32768)
+        result = reproject(
+            raster, 'EPSG:4326',
+            src_vertical_crs='EGM96', tgt_vertical_crs='ellipsoidal',
+        )
+        assert result.dtype == np.float32, (
+            f"expected float32 output for int16 input, got {result.dtype}"
+        )
+        # Nodata sentinel should follow the dtype promotion.
+        assert np.isnan(result.attrs['nodata']), (
+            f"expected NaN nodata after promotion, got {result.attrs['nodata']!r}"
+        )
+        # Numerical check against the known reference undulation.
+        cy = float(result.coords['y'].values[result.shape[0] // 2])
+        cx = float(result.coords['x'].values[result.shape[1] // 2])
+        N = geoid_height(cx, cy, model='EGM96')
+        cval = float(result.values[result.shape[0] // 2, result.shape[1] // 2])
+        # Allow loose tolerance for float32 plus interpolation noise.
+        assert abs(cval - (100.0 + N)) < 1.0, (
+            f"shifted value {cval} not within 1 m of expected {100.0 + N}"
+        )
+
+    def test_uint8_promotes_to_float32(self):
+        """uint8 raster also promotes to float32 (covers small unsigned ints)."""
+        from xrspatial.reproject import reproject
+        raster = self._ny_raster_int(np.uint8, 100, 0)
+        result = reproject(
+            raster, 'EPSG:4326',
+            src_vertical_crs='EGM96', tgt_vertical_crs='ellipsoidal',
+        )
+        assert result.dtype == np.float32
+        assert np.isnan(result.attrs['nodata'])
+        # Geoid undulation in NY is ~-33 m, so 100 + N is ~67. Sanity
+        # check that the shift actually happened and stays in a sane band.
+        finite = result.values[np.isfinite(result.values)]
+        assert finite.size > 0
+        assert np.all(finite < 100.0)  # ellipsoidal height < orthometric here
+        assert np.all(finite > 50.0)
+
+    def test_float32_no_vertical_promotion(self):
+        """float32 input is not further promoted by the vertical shift.
+
+        ``reproject()`` itself upcasts float32 to float64 in its resample
+        path; the vertical-shift code must not stack a second promotion
+        on top of that. Compare the dtype of the shifted output to the
+        dtype of a plain reproject of the same raster.
+        """
+        from xrspatial.reproject import reproject
+        y = np.linspace(41.1, 40.3, 8)
+        x = np.linspace(-74.4, -73.6, 8)
+        data = np.full((8, 8), 100.0, dtype=np.float32)
+        raster = xr.DataArray(
+            data, dims=['y', 'x'], coords={'y': y, 'x': x},
+            attrs={'crs': 'EPSG:4326', 'nodata': np.float32('nan')},
+        )
+        baseline = reproject(raster, 'EPSG:4326')
+        result = reproject(
+            raster, 'EPSG:4326',
+            src_vertical_crs='EGM96', tgt_vertical_crs='ellipsoidal',
+        )
+        assert result.dtype == baseline.dtype, (
+            f"vertical shift changed dtype from {baseline.dtype} to {result.dtype}"
+        )
+
+    def test_float64_stays_float64(self):
+        """float64 input keeps its precision through the shift."""
+        from xrspatial.reproject import reproject
+        y = np.linspace(41.1, 40.3, 8)
+        x = np.linspace(-74.4, -73.6, 8)
+        data = np.full((8, 8), 100.0, dtype=np.float64)
+        raster = xr.DataArray(
+            data, dims=['y', 'x'], coords={'y': y, 'x': x},
+            attrs={'crs': 'EPSG:4326', 'nodata': np.nan},
+        )
+        result = reproject(
+            raster, 'EPSG:4326',
+            src_vertical_crs='EGM96', tgt_vertical_crs='ellipsoidal',
+        )
+        assert result.dtype == np.float64
+
+    def test_int16_nodata_becomes_nan(self):
+        """Integer nodata pixels must map to NaN in the promoted output."""
+        from xrspatial.reproject import reproject
+        # Put a nodata pixel right in the middle of an otherwise valid raster.
+        y = np.linspace(41.1, 40.3, 8)
+        x = np.linspace(-74.4, -73.6, 8)
+        data = np.full((8, 8), 100, dtype=np.int16)
+        data[4, 4] = -32768  # mark one cell as nodata
+        raster = xr.DataArray(
+            data, dims=['y', 'x'], coords={'y': y, 'x': x},
+            attrs={'crs': 'EPSG:4326', 'nodata': -32768},
+        )
+        result = reproject(
+            raster, 'EPSG:4326',
+            src_vertical_crs='EGM96', tgt_vertical_crs='ellipsoidal',
+        )
+        assert result.dtype == np.float32
+        # The nodata cell must have propagated as NaN, not as -32768 + N.
+        assert np.isnan(result.values[4, 4]), (
+            f"expected NaN at nodata cell, got {result.values[4, 4]}"
+        )
+        # Surrounding cells should still carry a finite shifted value.
+        finite = np.isfinite(result.values)
+        assert finite.sum() >= 50  # most cells finite
+
+    def test_int16_fillvalue_attr_promoted(self):
+        """attrs['_FillValue'] and attrs['nodatavals'] follow the dtype.
+
+        ``reproject()`` carries both keys forward when the source had
+        them. After dtype promotion the values used to keep the original
+        integer sentinel, which contradicts the now-float array contents.
+        """
+        from xrspatial.reproject import reproject
+        y = np.linspace(41.1, 40.3, 8)
+        x = np.linspace(-74.4, -73.6, 8)
+        data = np.full((8, 8), 100, dtype=np.int16)
+        raster = xr.DataArray(
+            data, dims=['y', 'x'], coords={'y': y, 'x': x},
+            attrs={
+                'crs': 'EPSG:4326',
+                'nodata': -32768,
+                '_FillValue': -32768,
+                'nodatavals': (-32768,),
+            },
+        )
+        result = reproject(
+            raster, 'EPSG:4326',
+            src_vertical_crs='EGM96', tgt_vertical_crs='ellipsoidal',
+        )
+        assert np.isnan(result.attrs['_FillValue'])
+        assert np.isnan(result.attrs['nodatavals'][0])
+
+    def test_int16_dask_promotes_to_float32(self):
+        """Dask-backed int16 input must also promote correctly."""
+        import dask.array as da
+        from xrspatial.reproject import reproject
+        host = np.full((48, 48), 100, dtype=np.int16)
+        y = np.linspace(41.1, 40.3, 48)
+        x = np.linspace(-74.4, -73.6, 48)
+        raster = xr.DataArray(
+            da.from_array(host, chunks=(16, 16)), dims=['y', 'x'],
+            coords={'y': y, 'x': x},
+            attrs={'crs': 'EPSG:4326', 'nodata': -32768},
+        )
+        result = reproject(
+            raster, 'EPSG:4326',
+            src_vertical_crs='EGM96', tgt_vertical_crs='ellipsoidal',
+        )
+        # The dask graph must advertise float32 so downstream consumers
+        # don't get a dtype lie.
+        assert result.dtype == np.float32
+        assert np.isnan(result.attrs['nodata'])
+        vals = result.values
+        finite = vals[np.isfinite(vals)]
+        assert finite.size > 0
+        # NY undulation is ~-33 m, so 100 + N should sit around 67 m.
+        assert np.all(finite < 100.0)
+        assert np.all(finite > 50.0)
+
+
 class TestMetadataPreservation:
     """reproject() and merge() must carry input attrs forward."""
 


### PR DESCRIPTION
Closes #2565.

## Summary

- The vertical-datum shift path used to `result = data.copy()` at the input dtype and then do `strip_data[is_valid] += N_total[is_valid]`. For int16/uint16 DEMs (SRTM, Copernicus DEM, ASTER GDEM) this raised `UFuncTypeError` because a float offset cannot be cast back into an integer array.
- `_apply_vertical_shift` now picks an `out_dtype` once (float32 for integer or float32 inputs, float64 only when the source is float64) and forwards it through the numpy / cupy / dask backends. The numpy path casts up front and rewrites the integer nodata sentinel to NaN so the rest of the loop uses uniform NaN semantics.
- The caller picks up the promoted nodata and writes it back to `attrs['nodata']`, `attrs['_FillValue']`, and `attrs['nodatavals']` so the metadata stays consistent with the array.

## Backend coverage

- numpy: handled directly in `_apply_vertical_shift_numpy`.
- cupy: round-trips via the numpy path (existing behaviour), inherits the promotion.
- dask+numpy: `map_blocks` now advertises the promoted dtype in `meta` and forwards `out_dtype` into every per-block call.
- dask+cupy: collapses to numpy-backed dask upstream (pre-existing), so the same path applies.

## Test plan

- [x] `pytest xrspatial/tests/test_reproject.py::TestVerticalShiftIntegerDtype` -- 7 new tests covering int16 promotion, uint8 promotion, float32 / float64 no-extra-promotion, nodata to NaN propagation, `_FillValue` / `nodatavals` attr refresh, and the dask path.
- [x] `pytest xrspatial/tests/test_reproject.py::TestVerticalShift` -- 12 existing vertical-shift tests still pass.
- [x] Broader sweep: `pytest -k "vertical or geoid or Vertical"` -- 54 tests pass.
