### PR TITLE
geotiff: clear flake8 F811 and isort findings

### DIFF
--- a/xrspatial/geotiff/__init__.py
+++ b/xrspatial/geotiff/__init__.py
@@ -433,7 +433,6 @@ def _bbox_to_window(source, bbox, *, overview_level=None,
             "but this file has no GeoTIFF tags. Pass window= instead "
             "for pixel-space windowing.")
 
-    from ._attrs import _extent_to_window
     pixel_window = _extent_to_window(
         geo_info.transform, height, width,
         y_min, y_max, x_min, x_max)

--- a/xrspatial/geotiff/_reader.py
+++ b/xrspatial/geotiff/_reader.py
@@ -67,8 +67,8 @@ from ._header import parse_all_ifds, parse_header, select_overview_ifd
 #     preserved without churn.
 from ._layout import (_FULL_IMAGE_BUDGET_HEADER_SLACK, MAX_PIXELS_DEFAULT,  # noqa: F401
                       PixelSafetyLimitError, _check_dimensions, _check_source_dimensions,
-                      _compute_full_image_byte_budget, _gb_hint, _has_sparse,
-                      _ifd_required_extent, _sparse_fill_value)
+                      _compute_full_image_byte_budget, _gb_hint, _has_sparse, _ifd_required_extent,
+                      _sparse_fill_value)
 # The data-source layer (local mmap, HTTP with SSRF defences and DNS-rebind
 # pinning, fsspec cloud, BytesIO) lives in ``_sources``. It is imported back
 # here so that:


### PR DESCRIPTION
Closes #2634.

Style cleanup in the geotiff subpackage, scoped to the two findings the
project's own flake8 and isort config (setup.cfg) reports. CI doesn't gate
either tool, so these drifted in unnoticed.

## Changes

- Cat 3 (F811): drop the redundant local `from ._attrs import _extent_to_window`
  in `__init__.py:436`. The name is already imported at module level
  (line 55, in the re-export block), so pyflakes flagged the second import
  as a redefinition. This is a redundant local import, not a re-export, so
  removing it does not change what `xrspatial.geotiff` exposes. The call on
  the following line keeps using the module-level binding.
- Cat 4 (isort): let isort rewrap the multiline `from ._layout import (...)`
  block in `_reader.py` under line_length=100.

Neither change alters runtime behaviour: same names bound from the same
source modules.

## Verification

- `flake8 xrspatial/geotiff/*.py` -> clean (was 1 F811)
- `isort --check-only xrspatial/geotiff/*.py` -> clean (was 1 diff)
- `pytest xrspatial/geotiff/tests/read/test_bbox_2555.py` -> 15 passed
  (exercises the edited `_resolve_bbox_window` / `_extent_to_window` path)

## Backend coverage

Static import-level edits, uniform across numpy / cupy / dask backends.
No backend-specific verification needed.