### PR TITLE
Validate viewshed max_distance (reject negative / non-finite)

### DIFF
--- a/xrspatial/tests/test_viewshed.py
+++ b/xrspatial/tests/test_viewshed.py
@@ -580,6 +580,31 @@ def test_viewshed_custom_name(backend):
     assert result.name == "my_vs"
 
 
+@pytest.mark.parametrize("bad", [-1.0, -0.5, float("nan"),
+                                 float("inf"), float("-inf")])
+def test_viewshed_invalid_max_distance_raises(bad):
+    """Negative or non-finite max_distance raises a clear ValueError (#2855).
+
+    Validation lives at the public entry point, before backend dispatch,
+    so a single numpy raster covers every backend. Previously these
+    values fell through to confusing internal errors (e.g. "zero-size
+    array to reduction operation minimum" or "cannot convert float NaN
+    to integer").
+    """
+    raster = _make_raster("numpy")
+    with pytest.raises(ValueError, match="max_distance must be a finite"):
+        viewshed(raster, x=3, y=2, observer_elev=1, max_distance=bad)
+
+
+@pytest.mark.parametrize("backend", ["numpy", "dask+numpy"])
+@pytest.mark.parametrize("good", [0.0, 3.0])
+def test_viewshed_valid_max_distance_still_works(backend, good):
+    """Finite max_distance >= 0 passes validation and returns a result."""
+    raster = _make_raster(backend)
+    result = viewshed(raster, x=3, y=2, observer_elev=1, max_distance=good)
+    assert result.shape == raster.shape
+
+
 # -------------------------------------------------------------------
 # dask+cupy backend tests
 # -------------------------------------------------------------------

--- a/xrspatial/viewshed.py
+++ b/xrspatial/viewshed.py
@@ -1718,6 +1718,7 @@ def viewshed(raster: xarray.DataArray,
     """
     _validate_raster(raster, func_name='viewshed', name='raster')
 
+    # --- max_distance: validate, then extract spatial window for any backend ---
     if max_distance is not None:
         try:
             is_bad = not np.isfinite(max_distance) or max_distance < 0
@@ -1727,9 +1728,6 @@ def viewshed(raster: xarray.DataArray,
             raise ValueError(
                 "max_distance must be a finite number >= 0, "
                 f"got {max_distance!r}")
-
-    # --- max_distance: extract spatial window for any backend ---
-    if max_distance is not None:
         return _viewshed_windowed(raster, x, y, observer_elev, target_elev,
                                   max_distance, name)
 

--- a/xrspatial/viewshed.py
+++ b/xrspatial/viewshed.py
@@ -1637,10 +1637,12 @@ def viewshed(raster: xarray.DataArray,
         when it is being analyzed for visibility.
     max_distance : float, optional
         Maximum analysis distance from the observer in surface units.
-        Cells beyond this distance are marked INVISIBLE without being
-        evaluated. When set and the raster is dask-backed, only the
-        chunks within the distance window are loaded — this is the most
-        efficient way to run viewshed on very large dask rasters.
+        Must be a finite number >= 0; a negative or non-finite value
+        raises ``ValueError``. Cells beyond this distance are marked
+        INVISIBLE without being evaluated. When set and the raster is
+        dask-backed, only the chunks within the distance window are
+        loaded — this is the most efficient way to run viewshed on very
+        large dask rasters.
     name : str, default='viewshed'
         Name of the output DataArray. Set on every backend so the
         result name does not depend on which backend ran.
@@ -1715,6 +1717,16 @@ def viewshed(raster: xarray.DataArray,
 
     """
     _validate_raster(raster, func_name='viewshed', name='raster')
+
+    if max_distance is not None:
+        try:
+            is_bad = not np.isfinite(max_distance) or max_distance < 0
+        except (TypeError, ValueError):
+            is_bad = True
+        if is_bad:
+            raise ValueError(
+                "max_distance must be a finite number >= 0, "
+                f"got {max_distance!r}")
 
     # --- max_distance: extract spatial window for any backend ---
     if max_distance is not None:


### PR DESCRIPTION
Closes #2855

`viewshed()` didn't validate `max_distance`. Negative, NaN, and infinite
values fell through to the windowing math and raised internal errors that
never mentioned the argument (for example "zero-size array to reduction
operation minimum" for -1.0 and "cannot convert float NaN to integer" for
NaN).

What changed:
- Validate `max_distance` at the public `viewshed()` entry point, before
  backend dispatch, and raise `ValueError("max_distance must be a finite
  number >= 0, ...")` for negative or non-finite values.
- Document the requirement on the `max_distance` parameter.

Backend coverage: the check runs before dispatch, so it applies to all
four backends (numpy, cupy, dask+numpy, dask+cupy).

Test plan:
- [x] New test asserts the clear `ValueError` for -1.0, -0.5, NaN, +inf, -inf.
- [x] New test confirms finite values (0.0, 3.0) still work on numpy and dask+numpy.
- [x] Full `test_viewshed.py` passes (72 passed, 1 xfailed).

Skipped the user-guide-notebook and README-matrix steps: this is a pure
input-validation bug fix with no new public API and no change to backend
support.