### PR TITLE
fix(slope): reset .name on dask backends so all four backends agree

### DIFF
--- a/xrspatial/slope.py
+++ b/xrspatial/slope.py
@@ -429,8 +429,13 @@ def slope(agg: xr.DataArray,
         )
         out = mapper(agg)(agg.data, lat_2d, lon_2d, WGS84_A2, WGS84_B2, z_factor, boundary)
 
-    return xr.DataArray(out,
-                        name=name,
-                        coords=agg.coords,
-                        dims=agg.dims,
-                        attrs=agg.attrs)
+    result = xr.DataArray(out,
+                          name=name,
+                          coords=agg.coords,
+                          dims=agg.dims,
+                          attrs=agg.attrs)
+    # On dask backends, xr.DataArray keeps the dask array's internal graph
+    # token as .name when name=None, so reset it post-construction to match
+    # the numpy/cupy backends. (Same fix as zonal #2611, focal #2733.)
+    result.name = name
+    return result

--- a/xrspatial/tests/test_slope.py
+++ b/xrspatial/tests/test_slope.py
@@ -210,6 +210,68 @@ def test_name_none_accepted():
     assert result.name is None
 
 
+# The output .name must agree across backends. xr.DataArray keeps a dask
+# array's internal graph token (e.g. '_trim-<hash>' planar, 'getitem-<hash>'
+# geodesic) as .name when name=None, so the dask backends used to disagree
+# with numpy/cupy. Regression for the slope .name leak (same class as zonal
+# #2611, focal #2733, proximity #2723, viewshed #2743).
+def _assert_name_planar(backend, name):
+    data = np.random.default_rng(0).random((8, 10)).astype(np.float64) * 100
+    agg = create_test_raster(data, backend=backend, attrs={'res': (1, 1)},
+                             chunks=(3, 4))
+    assert slope(agg, name=name).name == name
+
+
+def _geodesic_raster(backend):
+    H, W = 8, 10
+    lat = np.linspace(40.0, 41.0, H)
+    lon = np.linspace(10.0, 11.0, W)
+    data = np.random.default_rng(1).random((H, W)) * 100
+    raster = xr.DataArray(
+        data, dims=['lat', 'lon'], coords={'lat': lat, 'lon': lon},
+    )
+    if 'cupy' in backend:
+        import cupy
+        raster.data = cupy.asarray(raster.data)
+    if 'dask' in backend:
+        import dask.array as da
+        raster.data = da.from_array(raster.data, chunks=(4, 5))
+    return raster
+
+
+def _assert_name_geodesic(backend, name):
+    result = slope(_geodesic_raster(backend), method='geodesic', name=name)
+    assert result.name == name
+
+
+@pytest.mark.parametrize("name", [None, 'slope'])
+def test_name_consistent_numpy(name):
+    _assert_name_planar('numpy', name)
+    _assert_name_geodesic('numpy', name)
+
+
+@dask_array_available
+@pytest.mark.parametrize("name", [None, 'slope'])
+def test_name_consistent_dask_numpy(name):
+    _assert_name_planar('dask+numpy', name)
+    _assert_name_geodesic('dask+numpy', name)
+
+
+@cuda_and_cupy_available
+@pytest.mark.parametrize("name", [None, 'slope'])
+def test_name_consistent_cupy(name):
+    _assert_name_planar('cupy', name)
+    _assert_name_geodesic('cupy', name)
+
+
+@dask_array_available
+@cuda_and_cupy_available
+@pytest.mark.parametrize("name", [None, 'slope'])
+def test_name_consistent_dask_cupy(name):
+    _assert_name_planar('dask+cupy', name)
+    _assert_name_geodesic('dask+cupy', name)
+
+
 # Degenerate shapes: a dimension too small for the 3x3 kernel to have an
 # interior. The planar CPU kernel loops over range(1, rows-1) (empty when
 # rows<=2), so the output keeps the input shape and comes back all-NaN. Pin


### PR DESCRIPTION
Closes #2837.

`slope(agg, name=None)` leaked the dask array's internal graph token as `.name` on the dask backends (`_trim-<hash>` planar, `getitem-<hash>` geodesic), while numpy and cupy returned `None`. Passing `name=None` to `xr.DataArray(dask_array, ...)` lets xarray adopt the dask name, so the public `.name` came out backend-dependent and non-deterministic.

The fix resets `result.name = name` after construction, so every backend returns `None` when `name=None` and the given name otherwise. Same approach already used for zonal (#2611), focal (#2733), and proximity (#2723).

### Tests
Four parametrized regression tests (one per backend) assert name consistency for both planar and geodesic methods. Full slope + geodesic-slope suite: 99 passed on a CUDA host.

Found by a metadata sweep of the slope module.