### PR TITLE
Validate focal_stats() stats_funcs before dispatch

### DIFF
--- a/xrspatial/focal.py
+++ b/xrspatial/focal.py
@@ -1121,6 +1121,28 @@ def _focal_stats_cpu(agg, kernel, stats_funcs, boundary='nan'):
     return stats
 
 
+_VALID_STATS_FUNCS = ('mean', 'max', 'min', 'range', 'std', 'var',
+                      'sum', 'variety')
+
+
+def _validate_stats_funcs(stats_funcs):
+    """Normalise and validate the ``stats_funcs`` argument of focal_stats.
+
+    A bare string is wrapped into a one-element list so it is not iterated
+    character by character. Unknown names raise a ValueError listing the
+    valid options.
+    """
+    if isinstance(stats_funcs, str):
+        stats_funcs = [stats_funcs]
+    unknown = [s for s in stats_funcs if s not in _VALID_STATS_FUNCS]
+    if unknown:
+        raise ValueError(
+            f"Invalid stats_funcs {unknown}, "
+            f"must be one of {list(_VALID_STATS_FUNCS)}"
+        )
+    return stats_funcs
+
+
 def focal_stats(agg,
                 kernel,
                 stats_funcs=None,
@@ -1193,8 +1215,9 @@ def focal_stats(agg,
         Dimensions without coordinates: dim_0, dim_1
     """
     if stats_funcs is None:
-        stats_funcs = ['mean', 'max', 'min', 'range', 'std', 'var',
-                       'sum', 'variety']
+        stats_funcs = list(_VALID_STATS_FUNCS)
+    else:
+        stats_funcs = _validate_stats_funcs(stats_funcs)
 
     _validate_raster(agg, func_name='focal_stats', name='agg', ndim=(2, 3))
 

--- a/xrspatial/focal.py
+++ b/xrspatial/focal.py
@@ -1134,6 +1134,11 @@ def _validate_stats_funcs(stats_funcs):
     """
     if isinstance(stats_funcs, str):
         stats_funcs = [stats_funcs]
+    if len(stats_funcs) == 0:
+        raise ValueError(
+            f"stats_funcs must not be empty, "
+            f"choose from {list(_VALID_STATS_FUNCS)}"
+        )
     unknown = [s for s in stats_funcs if s not in _VALID_STATS_FUNCS]
     if unknown:
         raise ValueError(

--- a/xrspatial/tests/test_focal.py
+++ b/xrspatial/tests/test_focal.py
@@ -1397,6 +1397,31 @@ def test_focal_stats_default_stats_funcs():
     assert result.sizes['stats'] == 8
 
 
+def test_focal_stats_rejects_unknown_stats_func():
+    # Regression for #2770: an unknown name used to fall through as a raw
+    # KeyError. It must now raise a clear ValueError listing valid options.
+    agg = xr.DataArray(data_random)
+    with pytest.raises(ValueError, match=r"Invalid stats_funcs.*bogus"):
+        focal_stats(agg, _api_kernel, stats_funcs=['bogus'])
+
+
+def test_focal_stats_accepts_bare_string():
+    # Regression for #2770: a bare string used to be iterated character by
+    # character (e.g. 'mean' -> 'm','e','a','n') and fail. It must be treated
+    # as a single stat name.
+    agg = xr.DataArray(data_random)
+    result = focal_stats(agg, _api_kernel, stats_funcs='mean')
+    assert result.sizes['stats'] == 1
+    assert list(result.coords['stats'].values) == ['mean']
+
+
+def test_focal_stats_valid_list_happy_path():
+    agg = xr.DataArray(data_random)
+    result = focal_stats(agg, _api_kernel, stats_funcs=['mean', 'sum'])
+    assert result.sizes['stats'] == 2
+    assert list(result.coords['stats'].values) == ['mean', 'sum']
+
+
 @cuda_and_cupy_available
 def test_focal_stats_name_gpu():
     import cupy

--- a/xrspatial/tests/test_focal.py
+++ b/xrspatial/tests/test_focal.py
@@ -1415,6 +1415,14 @@ def test_focal_stats_accepts_bare_string():
     assert list(result.coords['stats'].values) == ['mean']
 
 
+def test_focal_stats_rejects_empty_stats_funcs():
+    # Regression for #2770: an empty list used to reach xr.concat and fail with
+    # an obscure error. It must raise a clear ValueError instead.
+    agg = xr.DataArray(data_random)
+    with pytest.raises(ValueError, match=r"stats_funcs must not be empty"):
+        focal_stats(agg, _api_kernel, stats_funcs=[])
+
+
 def test_focal_stats_valid_list_happy_path():
     agg = xr.DataArray(data_random)
     result = focal_stats(agg, _api_kernel, stats_funcs=['mean', 'sum'])


### PR DESCRIPTION
Closes #2770

## Summary
`focal_stats()` now checks its `stats_funcs` argument before dispatching to a backend. Before this, an unknown name fell through as a raw `KeyError`, and passing a bare string like `'mean'` got iterated character by character and blew up on `'m'`.

A new `_validate_stats_funcs` helper wraps a bare string into a one-element list and raises a `ValueError` that lists the valid options when it sees an unknown name.

## Backend coverage
Validation happens before backend dispatch, so it applies to numpy, cupy, dask+numpy, and dask+cupy alike.

## Test plan
- [x] Unknown name raises a clear `ValueError`
- [x] Bare string is treated as a single stat name
- [x] Valid list still works
- [x] Existing focal_stats suite still passes (30 passed)