### PR TITLE
Fix proximity dask fallback mutating the caller's input chunks

### DIFF
--- a/xrspatial/proximity.py
+++ b/xrspatial/proximity.py
@@ -1378,12 +1378,15 @@ def _process(
 
     def _process_dask(raster, xs, ys):
 
+        # Rechunk into a local variable instead of reassigning raster.data,
+        # which would mutate the caller's input DataArray (issue #2847).
+        data = raster.data
         if max_distance >= max_possible_distance:
             # consider all targets in the whole raster
             # the data array is computed at once,
             # make sure your data fit your memory
             height, width = raster.shape
-            raster.data = raster.data.rechunk({0: height, 1: width})
+            data = data.rechunk({0: height, 1: width})
             xs = xs.rechunk({0: height, 1: width})
             ys = ys.rechunk({0: height, 1: width})
             pad_y = pad_x = 0
@@ -1393,7 +1396,7 @@ def _process(
 
         out = da.map_overlap(
             _process_numpy,
-            raster.data, xs, ys,
+            data, xs, ys,
             depth=(pad_y, pad_x),
             boundary=np.nan,
             meta=np.array((), dtype=np.float32),

--- a/xrspatial/tests/test_proximity.py
+++ b/xrspatial/tests/test_proximity.py
@@ -1621,3 +1621,62 @@ def test_great_circle_numpy_off_by_more_than_a_metre_is_fixed(
         raster, x='lon', y='lat', distance_metric='GREAT_CIRCLE').data
 
     assert np.nanmax(np.abs(result - expected)) < 1.0
+
+
+# ---------------------------------------------------------------------------
+# Regression: unbounded dask fallback must not mutate the caller's input
+# (issue #2847). _process_dask used to do raster.data = raster.data.rechunk(),
+# which rebound .data on the caller's DataArray for the GREAT_CIRCLE and
+# no-scipy fallback paths.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(da is None, reason="dask is not installed")
+@pytest.mark.parametrize("backend", ['dask+numpy', 'dask+cupy'])
+@pytest.mark.parametrize("op", [proximity, allocation, direction])
+def test_proximity_dask_great_circle_does_not_mutate_input(backend, op):
+    """GREAT_CIRCLE unbounded fallback keeps the input .data untouched."""
+    if has_cuda_and_cupy() is False and 'cupy' in backend:
+        pytest.skip("Requires CUDA and CuPy")
+
+    data = np.zeros((8, 10), dtype=np.float64)
+    data[2, 3] = 1.0
+    data[6, 8] = 2.0
+    raster = _backend_raster(data, backend)
+
+    data_before = raster.data
+    chunks_before = raster.data.chunks
+
+    op(raster, x='lon', y='lat', distance_metric='GREAT_CIRCLE')
+
+    assert raster.data is data_before, "proximity rebound the input .data"
+    assert raster.data.chunks == chunks_before, "proximity rechunked the input"
+
+
+@pytest.mark.skipif(da is None, reason="dask is not installed")
+@pytest.mark.parametrize("backend", ['dask+numpy', 'dask+cupy'])
+@pytest.mark.parametrize("op", [proximity, allocation, direction])
+def test_proximity_dask_no_scipy_does_not_mutate_input(backend, op):
+    """No-scipy unbounded fallback keeps the input .data untouched."""
+    if has_cuda_and_cupy() is False and 'cupy' in backend:
+        pytest.skip("Requires CUDA and CuPy")
+
+    import sys
+    prox_mod = sys.modules['xrspatial.proximity']
+
+    data = np.zeros((8, 10), dtype=np.float64)
+    data[2, 3] = 1.0
+    data[6, 8] = 2.0
+    raster = _backend_raster(data, backend)
+
+    data_before = raster.data
+    chunks_before = raster.data.chunks
+
+    original_ckdtree = prox_mod.cKDTree
+    try:
+        prox_mod.cKDTree = None
+        op(raster, x='lon', y='lat')
+    finally:
+        prox_mod.cKDTree = original_ckdtree
+
+    assert raster.data is data_before, "proximity rebound the input .data"
+    assert raster.data.chunks == chunks_before, "proximity rechunked the input"


### PR DESCRIPTION
Closes #2847

`_process_dask()` did `raster.data = raster.data.rechunk(...)` on the unbounded GREAT_CIRCLE and no-scipy fallback paths, which rebound `.data` on the caller's input DataArray. Code that reused the same DataArray afterward saw changed chunking.

## Changes
- Rechunk into a local variable in `_process_dask` instead of reassigning `raster.data`, so the input is left untouched.
- Add regression tests asserting the input `.data` keeps its identity and chunking after `proximity`/`allocation`/`direction` on both unbounded fallback paths.

## Backend coverage
The bug and fix are dask-only. Tests run on dask+numpy and dask+cupy. numpy and cupy paths never reassigned `.data` and are unaffected.

## Test plan
- [x] New mutation regression tests fail on the old code and pass on the fix
- [x] Full `test_proximity.py` suite passes (291 passed)