### PR TITLE
Guard dask geodesic aspect against single-chunk OOM

### DIFF
--- a/xrspatial/aspect.py
+++ b/xrspatial/aspect.py
@@ -15,11 +15,12 @@ import xarray as xr
 from numba import cuda
 
 from xrspatial.dataset_support import supports_dataset
-from xrspatial.geodesic import (INV_2R, WGS84_A2, WGS84_B2, _check_geodesic_memory,
+from xrspatial.geodesic import (INV_2R, WGS84_A2, WGS84_B2,
+                                _check_geodesic_memory_backend_aware,
                                 _cpu_geodesic_aspect, _run_gpu_geodesic_aspect)
 from xrspatial.utils import (Z_UNITS, ArrayTypeFunctionMapping, _boundary_to_dask,
                              _extract_latlon_coords, _pad_array, _validate_boundary,
-                             _validate_raster, cuda_args, get_dataarray_resolution, has_dask_array,
+                             _validate_raster, cuda_args, get_dataarray_resolution,
                              ngjit)
 
 
@@ -450,14 +451,7 @@ def aspect(agg: xr.DataArray,
             )
         z_factor = Z_UNITS[z_unit]
 
-        # The full-raster memory guard only applies to in-memory (numpy/cupy)
-        # arrays, which materialize the whole (3, H, W) stack at once. Dask
-        # backends process the raster chunk-by-chunk via map_overlap, so peak
-        # memory is bounded by chunk size, not full-raster size.
-        is_dask = has_dask_array() and isinstance(agg.data, da.Array)
-        if not is_dask:
-            rows, cols = agg.shape[-2], agg.shape[-1]
-            _check_geodesic_memory(rows, cols, func_name='aspect')
+        _check_geodesic_memory_backend_aware(agg, func_name='aspect')
 
         lat_2d, lon_2d = _extract_latlon_coords(agg)
 

--- a/xrspatial/tests/test_geodesic_aspect.py
+++ b/xrspatial/tests/test_geodesic_aspect.py
@@ -292,6 +292,22 @@ class TestGeodesicAspectMemoryGuard:
         computed = result.compute()
         assert computed.shape == (200, 200)
 
+    @dask_array_available
+    def test_dask_single_huge_chunk_still_rejected(self, monkeypatch):
+        """A dask array whose only chunk spans the whole raster has no memory
+        advantage over eager, so the backend-aware guard must still reject it
+        (issue #2840)."""
+        monkeypatch.setattr(
+            'xrspatial.geodesic._available_memory_bytes', lambda: 1024 * 1024
+        )
+        elev = _flat_surface(H=200, W=200)
+        raster = _make_geo_raster(
+            elev, 40.0, 41.0, 10.0, 11.0,
+            backend='dask+numpy', chunks=(200, 200),
+        )
+        with pytest.raises(MemoryError, match="aspect"):
+            aspect(raster, method='geodesic')
+
 
 # ---------------------------------------------------------------------------
 # Tests — cross-backend consistency


### PR DESCRIPTION
Closes #2840

## What changed

- The geodesic `aspect()` path skipped the memory guard for any dask-backed array, so a dask array whose only chunk spans the whole raster got no guard and could still OOM at compute time.
- Switched aspect to `_check_geodesic_memory_backend_aware`, the same helper `slope()` already uses. It sizes against the full raster for eager numpy/cupy and against the largest chunk plus the `map_overlap` halo for dask, so a single huge chunk is still rejected while small-chunked rasters stream through.
- Dropped the now-unused `has_dask_array` import and the inline `is_dask` check.

## Backend coverage

The guard now fires correctly on numpy, cupy, dask+numpy, and dask+cupy. The fix only changes which guard runs before the existing per-backend compute paths; those paths are unchanged.

## Test plan

- [x] Added `test_dask_single_huge_chunk_still_rejected` (mirrors slope's equivalent). Verified it fails on the old code (`DID NOT RAISE`) and passes with the fix.
- [x] `pytest xrspatial/tests/test_geodesic_aspect.py xrspatial/tests/test_aspect.py` — 236 passed.
- [x] flake8 clean on the changed lines.