### PR TITLE
polygonize: fix dask chunk-dependent merging and DN corruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@
 
 #### Fixed
 
+- `polygonize` on dask-backed float rasters now matches the numpy
+  reference for both polygon count and DN values across every chunking
+  pattern. The cross-chunk merge previously bucketed chunk-boundary
+  polygons by a single representative float value, which broke
+  transitive value chains (`1.0 -> 1.000009 -> 1.000018` returned 2
+  polygons instead of the numpy reference's 1) and silently rewrote DN
+  values on disconnected near-equal regions (`[1.0, 9.0, 1.000009]`
+  reported DN `1.0` for the third region instead of `1.000009`). The
+  merge now runs a spatial-topology + value-closeness union-find over
+  chunk-boundary polygons: two polygons land in the same group only
+  when their pixel value ranges overlap within `atol`/`rtol` AND they
+  are spatially adjacent (sharing a unit edge for 4-connectivity, or
+  any vertex for 8-connectivity). Disconnected close-valued regions
+  keep their own DN values, and transitive value chains merge
+  correctly across chunk boundaries. (#2583)
+
 - `polygonize` now auto-detects the raster's affine transform from
   `attrs['transform']` (xrspatial.geotiff convention) or
   `rio.transform()` (rioxarray) when the caller did not pass an

--- a/xrspatial/polygonize.py
+++ b/xrspatial/polygonize.py
@@ -324,6 +324,203 @@ def _bucket_key_for_value(boundary_by_value, val,
     return val
 
 
+def _ranges_close(range_a, range_b, atol, rtol):
+    """Return True if any value pair across two ``(min, max)`` ranges
+    compares close under ``_values_close``.
+
+    Each per-polygon value range from ``_polygonize_chunk`` describes
+    the actual span of pixel values that fall inside a region (after
+    the within-chunk tolerance-chain CCL has run).  Two chunk polygons
+    should union when *some* pair of their pixel values lies within
+    tolerance, which is what numpy CCL would have done if the same
+    pixels lived in one chunk.  Probing the four endpoint combinations
+    is enough because each input range is a single interval.
+    """
+    a_min, a_max = range_a
+    b_min, b_max = range_b
+    if _values_close(a_min, b_min, atol, rtol):
+        return True
+    if _values_close(a_min, b_max, atol, rtol):
+        return True
+    if _values_close(a_max, b_min, atol, rtol):
+        return True
+    if _values_close(a_max, b_max, atol, rtol):
+        return True
+    # Overlapping intervals always have a close pair (zero distance).
+    if a_min <= b_max and b_min <= a_max:
+        return True
+    return False
+
+
+def _group_boundary_polygons(boundary_polys,
+                             atol: float = _DEFAULT_ATOL,
+                             rtol: float = _DEFAULT_RTOL,
+                             connectivity_8: bool = False):
+    """Group chunk-boundary polygons by spatial topology + value closeness.
+
+    Replaces the legacy value-only bucket in ``_merge_chunk_polygons`` and
+    ``_polygonize_dask`` so dask polygonize matches numpy CCL semantics
+    (#2583).  Two boundary polygons land in the same group when:
+
+    1. their value ranges have at least one close pair under ``atol`` /
+       ``rtol``, AND
+    2. their rings share enough spatial topology to be connected under
+       the user-selected connectivity:
+
+       * ``connectivity_8=False`` (4-conn): they must share at least one
+         opposing unit-length ring edge.  Two polygons that only touch
+         at a corner are not 4-connected and stay in separate groups
+         even when their values are close.
+
+       * ``connectivity_8=True`` (8-conn): sharing any integer-grid
+         vertex is enough, mirroring numpy 8-connectivity which merges
+         diagonal-only neighbours of the same value.
+
+    Connectivity is a union-find closure over those pairs.  Disconnected
+    close-valued polygons fall into separate groups so the merge step
+    cannot silently overwrite their distinct DN values.
+
+    The value-range check (rather than a single representative value)
+    fixes the chunk-chain bug where numpy CCL chains
+    ``1.0 -> 1.000009 -> 1.000018`` via the middle pixel: when a chunk
+    contains both ``1.0`` and ``1.000009``, the polygon's range
+    captures both, so the neighbour chunk's ``1.000018`` pixel finds a
+    close partner (``1.000009``) at the chunk boundary even though
+    the representative ``1.0`` would have looked too far away.
+
+    Parameters
+    ----------
+    boundary_polys : list of (val, rings, (val_min, val_max))
+        Per-chunk boundary polygons collected from ``_polygonize_chunk``.
+    atol, rtol : float
+        Float tolerance forwarded to ``_ranges_close``.
+
+    Returns
+    -------
+    list of list of (val, rings, (val_min, val_max))
+        One sub-list per connected group.  Each sub-list holds all
+        chunk polygons that should be merged with edge cancellation and
+        assigned a single representative DN value downstream.
+    """
+    n = len(boundary_polys)
+    if n == 0:
+        return []
+    if n == 1:
+        return [boundary_polys]
+
+    # Build a spatial-adjacency index from each polygon's ring edges.
+    #
+    # Iterate every unit-length grid point / unit edge along each ring,
+    # not just the simplified ring corners.  Polygon rings only list
+    # turn-points after collinear-vertex simplification, so a ring that
+    # runs straight along a chunk boundary from (5, 1) to (5, 4) does
+    # not list (5, 2) or (5, 3) explicitly.  If a neighbour chunk has a
+    # tiny polygon with corners at (5, 2)-(5, 3), unioning by corners
+    # alone misses the adjacency.  Walk unit steps so every shared
+    # integer-grid point and unit edge is registered.
+    #
+    # For 4-connectivity we key by canonical (undirected) unit edge so
+    # two polygons sharing an opposing unit edge collide here; for
+    # 8-connectivity we key by vertex so diagonal-only neighbours
+    # collide too.
+    adjacency_index = {}
+    for idx, item in enumerate(boundary_polys):
+        rings = item[1]
+        seen = set()
+        for ring in rings:
+            for k in range(len(ring) - 1):
+                x1, y1 = int(ring[k, 0]), int(ring[k, 1])
+                x2, y2 = int(ring[k + 1, 0]), int(ring[k + 1, 1])
+                if x1 == x2 and y1 == y2:
+                    units = []
+                    points = [(x1, y1)]
+                elif x1 == x2:
+                    step = 1 if y2 > y1 else -1
+                    units = [
+                        ((x1, y, x1, y + step) if step > 0
+                         else (x1, y + step, x1, y))
+                        for y in range(y1, y2, step)
+                    ]
+                    points = [(x1, y) for y in range(y1, y2 + step, step)]
+                elif y1 == y2:
+                    step = 1 if x2 > x1 else -1
+                    units = [
+                        ((x, y1, x + step, y1) if step > 0
+                         else (x + step, y1, x, y1))
+                        for x in range(x1, x2, step)
+                    ]
+                    points = [(x, y1) for x in range(x1, x2 + step, step)]
+                else:
+                    # Diagonal ring segments should not appear; degrade
+                    # gracefully if they ever do.
+                    units = []
+                    points = [(x1, y1), (x2, y2)]
+
+                if connectivity_8:
+                    keys = points
+                else:
+                    keys = units
+
+                for key in keys:
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    adjacency_index.setdefault(key, []).append(idx)
+
+    # Union-find over polygon indices.
+    parent = list(range(n))
+
+    def find(i):
+        while parent[i] != i:
+            parent[i] = parent[parent[i]]
+            i = parent[i]
+        return i
+
+    def union(i, j):
+        ri, rj = find(i), find(j)
+        if ri != rj:
+            parent[max(ri, rj)] = min(ri, rj)
+
+    for poly_indices in adjacency_index.values():
+        if len(poly_indices) < 2:
+            continue
+        # Pairwise close-value check among polys sharing this
+        # adjacency key.  Typical degree is small (2 for a chunk-edge
+        # midpoint, up to 4 at chunk corners) so the inner loop is cheap.
+        for i in range(len(poly_indices)):
+            for j in range(i + 1, len(poly_indices)):
+                pi, pj = poly_indices[i], poly_indices[j]
+                if find(pi) == find(pj):
+                    continue
+                range_i = boundary_polys[pi][2]
+                range_j = boundary_polys[pj][2]
+                if _ranges_close(range_i, range_j, atol, rtol):
+                    union(pi, pj)
+
+    groups = {}
+    for idx in range(n):
+        groups.setdefault(find(idx), []).append(boundary_polys[idx])
+    return list(groups.values())
+
+
+def _representative_value(group):
+    """Pick the row-major-lowest constituent value for a polygon group.
+
+    Mirrors the numpy single-chunk rule (``column.append(values[ij])``
+    in ``_polygonize_numpy``): the DN value reported for a region is
+    the value of the first pixel in row-major order that belongs to it.
+    For a multi-chunk group we approximate that by sorting the
+    constituent chunk polygons by their exterior ring's min (y, x) and
+    taking the first one's value.
+    """
+    def sort_key(item):
+        ext = item[1][0]
+        min_y = float(np.min(ext[:, 1]))
+        min_x = float(np.min(ext[ext[:, 1] == min_y, 0]))
+        return (min_y, min_x)
+    return min(group, key=sort_key)[0]
+
+
 # Calculate region connectivity for the specified values raster and optional
 # mask raster.  Each region is labelled with a unique integer ID starting at
 # 1.  Regions corresponding to masked out pixels are all given the same region
@@ -906,6 +1103,15 @@ def _polygonize_chunk(block, mask_block, connectivity_8, row_offset, col_offset,
     boundary, already final) or "boundary" (touches an inter-chunk edge,
     needs merge with neighbours).  Raster-edge boundaries are NOT counted
     as inter-chunk boundaries.
+
+    Boundary polygons carry a ``(value, rings, (val_min, val_max))``
+    triple instead of just ``(value, rings)`` so the cross-chunk merge
+    can do tolerance-based union over the full value range present in
+    each polygon (#2583).  Within a chunk, ``_polygonize_numpy`` already
+    merged tolerance-close pixels into one region, so a polygon may
+    span values from ``val_min`` to ``val_max``; the cross-chunk merge
+    needs the extremes to reconstruct numpy CCL semantics across the
+    chunk boundary.
     """
     block = _to_numpy(block)
     if mask_block is not None:
@@ -915,10 +1121,20 @@ def _polygonize_chunk(block, mask_block, connectivity_8, row_offset, col_offset,
         block, mask_block, connectivity_8, transform=None,
         atol=atol, rtol=rtol)
 
-    interior = []  # (value, [ring, ...])
-    boundary = []  # (value, [ring, ...])
+    # Build a per-polygon (min, max) value pair so cross-chunk merging
+    # can probe whichever endpoint sits closest to a neighbour chunk's
+    # value.  For polygons that span only one value (the common case
+    # for integer rasters or floats with atol=rtol=0) the pair
+    # collapses to (val, val).  Computed by re-running _calculate_regions
+    # to recover per-pixel region IDs; cheaper than threading the regions
+    # array out of _polygonize_numpy across all backends.
+    val_ranges = _compute_region_value_ranges(
+        block, mask_block, connectivity_8, atol, rtol, column)
 
-    for val, rings in zip(column, polygon_points):
+    interior = []  # (value, [ring, ...])
+    boundary = []  # (value, [ring, ...], (val_min, val_max))
+
+    for val, rings, val_range in zip(column, polygon_points, val_ranges):
         offset_rings = []
         for ring in rings:
             ring = ring.copy()
@@ -942,11 +1158,87 @@ def _polygonize_chunk(block, mask_block, connectivity_8, row_offset, col_offset,
             on_boundary |= np.any(ys == row_offset + ny)
 
         if on_boundary:
-            boundary.append((val, offset_rings))
+            boundary.append((val, offset_rings, val_range))
         else:
             interior.append((val, offset_rings))
 
     return interior, boundary
+
+
+def _compute_region_value_ranges(block, mask_block, connectivity_8,
+                                 atol, rtol, column):
+    """Return ``(val_min, val_max)`` for each region in raster-scan order.
+
+    ``column`` is the polygon-order value list from ``_polygonize_numpy``;
+    the returned list is parallel to it.  Re-runs the same
+    ``_calculate_regions`` pass used inside ``_polygonize_numpy`` (so
+    region IDs match exactly), then groups pixel values by region.
+
+    Used by ``_polygonize_chunk`` (#2583) to carry the actual value
+    extent of each chunk-boundary polygon into the cross-chunk merge
+    where numpy CCL parity needs both endpoints.
+    """
+    ny, nx = block.shape
+    values_flat = block.ravel()
+
+    # Mirror the NaN / nx==1 handling in _polygonize_numpy so the region
+    # IDs line up with what _scan saw.
+    if np.issubdtype(block.dtype, np.floating):
+        nan_mask = ~np.isnan(block)
+        if mask_block is not None:
+            full_mask = mask_block & nan_mask
+        else:
+            full_mask = nan_mask
+    else:
+        full_mask = mask_block
+
+    if nx == 1:
+        nx_eff = 2
+        values_flat = np.hstack(
+            (block, np.empty_like(block))).ravel()
+        if full_mask is not None:
+            full_mask = np.hstack(
+                (full_mask, np.zeros_like(full_mask)))
+        else:
+            full_mask = np.zeros((ny, 2), dtype=bool)
+            full_mask[:, 0] = True
+    else:
+        nx_eff = nx
+
+    mask_flat = full_mask.ravel() if full_mask is not None else None
+    regions = _calculate_regions(
+        values_flat, mask_flat, connectivity_8, nx_eff, ny, atol, rtol)
+
+    # Aggregate min/max value per region in raster-scan order so the
+    # output is parallel to the polygon column from _scan.
+    n_regions = len(column)
+    if n_regions == 0:
+        return []
+    val_min = [None] * n_regions
+    val_max = [None] * n_regions
+    for ij in range(len(regions)):
+        r = regions[ij]
+        if r == 0:
+            continue
+        if mask_flat is not None and not mask_flat[ij]:
+            continue
+        idx = r - 1
+        if idx >= n_regions:
+            continue
+        v = values_flat[ij]
+        if val_min[idx] is None or v < val_min[idx]:
+            val_min[idx] = v
+        if val_max[idx] is None or v > val_max[idx]:
+            val_max[idx] = v
+    out = []
+    for i in range(n_regions):
+        if val_min[i] is None:
+            # Fall back to the polygon's representative value if no
+            # pixel matched (defensive; shouldn't happen).
+            out.append((column[i], column[i]))
+        else:
+            out.append((val_min[i], val_max[i]))
+    return out
 
 
 def _add_or_cancel_edge(edge_set, x1, y1, x2, y2):
@@ -1670,32 +1962,44 @@ def _merge_polygon_rings(polys_list, connectivity_8=False):
     return _group_rings_into_polygons(simplified)
 
 
-def _merge_chunk_polygons(chunk_results, transform, connectivity_8=False):
+def _merge_chunk_polygons(chunk_results, transform, connectivity_8=False,
+                          atol: float = _DEFAULT_ATOL,
+                          rtol: float = _DEFAULT_RTOL):
     """Merge polygons from all chunks and return final output.
 
     ``connectivity_8`` is forwarded to :func:`_merge_polygon_rings` to
     select the degree-4-vertex pairing rule used by the trace step.
+
+    Boundary polygons are grouped by spatial-topology + value-closeness
+    union-find (see :func:`_group_boundary_polygons` -- #2583) so close
+    floats from disconnected chunks no longer collapse onto a single
+    DN, and so transitive value chains across multiple chunks merge the
+    way numpy CCL does within a single chunk.
     """
     all_interior = []
-    boundary_by_value = {}
+    boundary_polys = []
 
     for interior, boundary in chunk_results:
         all_interior.extend(interior)
-        for val, rings in boundary:
-            key = _bucket_key_for_value(boundary_by_value, val)
-            boundary_by_value.setdefault(key, []).append(rings)
+        boundary_polys.extend(boundary)
 
-    # Merge boundary polygons per value using edge cancellation.
+    groups = _group_boundary_polygons(
+        boundary_polys, atol=atol, rtol=rtol,
+        connectivity_8=connectivity_8)
+
+    # Merge each connected group using edge cancellation; assign the
+    # row-major-lowest constituent value as the group's DN value.
     merged = []
-    for val, polys_list in boundary_by_value.items():
+    for group in groups:
+        rep_val = _representative_value(group)
+        polys_list = [item[1] for item in group]
         if len(polys_list) == 1:
-            # Single polygon set for this value -- nothing to merge.
-            merged.append((val, polys_list[0]))
+            merged.append((rep_val, polys_list[0]))
         else:
             merged_polys = _merge_polygon_rings(
                 polys_list, connectivity_8=connectivity_8)
             for rings in merged_polys:
-                merged.append((val, rings))
+                merged.append((rep_val, rings))
 
     # Combine interior and merged boundary polygons.
     all_polys = all_interior + merged
@@ -1722,28 +2026,38 @@ def _merge_chunk_polygons(chunk_results, transform, connectivity_8=False):
     return column, polygon_points
 
 
-def _merge_from_separated(all_interior, boundary_by_value, transform,
-                          connectivity_8=False):
+def _merge_from_separated(all_interior, boundary_polys, transform,
+                          connectivity_8=False,
+                          atol: float = _DEFAULT_ATOL,
+                          rtol: float = _DEFAULT_RTOL):
     """Merge pre-separated interior/boundary polygons into final output.
 
-    Like _merge_chunk_polygons but takes already-separated data so the
-    caller can accumulate incrementally (one chunk at a time) instead of
-    holding all chunk_results in memory simultaneously.
+    Like _merge_chunk_polygons but takes the boundary polygons as a flat
+    ``[(val, rings), ...]`` list (the incremental dask path accumulates
+    that list one chunk at a time).
 
     ``connectivity_8`` is forwarded to :func:`_merge_polygon_rings` so
     the trace step uses the right degree-4-vertex pairing rule when
     stitching boundary polygons across chunks.
+
+    ``atol`` / ``rtol`` are forwarded to :func:`_group_boundary_polygons`
+    (#2583) for the spatial-topology + value-closeness union-find.
     """
-    # Merge boundary polygons per value using edge cancellation.
+    groups = _group_boundary_polygons(
+        boundary_polys, atol=atol, rtol=rtol,
+        connectivity_8=connectivity_8)
+
     merged = []
-    for val, polys_list in boundary_by_value.items():
+    for group in groups:
+        rep_val = _representative_value(group)
+        polys_list = [item[1] for item in group]
         if len(polys_list) == 1:
-            merged.append((val, polys_list[0]))
+            merged.append((rep_val, polys_list[0]))
         else:
             merged_polys = _merge_polygon_rings(
                 polys_list, connectivity_8=connectivity_8)
             for rings in merged_polys:
-                merged.append((val, rings))
+                merged.append((rep_val, rings))
 
     all_polys = all_interior + merged
 
@@ -1789,7 +2103,7 @@ def _polygonize_dask(dask_data, mask_data, connectivity_8, transform,
     # peak memory proportional to boundary_polygon_count rather than
     # total_polygon_count * n_chunks.
     all_interior = []
-    boundary_by_value = {}
+    boundary_polys = []
 
     for iy in range(len(row_chunks)):
         for ix in range(len(col_chunks)):
@@ -1804,14 +2118,12 @@ def _polygonize_dask(dask_data, mask_data, connectivity_8, transform,
                     atol, rtol,
                 ))[0]
             all_interior.extend(interior)
-            for val, rings in boundary:
-                key = _bucket_key_for_value(
-                    boundary_by_value, val, atol, rtol)
-                boundary_by_value.setdefault(key, []).append(rings)
+            boundary_polys.extend(boundary)
 
     return _merge_from_separated(
-        all_interior, boundary_by_value, transform,
-        connectivity_8=connectivity_8)
+        all_interior, boundary_polys, transform,
+        connectivity_8=connectivity_8,
+        atol=atol, rtol=rtol)
 
 
 def polygonize(

--- a/xrspatial/polygonize.py
+++ b/xrspatial/polygonize.py
@@ -292,38 +292,6 @@ def _values_close(reference, value,
     return abs(value - reference) <= (atol + rtol * abs(reference))
 
 
-def _bucket_key_for_value(boundary_by_value, val,
-                          atol: float = _DEFAULT_ATOL,
-                          rtol: float = _DEFAULT_RTOL):
-    """Return the dict key that ``val`` should bucket into.
-
-    If an existing key in ``boundary_by_value`` is close to ``val`` under
-    ``_values_close`` (using the caller's ``atol`` / ``rtol``), return
-    that key so close float values from adjacent chunks land in the same
-    bucket.  Otherwise return ``val`` unchanged.
-
-    This keeps Dask chunk-stitching consistent with the tolerance-based
-    grouping the NumPy / numba path uses inside a single chunk (#2171),
-    and lets ``polygonize(atol=0, rtol=0)`` opt into exact-value
-    bucketing across chunks (#2173).
-
-    Performance note: the float branch is a linear scan over existing
-    keys, so total cost is O(B^2) in the number of distinct float
-    buckets B.  Polygonize inputs in practice have a small B (a handful
-    of categorical values), so the scan is cheap.  If a workload with
-    many thousand distinct float buckets shows up, swap the scan for a
-    sorted-keys structure (e.g. bisect over a sorted list).
-    """
-    # Integer-valued rasters use exact equality, so the existing dict
-    # lookup is already correct -- skip the linear scan.
-    if isinstance(val, (int, np.integer)):
-        return val
-    for existing in boundary_by_value:
-        if _values_close(existing, val, atol, rtol):
-            return existing
-    return val
-
-
 def _ranges_close(range_a, range_b, atol, rtol):
     """Return True if any value pair across two ``(min, max)`` ranges
     compares close under ``_values_close``.
@@ -346,7 +314,12 @@ def _ranges_close(range_a, range_b, atol, rtol):
         return True
     if _values_close(a_max, b_max, atol, rtol):
         return True
-    # Overlapping intervals always have a close pair (zero distance).
+    # The four endpoint checks above can miss wide-but-overlapping
+    # intervals: e.g. ``[0.0, 5.0]`` vs ``[3.0, 10.0]`` has all four
+    # endpoint pairs outside default tolerance, yet the intervals
+    # share the sub-range ``[3.0, 5.0]`` so a per-pixel CCL within a
+    # single chunk would have merged the two clusters.  Detect that
+    # case explicitly so the union-find still fires.
     if a_min <= b_max and b_min <= a_max:
         return True
     return False
@@ -432,34 +405,31 @@ def _group_boundary_polygons(boundary_polys,
                 x1, y1 = int(ring[k, 0]), int(ring[k, 1])
                 x2, y2 = int(ring[k + 1, 0]), int(ring[k + 1, 1])
                 if x1 == x2 and y1 == y2:
-                    units = []
-                    points = [(x1, y1)]
+                    keys = [(x1, y1)] if connectivity_8 else []
                 elif x1 == x2:
                     step = 1 if y2 > y1 else -1
-                    units = [
-                        ((x1, y, x1, y + step) if step > 0
-                         else (x1, y + step, x1, y))
-                        for y in range(y1, y2, step)
-                    ]
-                    points = [(x1, y) for y in range(y1, y2 + step, step)]
+                    if connectivity_8:
+                        keys = [(x1, y) for y in range(y1, y2 + step, step)]
+                    else:
+                        keys = [
+                            ((x1, y, x1, y + step) if step > 0
+                             else (x1, y + step, x1, y))
+                            for y in range(y1, y2, step)
+                        ]
                 elif y1 == y2:
                     step = 1 if x2 > x1 else -1
-                    units = [
-                        ((x, y1, x + step, y1) if step > 0
-                         else (x + step, y1, x, y1))
-                        for x in range(x1, x2, step)
-                    ]
-                    points = [(x, y1) for x in range(x1, x2 + step, step)]
+                    if connectivity_8:
+                        keys = [(x, y1) for x in range(x1, x2 + step, step)]
+                    else:
+                        keys = [
+                            ((x, y1, x + step, y1) if step > 0
+                             else (x + step, y1, x, y1))
+                            for x in range(x1, x2, step)
+                        ]
                 else:
                     # Diagonal ring segments should not appear; degrade
                     # gracefully if they ever do.
-                    units = []
-                    points = [(x1, y1), (x2, y2)]
-
-                if connectivity_8:
-                    keys = points
-                else:
-                    keys = units
+                    keys = [(x1, y1), (x2, y2)] if connectivity_8 else []
 
                 for key in keys:
                     if key in seen:
@@ -1123,13 +1093,16 @@ def _polygonize_chunk(block, mask_block, connectivity_8, row_offset, col_offset,
 
     # Build a per-polygon (min, max) value pair so cross-chunk merging
     # can probe whichever endpoint sits closest to a neighbour chunk's
-    # value.  For polygons that span only one value (the common case
-    # for integer rasters or floats with atol=rtol=0) the pair
-    # collapses to (val, val).  Computed by re-running _calculate_regions
-    # to recover per-pixel region IDs; cheaper than threading the regions
-    # array out of _polygonize_numpy across all backends.
-    val_ranges = _compute_region_value_ranges(
-        block, mask_block, connectivity_8, atol, rtol, column)
+    # value.  Integer CCL uses strict equality, so every polygon
+    # already spans exactly one value -- skip the second
+    # _calculate_regions pass and reuse ``column`` directly.  Float
+    # polygons may span a tolerance-chain cluster, so the full
+    # per-region min/max scan is still needed there.
+    if np.issubdtype(block.dtype, np.floating):
+        val_ranges = _compute_region_value_ranges(
+            block, mask_block, connectivity_8, atol, rtol, column)
+    else:
+        val_ranges = [(c, c) for c in column]
 
     interior = []  # (value, [ring, ...])
     boundary = []  # (value, [ring, ...], (val_min, val_max))

--- a/xrspatial/tests/test_polygonize.py
+++ b/xrspatial/tests/test_polygonize.py
@@ -1723,16 +1723,19 @@ def test_polygonize_dask_multi_chunk_default_tolerance():
     and at the chunk-stitching step, so close floats in adjacent chunks
     bucket together (#2171, #2173).
 
-    Pairwise (not transitive) bucketing: with [1.0, 1.000009, 1.000018]
-    split across single-pixel chunks, 1.000009 is within tolerance of
-    1.0 (diff 9e-6, threshold ~1.0e-5) and joins that bucket, but
-    1.000018 is outside (diff 18e-6) and stays separate.  Total area
-    still covers the raster.
+    Transitive bucketing across chunks must match numpy CCL within a
+    single chunk (#2583).  With [1.0, 1.000009, 1.000018] split into
+    single-pixel chunks, the middle pixel is within tolerance of both
+    ends so all three pixels join one region -- the same answer numpy
+    returns for the equivalent single-chunk input.
     """
     raster = xr.DataArray(da.from_array(_REPRO_2173, chunks=(1, 1)))
     values, polygons = polygonize(raster)
-    assert len(values) == 2
-    assert_allclose(sorted(values), [1.0, 1.000018])
+    # Numpy parity: single chunk numpy chains 1.0 -> 1.000009 -> 1.000018
+    # into one region, dask must agree.
+    v_np, _ = polygonize(xr.DataArray(_REPRO_2173))
+    assert len(values) == len(v_np) == 1
+    assert_allclose(sorted(values), sorted(v_np))
     total_area = sum(
         assert_polygon_valid_and_get_area(p) for p in polygons)
     assert_allclose(total_area, 3.0)

--- a/xrspatial/tests/test_polygonize_atol_rtol_backend_coverage_2026_05_27.py
+++ b/xrspatial/tests/test_polygonize_atol_rtol_backend_coverage_2026_05_27.py
@@ -199,24 +199,22 @@ class TestStrictFloatEqualityDaskCuPy:
         assert_allclose(sorted(v_dc), sorted(_REPRO_2173[0]))
 
     def test_default_tolerance_still_merges_multi_chunk(self):
-        """Sanity pin: default tolerance still merges adjacent pixels.
+        """Multi-chunk dask+cupy parity with single-chunk numpy under the
+        default tolerance (#2583).
 
-        Note the multi-chunk count (2) intentionally differs from the
-        single-chunk numpy reference (1) here.  Single-chunk numpy
-        transitively merges 1.0 -> 1.000009 -> 1.000018 because the
-        middle pixel is within tolerance of both ends.  The dask
-        cross-chunk merge bucket compares values pairwise against bucket
-        keys, so 1.0 and 1.000018 do not merge (their direct gap of
-        18e-6 exceeds the default rtol*|1.0| = 1e-5 threshold), leaving
-        two polygons.  This pin guards against a regression that hard-
-        coded atol=rtol=0 inside the dask+cupy dispatcher (which would
-        produce 3 polygons here instead of 2).
+        Numpy CCL chains 1.0 -> 1.000009 -> 1.000018 within a single
+        chunk because the middle pixel is within tolerance of both ends.
+        After #2583, the dask cross-chunk merge groups boundary polygons
+        by spatial-topology + value-closeness union-find, so the same
+        transitive chain applies across chunk boundaries: all three
+        single-pixel chunks collapse to one region with one DN value,
+        matching numpy.
         """
-        # 1.000009 is within tolerance of 1.0 (diff 9e-6, threshold ~1e-5)
-        # but 1.000018 is outside (diff 18e-6) -> 2 polygons.
+        v_np, _ = polygonize(xr.DataArray(_REPRO_2173))
         v_dc, _ = polygonize(
             _to_dask_cupy_array(_REPRO_2173, chunks=(1, 1)))
-        assert len(v_dc) == 2
+        assert len(v_dc) == len(v_np) == 1
+        assert_allclose(sorted(v_dc), sorted(v_np))
 
 
 # ---------------------------------------------------------------------------

--- a/xrspatial/tests/test_polygonize_atol_rtol_backend_coverage_2026_05_27.py
+++ b/xrspatial/tests/test_polygonize_atol_rtol_backend_coverage_2026_05_27.py
@@ -8,9 +8,10 @@ sweep on 2026-05-27.  The atol / rtol kwargs route through every backend:
               on float dtypes (polygonize.py:823-825 and 829-830) and
               documents them as no-ops on the integer GPU CCL path
   * dask    : _polygonize_dask(...) plumbs atol/rtol through
-              dask.delayed(_polygonize_chunk)(..., atol, rtol) at
-              polygonize.py:1748-1754 and into _bucket_key_for_value(...)
-              at polygonize.py:1757-1758 for cross-chunk merge bucketing
+              dask.delayed(_polygonize_chunk)(..., atol, rtol) and into
+              _group_boundary_polygons(..., atol, rtol) (replaced the
+              legacy _bucket_key_for_value bucket in #2583) for the
+              spatial-topology + value-closeness cross-chunk merge
   * dask+cupy: same _polygonize_dask path -- cupy chunks are converted to
               numpy inside _polygonize_chunk via _to_numpy(block) at
               polygonize.py:859-861, so atol/rtol again reach
@@ -159,10 +160,10 @@ class TestStrictFloatEqualityDaskCuPy:
     """atol=0, rtol=0 must reach _polygonize_numpy through dask+cupy.
 
     The dask+cupy path goes through _polygonize_dask -> _polygonize_chunk
-    -> _polygonize_numpy.  atol/rtol thread through dask.delayed at
-    polygonize.py:1748-1754 and _bucket_key_for_value at lines
-    1757-1758 for cross-chunk merge.  Pin both single-chunk (no merge)
-    and multi-chunk (merge engaged) cases.
+    -> _polygonize_numpy.  atol/rtol thread through dask.delayed and the
+    cross-chunk merge runs _group_boundary_polygons(..., atol, rtol)
+    (replaced the legacy _bucket_key_for_value bucket in #2583).  Pin
+    both single-chunk (no merge) and multi-chunk (merge engaged) cases.
     """
 
     def test_single_chunk(self):
@@ -277,10 +278,10 @@ class TestIntermediateAtolDaskCuPy:
 
     def test_large_atol_one_polygon_multi_chunk(self):
         """Large atol on a multi-chunk dask+cupy raster exercises the
-        cross-chunk merge bucket (_bucket_key_for_value at polygonize.py
-        line 1758) with non-default atol.  A regression that hard-coded
-        the default atol inside the merge bucket would split the result
-        into multiple polygons here.
+        cross-chunk merge (_group_boundary_polygons in polygonize.py,
+        formerly _bucket_key_for_value before #2583) with non-default
+        atol.  A regression that hard-coded the default atol inside the
+        merge would split the result into multiple polygons here.
         """
         v_np, _ = polygonize(
             xr.DataArray(_REPRO_2173), atol=1e-4, rtol=0.0)
@@ -376,10 +377,12 @@ class TestRtolCuPy:
 @dask_array_available
 class TestRtolDaskCuPy:
     """Non-default rtol on float dask+cupy raster must reach
-    _polygonize_numpy through _polygonize_chunk and _bucket_key_for_value.
+    _polygonize_numpy through _polygonize_chunk and
+    _group_boundary_polygons (replaced the legacy _bucket_key_for_value
+    in #2583).
 
     Mirrors TestRtolCuPy on the dask+cupy backend.  Multi-chunk variants
-    additionally exercise the cross-chunk merge bucket with rtol>0.
+    additionally exercise the cross-chunk merge with rtol>0.
     """
 
     def test_large_rtol_merges_all_single_chunk(self):

--- a/xrspatial/tests/test_polygonize_issue_2583.py
+++ b/xrspatial/tests/test_polygonize_issue_2583.py
@@ -176,3 +176,37 @@ class TestNumpyDaskParity2D:
             f"numpy={len(v_np)} dask={len(v_dk)}"
         )
         assert_allclose(sorted(v_dk), sorted(v_np))
+
+    def test_distant_close_valued_regions_5x5(self):
+        """Two close-valued regions in opposite corners of a 5x5 raster,
+        separated by several chunks of a different value, must NOT
+        merge into a single polygon -- adjacency probing must stay
+        local, not global, even when values lie within tolerance.
+
+        Guards against a future regression that drops the spatial
+        adjacency check and re-collapses on value alone.
+        """
+        arr = np.array([
+            [1.0, 9.0, 9.0, 9.0, 9.0],
+            [9.0, 9.0, 9.0, 9.0, 9.0],
+            [9.0, 9.0, 9.0, 9.0, 9.0],
+            [9.0, 9.0, 9.0, 9.0, 9.0],
+            [9.0, 9.0, 9.0, 9.0, 1.000009],
+        ], dtype=np.float64)
+        v_np, _ = polygonize(xr.DataArray(arr))
+        # Numpy reference: 1.0 region, 1.000009 region, plus a single
+        # 9.0 region with two holes (or two 9.0 regions depending on
+        # connectivity).  What matters here is that the two 1.0-ish
+        # values are reported distinctly with their original DNs.
+        v_dk, _ = polygonize(_to_dask(arr, chunks=(2, 2)))
+        assert len(v_dk) == len(v_np), (
+            f"5x5 distant close-valued count mismatch: "
+            f"numpy={len(v_np)} dask={len(v_dk)}"
+        )
+        assert_allclose(sorted(v_dk), sorted(v_np))
+        assert any(abs(v - 1.000009) < 1e-12 for v in v_dk), (
+            f"5x5 dask lost 1.000009 DN: {v_dk}"
+        )
+        assert any(abs(v - 1.0) < 1e-12 for v in v_dk), (
+            f"5x5 dask lost 1.0 DN: {v_dk}"
+        )

--- a/xrspatial/tests/test_polygonize_issue_2583.py
+++ b/xrspatial/tests/test_polygonize_issue_2583.py
@@ -1,0 +1,178 @@
+"""Dask polygonize parity tests for #2583.
+
+The dask cross-chunk merge used to bucket chunk-boundary polygons by a
+single representative float value, which produced two distinct bugs on
+float rasters:
+
+A. Geometry count diverged from the numpy reference because the value
+   bucket compared pairwise against existing keys, so a transitive
+   chain ``1.0 -> 1.000009 -> 1.000018`` (each pair within tolerance,
+   end pair outside) did not merge across chunks even though numpy CCL
+   merged it within a single chunk.
+
+B. DN values for disconnected near-equal regions silently collapsed
+   onto the bucket key, e.g. ``[1.0, 9.0, 1.000009]`` reported a third
+   polygon with DN ``1.0`` instead of ``1.000009``.
+
+Both modes are fixed by switching the cross-chunk merge to a
+spatial-topology + value-closeness union-find -- only polygons that
+share at least one integer-grid vertex AND have close values land in
+the same group.  These tests pin numpy/dask parity for both symptoms
+across dask+numpy and (where the backend is available) dask+cupy.
+"""
+import numpy as np
+import pytest
+import xarray as xr
+from numpy.testing import assert_allclose
+
+try:
+    import cupy
+except ImportError:
+    cupy = None
+
+try:
+    import dask.array as da
+except ImportError:
+    da = None
+
+from ..polygonize import polygonize
+from .general_checks import cuda_and_cupy_available, dask_array_available
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _to_dask(arr, chunks):
+    return xr.DataArray(da.from_array(arr, chunks=chunks))
+
+
+def _to_dask_cupy(arr, chunks):
+    return xr.DataArray(da.from_array(cupy.asarray(arr), chunks=chunks))
+
+
+# Symptom A: chain of three near-equal floats where each adjacent pair
+# is within the default tolerance but the end pair is outside.
+_SYMPTOM_A = np.array([[1.0, 1.000009, 1.000018]], dtype=np.float64)
+
+# Symptom B: two near-equal floats separated spatially by a third
+# distinct value -- the close pair must stay distinct, not collapse.
+_SYMPTOM_B = np.array([[1.0, 9.0, 1.000009]], dtype=np.float64)
+
+
+# ---------------------------------------------------------------------------
+# Symptom A: transitive chain merging across chunks
+# ---------------------------------------------------------------------------
+
+
+@dask_array_available
+class TestSymptomAChainMerging:
+    """Dask must chain ``1.0 -> 1.000009 -> 1.000018`` across single-pixel
+    chunks the same way numpy CCL chains it within a single chunk.
+    """
+
+    def test_dask_numpy_single_pixel_chunks(self):
+        v_np, _ = polygonize(xr.DataArray(_SYMPTOM_A))
+        v_dk, _ = polygonize(_to_dask(_SYMPTOM_A, chunks=(1, 1)))
+        assert len(v_dk) == len(v_np) == 1
+        assert_allclose(sorted(v_dk), sorted(v_np))
+
+    def test_dask_numpy_two_pixel_chunks(self):
+        # Chunk split between pixel 1 and pixel 2: same chain must merge.
+        v_np, _ = polygonize(xr.DataArray(_SYMPTOM_A))
+        v_dk, _ = polygonize(_to_dask(_SYMPTOM_A, chunks=(1, 2)))
+        assert len(v_dk) == len(v_np) == 1
+        assert_allclose(sorted(v_dk), sorted(v_np))
+
+
+@cuda_and_cupy_available
+@dask_array_available
+class TestSymptomAChainMergingDaskCuPy:
+    """Same chain merging guarantee on the dask+cupy backend."""
+
+    def test_dask_cupy_single_pixel_chunks(self):
+        v_np, _ = polygonize(xr.DataArray(_SYMPTOM_A))
+        v_dc, _ = polygonize(_to_dask_cupy(_SYMPTOM_A, chunks=(1, 1)))
+        assert len(v_dc) == len(v_np) == 1
+        assert_allclose(sorted(v_dc), sorted(v_np))
+
+
+# ---------------------------------------------------------------------------
+# Symptom B: DN values preserved on disconnected close-valued regions
+# ---------------------------------------------------------------------------
+
+
+@dask_array_available
+class TestSymptomBDNPreservation:
+    """Two near-equal floats separated by a distinct value must keep
+    their own DN values, not collapse onto a shared bucket key.
+    """
+
+    def test_dask_numpy_preserves_dn_for_disconnected_regions(self):
+        v_np, _ = polygonize(xr.DataArray(_SYMPTOM_B))
+        v_dk, _ = polygonize(_to_dask(_SYMPTOM_B, chunks=(1, 1)))
+        assert len(v_dk) == len(v_np) == 3
+        assert_allclose(sorted(v_dk), sorted(v_np))
+        # Specifically pin that 1.000009 is reported, not collapsed to 1.0.
+        assert any(abs(v - 1.000009) < 1e-12 for v in v_dk), (
+            f"dask DN values lost 1.000009: {v_dk}"
+        )
+
+    def test_dask_numpy_disconnected_regions_two_pixel_chunks(self):
+        v_np, _ = polygonize(xr.DataArray(_SYMPTOM_B))
+        v_dk, _ = polygonize(_to_dask(_SYMPTOM_B, chunks=(1, 2)))
+        assert len(v_dk) == len(v_np) == 3
+        assert_allclose(sorted(v_dk), sorted(v_np))
+
+
+@cuda_and_cupy_available
+@dask_array_available
+class TestSymptomBDNPreservationDaskCuPy:
+    """Same DN-preservation guarantee on dask+cupy."""
+
+    def test_dask_cupy_preserves_dn(self):
+        v_np, _ = polygonize(xr.DataArray(_SYMPTOM_B))
+        v_dc, _ = polygonize(_to_dask_cupy(_SYMPTOM_B, chunks=(1, 1)))
+        assert len(v_dc) == len(v_np) == 3
+        assert_allclose(sorted(v_dc), sorted(v_np))
+
+
+# ---------------------------------------------------------------------------
+# Cross-shape sanity: 2D arrays with the same patterns must also match
+# ---------------------------------------------------------------------------
+
+
+@dask_array_available
+class TestNumpyDaskParity2D:
+    """A handful of 2D shapes covering chunk-boundary chains and
+    disconnected close-valued regions.  Each chunking pattern must
+    match the single-chunk numpy reference for polygon count and DN
+    values.
+    """
+
+    @pytest.mark.parametrize(
+        "arr",
+        [
+            # Chain along a row across multiple chunks.
+            np.array([[1.0, 1.000009, 1.000018, 1.000027]],
+                     dtype=np.float64),
+            # Chain along a column.
+            np.array([[1.0], [1.000009], [1.000018]], dtype=np.float64),
+            # Disconnected near-equal pixels at the corners.
+            np.array([[1.0, 9.0],
+                      [9.0, 1.000009]], dtype=np.float64),
+            # Mixed: connected chain + disconnected near-equal.
+            np.array([[1.0, 1.000009, 9.0, 1.000018]], dtype=np.float64),
+        ],
+    )
+    @pytest.mark.parametrize("chunks", [(1, 1), (1, 2), (2, 1)])
+    def test_parity(self, arr, chunks):
+        if any(c > s for c, s in zip(chunks, arr.shape)):
+            pytest.skip(f"chunks {chunks} larger than array {arr.shape}")
+        v_np, _ = polygonize(xr.DataArray(arr))
+        v_dk, _ = polygonize(_to_dask(arr, chunks=chunks))
+        assert len(v_dk) == len(v_np), (
+            f"polygon count mismatch with chunks={chunks}: "
+            f"numpy={len(v_np)} dask={len(v_dk)}"
+        )
+        assert_allclose(sorted(v_dk), sorted(v_np))


### PR DESCRIPTION
## Summary

Fixes the dask polygonize value-bucket bug where the cross-chunk merge produced different polygon counts and DN values than the numpy reference on float rasters. Closes #2583.

- Boundary polygons now carry a per-region `(val_min, val_max)` so the cross-chunk merge can match on the closest endpoint of the range instead of a single representative float.
- `_group_boundary_polygons` replaces the value-only bucket with a union-find over spatial adjacency AND value-range closeness, matching numpy CCL semantics across chunk boundaries.
- Spatial adjacency is connectivity-aware: unit-edge sharing under 4-connectivity, vertex sharing under 8-connectivity.

## Backend coverage

- dask+numpy: covered by new tests in `test_polygonize_issue_2583.py` and the updated default-tolerance pins.
- dask+cupy: same code path; covered by the `cuda_and_cupy_available` classes in `test_polygonize_issue_2583.py` and the updated `test_polygonize_atol_rtol_backend_coverage_2026_05_27.py` pin.
- numpy / cupy single-chunk paths: unchanged.

## Test plan

- [x] New `test_polygonize_issue_2583.py` covers both symptoms across dask+numpy and dask+cupy.
- [x] Updated existing pins that asserted the broken behaviour to assert numpy/dask parity instead.
- [x] Full polygonize test suite green locally (286 passed, 16 skipped).
- [x] Rest of the suite green locally (4008 passed, 4 skipped).