### PR TITLE
polygonize: optimize visvalingam_whyatt with min-heap

### DIFF
--- a/benchmarks/benchmarks/polygonize.py
+++ b/benchmarks/benchmarks/polygonize.py
@@ -3,7 +3,7 @@ import xarray as xr
 
 from xrspatial import polygonize
 from xrspatial.polygonize import (
-    _calculate_regions, _scan,
+    _calculate_regions, _scan, _simplify_polygons,
 )
 
 try:
@@ -122,3 +122,22 @@ class PolygonizeTracing:
     def time_scan(self, nx):
         _scan(self.regions, self.values, self.mask, False, None,
               self.nx, self.ny)
+
+
+class PolygonizeSimplify:
+    """Benchmark polygonize with simplification (DP and VW)."""
+    params = (
+        [100, 300, 1000],
+        ["douglas-peucker", "visvalingam-whyatt"],
+    )
+    param_names = ("nx", "method")
+
+    def setup(self, nx, method):
+        ny = nx // 2
+        rng = np.random.default_rng(9461713)
+        raster = rng.integers(low=0, high=4, size=(ny, nx), dtype=np.int32)
+        self.raster = xr.DataArray(raster)
+
+    def time_simplify(self, nx, method):
+        polygonize(self.raster, simplify_tolerance=1.0,
+                   simplify_method=method)

--- a/xrspatial/polygonize.py
+++ b/xrspatial/polygonize.py
@@ -1809,7 +1809,8 @@ def _heap_push(heap_areas, heap_indices, heap_size, area, idx):
 def _heap_pop(heap_areas, heap_indices, heap_size):
     """Pop minimum from heap. Returns (area, idx, new_heap_size).
 
-    Returns (-1.0, -1, heap_size) if heap is empty.
+    Returns (-1.0, -1, heap_size) if heap is empty.  -1.0 is safe
+    as a sentinel because triangle areas are always non-negative.
     """
     if heap_size == 0:
         return -1.0, -1, heap_size
@@ -1870,16 +1871,19 @@ def _visvalingam_whyatt(coords, tolerance):
         areas[i] = abs((ax * (by - cy) + bx * (cy - ay) + cx * (ay - by)) / 2.0)
 
     removed = np.zeros(n, dtype=np.bool_)
-    remaining = n
 
     # Build min-heap of (area, index) for interior vertices.
+    # Each interior vertex is pushed once initially (n-2 entries), and at
+    # most 2 new entries are pushed per removal (one per affected neighbor),
+    # for a total of at most (n-2) + 2*(n-2) = 3n-6 entries.  n * 3
+    # provides a small safety margin.
     heap_areas = np.empty(n * 3, dtype=np.float64)
     heap_indices = np.empty(n * 3, dtype=np.int64)
     heap_size = 0
     for i in range(1, n - 1):
         heap_size = _heap_push(heap_areas, heap_indices, heap_size, areas[i], i)
 
-    while remaining > 2:
+    while True:
         # Pop minimum, skipping stale entries (lazy deletion).
         min_area = -1.0
         min_idx = -1
@@ -1897,7 +1901,6 @@ def _visvalingam_whyatt(coords, tolerance):
 
         # Remove vertex.
         removed[min_idx] = True
-        remaining -= 1
 
         # Update linked list.
         p = prev_idx[min_idx]

--- a/xrspatial/polygonize.py
+++ b/xrspatial/polygonize.py
@@ -1756,12 +1756,84 @@ def _douglas_peucker(coords, tolerance):
 
 
 @ngjit
+def _heap_sift_down(heap_areas, heap_indices, heap_size, idx):
+    """Sift element at idx down to restore min-heap property.
+
+    Ties on area are broken by smallest index, matching the O(n^2)
+    linear scan which uses strict ``<`` and iterates in index order.
+    """
+    while True:
+        smallest = idx
+        left = 2 * idx + 1
+        right = 2 * idx + 2
+        if left < heap_size:
+            if (heap_areas[left] < heap_areas[smallest]
+                    or (heap_areas[left] == heap_areas[smallest]
+                        and heap_indices[left] < heap_indices[smallest])):
+                smallest = left
+        if right < heap_size:
+            if (heap_areas[right] < heap_areas[smallest]
+                    or (heap_areas[right] == heap_areas[smallest]
+                        and heap_indices[right] < heap_indices[smallest])):
+                smallest = right
+        if smallest == idx:
+            break
+        heap_areas[idx], heap_areas[smallest] = heap_areas[smallest], heap_areas[idx]
+        heap_indices[idx], heap_indices[smallest] = heap_indices[smallest], heap_indices[idx]
+        idx = smallest
+
+
+@ngjit
+def _heap_push(heap_areas, heap_indices, heap_size, area, idx):
+    """Push (area, idx) onto heap and sift up. Returns new heap size.
+
+    Ties on area are broken by smallest index.
+    """
+    heap_areas[heap_size] = area
+    heap_indices[heap_size] = idx
+    i = heap_size
+    while i > 0:
+        parent = (i - 1) // 2
+        if (heap_areas[i] < heap_areas[parent]
+                or (heap_areas[i] == heap_areas[parent]
+                    and heap_indices[i] < heap_indices[parent])):
+            heap_areas[i], heap_areas[parent] = heap_areas[parent], heap_areas[i]
+            heap_indices[i], heap_indices[parent] = heap_indices[parent], heap_indices[i]
+            i = parent
+        else:
+            break
+    return heap_size + 1
+
+
+@ngjit
+def _heap_pop(heap_areas, heap_indices, heap_size):
+    """Pop minimum from heap. Returns (area, idx, new_heap_size).
+
+    Returns (-1.0, -1, heap_size) if heap is empty.
+    """
+    if heap_size == 0:
+        return -1.0, -1, heap_size
+    area = heap_areas[0]
+    idx = heap_indices[0]
+    heap_size -= 1
+    if heap_size > 0:
+        heap_areas[0] = heap_areas[heap_size]
+        heap_indices[0] = heap_indices[heap_size]
+        _heap_sift_down(heap_areas, heap_indices, heap_size, 0)
+    return area, idx, heap_size
+
+
+@ngjit
 def _visvalingam_whyatt(coords, tolerance):
     """Visvalingam-Whyatt area-based line simplification.
 
     Iteratively removes the vertex that forms the smallest triangle
     area with its neighbors, until no triangle area is below tolerance.
     Endpoints are always preserved.
+
+    Uses a binary min-heap keyed on triangle area for O(n log n) scaling
+    instead of the O(n^2) linear scan.  Lazy deletion via the ``removed``
+    flag handles stale heap entries.
 
     Parameters
     ----------
@@ -1786,7 +1858,6 @@ def _visvalingam_whyatt(coords, tolerance):
     for i in range(n):
         prev_idx[i] = i - 1
         next_idx[i] = i + 1
-    # Endpoints are never removed (sentinel values).
     prev_idx[0] = -1
     next_idx[n - 1] = -1
 
@@ -1801,14 +1872,25 @@ def _visvalingam_whyatt(coords, tolerance):
     removed = np.zeros(n, dtype=np.bool_)
     remaining = n
 
+    # Build min-heap of (area, index) for interior vertices.
+    heap_areas = np.empty(n * 3, dtype=np.float64)
+    heap_indices = np.empty(n * 3, dtype=np.int64)
+    heap_size = 0
+    for i in range(1, n - 1):
+        heap_size = _heap_push(heap_areas, heap_indices, heap_size, areas[i], i)
+
     while remaining > 2:
-        # Find vertex with minimum area.
-        min_area = np.inf
+        # Pop minimum, skipping stale entries (lazy deletion).
+        min_area = -1.0
         min_idx = -1
-        for i in range(1, n - 1):
-            if not removed[i] and areas[i] < min_area:
-                min_area = areas[i]
-                min_idx = i
+        while heap_size > 0:
+            area, idx, heap_size = _heap_pop(heap_areas, heap_indices, heap_size)
+            if idx == -1:
+                break
+            if not removed[idx] and area == areas[idx]:
+                min_area = area
+                min_idx = idx
+                break
 
         if min_idx == -1 or min_area >= tolerance:
             break
@@ -1825,7 +1907,7 @@ def _visvalingam_whyatt(coords, tolerance):
         if nx_i >= 0 and nx_i < n:
             prev_idx[nx_i] = p
 
-        # Recompute areas for affected neighbors.
+        # Recompute areas for affected neighbors and push to heap.
         if p > 0 and prev_idx[p] >= 0:
             ax, ay = coords[prev_idx[p], 0], coords[prev_idx[p], 1]
             bx, by = coords[p, 0], coords[p, 1]
@@ -1833,6 +1915,8 @@ def _visvalingam_whyatt(coords, tolerance):
             new_area = abs((ax * (by - cy) + bx * (cy - ay) + cx * (ay - by)) / 2.0)
             # Enforce monotonicity: area can only increase.
             areas[p] = max(new_area, min_area)
+            if not removed[p]:
+                heap_size = _heap_push(heap_areas, heap_indices, heap_size, areas[p], p)
 
         if nx_i >= 0 and nx_i < n - 1 and next_idx[nx_i] >= 0:
             ax, ay = coords[prev_idx[nx_i], 0], coords[prev_idx[nx_i], 1]
@@ -1840,6 +1924,8 @@ def _visvalingam_whyatt(coords, tolerance):
             cx, cy = coords[next_idx[nx_i], 0], coords[next_idx[nx_i], 1]
             new_area = abs((ax * (by - cy) + bx * (cy - ay) + cx * (ay - by)) / 2.0)
             areas[nx_i] = max(new_area, min_area)
+            if not removed[nx_i]:
+                heap_size = _heap_push(heap_areas, heap_indices, heap_size, areas[nx_i], nx_i)
 
     # Collect remaining vertices.
     count = 0

--- a/xrspatial/tests/test_polygonize.py
+++ b/xrspatial/tests/test_polygonize.py
@@ -1162,7 +1162,7 @@ class TestSimplifyHelpers:
 
         sizes = [50, 100, 200, 500]
         tolerance = 0.1
-        iterations = 20
+        iterations = 200
 
         for n in sizes:
             coords = make_coords(n)
@@ -1180,8 +1180,8 @@ class TestSimplifyHelpers:
             o2_time = (time.perf_counter() - start) / iterations
 
             ratio = heap_time / o2_time if o2_time > 0 else 0
-            # Sub-microsecond times have significant measurement noise;
-            # allow up to 3x overhead at this scale.
+            # 200 iterations reduce measurement noise; sub-microsecond times
+            # still have variance so allow up to 3x overhead at this scale.
             assert ratio < 3.0, (
                 f"Heap is {ratio:.2f}x slower than O(n^2) for n={n}, "
                 f"expected < 3x (heap={heap_time:.6f}s, o2={o2_time:.6f}s)"
@@ -1195,7 +1195,7 @@ class TestSimplifyHelpers:
         The heap-based implementation should scale as O(n log n), so
         when input size doubles, runtime should increase by less than 3x.
 
-        Uses larger inputs (2000-32000) and more iterations (10) for stable
+        Uses larger inputs (2000-32000) and more iterations (50) for stable
         timing measurements that avoid sub-millisecond noise.
         """
         import time
@@ -1218,9 +1218,9 @@ class TestSimplifyHelpers:
             _visvalingam_whyatt(coords, tolerance)
 
             start = time.perf_counter()
-            for _ in range(10):
+            for _ in range(50):
                 _visvalingam_whyatt(coords, tolerance)
-            elapsed = (time.perf_counter() - start) / 10
+            elapsed = (time.perf_counter() - start) / 50
             timings.append(elapsed)
 
         # When input size doubles, time should increase by less than 3x.

--- a/xrspatial/tests/test_polygonize.py
+++ b/xrspatial/tests/test_polygonize.py
@@ -948,6 +948,271 @@ class TestSimplifyHelpers:
         result = _visvalingam_whyatt(coords, 1.0)
         assert_allclose(result, coords)
 
+    def test_visvalingam_whyatt_heap_correctness(self):
+        """Heap implementation must produce identical results to O(n^2) baseline."""
+        from numba import njit
+
+        from ..polygonize import _visvalingam_whyatt
+
+        @njit
+        def _triangle_area_numba(a, b, c):
+            ax, ay = a[0], a[1]
+            bx, by = b[0], b[1]
+            cx, cy = c[0], c[1]
+            return abs((ax * (by - cy) + bx * (cy - ay) + cx * (ay - by)) / 2.0)
+
+        @njit
+        def _visvalingam_whyatt_o2(coords, tolerance):
+            """Original O(n^2) implementation for correctness comparison."""
+            n = len(coords)
+            if n <= 2:
+                return coords.copy()
+            prev_idx = np.empty(n, dtype=np.int64)
+            next_idx = np.empty(n, dtype=np.int64)
+            for i in range(n):
+                prev_idx[i] = i - 1
+                next_idx[i] = i + 1
+            prev_idx[0] = -1
+            next_idx[n - 1] = -1
+            areas = np.full(n, np.inf, dtype=np.float64)
+            for i in range(1, n - 1):
+                areas[i] = _triangle_area_numba(
+                    coords[prev_idx[i]], coords[i], coords[next_idx[i]]
+                )
+            removed = np.zeros(n, dtype=np.bool_)
+            remaining = n
+            while remaining > 2:
+                min_area = np.inf
+                min_idx = -1
+                for i in range(1, n - 1):
+                    if not removed[i] and areas[i] < min_area:
+                        min_area = areas[i]
+                        min_idx = i
+                if min_idx == -1 or min_area >= tolerance:
+                    break
+                removed[min_idx] = True
+                remaining -= 1
+                p = prev_idx[min_idx]
+                nx_i = next_idx[min_idx]
+                if p >= 0:
+                    next_idx[p] = nx_i
+                if nx_i >= 0 and nx_i < n:
+                    prev_idx[nx_i] = p
+                if p > 0 and prev_idx[p] >= 0:
+                    new_area = _triangle_area_numba(
+                        coords[prev_idx[p]], coords[p], coords[next_idx[p]]
+                    )
+                    areas[p] = max(new_area, min_area)
+                if nx_i >= 0 and nx_i < n - 1 and next_idx[nx_i] >= 0:
+                    new_area = _triangle_area_numba(
+                        coords[prev_idx[nx_i]], coords[nx_i], coords[next_idx[nx_i]]
+                    )
+                    areas[nx_i] = max(new_area, min_area)
+            count = 0
+            for i in range(n):
+                if not removed[i]:
+                    count += 1
+            result = np.empty((count, 2), dtype=np.float64)
+            j = 0
+            for i in range(n):
+                if not removed[i]:
+                    result[j, 0] = coords[i, 0]
+                    result[j, 1] = coords[i, 1]
+                    j += 1
+            return result
+
+        def make_coords(n, pattern="zigzag"):
+            if pattern == "straight":
+                return np.array([[float(i), 0.0] for i in range(n)], dtype=np.float64)
+            if pattern == "zigzag":
+                return np.array(
+                    [[float(i), float((i % 3) * 0.5)] for i in range(n)],
+                    dtype=np.float64,
+                )
+            if pattern == "triangle":
+                pts = []
+                for i in range(n):
+                    angle = 2.0 * np.pi * i / n
+                    pts.append([np.cos(angle), np.sin(angle)])
+                return np.array(pts, dtype=np.float64)
+            return np.array([[float(i), float(i * 0.1)] for i in range(n)], dtype=np.float64)
+
+        sizes = [5, 10, 50, 100, 500]
+        patterns = ["straight", "zigzag", "triangle", "linear"]
+        tolerances = [0.01, 0.1, 1.0]
+
+        for pattern in patterns:
+            for n in sizes:
+                for tol in tolerances:
+                    coords = make_coords(n, pattern)
+                    heap_result = _visvalingam_whyatt(coords, tol)
+                    o2_result = _visvalingam_whyatt_o2(coords, tol)
+                    assert heap_result.shape == o2_result.shape, (
+                        f"Shape mismatch for {pattern} n={n} tol={tol}: "
+                        f"heap={heap_result.shape} o2={o2_result.shape}"
+                    )
+                    assert_allclose(
+                        heap_result, o2_result, rtol=1e-10,
+                        err_msg=f"Output mismatch for {pattern} n={n} tol={tol}"
+                    )
+
+    def test_visvalingam_whyatt_no_regression_small_inputs(self):
+        """Heap must not regress performance for small inputs (n < 1000).
+
+        For typical polygon ring sizes, the heap overhead should not make
+        the implementation more than 2x slower than the O(n^2) baseline.
+        """
+        import time
+
+        from numba import njit
+
+        from ..polygonize import _visvalingam_whyatt
+
+        @njit
+        def _triangle_area_numba(a, b, c):
+            ax, ay = a[0], a[1]
+            bx, by = b[0], b[1]
+            cx, cy = c[0], c[1]
+            return abs((ax * (by - cy) + bx * (cy - ay) + cx * (ay - by)) / 2.0)
+
+        @njit
+        def _visvalingam_whyatt_o2(coords, tolerance):
+            n = len(coords)
+            if n <= 2:
+                return coords.copy()
+            prev_idx = np.empty(n, dtype=np.int64)
+            next_idx = np.empty(n, dtype=np.int64)
+            for i in range(n):
+                prev_idx[i] = i - 1
+                next_idx[i] = i + 1
+            prev_idx[0] = -1
+            next_idx[n - 1] = -1
+            areas = np.full(n, np.inf, dtype=np.float64)
+            for i in range(1, n - 1):
+                areas[i] = _triangle_area_numba(
+                    coords[prev_idx[i]], coords[i], coords[next_idx[i]]
+                )
+            removed = np.zeros(n, dtype=np.bool_)
+            remaining = n
+            while remaining > 2:
+                min_area = np.inf
+                min_idx = -1
+                for i in range(1, n - 1):
+                    if not removed[i] and areas[i] < min_area:
+                        min_area = areas[i]
+                        min_idx = i
+                if min_idx == -1 or min_area >= tolerance:
+                    break
+                removed[min_idx] = True
+                remaining -= 1
+                p = prev_idx[min_idx]
+                nx_i = next_idx[min_idx]
+                if p >= 0:
+                    next_idx[p] = nx_i
+                if nx_i >= 0 and nx_i < n:
+                    prev_idx[nx_i] = p
+                if p > 0 and prev_idx[p] >= 0:
+                    new_area = _triangle_area_numba(
+                        coords[prev_idx[p]], coords[p], coords[next_idx[p]]
+                    )
+                    areas[p] = max(new_area, min_area)
+                if nx_i >= 0 and nx_i < n - 1 and next_idx[nx_i] >= 0:
+                    new_area = _triangle_area_numba(
+                        coords[prev_idx[nx_i]], coords[nx_i], coords[next_idx[nx_i]]
+                    )
+                    areas[nx_i] = max(new_area, min_area)
+            count = 0
+            for i in range(n):
+                if not removed[i]:
+                    count += 1
+            result = np.empty((count, 2), dtype=np.float64)
+            j = 0
+            for i in range(n):
+                if not removed[i]:
+                    result[j, 0] = coords[i, 0]
+                    result[j, 1] = coords[i, 1]
+                    j += 1
+            return result
+
+        def make_coords(n):
+            return np.array(
+                [[float(i), float((i % 3) * 0.5)] for i in range(n)],
+                dtype=np.float64,
+            )
+
+        sizes = [50, 100, 200, 500]
+        tolerance = 0.1
+        iterations = 20
+
+        for n in sizes:
+            coords = make_coords(n)
+            _visvalingam_whyatt(coords, tolerance)
+            _visvalingam_whyatt_o2(coords, tolerance)
+
+            start = time.perf_counter()
+            for _ in range(iterations):
+                _visvalingam_whyatt(coords, tolerance)
+            heap_time = (time.perf_counter() - start) / iterations
+
+            start = time.perf_counter()
+            for _ in range(iterations):
+                _visvalingam_whyatt_o2(coords, tolerance)
+            o2_time = (time.perf_counter() - start) / iterations
+
+            ratio = heap_time / o2_time if o2_time > 0 else 0
+            # Sub-microsecond times have significant measurement noise;
+            # allow up to 3x overhead at this scale.
+            assert ratio < 3.0, (
+                f"Heap is {ratio:.2f}x slower than O(n^2) for n={n}, "
+                f"expected < 3x (heap={heap_time:.6f}s, o2={o2_time:.6f}s)"
+            )
+
+    def test_visvalingam_whyatt_scales_subquadratic(self):
+        """_visvalingam_whyatt must scale sub-quadratically with input size.
+
+        Issue #2539: the original O(n^2) linear min-area scan caused
+        simplification to dominate on rings with thousands of vertices.
+        The heap-based implementation should scale as O(n log n), so
+        when input size doubles, runtime should increase by less than 3x.
+
+        Uses larger inputs (2000-32000) and more iterations (10) for stable
+        timing measurements that avoid sub-millisecond noise.
+        """
+        import time
+
+        from ..polygonize import _visvalingam_whyatt
+
+        def make_coords(n):
+            return np.array(
+                [[float(i), float((i % 3) * 0.5)] for i in range(n)],
+                dtype=np.float64,
+            )
+
+        sizes = [2000, 4000, 8000, 16000, 32000]
+        tolerance = 0.1
+        timings = []
+
+        for n in sizes:
+            coords = make_coords(n)
+            # Warm up (numba compilation + cache).
+            _visvalingam_whyatt(coords, tolerance)
+
+            start = time.perf_counter()
+            for _ in range(10):
+                _visvalingam_whyatt(coords, tolerance)
+            elapsed = (time.perf_counter() - start) / 10
+            timings.append(elapsed)
+
+        # When input size doubles, time should increase by less than 3x.
+        # O(n^2) would give ~4x; O(n log n) gives ~2.1-2.3x.
+        for i in range(len(timings) - 1):
+            ratio = timings[i + 1] / timings[i]
+            assert ratio < 3.0, (
+                f"Time ratio for {sizes[i]} -> {sizes[i+1]} is {ratio:.2f}x, "
+                f"expected < 3x (O(n^2) would give ~4x)"
+            )
+
+
     def test_simplify_polygons_drops_degenerate(self):
         """Polygons that collapse below 4 vertices should be dropped."""
         from ..polygonize import _simplify_polygons

--- a/xrspatial/tests/test_polygonize.py
+++ b/xrspatial/tests/test_polygonize.py
@@ -948,6 +948,26 @@ class TestSimplifyHelpers:
         result = _visvalingam_whyatt(coords, 1.0)
         assert_allclose(result, coords)
 
+    def test_visvalingam_whyatt_nan_coords(self):
+        """VW on all-NaN coords should return all points unchanged."""
+        from ..polygonize import _visvalingam_whyatt
+        coords = np.array(
+            [[np.nan, np.nan], [np.nan, np.nan], [np.nan, np.nan],
+             [np.nan, np.nan], [np.nan, np.nan]],
+            dtype=np.float64)
+        result = _visvalingam_whyatt(coords, 0.1)
+        assert_allclose(result, coords)
+
+    def test_visvalingam_whyatt_identical_coords(self):
+        """VW on all-identical coords should simplify to just endpoints."""
+        from ..polygonize import _visvalingam_whyatt
+        coords = np.array(
+            [[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]],
+            dtype=np.float64)
+        result = _visvalingam_whyatt(coords, 0.01)
+        expected = np.array([[0.0, 0.0], [0.0, 0.0]], dtype=np.float64)
+        assert_allclose(result, expected)
+
     def test_visvalingam_whyatt_heap_correctness(self):
         """Heap implementation must produce identical results to O(n^2) baseline."""
         from numba import njit


### PR DESCRIPTION
Closes #2539

# Summary
Replace the O(n²) linear minimum-area scan in `_visvalingam_whyatt` with a binary min-heap keyed on triangle area, achieving **O(n log n)** scaling for line/polygon simplification.

## Why this solves the performance problem
The original `_visvalingam_whyatt` iteratively removes the vertex with the smallest triangle area
On each iteration it scans all remaining interior vertices to find the minimum — an O(n²) cost. 
For polygon rings with tens of thousands of vertices (common in high-resolution rasters), this quadratic scan dominates runtime.
This PR replaces that linear scan with a binary min-heap storing (area, index) pairs:

- Heap operations are O(log n): `_heap_push` and `_heap_pop` sift up/down in logarithmic time, so each of the n removals costs **O(log n)** instead of **O(n)**.
- Lazy deletion handles stale entries: After a vertex is removed, its neighbors' areas change. Rather than updating arbitrary heap elements (which would require an index map), the new area is simply `_heap_pushed` as a fresh entry. When the stale entry is popped later, the removed[idx] flag or a mismatched area tells us to skip it and pop the next one.
- Overall complexity drops from **O(n²)** to **O(n log n)**: Building the initial heap is **O(n)**, each removal is **O(log n)**, and each neighbor recomputation pushes **O(1)** entries — **totaling O(n log n).**