### PR TITLE
geotiff: accept projected GeoTIFFs that carry a base geographic CRS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@
 
 #### Fixed
 
+- `open_geotiff` no longer rejects a projected GeoTIFF that also carries
+  its base geographic CRS. A file declaring both `ProjectedCSTypeGeoKey`
+  (e.g. UTM 32633) and `GeographicTypeGeoKey` (e.g. WGS84 4326) is the
+  normal projected shape: the geographic key names the base geographic
+  CRS and the coordinates live in the projected CRS. The reader already
+  resolves the projected code first, so it now reads cleanly and stamps
+  the projected EPSG on `attrs['crs']`. The `allow_inconsistent_geokeys`
+  read kwarg is removed; the two genuine `ModelTypeGeoKey` contradictions
+  (a projected model with only `GeographicTypeGeoKey`, or a geographic
+  model carrying `ProjectedCSTypeGeoKey`) still raise
+  `InconsistentGeoKeysError`. (#2602)
+
 - `polygonize` now auto-detects the raster's affine transform from
   `attrs['transform']` (xrspatial.geotiff convention) or
   `rio.transform()` (rioxarray) when the caller did not pass an

--- a/docs/source/user_guide/geotiff_safe_io.rst
+++ b/docs/source/user_guide/geotiff_safe_io.rst
@@ -225,10 +225,12 @@ the ambiguous-metadata family at once.
    * - :class:`~xrspatial.geotiff.InconsistentGeoKeysError`
      - The source's GeoKey directory is internally contradictory:
        ``ModelTypeGeoKey`` disagrees with the type-specific keys
-       actually populated, or ``ProjectedCSTypeGeoKey`` and
-       ``GeographicTypeGeoKey`` resolve to different EPSG codes.
-     - ``allow_inconsistent_geokeys=True`` to keep the legacy silent
-       acceptance for known-quirky historical files.
+       actually populated (a projected model with only
+       ``GeographicTypeGeoKey``, or a geographic model carrying
+       ``ProjectedCSTypeGeoKey``). A projected file that also names its
+       base geographic CRS is the normal shape and reads without error.
+     - No opt-in. Fix the source's GeoKey directory so the model type
+       matches the CRS codes it declares.
    * - :class:`~xrspatial.geotiff.ConflictingNodataError`
      - ``attrs['nodata']`` and ``attrs['nodatavals']`` disagree on
        write.

--- a/xrspatial/geotiff/__init__.py
+++ b/xrspatial/geotiff/__init__.py
@@ -462,7 +462,6 @@ def open_geotiff(source: str | BinaryIO, *,
                  missing_sources: str = _MISSING_SOURCES_SENTINEL,
                  allow_rotated: bool = False,
                  allow_unparseable_crs: bool = False,
-                 allow_inconsistent_geokeys: bool = False,
                  allow_invalid_nodata: bool = False,
                  stable_only: bool = False,
                  allow_experimental_codecs: bool = False,
@@ -670,18 +669,6 @@ def open_geotiff(source: str | BinaryIO, *,
         behaviour where the citation field passes through unchanged.
         Matches the same kwarg on ``to_geotiff`` / ``write_geotiff_gpu``
         so a value the reader accepted can survive a round-trip.
-    allow_inconsistent_geokeys : bool, default False
-        [advanced] Read-side opt-in for GeoTIFF sources whose GeoKey
-        directory is internally contradictory: ``ModelTypeGeoKey``
-        disagrees with the type-specific keys actually populated, or
-        ``ProjectedCSTypeGeoKey`` and ``GeographicTypeGeoKey`` resolve
-        to different EPSG codes. The legacy reader took the projected
-        code first and silently fabricated an
-        ``attrs['crs']`` / ``attrs['crs_wkt']`` from contradictory
-        inputs. When ``False`` (the default), the read
-        raises ``InconsistentGeoKeysError``. Set to ``True`` to keep
-        the legacy permissive behaviour for files known to carry
-        quirky-but-trusted GeoKey layouts.
     allow_invalid_nodata : bool, default False
         [advanced] Read-side opt-in for integer-dtype sources whose
         ``GDAL_NODATA`` tag is non-finite (``"NaN"``, ``"Inf"``,
@@ -865,8 +852,6 @@ def open_geotiff(source: str | BinaryIO, *,
                         max_pixels=max_pixels,
                         allow_rotated=allow_rotated,
                         allow_unparseable_crs=allow_unparseable_crs,
-                        allow_inconsistent_geokeys=(
-                            allow_inconsistent_geokeys),
                         allow_invalid_nodata=allow_invalid_nodata,
                         stable_only=stable_only,
                         allow_experimental_codecs=allow_experimental_codecs,
@@ -891,8 +876,6 @@ def open_geotiff(source: str | BinaryIO, *,
                                 max_pixels=max_pixels,
                                 allow_rotated=allow_rotated,
                                 allow_unparseable_crs=allow_unparseable_crs,
-                                allow_inconsistent_geokeys=(
-                                    allow_inconsistent_geokeys),
                                 allow_invalid_nodata=allow_invalid_nodata,
                                 stable_only=stable_only,
                                 allow_experimental_codecs=(
@@ -910,8 +893,6 @@ def open_geotiff(source: str | BinaryIO, *,
                                  max_pixels=max_pixels, name=name,
                                  allow_rotated=allow_rotated,
                                  allow_unparseable_crs=allow_unparseable_crs,
-                                 allow_inconsistent_geokeys=(
-                                     allow_inconsistent_geokeys),
                                  allow_invalid_nodata=allow_invalid_nodata,
                                  stable_only=stable_only,
                                  allow_experimental_codecs=(
@@ -970,7 +951,6 @@ def open_geotiff(source: str | BinaryIO, *,
         name=name,
         allow_rotated=allow_rotated,
         allow_unparseable_crs=allow_unparseable_crs,
-        allow_inconsistent_geokeys=allow_inconsistent_geokeys,
     )
 
 

--- a/xrspatial/geotiff/_attrs.py
+++ b/xrspatial/geotiff/_attrs.py
@@ -1050,7 +1050,6 @@ def _validate_read_geo_info(
     window=None,
     allow_rotated: bool = False,
     allow_unparseable_crs: bool = False,
-    allow_inconsistent_geokeys: bool = False,
     band_nodata: str | None = None,
     band_nodata_values: list | None = None,
 ) -> None:
@@ -1116,7 +1115,6 @@ def _validate_read_geo_info(
     validate_read_metadata({
         'allow_rotated': allow_rotated,
         'allow_unparseable_crs': allow_unparseable_crs,
-        'allow_inconsistent_geokeys': allow_inconsistent_geokeys,
         'transform': transform_for_check,
         'crs_wkt': geo_info.crs_wkt,
         'model_type': model_type_ctx,
@@ -1541,7 +1539,6 @@ def _finalize_eager_read(
     name,
     allow_rotated: bool = False,
     allow_unparseable_crs: bool = False,
-    allow_inconsistent_geokeys: bool = False,
     attrs_in: dict | None = None,
 ):
     """Validate, populate attrs, mask, cast, and build an eager DataArray.
@@ -1588,7 +1585,6 @@ def _finalize_eager_read(
         geo_info, window=window,
         allow_rotated=allow_rotated,
         allow_unparseable_crs=allow_unparseable_crs,
-        allow_inconsistent_geokeys=allow_inconsistent_geokeys,
     )
 
     # Populate attrs from geo_info onto a fresh dict (or onto a
@@ -1656,7 +1652,6 @@ def _finalize_lazy_read_attrs(
     window,
     allow_rotated: bool = False,
     allow_unparseable_crs: bool = False,
-    allow_inconsistent_geokeys: bool = False,
     band_nodata: str | None = None,
     band_nodata_values: list | None = None,
     attrs_in: dict | None = None,
@@ -1729,7 +1724,6 @@ def _finalize_lazy_read_attrs(
         geo_info, window=window,
         allow_rotated=allow_rotated,
         allow_unparseable_crs=allow_unparseable_crs,
-        allow_inconsistent_geokeys=allow_inconsistent_geokeys,
         band_nodata=band_nodata,
         band_nodata_values=band_nodata_values,
     )

--- a/xrspatial/geotiff/_backends/dask.py
+++ b/xrspatial/geotiff/_backends/dask.py
@@ -35,7 +35,6 @@ def read_geotiff_dask(source: str, *,
                       missing_sources: str = _MISSING_SOURCES_SENTINEL,
                       allow_rotated: bool = False,
                       allow_unparseable_crs: bool = False,
-                      allow_inconsistent_geokeys: bool = False,
                       allow_invalid_nodata: bool = False,
                       stable_only: bool = False,
                       allow_experimental_codecs: bool = False,
@@ -121,14 +120,6 @@ def read_geotiff_dask(source: str, *,
         instead of carrying the unrecognised payload through
         ``attrs['crs_wkt']``. See ``open_geotiff`` for the full
         description.
-    allow_inconsistent_geokeys : bool, default False
-        [advanced] Read-side opt-in for sources whose GeoKey directory
-        is internally contradictory (``ModelTypeGeoKey`` disagrees
-        with the populated type-specific keys, or
-        ``ProjectedCSTypeGeoKey`` and ``GeographicTypeGeoKey`` resolve
-        to different EPSG codes). The default raises
-        ``InconsistentGeoKeysError``. See ``open_geotiff`` for the
-        full description.
     allow_invalid_nodata : bool, default False
         [advanced] Read-side opt-in for integer-dtype sources whose
         ``GDAL_NODATA`` tag is non-finite or fractional. Default raises
@@ -223,7 +214,6 @@ def read_geotiff_dask(source: str, *,
             chunks=chunks, max_pixels=max_pixels,
             allow_rotated=allow_rotated,
             allow_unparseable_crs=allow_unparseable_crs,
-            allow_inconsistent_geokeys=allow_inconsistent_geokeys,
             allow_invalid_nodata=allow_invalid_nodata,
             stable_only=stable_only,
             allow_experimental_codecs=allow_experimental_codecs,
@@ -505,7 +495,6 @@ def read_geotiff_dask(source: str, *,
         window=window,
         allow_rotated=allow_rotated,
         allow_unparseable_crs=allow_unparseable_crs,
-        allow_inconsistent_geokeys=allow_inconsistent_geokeys,
     )
 
     if isinstance(chunks, int):

--- a/xrspatial/geotiff/_backends/gpu.py
+++ b/xrspatial/geotiff/_backends/gpu.py
@@ -67,7 +67,6 @@ def read_geotiff_gpu(source: str, *,
                      missing_sources: str = _MISSING_SOURCES_SENTINEL,
                      allow_rotated: bool = False,
                      allow_unparseable_crs: bool = False,
-                     allow_inconsistent_geokeys: bool = False,
                      allow_invalid_nodata: bool = False,
                      stable_only: bool = False,
                      allow_experimental_codecs: bool = False,
@@ -201,12 +200,6 @@ def read_geotiff_gpu(source: str, *,
         cannot resolve and do not parse as WKT. ``False`` (the default)
         raises ``UnparseableCRSError``; ``True`` keeps the legacy
         permissive behaviour. See ``open_geotiff`` for the full
-        description.
-    allow_inconsistent_geokeys : bool, default False
-        [experimental] Read-side opt-in for sources whose GeoKey
-        directory is internally contradictory. ``False`` (the default)
-        raises ``InconsistentGeoKeysError``; ``True`` restores the
-        legacy silent acceptance. See ``open_geotiff`` for the full
         description.
     allow_invalid_nodata : bool, default False
         [experimental] Read-side opt-in for integer-dtype sources whose
@@ -346,7 +339,6 @@ def read_geotiff_gpu(source: str, *,
             name=name, max_pixels=max_pixels,
             allow_rotated=allow_rotated,
             allow_unparseable_crs=allow_unparseable_crs,
-            allow_inconsistent_geokeys=allow_inconsistent_geokeys,
             allow_invalid_nodata=allow_invalid_nodata,
             allow_experimental_codecs=allow_experimental_codecs,
             allow_internal_only_jpeg=allow_internal_only_jpeg,
@@ -399,7 +391,6 @@ def read_geotiff_gpu(source: str, *,
             overview_level=overview_level, band=band, name=name,
             max_pixels=max_pixels, allow_rotated=allow_rotated,
             allow_unparseable_crs=allow_unparseable_crs,
-            allow_inconsistent_geokeys=allow_inconsistent_geokeys,
             allow_invalid_nodata=allow_invalid_nodata,
             allow_experimental_codecs=allow_experimental_codecs,
             allow_internal_only_jpeg=allow_internal_only_jpeg,
@@ -634,7 +625,6 @@ def read_geotiff_gpu(source: str, *,
                 name=name,
                 allow_rotated=allow_rotated,
                 allow_unparseable_crs=allow_unparseable_crs,
-                allow_inconsistent_geokeys=allow_inconsistent_geokeys,
             )
             # ``chunks`` was previously honoured only on the tiled path,
             # so stripped TIFFs returned an unchunked DataArray even when
@@ -1037,7 +1027,6 @@ def read_geotiff_gpu(source: str, *,
             name=name,
             allow_rotated=allow_rotated,
             allow_unparseable_crs=allow_unparseable_crs,
-            allow_inconsistent_geokeys=allow_inconsistent_geokeys,
         )
 
         # ``chunks=`` is handled at function entry via
@@ -1062,7 +1051,6 @@ def _read_geotiff_gpu_eager_via_cpu(source, *, dtype, window, overview_level,
                                     band, name, max_pixels,
                                     allow_rotated: bool = False,
                                     allow_unparseable_crs: bool = False,
-                                    allow_inconsistent_geokeys: bool = False,
                                     allow_invalid_nodata: bool = False,
                                     allow_experimental_codecs: bool = False,
                                     allow_internal_only_jpeg: bool = False,
@@ -1148,7 +1136,6 @@ def _read_geotiff_gpu_eager_via_cpu(source, *, dtype, window, overview_level,
         name=name,
         allow_rotated=allow_rotated,
         allow_unparseable_crs=allow_unparseable_crs,
-        allow_inconsistent_geokeys=allow_inconsistent_geokeys,
     )
 
 
@@ -1295,7 +1282,6 @@ def _read_geotiff_gpu_chunked(source, *, dtype, chunks, overview_level,
                               window, band, name, max_pixels,
                               allow_rotated: bool = False,
                               allow_unparseable_crs: bool = False,
-                              allow_inconsistent_geokeys: bool = False,
                               allow_invalid_nodata: bool = False,
                               allow_experimental_codecs: bool = False,
                               allow_internal_only_jpeg: bool = False,
@@ -1406,8 +1392,6 @@ def _read_geotiff_gpu_chunked(source, *, dtype, chunks, overview_level,
                     name=name, max_pixels=max_pixels,
                     allow_rotated=allow_rotated,
                     allow_unparseable_crs=allow_unparseable_crs,
-                    allow_inconsistent_geokeys=(
-                        allow_inconsistent_geokeys),
                     allow_invalid_nodata=allow_invalid_nodata,
                     mask_nodata=mask_nodata,
                 )
@@ -1423,7 +1407,6 @@ def _read_geotiff_gpu_chunked(source, *, dtype, chunks, overview_level,
         max_pixels=max_pixels, name=name,
         allow_rotated=allow_rotated,
         allow_unparseable_crs=allow_unparseable_crs,
-        allow_inconsistent_geokeys=allow_inconsistent_geokeys,
         allow_invalid_nodata=allow_invalid_nodata,
         allow_experimental_codecs=allow_experimental_codecs,
         allow_internal_only_jpeg=allow_internal_only_jpeg,
@@ -1452,7 +1435,6 @@ def _read_geotiff_gpu_chunked_gds(source, ifd, geo_info, header, *,
                                   max_pixels,
                                   allow_rotated: bool = False,
                                   allow_unparseable_crs: bool = False,
-                                  allow_inconsistent_geokeys: bool = False,
                                   allow_invalid_nodata: bool = False,
                                   mask_nodata: bool = True):
     """Build a Dask+CuPy graph that decodes each chunk disk->GPU.
@@ -1690,7 +1672,6 @@ def _read_geotiff_gpu_chunked_gds(source, ifd, geo_info, header, *,
         window=window,
         allow_rotated=allow_rotated,
         allow_unparseable_crs=allow_unparseable_crs,
-        allow_inconsistent_geokeys=allow_inconsistent_geokeys,
     )
 
     if name is None:

--- a/xrspatial/geotiff/_backends/vrt.py
+++ b/xrspatial/geotiff/_backends/vrt.py
@@ -126,7 +126,6 @@ def read_vrt(source: str, *,
              missing_sources: str = 'raise',
              allow_rotated: bool = False,
              allow_unparseable_crs: bool = False,
-             allow_inconsistent_geokeys: bool = False,
              allow_invalid_nodata: bool = False,
              stable_only: bool = False,
              allow_experimental_codecs: bool = False,
@@ -256,15 +255,6 @@ def read_vrt(source: str, *,
         raises ``UnparseableCRSError`` rather than carrying the
         unrecognised payload through. See ``open_geotiff`` for the
         full description.
-    allow_inconsistent_geokeys : bool, default False
-        [advanced] Read-side opt-in for sources whose GeoKey directory
-        is internally contradictory. Accepted for signature symmetry
-        with ``open_geotiff`` and the GeoTIFF readers; VRT capability
-        validation itself does not parse GeoKeys (it consumes the GDAL
-        ``<SRS>`` field), and the legacy VRT internal reader does not
-        thread per-GeoTIFF-source kwargs, so this kwarg is currently a
-        no-op on the VRT path. See ``open_geotiff`` for the full
-        description.
     allow_invalid_nodata : bool, default False
         [advanced] Read-side opt-in for integer-dtype source files whose
         ``GDAL_NODATA`` tag is non-finite or fractional. Forwarded to
@@ -477,7 +467,6 @@ def read_vrt(source: str, *,
             missing_sources=missing_sources,
             allow_rotated=allow_rotated,
             allow_unparseable_crs=allow_unparseable_crs,
-            allow_inconsistent_geokeys=allow_inconsistent_geokeys,
             allow_invalid_nodata=allow_invalid_nodata,
             allow_experimental_codecs=allow_experimental_codecs,
             allow_internal_only_jpeg=allow_internal_only_jpeg,
@@ -739,7 +728,6 @@ def read_vrt(source: str, *,
         window=window,
         allow_rotated=allow_rotated,
         allow_unparseable_crs=allow_unparseable_crs,
-        allow_inconsistent_geokeys=allow_inconsistent_geokeys,
         band_nodata=band_nodata,
         band_nodata_values=_band_nodata_values,
         attrs_in=attrs_seed,
@@ -827,7 +815,6 @@ def _read_vrt_chunked(source, *, window, band, name, chunks, gpu, dtype,
                       max_pixels, missing_sources,
                       allow_rotated: bool = False,
                       allow_unparseable_crs: bool = False,
-                      allow_inconsistent_geokeys: bool = False,
                       allow_invalid_nodata: bool = False,
                       allow_experimental_codecs: bool = False,
                       allow_internal_only_jpeg: bool = False,
@@ -1262,7 +1249,6 @@ def _read_vrt_chunked(source, *, window, band, name, chunks, gpu, dtype,
         window=helper_window,
         allow_rotated=allow_rotated,
         allow_unparseable_crs=allow_unparseable_crs,
-        allow_inconsistent_geokeys=allow_inconsistent_geokeys,
         band_nodata=band_nodata,
         band_nodata_values=band_nodata_values,
         attrs_in=attrs_seed,

--- a/xrspatial/geotiff/_errors.py
+++ b/xrspatial/geotiff/_errors.py
@@ -148,8 +148,16 @@ class InconsistentGeoKeysError(GeoTIFFAmbiguousMetadataError):
 
     Raised when a GeoTIFF source ships a GeoKey directory whose
     ``ModelTypeGeoKey`` does not agree with the type-specific keys
-    actually populated, or whose ``ProjectedCSTypeGeoKey`` and
-    ``GeographicTypeGeoKey`` resolve to different EPSG codes.
+    actually populated: ``ModelTypeGeoKey = projected`` with only
+    ``GeographicTypeGeoKey`` set, or ``ModelTypeGeoKey = geographic``
+    with ``ProjectedCSTypeGeoKey`` set.
+
+    A file that populates both ``ProjectedCSTypeGeoKey`` and
+    ``GeographicTypeGeoKey`` with different EPSG codes is not an error:
+    that is the normal projected GeoTIFF shape, where the geographic
+    key names the base geographic CRS and the coordinates live in the
+    projected CRS. The reader takes the projected code first, so it
+    resolves correctly.
 
     The legacy reader took ``ProjectedCSTypeGeoKey`` first, then fell
     back to ``GeographicTypeGeoKey``, without ever cross-checking
@@ -161,10 +169,6 @@ class InconsistentGeoKeysError(GeoTIFFAmbiguousMetadataError):
     geospatial metadata is the failure mode the rest of the
     ambiguous-metadata family already rejects; this check extends the
     same contract to the GeoKey shape itself.
-
-    Pass ``allow_inconsistent_geokeys=True`` on the public read entry
-    points to keep the legacy permissive behaviour for files known to
-    carry quirky-but-trusted GeoKey layouts.
     """
 
 

--- a/xrspatial/geotiff/_validation.py
+++ b/xrspatial/geotiff/_validation.py
@@ -1471,14 +1471,20 @@ def _check_read_inconsistent_geokeys(context: Mapping[str, Any]) -> None:
     handing downstream callers trustworthy-looking spatial metadata
     fabricated from inconsistent inputs.
 
-    The check rejects three structurally bad combinations:
+    The check rejects two structurally bad combinations:
 
     1. ``ModelTypeGeoKey = projected`` with ``GeographicTypeGeoKey``
        populated but ``ProjectedCSTypeGeoKey`` absent.
     2. ``ModelTypeGeoKey = geographic`` with ``ProjectedCSTypeGeoKey``
        populated (the geographic model may not stash a projected code).
-    3. Both ``ProjectedCSTypeGeoKey`` and ``GeographicTypeGeoKey``
-       populated with different non-user-defined EPSG codes.
+
+    A file that populates *both* ``ProjectedCSTypeGeoKey`` and
+    ``GeographicTypeGeoKey`` with different EPSG codes is **not**
+    rejected: that is the normal shape of a projected GeoTIFF, where
+    ``GeographicTypeGeoKey`` names the base geographic CRS the
+    projection is built on and the pixel coordinates live in the
+    projected CRS. The reader already takes the projected code first
+    (see ``extract_geo_info``), so this case resolves correctly.
 
     ``32767`` (user-defined) is treated as "no resolved code" because
     the actual CRS is defined by sibling keys (``GeogGeodeticDatumGeoKey``
@@ -1495,7 +1501,6 @@ def _check_read_inconsistent_geokeys(context: Mapping[str, Any]) -> None:
 
     Context keys consumed:
 
-    * ``allow_inconsistent_geokeys`` -- caller opt-out kwarg.
     * ``model_type`` -- value of ``ModelTypeGeoKey`` (0 if absent).
     * ``projected_cs_type`` -- value of ``ProjectedCSTypeGeoKey`` (None
       if absent).
@@ -1506,8 +1511,6 @@ def _check_read_inconsistent_geokeys(context: Mapping[str, Any]) -> None:
     a no-op, so callers that did not (or could not) parse a GeoKey
     directory at all still pass through unchanged.
     """
-    if context.get('allow_inconsistent_geokeys'):
-        return
     proj_cs = context.get('projected_cs_type')
     geog = context.get('geographic_type')
     model_type = context.get('model_type')
@@ -1550,9 +1553,8 @@ def _check_read_inconsistent_geokeys(context: Mapping[str, Any]) -> None:
             f"resolved ProjectedCSTypeGeoKey. A projected model must "
             f"declare the projected CRS code in ProjectedCSTypeGeoKey; "
             f"the geographic key on its own cannot identify the "
-            f"projection. Pass allow_inconsistent_geokeys=True to keep "
-            f"the legacy behaviour of treating the geographic code as "
-            f"the file's CRS. See issue #2417."
+            f"projection. Fix the source's GeoKey directory so the "
+            f"projected CRS code is present. See issue #2417."
         )
 
     # Case 2: ModelType = geographic but ProjectedCSTypeGeoKey set.
@@ -1562,21 +1564,9 @@ def _check_read_inconsistent_geokeys(context: Mapping[str, Any]) -> None:
             f"but populates ProjectedCSTypeGeoKey={proj_cs_i!r}. The "
             f"geographic model may not carry a projected CRS code; the "
             f"legacy reader would publish EPSG {proj_cs_i!r} verbatim "
-            f"in attrs['crs'] from contradictory inputs. Pass "
-            f"allow_inconsistent_geokeys=True to keep the legacy "
-            f"behaviour. See issue #2417."
-        )
-
-    # Case 3: both type keys resolved to different EPSG codes.
-    if proj_resolved and geog_resolved and proj_cs_i != geog_i:
-        raise InconsistentGeoKeysError(
-            f"GeoTIFF source populates both ProjectedCSTypeGeoKey="
-            f"{proj_cs_i!r} and GeographicTypeGeoKey={geog_i!r} with "
-            f"different EPSG codes. The legacy reader took the "
-            f"projected code first and silently dropped the geographic "
-            f"one. Pass allow_inconsistent_geokeys=True to keep that "
-            f"behaviour, or fix the source's GeoKey directory. See "
-            f"issue #2417."
+            f"in attrs['crs'] from contradictory inputs. Fix the "
+            f"source's GeoKey directory so ModelTypeGeoKey matches the "
+            f"CRS it declares. See issue #2417."
         )
 
 

--- a/xrspatial/geotiff/tests/unit/test_geotags.py
+++ b/xrspatial/geotiff/tests/unit/test_geotags.py
@@ -581,18 +581,17 @@ def test_validate_rejects_model_projected_with_only_geographic_key():
     assert '4326' in msg
 
 
-def test_validate_rejects_both_type_keys_with_different_epsg():
-    """Both ProjectedCSTypeGeoKey and GeographicTypeGeoKey set to
-    different EPSG codes."""
-    with pytest.raises(InconsistentGeoKeysError) as excinfo:
-        validate_read_metadata({
-            'model_type': 1,
-            'projected_cs_type': 32633,
-            'geographic_type': 4326,
-        })
-    msg = str(excinfo.value)
-    assert '32633' in msg
-    assert '4326' in msg
+def test_validate_accepts_both_type_keys_with_different_epsg():
+    """Both ProjectedCSTypeGeoKey and GeographicTypeGeoKey populated with
+    different EPSG codes is the normal projected GeoTIFF shape (#2602):
+    the geographic key names the base geographic CRS and the projected
+    key the CRS the coordinates live in. The validator must not reject
+    it."""
+    validate_read_metadata({
+        'model_type': 1,
+        'projected_cs_type': 32633,
+        'geographic_type': 4326,
+    })
 
 
 def test_validate_passes_consistent_projected():
@@ -656,30 +655,6 @@ def test_validate_passes_when_model_type_undefined():
         'model_type': 0,
         'projected_cs_type': 4326,
         'geographic_type': None,
-    })
-
-
-def test_opt_out_short_circuits_each_case():
-    """``allow_inconsistent_geokeys=True`` keeps the legacy permissive
-    behaviour across all three rejection cases."""
-    # Case 2 (the issue's exact reproducer).
-    validate_read_metadata({
-        'model_type': 2,
-        'projected_cs_type': 4326,
-        'allow_inconsistent_geokeys': True,
-    })
-    # Case 1.
-    validate_read_metadata({
-        'model_type': 1,
-        'geographic_type': 4326,
-        'allow_inconsistent_geokeys': True,
-    })
-    # Case 3.
-    validate_read_metadata({
-        'model_type': 1,
-        'projected_cs_type': 32633,
-        'geographic_type': 4326,
-        'allow_inconsistent_geokeys': True,
     })
 
 
@@ -874,16 +849,22 @@ def test_open_geotiff_rejects_model_projected_with_only_geographic_key(tmp_path)
         open_geotiff(str(path))
 
 
-def test_open_geotiff_rejects_both_keys_with_different_epsg(tmp_path):
-    path = tmp_path / "tmp_2417_both_keys_disagree.tif"
+def test_open_geotiff_accepts_both_keys_with_different_epsg(tmp_path):
+    """A projected GeoTIFF that also carries its base geographic CRS
+    (e.g. UTM 32633 over WGS84 4326) must read, with the projected code
+    surfacing in ``attrs['crs']`` (#2602). Both keys populated with
+    different EPSG codes is the normal shape, not a contradiction."""
+    path = tmp_path / "tmp_2602_both_keys_projected_over_geographic.tif"
     _write_tiff_with_geokeys(
         str(path),
         model_type=1,
         projected_cs_type=32633,
         geographic_type=4326,
     )
-    with pytest.raises(InconsistentGeoKeysError):
-        open_geotiff(str(path))
+    da = open_geotiff(str(path))
+    assert da.shape == (4, 4)
+    # Projected code wins; the geographic key is the base geographic CRS.
+    assert da.attrs.get('crs') == 32633
 
 
 def test_open_geotiff_accepts_consistent_projected(tmp_path):
@@ -915,19 +896,3 @@ def test_open_geotiff_accepts_consistent_geographic(tmp_path):
     assert da.attrs.get('crs') == 4326
 
 
-def test_open_geotiff_opt_out_restores_legacy_behaviour(tmp_path):
-    """``allow_inconsistent_geokeys=True`` keeps the pre-#2417 silent
-    acceptance for callers with known-quirky historical files."""
-    path = tmp_path / "tmp_2417_opt_out.tif"
-    _write_tiff_with_geokeys(
-        str(path),
-        model_type=2,
-        projected_cs_type=4326,
-        geographic_type=None,
-    )
-    da = open_geotiff(str(path), allow_inconsistent_geokeys=True)
-    # The legacy reader takes ProjectedCSTypeGeoKey first, so the EPSG
-    # surfaces in attrs['crs'] verbatim. The bug is that the surface
-    # looks trustworthy; the opt-in is the documented way to keep that
-    # behaviour for callers who need the legacy contract.
-    assert da.attrs.get('crs') == 4326

--- a/xrspatial/geotiff/tests/unit/test_geotags.py
+++ b/xrspatial/geotiff/tests/unit/test_geotags.py
@@ -594,6 +594,21 @@ def test_validate_accepts_both_type_keys_with_different_epsg():
     })
 
 
+def test_validate_accepts_projected_with_unexpected_base_geographic():
+    """Acceptance does not cross-validate the projected code against the
+    declared base geographic key (#2602). A projected model that names a
+    base geographic CRS the projection was not actually built on (here
+    UTM 32633 over NAD27 4267 instead of WGS84) still passes: the reader
+    takes the projected code as the file's CRS and treats the geographic
+    key as the base, by design. This is the one shape the old Case 3
+    rejected; the silent-accept is deliberate, not an oversight."""
+    validate_read_metadata({
+        'model_type': 1,
+        'projected_cs_type': 32633,
+        'geographic_type': 4267,
+    })
+
+
 def test_validate_passes_consistent_projected():
     """ModelType=projected with a projected EPSG and no geographic key."""
     validate_read_metadata({

--- a/xrspatial/geotiff/tests/unit/test_signatures.py
+++ b/xrspatial/geotiff/tests/unit/test_signatures.py
@@ -412,10 +412,6 @@ _CANONICAL_ORDER = (
     "missing_sources",
     "allow_rotated",
     "allow_unparseable_crs",
-    # GeoKey-shape fail-closed opt-out. Sits alongside the other
-    # ambiguous-metadata opt-outs so the canonical order keeps the
-    # typed-error gates grouped.
-    "allow_inconsistent_geokeys",
     # Integer-nodata fail-closed opt-out. Sits alongside the other
     # ambiguous-metadata opt-outs so the canonical order keeps the
     # typed-error gates grouped.


### PR DESCRIPTION
Closes #2602

## What changed

- `open_geotiff` now reads a projected GeoTIFF that also carries its base
  geographic CRS. The `_check_read_inconsistent_geokeys` validator used to
  reject "both `ProjectedCSTypeGeoKey` and `GeographicTypeGeoKey` resolve
  to different EPSG codes" (its Case 3), which is the normal UTM-over-WGS84
  shape. The reader already takes the projected code first, so dropping
  that case lands the projected EPSG on `attrs['crs']` and keeps the
  geographic key as the base geographic CRS.
- Removed the `allow_inconsistent_geokeys` read kwarg from `open_geotiff`,
  `read_geotiff_dask`, `read_vrt`, `read_geotiff_gpu`, and the internal
  reader plumbing (`_attrs.py`, `_validation.py`).
- The two genuine `ModelTypeGeoKey` contradictions still raise
  `InconsistentGeoKeysError` (Case 1: projected model, only
  `GeographicTypeGeoKey`; Case 2: geographic model carrying
  `ProjectedCSTypeGeoKey`). With the flag gone there is no opt-out for
  those.

## Backend coverage

The validator runs on the shared read-finalization path, so the change
applies to all read backends: numpy (eager), dask+numpy, cupy, and
dask+cupy. The flag was removed from every backend signature.

## Test plan

- [x] `test_validate_accepts_both_type_keys_with_different_epsg` (unit) and
      `test_open_geotiff_accepts_both_keys_with_different_epsg` (file-level)
      cover the fix; the projected EPSG surfaces on `attrs['crs']`.
- [x] Case 1 / Case 2 reject tests still pass.
- [x] Full geotiff suite: 6007 passed, 81 skipped, 1 xfailed.
- [x] Signature-contract and release-gate feature tests pass.
