### PR TITLE
test(slope): cover planar boundary modes on cupy and dask+cupy backends

### DIFF
--- a/xrspatial/tests/test_slope.py
+++ b/xrspatial/tests/test_slope.py
@@ -111,6 +111,46 @@ def test_boundary_numpy_equals_dask(boundary, size, chunks):
         np_result.data, da_result.data.compute(), equal_nan=True, rtol=1e-5)
 
 
+@cuda_and_cupy_available
+@pytest.mark.parametrize("boundary", ['nan', 'nearest', 'reflect', 'wrap'])
+def test_boundary_numpy_equals_cupy(boundary):
+    # The planar cupy backend has its own non-'nan' boundary branch
+    # (_run_cupy pads, recurses, then crops). Pin it against the numpy
+    # reference for every boundary mode so a GPU-only boundary regression
+    # can't ship undetected.
+    rng = np.random.default_rng(42)
+    data = (rng.random((10, 15)).astype(np.float64) * 500)
+    numpy_agg = create_test_raster(data, backend='numpy', attrs={'res': (1, 1)})
+    cupy_agg = create_test_raster(data, backend='cupy', attrs={'res': (1, 1)})
+    np_result = slope(numpy_agg, boundary=boundary)
+    cupy_result = slope(cupy_agg, boundary=boundary)
+    np.testing.assert_allclose(
+        np_result.data, cupy_result.data.get(), equal_nan=True, rtol=1e-5)
+
+
+@dask_array_available
+@cuda_and_cupy_available
+@pytest.mark.parametrize("boundary", ['nan', 'nearest', 'reflect', 'wrap'])
+@pytest.mark.parametrize("size,chunks", [
+    ((10, 15), (5, 5)),    # multiple chunks → exercises overlap
+    ((10, 15), (10, 15)),  # single chunk (no overlap needed)
+])
+def test_boundary_numpy_equals_dask_cupy(boundary, size, chunks):
+    # The planar dask+cupy backend threads `boundary` through
+    # `_boundary_to_dask(..., is_cupy=True)` and map_overlap. Pin it against
+    # the numpy reference across chunkings so a GPU dask boundary regression
+    # can't ship undetected.
+    rng = np.random.default_rng(42)
+    data = (rng.random(size).astype(np.float64) * 500)
+    numpy_agg = create_test_raster(data, backend='numpy', attrs={'res': (1, 1)})
+    dask_cupy_agg = create_test_raster(data, backend='dask+cupy',
+                                       attrs={'res': (1, 1)}, chunks=chunks)
+    np_result = slope(numpy_agg, boundary=boundary)
+    dc_result = slope(dask_cupy_agg, boundary=boundary)
+    np.testing.assert_allclose(
+        np_result.data, dc_result.data.compute().get(), equal_nan=True, rtol=1e-5)
+
+
 @dask_array_available
 @pytest.mark.parametrize("boundary", ['nearest', 'reflect', 'wrap'])
 def test_boundary_no_nan_edges(boundary, elevation_raster_no_nans):

--- a/xrspatial/tests/test_slope.py
+++ b/xrspatial/tests/test_slope.py
@@ -134,6 +134,7 @@ def test_boundary_numpy_equals_cupy(boundary):
 @pytest.mark.parametrize("size,chunks", [
     ((10, 15), (5, 5)),    # multiple chunks → exercises overlap
     ((10, 15), (10, 15)),  # single chunk (no overlap needed)
+    ((7, 9), (3, 3)),      # ragged last chunk under depth-1 overlap
 ])
 def test_boundary_numpy_equals_dask_cupy(boundary, size, chunks):
     # The planar dask+cupy backend threads `boundary` through


### PR DESCRIPTION
Each planar slope backend handles the `boundary` parameter on its own. `test_boundary_modes` and `test_boundary_numpy_equals_dask` cover the numpy and dask+numpy paths across every mode, but neither GPU backend was ever tested with a non-default boundary.

That leaves two code paths unexercised. `_run_cupy` has its own pad-recurse-crop branch for `boundary != 'nan'`, and `_run_dask_cupy` passes the mode through `_boundary_to_dask(..., is_cupy=True)` and `map_overlap`. A regression in either would have shipped without a test catching it.

This adds two parametrized tests that compare the cupy and dask+cupy planar output against the numpy reference for `nan`, `nearest`, `reflect`, and `wrap`. The dask+cupy test runs both a multi-chunk and a single-chunk layout so the overlap path is covered.

Test-only, no source changes. Ran on a CUDA host: 12 new tests pass, full slope suite 103 passed.

---
Found by the test-coverage sweep against `slope`.
