### PR TITLE
Fix invalid z_unit error to list accepted unit names

### DIFF
--- a/xrspatial/aspect.py
+++ b/xrspatial/aspect.py
@@ -445,7 +445,7 @@ def aspect(agg: xr.DataArray,
     else:  # geodesic
         if z_unit not in Z_UNITS:
             raise ValueError(
-                f"z_unit must be one of {sorted(set(Z_UNITS.values()), key=str)}, "
+                f"z_unit must be one of {sorted(Z_UNITS)}, "
                 f"got {z_unit!r}"
             )
         z_factor = Z_UNITS[z_unit]

--- a/xrspatial/slope.py
+++ b/xrspatial/slope.py
@@ -412,7 +412,7 @@ def slope(agg: xr.DataArray,
     else:  # geodesic
         if z_unit not in Z_UNITS:
             raise ValueError(
-                f"z_unit must be one of {sorted(set(Z_UNITS.values()), key=str)}, "
+                f"z_unit must be one of {sorted(Z_UNITS)}, "
                 f"got {z_unit!r}"
             )
         z_factor = Z_UNITS[z_unit]

--- a/xrspatial/tests/test_geodesic_aspect.py
+++ b/xrspatial/tests/test_geodesic_aspect.py
@@ -213,8 +213,17 @@ class TestGeodesicAspectValidation:
     def test_invalid_z_unit_raises(self):
         elev = _flat_surface()
         raster = _make_geo_raster(elev, 40.0, 41.0, 10.0, 11.0)
-        with pytest.raises(ValueError, match="z_unit"):
+        with pytest.raises(ValueError, match="z_unit") as excinfo:
             aspect(raster, method='geodesic', z_unit='cubit')
+
+        # The message must list the accepted unit-name strings (the keys a
+        # user is allowed to pass), not the numeric conversion factors.
+        msg = str(excinfo.value)
+        assert "'meter'" in msg
+        assert "'foot'" in msg
+        # Bare numeric conversion factors must not leak into the message.
+        assert "0.3048" not in msg
+        assert "1609.344" not in msg
 
     def test_missing_coords_raises(self):
         data = np.ones((5, 5))

--- a/xrspatial/tests/test_geodesic_aspect.py
+++ b/xrspatial/tests/test_geodesic_aspect.py
@@ -1,4 +1,6 @@
 """Tests for geodesic aspect computation."""
+import re
+
 import numpy as np
 import pytest
 import xarray as xr
@@ -221,9 +223,8 @@ class TestGeodesicAspectValidation:
         msg = str(excinfo.value)
         assert "'meter'" in msg
         assert "'foot'" in msg
-        # Bare numeric conversion factors must not leak into the message.
-        assert "0.3048" not in msg
-        assert "1609.344" not in msg
+        # No bare numeric conversion factor should leak into the message.
+        assert not re.search(r"\d+\.\d+", msg)
 
     def test_missing_coords_raises(self):
         data = np.ones((5, 5))

--- a/xrspatial/tests/test_geodesic_slope.py
+++ b/xrspatial/tests/test_geodesic_slope.py
@@ -1,4 +1,6 @@
 """Tests for geodesic slope computation."""
+import re
+
 import numpy as np
 import pytest
 import xarray as xr
@@ -217,9 +219,8 @@ class TestGeodesicSlopeValidation:
         msg = str(excinfo.value)
         assert "'meter'" in msg
         assert "'foot'" in msg
-        # Bare numeric conversion factors must not leak into the message.
-        assert "0.3048" not in msg
-        assert "1609.344" not in msg
+        # No bare numeric conversion factor should leak into the message.
+        assert not re.search(r"\d+\.\d+", msg)
 
     def test_missing_coords_raises(self):
         data = np.ones((5, 5))

--- a/xrspatial/tests/test_geodesic_slope.py
+++ b/xrspatial/tests/test_geodesic_slope.py
@@ -209,8 +209,17 @@ class TestGeodesicSlopeValidation:
     def test_invalid_z_unit_raises(self):
         elev = _flat_surface()
         raster = _make_geo_raster(elev, 40.0, 41.0, 10.0, 11.0)
-        with pytest.raises(ValueError, match="z_unit"):
+        with pytest.raises(ValueError, match="z_unit") as excinfo:
             slope(raster, method='geodesic', z_unit='cubit')
+
+        # The message must list the accepted unit-name strings (the keys a
+        # user is allowed to pass), not the numeric conversion factors.
+        msg = str(excinfo.value)
+        assert "'meter'" in msg
+        assert "'foot'" in msg
+        # Bare numeric conversion factors must not leak into the message.
+        assert "0.3048" not in msg
+        assert "1609.344" not in msg
 
     def test_missing_coords_raises(self):
         data = np.ones((5, 5))


### PR DESCRIPTION
Closes #2858

## What changed

- The geodesic `z_unit` check in `aspect()` and `slope()` built its error message from `sorted(set(Z_UNITS.values()))`, which are the numeric conversion factors (`0.3048`, `1.0`, `1000.0`, `1609.344`), not the unit names a user can pass. It now reports `sorted(Z_UNITS)` so the message lists the accepted unit names.
- Fixed in both `aspect.py` and `slope.py` since they share the same check and message format.

Before:

```
z_unit must be one of [0.3048, 1.0, 1000.0, 1609.344], got 'cubit'
```

After:

```
z_unit must be one of ['feet', 'foot', 'ft', 'kilometer', 'kilometers', 'km', 'm', 'meter', 'meters', 'mi', 'mile', 'miles'], got 'cubit'
```

## Backend coverage

This is a validation-path change that runs before any backend dispatch, so it applies to all four backends (numpy / cupy / dask+numpy / dask+cupy).

## Test plan

- [x] Extended `test_invalid_z_unit_raises` in `test_geodesic_aspect.py` and `test_geodesic_slope.py` to assert the message contains the accepted unit names and not bare numeric factors.
- [x] `pytest` passes for both updated tests.
