### PR TITLE
polygonize: batch dask per-chunk compute instead of serial loop

### DIFF
--- a/docs/source/reference/dask_laziness.rst
+++ b/docs/source/reference/dask_laziness.rst
@@ -248,3 +248,26 @@ Pathfinding
    * - ``multi_stop_search``
      - Fully materialized
      - Iterative A*
+
+
+Vector conversion
+=================
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 20 50
+
+   * - Function
+     - Laziness
+     - Notes
+   * - ``polygonize``
+     - Fully materialized
+     - Polygonizes each chunk, then merges polygons across chunk edges
+
+``polygonize`` runs per chunk and stitches the results, so it never holds the
+whole raster in memory at once.  Chunks are polygonized in batches: each batch
+is one ``dask.compute`` call, so dask schedules the batch in parallel instead
+of computing one chunk at a time.  Peak memory is bounded by one batch worth of
+per-chunk polygons plus the boundary polygons that accumulate for the merge.
+Larger inputs with many small chunks parallelize well; rasters whose chunks each
+produce many polygons use more memory per batch.

--- a/xrspatial/polygonize.py
+++ b/xrspatial/polygonize.py
@@ -2166,9 +2166,39 @@ def _merge_from_separated(all_interior, boundary_polys, transform,
     return column, polygon_points
 
 
+# Number of chunks polygonized per dask.compute call.  Caps how many
+# per-chunk results (interior + boundary polygons) are materialized at
+# once, bounding peak memory while still letting dask schedule the batch
+# in parallel.  See _polygonize_dask for the memory/parallelism tradeoff.
+_DASK_CHUNK_BATCH_SIZE = 32
+
+
 def _polygonize_dask(dask_data, mask_data, connectivity_8, transform,
-                     atol=_DEFAULT_ATOL, rtol=_DEFAULT_RTOL):
-    """Dask backend for polygonize: per-chunk polygonize + edge merge."""
+                     atol=_DEFAULT_ATOL, rtol=_DEFAULT_RTOL,
+                     batch_size=_DASK_CHUNK_BATCH_SIZE):
+    """Dask backend for polygonize: per-chunk polygonize + edge merge.
+
+    Chunks are polygonized in batches via :func:`dask.compute`.  Each
+    batch holds up to ``batch_size`` ``dask.delayed`` tasks computed in a
+    single call, so dask schedules them in parallel instead of running
+    one chunk at a time.
+
+    Memory / parallelism tradeoff: a single ``dask.compute`` over every
+    chunk would maximize parallelism but materialize all per-chunk
+    results at once, so peak memory grows with the total polygon count.
+    Computing one chunk at a time bounds memory but throws away
+    parallelism.  A fixed ``batch_size`` splits the difference: peak
+    memory is bounded by ``batch_size`` chunks' worth of polygons, and
+    dask still runs each batch concurrently.  Increase ``batch_size`` to
+    trade memory for more parallelism, decrease it to cap memory harder.
+    A fixed batch also bounds memory independently of the chunk-grid
+    shape, unlike a per-row batch whose size scales with the number of
+    column chunks.
+
+    Tasks are built and their results consumed in row-major ``(iy, ix)``
+    order so polygons map back to the right block; the downstream
+    boundary-merge stage depends on that ordering.
+    """
     # Ensure mask chunks match raster chunks.
     if mask_data is not None and mask_data.chunks != dask_data.chunks:
         mask_data = mask_data.rechunk(dask_data.chunks)
@@ -2182,31 +2212,31 @@ def _polygonize_dask(dask_data, mask_data, connectivity_8, transform,
     ny_total = int(sum(row_chunks))
     nx_total = int(sum(col_chunks))
 
-    # Process chunks one row at a time: build the delayed tasks for a whole
-    # row of chunks and hand them to a single dask.compute() call so the
-    # scheduler can run the chunks in that row concurrently.  Computing per
-    # row (instead of per chunk) recovers parallelism while keeping peak
-    # driver memory bounded by one row of chunk results rather than the full
-    # raster -- interior polygons (fully inside a chunk, no merging needed)
-    # still go straight to the output list, and only boundary polygons
-    # accumulate across rows for the cross-chunk merge.
-    all_interior = []
-    boundary_polys = []
-
+    # Build one delayed task per chunk in row-major order.  Interior
+    # polygons (fully inside a chunk, no merging needed) go straight to
+    # the output list; only boundary polygons accumulate for the merge.
+    tasks = []
     for iy in range(len(row_chunks)):
-        row_tasks = []
         for ix in range(len(col_chunks)):
             block = dask_data.blocks[iy, ix]
             mask_block = (mask_data.blocks[iy, ix]
                           if mask_data is not None else None)
-            row_tasks.append(
-                dask.delayed(_polygonize_chunk)(
-                    block, mask_block, connectivity_8,
-                    int(row_offsets[iy]), int(col_offsets[ix]),
-                    ny_total, nx_total,
-                    atol, rtol,
-                ))
-        for interior, boundary in dask.compute(*row_tasks):
+            tasks.append(dask.delayed(_polygonize_chunk)(
+                block, mask_block, connectivity_8,
+                int(row_offsets[iy]), int(col_offsets[ix]),
+                ny_total, nx_total,
+                atol, rtol,
+            ))
+
+    all_interior = []
+    boundary_polys = []
+
+    # Compute in bounded batches, consuming results in task order so the
+    # accumulated lists keep the same row-major ordering as the serial
+    # per-chunk loop.
+    for start in range(0, len(tasks), batch_size):
+        results = dask.compute(*tasks[start:start + batch_size])
+        for interior, boundary in results:
             all_interior.extend(interior)
             boundary_polys.extend(boundary)
 

--- a/xrspatial/polygonize.py
+++ b/xrspatial/polygonize.py
@@ -2193,7 +2193,10 @@ def _polygonize_dask(dask_data, mask_data, connectivity_8, transform,
     trade memory for more parallelism, decrease it to cap memory harder.
     A fixed batch also bounds memory independently of the chunk-grid
     shape, unlike a per-row batch whose size scales with the number of
-    column chunks.
+    column chunks.  ``batch_size`` is not exposed through the public
+    :func:`polygonize` API; the default comes from the module-level
+    ``_DASK_CHUNK_BATCH_SIZE`` constant, so tuning it means editing that
+    constant.
 
     Tasks are built and their results consumed in row-major ``(iy, ix)``
     order so polygons map back to the right block; the downstream

--- a/xrspatial/tests/test_polygonize.py
+++ b/xrspatial/tests/test_polygonize.py
@@ -26,7 +26,7 @@ except ImportError:
     sp = None
 
 
-from ..polygonize import polygonize
+from ..polygonize import _polygonize_dask, polygonize
 from .general_checks import cuda_and_cupy_available, dask_array_available
 
 
@@ -323,6 +323,74 @@ def test_polygonize_dask_matches_numpy_big(chunks):
 
     for val in areas_np:
         assert val in areas_da, f"Value {val} missing from dask result"
+        assert_allclose(areas_da[val], areas_np[val],
+                        err_msg=f"Area mismatch for value {val}")
+
+
+def _assert_polygonize_results_equal(result_a, result_b):
+    """Assert two (values, polygons) results are element-wise identical."""
+    vals_a, polys_a = result_a
+    vals_b, polys_b = result_b
+    assert_allclose(vals_a, vals_b)
+    assert len(polys_a) == len(polys_b)
+    for pa, pb in zip(polys_a, polys_b):
+        assert len(pa) == len(pb)
+        for ra, rb in zip(pa, pb):
+            assert_allclose(ra, rb)
+
+
+@dask_array_available
+@pytest.mark.parametrize("batch_size", [1, 2, 3, 100])
+def test_polygonize_dask_batch_size_invariant(batch_size):
+    """Batched dask compute gives byte-identical output regardless of batch.
+
+    The raster is split into 3x3 = 9 chunks, so batch_size=1 (one compute
+    per chunk, the old serial behaviour) and larger batches all exercise
+    the row-major task ordering.  Batching is a performance change only:
+    every batch_size, including ones that force multiple batches, must
+    produce the exact same values and polygon vertices as batch_size=1.
+    """
+    shape = (15, 18)
+    rng = np.random.default_rng(28403)
+    data = rng.integers(low=0, high=3, size=shape, dtype=np.int64)
+    mask = rng.uniform(0, 1, size=shape) < 0.9
+
+    raster_da = xr.DataArray(da.from_array(data, chunks=(5, 6)))
+    mask_da = xr.DataArray(da.from_array(mask, chunks=(5, 6)))
+
+    # batch_size=1 reproduces the pre-batching serial per-chunk loop.
+    result_serial = _polygonize_dask(
+        raster_da.data, mask_da.data, connectivity_8=False,
+        transform=None, batch_size=1)
+    result_batched = _polygonize_dask(
+        raster_da.data, mask_da.data, connectivity_8=False,
+        transform=None, batch_size=batch_size)
+
+    _assert_polygonize_results_equal(result_serial, result_batched)
+
+
+@dask_array_available
+@pytest.mark.parametrize("batch_size", [1, 4, 100])
+def test_polygonize_dask_batched_matches_numpy_areas(batch_size):
+    """Batched multi-chunk dask areas match numpy for every batch size."""
+    shape = (15, 18)
+    rng = np.random.default_rng(28403)
+    data = rng.integers(low=0, high=3, size=shape, dtype=np.int64)
+    mask = rng.uniform(0, 1, size=shape) < 0.9
+
+    vals_np, polys_np = polygonize(
+        xr.DataArray(data), mask=xr.DataArray(mask), connectivity=4)
+    areas_np = _area_by_value(vals_np, polys_np)
+
+    raster_da = xr.DataArray(da.from_array(data, chunks=(5, 6)))
+    mask_da = xr.DataArray(da.from_array(mask, chunks=(5, 6)))
+    vals_da, polys_da = _polygonize_dask(
+        raster_da.data, mask_da.data, connectivity_8=False,
+        transform=None, batch_size=batch_size)
+    areas_da = _area_by_value(vals_da, polys_da)
+
+    assert set(areas_np) == set(areas_da)
+    for val in areas_np:
         assert_allclose(areas_da[val], areas_np[val],
                         err_msg=f"Area mismatch for value {val}")
 

--- a/xrspatial/tests/test_polygonize_dask_row_batch_2608.py
+++ b/xrspatial/tests/test_polygonize_dask_row_batch_2608.py
@@ -1,12 +1,14 @@
-"""Regression tests for the row-batched dask compute path in polygonize.
+"""Regression tests for the batched dask compute path in polygonize.
 
 Issue #2608: `_polygonize_dask` used to call `dask.compute()` once per
 chunk inside a nested Python loop, which serialized chunk processing.
-It now issues one `dask.compute()` per row of chunks so the scheduler can
-run a row's chunks concurrently while peak driver memory stays bounded by
-a single row of chunk results.  These tests pin both the output parity
-(against numpy) and the per-row compute structure so the batching can't
-silently regress to per-chunk (slow) or per-raster (memory-heavy).
+Issue #2664 batched the per-chunk tasks into bounded `dask.compute()`
+calls so the scheduler can run a batch's chunks concurrently while peak
+driver memory stays bounded by ``batch_size`` chunk results (independent
+of the chunk-grid shape, unlike the earlier per-row batching).  These
+tests pin both the output parity (against numpy) and the batched compute
+structure so it can't silently regress to per-chunk (slow) or per-raster
+(memory-heavy).
 """
 import numpy as np
 import pytest
@@ -115,11 +117,15 @@ def test_dask_with_mask_row_batched_matches_numpy():
 
 
 @dask_array_available
-def test_one_compute_per_chunk_row(monkeypatch):
-    """`_polygonize_dask` should call dask.compute once per chunk row.
+def test_compute_batches_chunks(monkeypatch):
+    """`_polygonize_dask` should batch chunks per dask.compute call.
 
-    A 4x3 chunk grid (4 rows, 3 cols) must produce exactly 4 compute
-    calls -- one per row -- not 12 (per chunk) and not 1 (per raster).
+    A 4x3 chunk grid is 12 chunks total.  With ``batch_size=5`` that is
+    ceil(12 / 5) = 3 compute calls (sizes 5, 5, 2) -- not 12 (per chunk,
+    serial) and not 1 (per raster, memory-heavy).  This pins the bounded
+    batching from #2664, which superseded the per-row batching of #2608
+    so peak memory is bounded by ``batch_size`` rather than by the number
+    of column chunks.
     """
     shape = (40, 30)
     rng = np.random.default_rng(5)
@@ -128,6 +134,7 @@ def test_one_compute_per_chunk_row(monkeypatch):
     n_rows = len(dask_data.chunks[0])
     n_cols = len(dask_data.chunks[1])
     assert (n_rows, n_cols) == (4, 3)
+    n_chunks = n_rows * n_cols
 
     import sys
     # The package re-exports ``polygonize`` (the function) as
@@ -148,9 +155,12 @@ def test_one_compute_per_chunk_row(monkeypatch):
 
     monkeypatch.setattr(poly_mod.dask, "compute", counting_compute)
 
-    _polygonize_dask(dask_data, None, False, None)
+    batch_size = 5
+    _polygonize_dask(dask_data, None, False, None, batch_size=batch_size)
 
-    # One compute per row of chunks.
-    assert calls["count"] == n_rows
-    # Each compute batches all chunks in that row.
-    assert all(size == n_cols for size in calls["sizes"])
+    # ceil(n_chunks / batch_size) compute calls.
+    expected_calls = -(-n_chunks // batch_size)
+    assert calls["count"] == expected_calls
+    # Each call batches up to batch_size chunks; total chunks add up.
+    assert all(size <= batch_size for size in calls["sizes"])
+    assert sum(calls["sizes"]) == n_chunks


### PR DESCRIPTION
Closes #2664

## Background

The dask backend for `polygonize` originally called `dask.compute` once per chunk in a nested loop, so it ran serially. #2608 already moved it to per-row batching (one compute per row of chunks). This PR generalizes that into a fixed `batch_size` so the memory bound no longer scales with the chunk-grid shape.

## What

- Build the per-chunk `dask.delayed(_polygonize_chunk)` tasks in row-major order, then compute them in bounded batches (one `dask.compute(*tasks)` call per batch).
- Default batch size is 32 chunks. Larger batches mean more parallelism and higher peak memory; smaller batches cap memory harder. Per-row batching bounded memory by one row of chunks, which grows with the number of column chunks; a fixed batch size bounds it independent of grid shape. The tradeoff is documented in the `_polygonize_dask` docstring, a code comment, and `docs/source/reference/dask_laziness.rst`.

## Why it is output-identical

Tasks are built and their results consumed in the same row-major `(iy, ix)` order the serial loop used. Interior and boundary polygons accumulate in that order, so the downstream boundary-merge stage sees the same input. `batch_size=1` reproduces the old per-chunk behaviour exactly.

## Backend coverage

Touches the dask path only (dask+numpy and dask+cupy both route through `_polygonize_dask`). numpy and cupy paths are unchanged.

## Test plan

- [x] `test_polygonize_dask_batch_size_invariant`: batched output is vertex-identical to `batch_size=1` across batch sizes 1, 2, 3, 100 on a 9-chunk raster.
- [x] `test_polygonize_dask_batched_matches_numpy_areas`: batched multi-chunk areas match numpy for batch sizes 1, 4, 100.
- [x] Updated the #2608 regression test (`test_compute_batches_chunks`) to pin the bounded-batch contract: ceil(n_chunks / batch_size) compute calls, neither per-chunk nor per-raster.
- [x] Existing `xrspatial/tests/test_polygonize*.py` pass.