### PR TITLE
Reject non-finite target_values in proximity tools

### DIFF
--- a/xrspatial/proximity.py
+++ b/xrspatial/proximity.py
@@ -1180,10 +1180,15 @@ def _process(
     # matched target_values=[inf] and ran the search, while dask/cupy mask
     # non-finite pixels out and returned all-NaN for the same input. nan can
     # never match a pixel anyway (nan == nan is False). Fail fast instead of
-    # producing backend-dependent output (issue #2850).
-    if target_values.size and not np.isfinite(target_values).all():
+    # producing backend-dependent output (issue #2850). A non-numeric dtype
+    # (e.g. strings) can't index a raster either, so it gets the same error
+    # rather than a downstream TypeError from np.isfinite.
+    if target_values.size and (
+        target_values.dtype.kind not in "iuf"
+        or not np.isfinite(target_values).all()
+    ):
         raise ValueError(
-            "target_values must all be finite, got {0!r}.".format(
+            "target_values must all be finite numbers, got {0!r}.".format(
                 target_values.tolist()
             )
         )

--- a/xrspatial/proximity.py
+++ b/xrspatial/proximity.py
@@ -1176,6 +1176,18 @@ def _process(
 
     target_values = np.asarray(target_values)
 
+    # Reject non-finite explicit target_values. On numpy a pixel holding inf
+    # matched target_values=[inf] and ran the search, while dask/cupy mask
+    # non-finite pixels out and returned all-NaN for the same input. nan can
+    # never match a pixel anyway (nan == nan is False). Fail fast instead of
+    # producing backend-dependent output (issue #2850).
+    if target_values.size and not np.isfinite(target_values).all():
+        raise ValueError(
+            "target_values must all be finite, got {0!r}.".format(
+                target_values.tolist()
+            )
+        )
+
     if max_distance is None:
         max_distance = np.inf
 
@@ -1547,7 +1559,8 @@ def proximity(
     target_values: list
         Target pixel values to measure the distance from. If this option
         is not provided, proximity will be computed from non-zero pixel
-        values.
+        values. All entries must be finite; a non-finite value (inf or
+        nan) raises ValueError.
 
     max_distance: float, default=np.inf
         The maximum distance to search. Proximity distances greater than
@@ -1696,7 +1709,8 @@ def allocation(
     target_values : list
         Target pixel values to measure the distance from. If this option
         is not provided, allocation will be computed from non-zero pixel
-        values.
+        values. All entries must be finite; a non-finite value (inf or
+        nan) raises ValueError.
 
     max_distance: float, default=np.inf
         The maximum distance to search. Proximity distances greater than
@@ -1847,7 +1861,8 @@ def direction(
     target_values: list
         Target pixel values to measure the distance from. If this
         option is not provided, proximity will be computed from
-        non-zero pixel values.
+        non-zero pixel values. All entries must be finite; a non-finite
+        value (inf or nan) raises ValueError.
 
     max_distance: float, default=np.inf
         The maximum distance to search. Proximity distances greater than

--- a/xrspatial/tests/test_proximity.py
+++ b/xrspatial/tests/test_proximity.py
@@ -361,6 +361,30 @@ def test_zero_max_distance_keeps_meaning(test_raster, func):
     general_output_checks(test_raster, result)
 
 
+@pytest.mark.parametrize("backend", ['numpy', 'dask+numpy', 'cupy', 'dask+cupy'])
+@pytest.mark.parametrize("func", [proximity, allocation, direction])
+@pytest.mark.parametrize("target_values", [[np.inf], [-np.inf], [np.nan], [2, np.inf]])
+def test_non_finite_target_values_raises(test_raster, func, target_values):
+    # A non-finite target_values entry used to produce backend-dependent
+    # output: numpy matched inf pixels and returned a real grid, while
+    # dask/cupy masked non-finite pixels out and returned all-NaN for the
+    # same raster (issue #2850).  It must raise on every backend instead.
+    with pytest.raises(ValueError, match="target_values"):
+        func(test_raster, x='lon', y='lat', target_values=target_values)
+
+
+@pytest.mark.parametrize("backend", ['numpy', 'dask+numpy', 'cupy', 'dask+cupy'])
+@pytest.mark.parametrize("func", [proximity, allocation, direction])
+def test_finite_target_values_run(test_raster, func):
+    # The raster carries an inf and a nan pixel; the default (empty
+    # target_values) path must keep ignoring them on every backend, and
+    # explicit finite targets must keep working unchanged.
+    result_default = func(test_raster, x='lon', y='lat')
+    general_output_checks(test_raster, result_default)
+    result_explicit = func(test_raster, x='lon', y='lat', target_values=[1, 3])
+    general_output_checks(test_raster, result_explicit)
+
+
 def test_proximity_distance_against_qgis(raster, qgis_proximity_distance_target_values):
     target_values, qgis_result = qgis_proximity_distance_target_values
     input_raster = create_test_raster(raster)

--- a/xrspatial/tests/test_proximity.py
+++ b/xrspatial/tests/test_proximity.py
@@ -375,6 +375,15 @@ def test_non_finite_target_values_raises(test_raster, func, target_values):
 
 @pytest.mark.parametrize("backend", ['numpy', 'dask+numpy', 'cupy', 'dask+cupy'])
 @pytest.mark.parametrize("func", [proximity, allocation, direction])
+def test_non_numeric_target_values_raises(test_raster, func):
+    # A non-numeric target_values can't index a raster; it must raise a clear
+    # ValueError on every backend rather than a downstream TypeError (#2850).
+    with pytest.raises(ValueError, match="target_values"):
+        func(test_raster, x='lon', y='lat', target_values=['a', 'b'])
+
+
+@pytest.mark.parametrize("backend", ['numpy', 'dask+numpy', 'cupy', 'dask+cupy'])
+@pytest.mark.parametrize("func", [proximity, allocation, direction])
 def test_finite_target_values_run(test_raster, func):
     # The raster carries an inf and a nan pixel; the default (empty
     # target_values) path must keep ignoring them on every backend, and


### PR DESCRIPTION
Closes #2850

## What

`proximity`, `allocation`, and `direction` treated non-finite `target_values` differently per backend. NumPy matched `inf`-valued pixels for `target_values=[np.inf]` and returned a real grid, while dask and cupy masked non-finite pixels out and returned all-NaN for the same raster.

- Validate `target_values` in the shared `_process` dispatch, next to the existing `distance_metric` and `max_distance` checks. A non-finite entry (inf, -inf, nan) now raises `ValueError` on every backend.
- The empty-`target_values` default path is unchanged. It already ignores non-finite pixels everywhere.
- Note the finiteness requirement in the three `target_values` docstrings.

## Chosen resolution

Reject up front rather than silently ignore. A non-finite target is not a meaningful raster category: `nan` can never match a pixel (`nan == nan` is False), and `inf` only "matched" on NumPy by accident. An explicit error is clearer than dropping entries silently and matches the existing validation style in `_process`.

## Backend coverage

numpy, cupy, dask+numpy, dask+cupy. The validation lives in the shared dispatch ahead of backend branching, so all four paths raise identically.

## Test plan

- [x] New `test_non_finite_target_values_raises` over [inf, -inf, nan, [2, inf]] x {proximity, allocation, direction} x 4 backends
- [x] New `test_finite_target_values_run` confirms the default path and explicit finite targets still work on every backend
- [x] Full `test_proximity.py` passes (339 tests)