### PR TITLE
Enforce single-line records in sweep state CSV writers

### DIFF
--- a/.claude/commands/deep-sweep.md
+++ b/.claude/commands/deep-sweep.md
@@ -119,11 +119,17 @@ with path.open() as f:
     reader = csv.DictReader(f)
     header = reader.fieldnames
     rows = [r for r in reader if r["module"] != "{module}"]
+def _oneline(v):
+    # merge=union is line-based: a newline inside a quoted field splits
+    # the record on parallel-agent merges. Force one physical line per
+    # record by collapsing embedded newlines to " | ".
+    return "" if v is None else str(v).replace("\r\n", " | ").replace("\r", " | ").replace("\n", " | ")
+
 with path.open("w", newline="") as f:
     w = csv.DictWriter(f, fieldnames=header, quoting=csv.QUOTE_MINIMAL)
     w.writeheader()
     for r in rows:
-        w.writerow(r)
+        w.writerow({k: _oneline(v) for k, v in r.items()})
 ```
 
 This removes only the target module's row from each state file, leaving

--- a/.claude/commands/sweep-accuracy.md
+++ b/.claude/commands/sweep-accuracy.md
@@ -263,11 +263,17 @@ If CUDA_AVAILABLE is false:
        "notes": "<single-line notes (replace any newlines with spaces), or empty>",
    }
 
+   def _oneline(v):
+       # merge=union is line-based: a newline inside a quoted field splits
+       # the record on parallel-agent merges. Force one physical line per
+       # record by collapsing embedded newlines to " | ".
+       return "" if v is None else str(v).replace("\r\n", " | ").replace("\r", " | ").replace("\n", " | ")
+
    with path.open("w", newline="") as f:
        w = csv.DictWriter(f, fieldnames=header, quoting=csv.QUOTE_MINIMAL)
        w.writeheader()
        for m in sorted(rows):
-           w.writerow(rows[m])
+           w.writerow({k: _oneline(v) for k, v in rows[m].items()})
    ```
 
    Use empty strings (not `null`) for missing values. Set `issue` to the

--- a/.claude/commands/sweep-api-consistency.md
+++ b/.claude/commands/sweep-api-consistency.md
@@ -238,11 +238,17 @@ If CUDA_AVAILABLE is false:
        "notes": "<single-line notes or empty>",
    }
 
+   def _oneline(v):
+       # merge=union is line-based: a newline inside a quoted field splits
+       # the record on parallel-agent merges. Force one physical line per
+       # record by collapsing embedded newlines to " | ".
+       return "" if v is None else str(v).replace("\r\n", " | ").replace("\r", " | ").replace("\n", " | ")
+
    with path.open("w", newline="") as f:
        w = csv.DictWriter(f, fieldnames=header, quoting=csv.QUOTE_MINIMAL)
        w.writeheader()
        for m in sorted(rows):
-           w.writerow(rows[m])
+           w.writerow({k: _oneline(v) for k, v in rows[m].items()})
    ```
 
    Then `git add` and commit.

--- a/.claude/commands/sweep-metadata.md
+++ b/.claude/commands/sweep-metadata.md
@@ -266,11 +266,17 @@ If CUDA_AVAILABLE is false:
        "notes": "<single-line notes (replace any newlines with spaces), or empty>",
    }
 
+   def _oneline(v):
+       # merge=union is line-based: a newline inside a quoted field splits
+       # the record on parallel-agent merges. Force one physical line per
+       # record by collapsing embedded newlines to " | ".
+       return "" if v is None else str(v).replace("\r\n", " | ").replace("\r", " | ").replace("\n", " | ")
+
    with path.open("w", newline="") as f:
        w = csv.DictWriter(f, fieldnames=header, quoting=csv.QUOTE_MINIMAL)
        w.writeheader()
        for m in sorted(rows):
-           w.writerow(rows[m])
+           w.writerow({k: _oneline(v) for k, v in rows[m].items()})
    ```
 
    Use empty strings (not `null`) for missing values.

--- a/.claude/commands/sweep-performance.md
+++ b/.claude/commands/sweep-performance.md
@@ -289,11 +289,17 @@ If CUDA_AVAILABLE is false:
        "notes": "<single-line notes (replace any newlines with spaces), or empty>",
    }
 
+   def _oneline(v):
+       # merge=union is line-based: a newline inside a quoted field splits
+       # the record on parallel-agent merges. Force one physical line per
+       # record by collapsing embedded newlines to " | ".
+       return "" if v is None else str(v).replace("\r\n", " | ").replace("\r", " | ").replace("\n", " | ")
+
    with path.open("w", newline="") as f:
        w = csv.DictWriter(f, fieldnames=header, quoting=csv.QUOTE_MINIMAL)
        w.writeheader()
        for m in sorted(rows):
-           w.writerow(rows[m])
+           w.writerow({k: _oneline(v) for k, v in rows[m].items()})
    ```
 
    Use empty strings (not `null`) for missing values. Set `issue` to the

--- a/.claude/commands/sweep-security.md
+++ b/.claude/commands/sweep-security.md
@@ -264,11 +264,17 @@ If CUDA_AVAILABLE is false:
        "notes": "<single-line notes (replace any newlines with spaces), or empty>",
    }
 
+   def _oneline(v):
+       # merge=union is line-based: a newline inside a quoted field splits
+       # the record on parallel-agent merges. Force one physical line per
+       # record by collapsing embedded newlines to " | ".
+       return "" if v is None else str(v).replace("\r\n", " | ").replace("\r", " | ").replace("\n", " | ")
+
    with path.open("w", newline="") as f:
        w = csv.DictWriter(f, fieldnames=header, quoting=csv.QUOTE_MINIMAL)
        w.writeheader()
        for m in sorted(rows):
-           w.writerow(rows[m])
+           w.writerow({k: _oneline(v) for k, v in rows[m].items()})
    ```
 
    Use empty strings (not `null`) for missing values. Set `issue` to the

--- a/.claude/commands/sweep-test-coverage.md
+++ b/.claude/commands/sweep-test-coverage.md
@@ -239,11 +239,17 @@ If CUDA_AVAILABLE is false:
        "notes": "<single-line notes or empty>",
    }
 
+   def _oneline(v):
+       # merge=union is line-based: a newline inside a quoted field splits
+       # the record on parallel-agent merges. Force one physical line per
+       # record by collapsing embedded newlines to " | ".
+       return "" if v is None else str(v).replace("\r\n", " | ").replace("\r", " | ").replace("\n", " | ")
+
    with path.open("w", newline="") as f:
        w = csv.DictWriter(f, fieldnames=header, quoting=csv.QUOTE_MINIMAL)
        w.writeheader()
        for m in sorted(rows):
-           w.writerow(rows[m])
+           w.writerow({k: _oneline(v) for k, v in rows[m].items()})
    ```
 
    Then `git add` and commit.


### PR DESCRIPTION
Closes #2680

## What

Adds an `_oneline()` sanitizer to every sweep state-CSV writer so each record is always one physical line, even when a note contains newlines.

## Why

The `.claude/sweep-*-state.csv` files use `merge=union` so parallel sweep agents can append rows. Union merge is line-based, but the writers used `csv.DictWriter` with `QUOTE_MINIMAL`, which is valid CSV yet writes a newline-containing note as a quoted field spanning several physical lines. Concurrent appends then split those records on their internal newlines, producing phantom rows and duplicate headers. PR #2679 repaired one such corruption by hand; this stops it recurring at the source.

The previous `"single-line notes or empty"` placeholder was a hint, not enforcement, so nothing prevented a multi-line note.

## How

Each writer (six `sweep-*.md` commands plus the `deep-sweep` reset path) now routes every field through `_oneline()`, which replaces CR/LF with `" | "` right before `writerow`.

## Verification

Simulated the patched writer and a union merge:
- A note containing `\n`, `\r\n`, and `\r` writes to exactly one physical line and round-trips through `csv.DictReader`.
- Control: the old writer produced 4 physical lines for the same note (the bug).
- A union merge of two concurrent single-line writes yields clean records with no phantom rows.

No pytest test is added: these are instruction templates in `.claude/commands/`, not importable code, so there is no unit to import in `xrspatial/tests/`. Verification is the simulation above.

## Scope note

`.claude/commands/sweep-style.md` is untracked in the working tree and not part of this branch, so it is not patched here. It needs the same `_oneline()` change when it is committed.