### PR TITLE
contours: handle infinite nan coords

### DIFF
--- a/xrspatial/contour.py
+++ b/xrspatial/contour.py
@@ -66,8 +66,9 @@ def _marching_squares_kernel(data, level, seg_rows, seg_cols, seg_count):
             bl = data[r + 1, c]
             br = data[r + 1, c + 1]
 
-            # Skip quads with any NaN corner.
-            if tl != tl or tr != tr or bl != bl or br != br:
+            # Skip quads with any non-finite corner (NaN or +/-inf).
+            if not (np.isfinite(tl) and np.isfinite(tr) and
+                    np.isfinite(bl) and np.isfinite(br)):
                 continue
 
             # Build 4-bit case index.

--- a/xrspatial/tests/test_contour.py
+++ b/xrspatial/tests/test_contour.py
@@ -133,6 +133,65 @@ class TestNaNHandling:
 
 
 # ---------------------------------------------------------------------------
+# Inf handling
+# ---------------------------------------------------------------------------
+
+class TestInfHandling:
+
+    def test_pos_inf_center(self):
+        """A quad touching +inf must not produce NaN coordinates."""
+        data = np.array([
+            [0., 0., 0., 0., 0.],
+            [0., 1., 1., 1., 0.],
+            [0., 1., np.inf, 1., 0.],
+            [0., 1., 1., 1., 0.],
+            [0., 0., 0., 0., 0.],
+        ], dtype=np.float64)
+        agg = create_test_raster(data, backend='numpy')
+        result = contours(agg, levels=[1.5])
+        for level, coords in result:
+            assert np.isfinite(coords).all(), \
+                f"Non-finite coordinates found at level {level}"
+
+    def test_neg_inf_center(self):
+        """A quad touching -inf must not produce NaN coordinates."""
+        data = np.array([
+            [0., 0., 0., 0., 0.],
+            [0., 1., 1., 1., 0.],
+            [0., 1., -np.inf, 1., 0.],
+            [0., 1., 1., 1., 0.],
+            [0., 0., 0., 0., 0.],
+        ], dtype=np.float64)
+        agg = create_test_raster(data, backend='numpy')
+        result = contours(agg, levels=[1.5])
+        for level, coords in result:
+            assert np.isfinite(coords).all(), \
+                f"Non-finite coordinates found at level {level}"
+
+    def test_mixed_inf(self):
+        """Multiple infinities of opposite signs must not produce NaN."""
+        data = np.array([
+            [0., 0., 0., 0., 0.],
+            [0., np.inf, 1., -np.inf, 0.],
+            [0., 1., 1., 1., 0.],
+            [0., -np.inf, 1., np.inf, 0.],
+            [0., 0., 0., 0., 0.],
+        ], dtype=np.float64)
+        agg = create_test_raster(data, backend='numpy')
+        result = contours(agg, levels=[0.5])
+        for level, coords in result:
+            assert np.isfinite(coords).all(), \
+                f"Non-finite coordinates found at level {level}"
+
+    def test_all_inf_quad(self):
+        """A 2x2 raster with all corners infinite produces no contours."""
+        data = np.full((2, 2), np.inf, dtype=np.float64)
+        agg = create_test_raster(data, backend='numpy')
+        result = contours(agg, levels=[1.0])
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
 # Edge cases
 # ---------------------------------------------------------------------------
 

--- a/xrspatial/tests/test_contour.py
+++ b/xrspatial/tests/test_contour.py
@@ -133,65 +133,6 @@ class TestNaNHandling:
 
 
 # ---------------------------------------------------------------------------
-# Inf handling
-# ---------------------------------------------------------------------------
-
-class TestInfHandling:
-
-    def test_pos_inf_center(self):
-        """A quad touching +inf must not produce NaN coordinates."""
-        data = np.array([
-            [0., 0., 0., 0., 0.],
-            [0., 1., 1., 1., 0.],
-            [0., 1., np.inf, 1., 0.],
-            [0., 1., 1., 1., 0.],
-            [0., 0., 0., 0., 0.],
-        ], dtype=np.float64)
-        agg = create_test_raster(data, backend='numpy')
-        result = contours(agg, levels=[1.5])
-        for level, coords in result:
-            assert np.isfinite(coords).all(), \
-                f"Non-finite coordinates found at level {level}"
-
-    def test_neg_inf_center(self):
-        """A quad touching -inf must not produce NaN coordinates."""
-        data = np.array([
-            [0., 0., 0., 0., 0.],
-            [0., 1., 1., 1., 0.],
-            [0., 1., -np.inf, 1., 0.],
-            [0., 1., 1., 1., 0.],
-            [0., 0., 0., 0., 0.],
-        ], dtype=np.float64)
-        agg = create_test_raster(data, backend='numpy')
-        result = contours(agg, levels=[1.5])
-        for level, coords in result:
-            assert np.isfinite(coords).all(), \
-                f"Non-finite coordinates found at level {level}"
-
-    def test_mixed_inf(self):
-        """Multiple infinities of opposite signs must not produce NaN."""
-        data = np.array([
-            [0., 0., 0., 0., 0.],
-            [0., np.inf, 1., -np.inf, 0.],
-            [0., 1., 1., 1., 0.],
-            [0., -np.inf, 1., np.inf, 0.],
-            [0., 0., 0., 0., 0.],
-        ], dtype=np.float64)
-        agg = create_test_raster(data, backend='numpy')
-        result = contours(agg, levels=[0.5])
-        for level, coords in result:
-            assert np.isfinite(coords).all(), \
-                f"Non-finite coordinates found at level {level}"
-
-    def test_all_inf_quad(self):
-        """A 2x2 raster with all corners infinite produces no contours."""
-        data = np.full((2, 2), np.inf, dtype=np.float64)
-        agg = create_test_raster(data, backend='numpy')
-        result = contours(agg, levels=[1.0])
-        assert result == []
-
-
-# ---------------------------------------------------------------------------
 # Edge cases
 # ---------------------------------------------------------------------------
 
@@ -597,18 +538,11 @@ class TestInfHandling:
             assert np.isfinite(coords).all(), (
                 "level 0.5 ring should not include the inf quad")
 
-    @pytest.mark.xfail(
-        reason="contours() emits NaN coordinates near an inf corner; "
-               "see https://github.com/xarray-contrib/xarray-spatial/"
-               "issues/2704",
-        strict=True,
-    )
     def test_inf_corner_no_nan_coords(self):
         """A finite level near a +inf cell must not leak NaN coordinates.
 
-        The NaN-skip guard in the kernel uses ``x != x`` which does not
-        catch infinity, so the inf quad is interpolated and produces NaN.
-        Tracked as a source bug in #2704.
+        Regression for #2704: the NaN-skip guard in the kernel used ``x != x``
+        which does not catch infinity; fixed by using ``np.isfinite``.
         """
         data = self._inf_peak(np.inf)
         agg = create_test_raster(data, backend='numpy')
@@ -617,20 +551,39 @@ class TestInfHandling:
             assert np.isfinite(coords).all(), (
                 f"non-finite coordinate in contour at level {level}: {coords}")
 
-    @pytest.mark.xfail(
-        reason="contours() emits NaN coordinates near a -inf corner; "
-               "see https://github.com/xarray-contrib/xarray-spatial/"
-               "issues/2704",
-        strict=True,
-    )
     def test_neg_inf_corner_no_nan_coords(self):
-        """Same NaN leak for a -inf corner. Tracked in #2704."""
+        """A finite level near a -inf cell must not leak NaN coordinates.
+
+        Regression for #2704: same fix as test_inf_corner_no_nan_coords.
+        """
         data = self._inf_peak(-np.inf)
         agg = create_test_raster(data, backend='numpy')
         result = contours(agg, levels=[0.5])
         for level, coords in result:
             assert np.isfinite(coords).all(), (
                 f"non-finite coordinate in contour at level {level}: {coords}")
+
+    def test_mixed_inf(self):
+        """Multiple infinities of opposite signs must not produce NaN."""
+        data = np.array([
+            [0., 0., 0., 0., 0.],
+            [0., np.inf, 1., -np.inf, 0.],
+            [0., 1., 1., 1., 0.],
+            [0., -np.inf, 1., np.inf, 0.],
+            [0., 0., 0., 0., 0.],
+        ], dtype=np.float64)
+        agg = create_test_raster(data, backend='numpy')
+        result = contours(agg, levels=[0.5])
+        for level, coords in result:
+            assert np.isfinite(coords).all(), \
+                f"Non-finite coordinates found at level {level}"
+
+    def test_all_inf_quad(self):
+        """A 2x2 raster with all corners infinite produces no contours."""
+        data = np.full((2, 2), np.inf, dtype=np.float64)
+        agg = create_test_raster(data, backend='numpy')
+        result = contours(agg, levels=[1.0])
+        assert result == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Closes #2704 
This PR fixes the contour generation to properly handle input data containing infinite values. The marching squares algorithm now skips quadrilaterals with non-finite corners instead of producing invalid output or raising errors.

**Key change:**
- **contour**: Skip quads with any non-finite (NaN, +inf, -inf) corner values during contour line generation

## AI-assisted review

- [x] I ran the xarray-spatial AI-assisted review workflow for this PR.
- [x] I reviewed the AI output myself and made my own judgment about what to accept.
- [x] I understand this change and can maintain it.
- [x] This PR does not attribute authorship to an AI tool or service.

## AI-assisted review notes

The xarray-spatial review workflow was run against this change.

**Issues found and addressed:**
- Added regression tests for contour handling of infinite values (`np.inf`, `-np.inf`)
- Verified no change to public API behavior
- Confirmed existing NaN handling remains correct

**Open concerns:**
- None identified

## Tests

Added tests in `test_contour.py` covering:
- Contour generation with `np.inf` values in input arrays
- Contour generation with `-np.inf` values in input arrays
- Mixed finite and infinite value scenarios