### PR TITLE
Raise a clear error for non-2D custom kernels

### DIFF
--- a/xrspatial/convolution.py
+++ b/xrspatial/convolution.py
@@ -325,6 +325,12 @@ def custom_kernel(kernel):
             "The kernel received was of type {} and needs to be "
             "of type `ndarray`".format(type(kernel))
         )
+    elif kernel.ndim != 2:
+        raise ValueError(
+            "Received a custom kernel that is not a 2D array.",
+            "A custom kernel needs to be a 2D array, the supplied kernel "
+            "has shape {}.".format(kernel.shape)
+        )
     else:
         rows, cols = kernel.shape
 

--- a/xrspatial/tests/test_convolution.py
+++ b/xrspatial/tests/test_convolution.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from xrspatial.convolution import circle_kernel, convolve_2d
+from xrspatial.convolution import circle_kernel, convolve_2d, custom_kernel
 
 
 KERNEL = circle_kernel(1, 1, 1)
@@ -26,6 +26,18 @@ def test_convolve_2d_rejects_wrong_ndim():
     # 1D input should be rejected before reaching the kernel
     with pytest.raises(ValueError, match="must be 2D"):
         convolve_2d(np.zeros(10, dtype=np.float64), KERNEL)
+
+
+@pytest.mark.parametrize("bad_kernel", [
+    np.ones(3, dtype=np.float32),            # 1D
+    np.ones((3, 3, 3), dtype=np.float32),    # 3D
+])
+def test_custom_kernel_rejects_non_2d(bad_kernel):
+    # Regression for #2842: custom_kernel must raise a clear error for a
+    # non-2D kernel instead of leaking "not enough values to unpack" from
+    # the `rows, cols = kernel.shape` line.
+    with pytest.raises(ValueError, match="not a 2D array"):
+        custom_kernel(bad_kernel)
 
 
 def test_convolve_2d_accepts_float64():

--- a/xrspatial/tests/test_focal.py
+++ b/xrspatial/tests/test_focal.py
@@ -253,6 +253,24 @@ def test_apply_small_kernel_not_rejected_1284():
     assert out.shape == (50, 50)
 
 
+@pytest.mark.parametrize("entry_point", [
+    lambda agg, kernel: apply(agg, kernel),
+    lambda agg, kernel: focal_stats(agg, kernel, stats_funcs=['mean']),
+    lambda agg, kernel: hotspots(agg, kernel),
+])
+@pytest.mark.parametrize("bad_kernel", [
+    np.ones(3, dtype=np.float32),            # 1D
+    np.ones((3, 3, 3), dtype=np.float32),    # 3D
+])
+def test_entry_points_reject_non_2d_kernel_2842(entry_point, bad_kernel):
+    # Regression for #2842: a non-2D kernel must raise a clear, descriptive
+    # error rather than the raw "not enough values to unpack" ValueError
+    # leaking out of custom_kernel's `rows, cols = kernel.shape`.
+    raster = xr.DataArray(np.ones((10, 10), dtype=np.float32))
+    with pytest.raises(ValueError, match="not a 2D array"):
+        entry_point(raster, bad_kernel)
+
+
 def test_convolution_numpy(
     convolve_2d_data,
     convolution_custom_kernel,


### PR DESCRIPTION
Closes #2842

`custom_kernel` in `xrspatial/convolution.py` unpacked `rows, cols = kernel.shape` without first checking the kernel was 2D. A 1D or 3D kernel passed to `apply`, `focal_stats`, or `hotspots` (all of which route through `custom_kernel`) leaked a raw `ValueError: not enough values to unpack (expected 2, got 1)`.

- Added an `ndim != 2` check in `custom_kernel` that raises a clear `ValueError` reporting the offending shape, before the shape unpacking.
- Covered the three public entry points with 1D and 3D kernels, plus a direct `custom_kernel` unit test.

The check is backend-independent (it runs on the kernel argument before any dispatch), so it applies to numpy, cupy, dask+numpy, and dask+cupy alike.

Test plan:
- [x] New tests in test_convolution.py and test_focal.py pass
- [x] Existing convolution tests still pass