### PR TITLE
contours: validate input raster, reject complex dtype

### DIFF
--- a/xrspatial/contour.py
+++ b/xrspatial/contour.py
@@ -13,7 +13,7 @@ from typing import List, Optional, Sequence, Tuple, Union
 import numpy as np
 import xarray as xr
 
-from .utils import ArrayTypeFunctionMapping, ngjit
+from .utils import ArrayTypeFunctionMapping, _validate_raster, ngjit
 
 try:
     import dask
@@ -602,8 +602,7 @@ def contours(
     >>> # Each entry is (level_value, Nx2_coordinate_array)
     >>> level, coords = lines[0]
     """
-    if agg.ndim != 2:
-        raise ValueError("Input raster must be 2D")
+    _validate_raster(agg, func_name='contours', name='agg', ndim=2)
     if agg.shape[0] < 2 or agg.shape[1] < 2:
         raise ValueError(
             "Input raster must have at least 2 rows and 2 columns"

--- a/xrspatial/tests/test_contour.py
+++ b/xrspatial/tests/test_contour.py
@@ -180,6 +180,19 @@ class TestEdgeCases:
         with pytest.raises(ValueError, match="at least 2"):
             contours(agg, levels=[0.5])
 
+    def test_complex_dtype_rejected(self):
+        """Complex input raises instead of silently dropping the imaginary part."""
+        data = np.ones((3, 3), dtype=np.complex128)
+        agg = xr.DataArray(data, dims=['y', 'x'])
+        with pytest.raises(ValueError, match="real numeric"):
+            contours(agg, levels=[0.5])
+
+    def test_non_dataarray_rejected(self):
+        """A plain ndarray raises a clear TypeError, not a late dispatch error."""
+        data = np.ones((3, 3), dtype=np.float64)
+        with pytest.raises(TypeError, match="xarray.DataArray"):
+            contours(data, levels=[0.5])
+
 
 # ---------------------------------------------------------------------------
 # Segment stitching


### PR DESCRIPTION
Closes #2701

## What

`contours()` did not validate its input before processing. This adds the standard `_validate_raster()` check the rest of the codebase uses.

- A complex-dtype DataArray was silently coerced to float64 (imaginary part dropped, only a ComplexWarning), so contours were traced on the real part instead of being rejected. Now raises ValueError.
- A non-DataArray input failed late inside `ArrayTypeFunctionMapping` with `TypeError: Unsupported Array Type`. Now raises a clear TypeError up front.

The inline `ndim == 2` check is removed because `_validate_raster(..., ndim=2)` covers it with the same "must be 2D" message.

## Backends

Validation runs before backend dispatch, so the single check covers numpy, cupy, dask+numpy, and dask+cupy. No backend-specific code changed.

## Test plan

- [x] Added test for complex dtype rejection (ValueError)
- [x] Added test for non-DataArray rejection (TypeError)
- [x] Full test_contour.py suite passes (26 tests, including cupy and dask+cupy equivalence on a CUDA host)