### PR TITLE
geotiff: cross-backend parity tests for open_geotiff(bbox=)

### DIFF
--- a/xrspatial/geotiff/tests/read/test_bbox_2555.py
+++ b/xrspatial/geotiff/tests/read/test_bbox_2555.py
@@ -16,6 +16,8 @@ import xarray as xr
 
 from xrspatial.geotiff import open_geotiff, to_geotiff
 
+from .._helpers.markers import requires_gpu
+
 
 @pytest.fixture
 def georef_raster_2555(tmp_path):
@@ -202,6 +204,51 @@ class TestBboxOverviewLevel:
         assert sub_base.shape[1] >= sub_ov.shape[1] >= sub_ov2.shape[1]
         # All slices must be non-empty.
         assert sub_ov2.shape[0] > 0 and sub_ov2.shape[1] > 0
+
+
+class TestBboxBackendParity:
+    """``bbox=`` resolves to a pixel window at the dispatcher and is
+    forwarded to every backend. The eager-numpy path is covered above;
+    these cells assert the GPU, dask+numpy, and dask+gpu paths consume
+    the bbox-derived window and return pixels identical to the eager
+    read. Without them a regression in the bbox->window->backend
+    forwarding on any non-eager path ships undetected.
+    """
+
+    _BB = (-122.4, 37.4, -122.1, 37.7)
+
+    @staticmethod
+    def _materialise(da):
+        raw = da.data
+        if hasattr(raw, "compute"):
+            raw = raw.compute()
+        if hasattr(raw, "get"):
+            raw = raw.get()
+        return np.asarray(raw)
+
+    @requires_gpu
+    def test_bbox_gpu_matches_eager(self, georef_raster_2555):
+        eager = open_geotiff(georef_raster_2555, bbox=self._BB)
+        gpu = open_geotiff(georef_raster_2555, bbox=self._BB, gpu=True)
+        assert gpu.shape == eager.shape
+        np.testing.assert_array_equal(
+            self._materialise(gpu), eager.values)
+
+    def test_bbox_dask_matches_eager(self, georef_raster_2555):
+        eager = open_geotiff(georef_raster_2555, bbox=self._BB)
+        dask = open_geotiff(georef_raster_2555, bbox=self._BB, chunks=16)
+        assert dask.shape == eager.shape
+        np.testing.assert_array_equal(
+            self._materialise(dask), eager.values)
+
+    @requires_gpu
+    def test_bbox_dask_gpu_matches_eager(self, georef_raster_2555):
+        eager = open_geotiff(georef_raster_2555, bbox=self._BB)
+        dask_gpu = open_geotiff(
+            georef_raster_2555, bbox=self._BB, gpu=True, chunks=16)
+        assert dask_gpu.shape == eager.shape
+        np.testing.assert_array_equal(
+            self._materialise(dask_gpu), eager.values)
 
 
 class TestSafetyHintMentionsBbox:


### PR DESCRIPTION
The `bbox=` argument to `open_geotiff` resolves a geographic bounding box to a pixel window in the dispatcher, then forwards that window to whichever backend the caller selected. Until now the resolved window was only checked on the eager numpy path. `window=` is tested directly on the GPU and dask backends, but the composed `bbox -> window -> backend` path was never run with `gpu=True`, `chunks=`, or both, so a regression that dropped the bbox-derived window before GPU or dask dispatch would have shipped without a failing test.

This adds `TestBboxBackendParity` to `test_bbox_2555.py` with three cells that read the same bbox on GPU, dask+numpy, and dask+gpu and assert the pixels and shape match the eager read. A mutation check confirmed they fail when the window is dropped (a dask read returns 100x100 instead of the expected 60x60). Test-only; no source changes.

Found by the geotiff deep-sweep test-coverage pass.