### PR TITLE
Fix compass-direction table in aspect() docstring

### DIFF
--- a/xrspatial/aspect.py
+++ b/xrspatial/aspect.py
@@ -350,8 +350,9 @@ def aspect(agg: xr.DataArray,
     From 67.5  to 112.5: East
     From 112.5 to 157.5: Southeast
     From 157.5 to 202.5: South
-    From 202.5 to 247.5: West
-    From 247.5 to 292.5: Northwest
+    From 202.5 to 247.5: Southwest
+    From 247.5 to 292.5: West
+    From 292.5 to 337.5: Northwest
     From 337.5 to 360:   North
 
     Note that values of -1 denote flat areas.


### PR DESCRIPTION
Closes #2825

The compass table in the `aspect()` docstring listed `247.5 to 292.5` twice (as both West and Northwest) and skipped `292.5 to 337.5`. This corrects it to the standard 8-point clockwise-from-north mapping.

- Docstring only; no behavior change
- The numeric aspect output was already correct, only the reference table was wrong

Backend coverage: not applicable (docstring change, no code path touched).

Test plan:
- [x] `from xrspatial import aspect` imports cleanly
- [x] Table has no duplicated or missing direction range