### PR TITLE
Fix viewshed() mutating the caller's input raster (#2852)

### DIFF
--- a/xrspatial/tests/test_viewshed.py
+++ b/xrspatial/tests/test_viewshed.py
@@ -827,3 +827,57 @@ def test_viewshed_max_distance_anisotropic(backend, fine_axis):
     # A cell 9 fine-axis cells away (> max_distance) stays INVISIBLE.
     far = (10, 19) if fine_axis == "x" else (19, 10)
     assert result[far] == INVISIBLE
+
+
+# -------------------------------------------------------------------
+# Input-not-mutated regression tests (issue #2852)
+# -------------------------------------------------------------------
+
+def _build_int16_raster(backend):
+    """5x5 int16 raster with a single non-zero cell, optionally cupy-backed."""
+    ny, nx = 5, 5
+    arr = np.zeros((ny, nx), dtype="int16")
+    arr[2, 2] = 3
+    xs = np.arange(nx, dtype=float)
+    ys = np.arange(ny, dtype=float)
+    if backend == "cupy":
+        import cupy as cp
+        arr = cp.asarray(arr)
+    elif backend == "dask":
+        arr = da.from_array(arr, chunks=(3, 3))
+    return xa.DataArray(arr, coords=dict(x=xs, y=ys), dims=["y", "x"])
+
+
+@pytest.mark.parametrize("backend", ["numpy", "dask"])
+def test_viewshed_does_not_mutate_input(backend):
+    """viewshed() must not change the caller's input dtype or data (#2852)."""
+    raster = _build_int16_raster(backend)
+    before = np.asarray(raster.data.compute() if backend == "dask"
+                        else raster.data).copy()
+    before_dtype = raster.dtype
+
+    viewshed(raster, x=2, y=2, observer_elev=2)
+
+    assert raster.dtype == before_dtype == np.dtype("int16")
+    after = np.asarray(raster.data.compute() if backend == "dask"
+                       else raster.data)
+    np.testing.assert_array_equal(after, before)
+
+
+@pytest.mark.skipif(not has_cuda_and_cupy(), reason="Requires cupy")
+@pytest.mark.skipif(has_rtx(), reason="Tests the no-rtx CuPy CPU fallback")
+def test_viewshed_does_not_mutate_cupy_input():
+    """CuPy fallback path must leave the caller's CuPy input unchanged (#2852).
+
+    With cupy present but rtxpy absent, viewshed converts to numpy and runs on
+    the CPU. The input must stay a CuPy array of its original dtype.
+    """
+    import cupy as cp
+    raster = _build_int16_raster("cupy")
+    before = raster.data.get().copy()
+
+    viewshed(raster, x=2, y=2, observer_elev=2)
+
+    assert isinstance(raster.data, cp.ndarray)
+    assert raster.dtype == np.dtype("int16")
+    np.testing.assert_array_equal(raster.data.get(), before)

--- a/xrspatial/viewshed.py
+++ b/xrspatial/viewshed.py
@@ -1581,9 +1581,11 @@ def _viewshed_cpu(
     num_events = 3 * (n_rows * n_cols - 1)
     event_list = np.zeros((num_events, 7), dtype=np.float64)
 
-    raster.data = raster.data.astype(np.float64, copy=False)
+    # Convert to float64 on a copy so the caller's input DataArray is never
+    # mutated (an int16 input must stay int16 after viewshed returns).
+    raster_data = raster.data.astype(np.float64)
 
-    _init_event_list(event_list=event_list, raster=raster.data,
+    _init_event_list(event_list=event_list, raster=raster_data,
                      vp_row=viewpoint_row, vp_col=viewpoint_col,
                      data=data, visibility_grid=visibility_grid)
 
@@ -1598,7 +1600,7 @@ def _viewshed_cpu(
     event_aes = event_list[:, 3:].copy()
 
     viewshed_img = _viewshed_cpu_sweep(
-        raster.data, viewpoint_row, viewpoint_col, viewpoint_elev,
+        raster_data, viewpoint_row, viewpoint_col, viewpoint_elev,
         viewpoint_target, ew_res, ns_res, event_rcts, event_aes, data,
         visibility_grid)
 
@@ -1730,10 +1732,15 @@ def viewshed(raster: xarray.DataArray,
             from .gpu_rtx.viewshed import viewshed_gpu
             return viewshed_gpu(raster, x, y, observer_elev, target_elev, name)
         else:
-            # Convert to numpy and run on cpu
+            # Convert to numpy and run on cpu. Build a new DataArray instead
+            # of reassigning raster.data so the caller's CuPy input is left
+            # unchanged.
             import cupy as cp
-            raster.data = cp.asnumpy(raster.data)
-            return _viewshed_cpu(raster, x, y, observer_elev, target_elev,
+            raster_np = xarray.DataArray(cp.asnumpy(raster.data),
+                                         coords=raster.coords,
+                                         attrs=raster.attrs,
+                                         dims=raster.dims)
+            return _viewshed_cpu(raster_np, x, y, observer_elev, target_elev,
                                  name)
 
     elif has_dask_array():


### PR DESCRIPTION
Closes #2852

`viewshed()` was changing its caller's input raster in place:

- The CPU path reassigned `raster.data` to a float64 array, so an int16 input came back as float64 after the call.
- The CuPy fallback (cupy present, rtxpy absent) reassigned `raster.data` to a numpy array, silently converting the caller's CuPy input.

## Changes

- CPU path: do the float64 conversion on a local copy and feed that to the sweep kernels; `raster.data` is left alone.
- CuPy fallback: build a new numpy-backed DataArray for the CPU run instead of reassigning the input's `.data`.
- Add regression tests that assert the input dtype and data are unchanged after `viewshed()`.

## Backend coverage

- numpy: covered (int16 stays int16, data unchanged)
- dask+numpy: covered (same assertion)
- cupy: regression test for the no-rtx CPU fallback, skipped when cupy/rtx unavailable
- dask+cupy: not separately exercised; relies on the same dask/cupy paths

Pure bug fix, no public API change. Skipped the user-guide-notebook and README feature-matrix steps for that reason. No docs `.rst` change needed (no new public function).

## Test plan

- [x] `pytest xrspatial/tests/test_viewshed.py` passes (65 passed, 1 skipped, 1 xfailed)
- [x] New `test_viewshed_does_not_mutate_input` (numpy, dask) passes
- [x] Manual repro confirms int16 input stays int16 after the call