### PR TITLE
Validate MFD companion raster shape against grid (#2863)

### DIFF
--- a/xrspatial/hydro/flow_path_mfd.py
+++ b/xrspatial/hydro/flow_path_mfd.py
@@ -29,6 +29,7 @@ except ImportError:
     da = None
 
 from xrspatial.utils import (
+    _validate_matching_shape,
     _validate_raster,
     has_cuda_and_cupy,
     is_cupy_array,
@@ -429,6 +430,10 @@ def flow_path_mfd(flow_dir_mfd: xr.DataArray,
             f"flow_dir_mfd must have shape (8, H, W), got {data.shape}")
 
     _, H, W = data.shape
+
+    _validate_matching_shape(
+        start_points, (H, W), func_name='flow_path_mfd',
+        name='start_points', expected_name='flow_dir_mfd')
 
     if isinstance(data, np.ndarray):
         _check_memory(H, W)

--- a/xrspatial/hydro/hand_mfd.py
+++ b/xrspatial/hydro/hand_mfd.py
@@ -27,6 +27,7 @@ from xrspatial.hydro.watershed_mfd import (
     _to_numpy_f64,
 )
 from xrspatial.utils import (
+    _validate_matching_shape,
     _validate_raster,
     has_cuda_and_cupy,
     is_cupy_array,
@@ -709,6 +710,13 @@ def hand_mfd(flow_dir_mfd: xr.DataArray,
             f"flow_dir_mfd must have shape (8, H, W), got {data.shape}")
 
     _, H, W = data.shape
+
+    _validate_matching_shape(
+        flow_accum, (H, W), func_name='hand_mfd',
+        name='flow_accum', expected_name='flow_dir_mfd')
+    _validate_matching_shape(
+        elevation, (H, W), func_name='hand_mfd',
+        name='elevation', expected_name='flow_dir_mfd')
 
     if isinstance(data, np.ndarray):
         _check_memory(H, W)

--- a/xrspatial/hydro/stream_link_mfd.py
+++ b/xrspatial/hydro/stream_link_mfd.py
@@ -40,6 +40,7 @@ except ImportError:
     da = None
 
 from xrspatial.utils import (
+    _validate_matching_shape,
     _validate_raster,
     cuda_args,
     has_cuda_and_cupy,
@@ -1024,6 +1025,10 @@ def stream_link_mfd(fractions: xr.DataArray,
             "fractions must be a 3-D array of shape (8, H, W), "
             f"got shape {data.shape}"
         )
+
+    _validate_matching_shape(
+        flow_accum, data.shape[1:], func_name='stream_link_mfd',
+        name='flow_accum', expected_name='fractions')
 
     fa_data = flow_accum.data
 

--- a/xrspatial/hydro/stream_order_mfd.py
+++ b/xrspatial/hydro/stream_order_mfd.py
@@ -37,6 +37,7 @@ except ImportError:
     da = None
 
 from xrspatial.utils import (
+    _validate_matching_shape,
     _validate_raster,
     cuda_args,
     has_cuda_and_cupy,
@@ -1511,6 +1512,10 @@ def stream_order_mfd(fractions: xr.DataArray,
             "fractions must be a 3-D array of shape (8, H, W), "
             f"got shape {frac_data.shape}"
         )
+
+    _validate_matching_shape(
+        flow_accum, frac_data.shape[1:], func_name='stream_order_mfd',
+        name='flow_accum', expected_name='fractions')
 
     if isinstance(frac_data, np.ndarray):
         _check_memory(frac_data.shape[1], frac_data.shape[2])

--- a/xrspatial/hydro/tests/test_validate_mfd_companion_shape.py
+++ b/xrspatial/hydro/tests/test_validate_mfd_companion_shape.py
@@ -59,6 +59,9 @@ class TestFlowPathMfdShape:
         sp.data[0, 0] = 7.0
         out = flow_path_mfd(fr, sp)
         assert out.shape == (3, 3)
+        # All-east flow: the path from (0, 0) labels the whole top row 7.
+        np.testing.assert_array_equal(out.data[0], [7.0, 7.0, 7.0])
+        assert np.isnan(out.data[1:]).all()
 
 
 class TestWatershedMfdShape:

--- a/xrspatial/hydro/tests/test_validate_mfd_companion_shape.py
+++ b/xrspatial/hydro/tests/test_validate_mfd_companion_shape.py
@@ -1,0 +1,128 @@
+"""Tests for issue #2863: MFD hydro APIs validate companion raster shape.
+
+Each MFD function below validated that its companion raster (start points,
+pour points, flow accumulation, elevation) is a 2-D DataArray, but never
+checked that the companion's (H, W) matched the primary MFD grid.  A
+mismatched companion let the CPU kernel read out of bounds and return
+uninitialised garbage instead of raising.  The fix adds an early
+``ValueError`` when the shapes disagree.
+"""
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from xrspatial.hydro import (
+    flow_path_mfd,
+    hand_mfd,
+    stream_link_mfd,
+    stream_order_mfd,
+    watershed_mfd,
+)
+from xrspatial.tests.general_checks import create_test_raster
+
+
+def _mfd_fractions(H, W):
+    """All-east MFD fraction grid of shape (8, H, W)."""
+    fracs = np.zeros((8, H, W), dtype=np.float64)
+    fracs[0, :, :-1] = 1.0  # E for non-pit cells
+    neighbor = ['E', 'SE', 'S', 'SW', 'W', 'NW', 'N', 'NE']
+    return xr.DataArray(
+        fracs,
+        dims=('neighbor', 'y', 'x'),
+        coords={
+            'neighbor': neighbor,
+            'y': np.arange(H, dtype=np.float64),
+            'x': np.arange(W, dtype=np.float64),
+        },
+        name='mfd_fdir',
+        attrs={'res': (1.0, 1.0)},
+    )
+
+
+def _companion(H, W, fill=1.0):
+    return create_test_raster(
+        np.full((H, W), fill, dtype=np.float64), name='companion')
+
+
+class TestFlowPathMfdShape:
+    def test_mismatched_start_points_raises(self):
+        fr = _mfd_fractions(3, 3)
+        sp = _companion(1, 1, fill=5.0)
+        with pytest.raises(ValueError, match='does not match'):
+            flow_path_mfd(fr, sp)
+
+    def test_matching_start_points_ok(self):
+        fr = _mfd_fractions(3, 3)
+        sp = create_test_raster(
+            np.full((3, 3), np.nan, dtype=np.float64), name='sp')
+        sp.data[0, 0] = 7.0
+        out = flow_path_mfd(fr, sp)
+        assert out.shape == (3, 3)
+
+
+class TestWatershedMfdShape:
+    def test_mismatched_pour_points_raises(self):
+        fr = _mfd_fractions(3, 3)
+        pp = _companion(2, 4, fill=1.0)
+        with pytest.raises(ValueError, match='does not match'):
+            watershed_mfd(fr, pp)
+
+    def test_matching_pour_points_ok(self):
+        fr = _mfd_fractions(3, 3)
+        pp = create_test_raster(
+            np.full((3, 3), np.nan, dtype=np.float64), name='pp')
+        pp.data[0, 2] = 1.0
+        out = watershed_mfd(fr, pp)
+        assert out.shape == (3, 3)
+
+
+class TestHandMfdShape:
+    def test_mismatched_flow_accum_raises(self):
+        fr = _mfd_fractions(3, 3)
+        fa = _companion(2, 2)
+        el = _companion(3, 3)
+        with pytest.raises(ValueError, match='`flow_accum`.*does not match'):
+            hand_mfd(fr, fa, el)
+
+    def test_mismatched_elevation_raises(self):
+        fr = _mfd_fractions(3, 3)
+        fa = _companion(3, 3)
+        el = _companion(4, 4)
+        with pytest.raises(ValueError, match='`elevation`.*does not match'):
+            hand_mfd(fr, fa, el)
+
+    def test_matching_companions_ok(self):
+        fr = _mfd_fractions(3, 3)
+        fa = _companion(3, 3, fill=5.0)
+        el = _companion(3, 3, fill=10.0)
+        out = hand_mfd(fr, fa, el, threshold=3)
+        assert out.shape == (3, 3)
+
+
+class TestStreamOrderMfdShape:
+    def test_mismatched_flow_accum_raises(self):
+        fr = _mfd_fractions(3, 3)
+        fa = _companion(1, 3)
+        with pytest.raises(ValueError, match='does not match'):
+            stream_order_mfd(fr, fa)
+
+    def test_matching_flow_accum_ok(self):
+        fr = _mfd_fractions(3, 3)
+        fa = _companion(3, 3, fill=5.0)
+        out = stream_order_mfd(fr, fa, threshold=1)
+        assert out.shape == (3, 3)
+
+
+class TestStreamLinkMfdShape:
+    def test_mismatched_flow_accum_raises(self):
+        fr = _mfd_fractions(3, 3)
+        fa = _companion(3, 1)
+        with pytest.raises(ValueError, match='does not match'):
+            stream_link_mfd(fr, fa)
+
+    def test_matching_flow_accum_ok(self):
+        fr = _mfd_fractions(3, 3)
+        fa = _companion(3, 3, fill=5.0)
+        out = stream_link_mfd(fr, fa, threshold=1)
+        assert out.shape == (3, 3)

--- a/xrspatial/hydro/watershed_mfd.py
+++ b/xrspatial/hydro/watershed_mfd.py
@@ -29,6 +29,7 @@ except ImportError:
 
 from xrspatial.hydro._boundary_store import BoundaryStore
 from xrspatial.utils import (
+    _validate_matching_shape,
     _validate_raster,
     has_cuda_and_cupy,
     is_cupy_array,
@@ -679,6 +680,10 @@ def watershed_mfd(flow_dir_mfd: xr.DataArray,
             f"flow_dir_mfd must have shape (8, H, W), got {data.shape}")
 
     _, H, W = data.shape
+
+    _validate_matching_shape(
+        pour_points, (H, W), func_name='watershed_mfd',
+        name='pour_points', expected_name='flow_dir_mfd')
 
     if isinstance(data, np.ndarray):
         _check_memory(H, W)

--- a/xrspatial/utils.py
+++ b/xrspatial/utils.py
@@ -109,6 +109,45 @@ def _validate_raster(
                 )
 
 
+def _validate_matching_shape(
+    agg,
+    expected_shape,
+    *,
+    func_name: str,
+    name: str = 'raster',
+    expected_name: str = 'the primary raster',
+):
+    """Validate that *agg* has spatial shape ``expected_shape``.
+
+    Used to confirm a companion raster (e.g. start points, pour points,
+    flow accumulation) covers the same (H, W) grid as the primary input
+    before any kernel indexes into it.
+
+    Parameters
+    ----------
+    agg : xarray.DataArray
+        Companion raster to validate.
+    expected_shape : tuple of int
+        Required ``(H, W)`` shape.
+    func_name : str
+        Name of the calling function (for error messages).
+    name : str
+        Parameter name (for error messages).
+    expected_name : str
+        Description of the raster whose shape is the reference.
+
+    Raises
+    ------
+    ValueError
+        If ``agg.shape`` does not equal ``expected_shape``.
+    """
+    if tuple(agg.shape) != tuple(expected_shape):
+        raise ValueError(
+            f"{func_name}(): `{name}` shape {tuple(agg.shape)} does not "
+            f"match {expected_name} shape {tuple(expected_shape)}"
+        )
+
+
 def _validate_scalar(
     value,
     *,


### PR DESCRIPTION
Closes #2863

The MFD hydrology functions checked that their companion rasters were 2-D DataArrays but never confirmed the companion's (H, W) matched the primary MFD grid. A mismatched companion let the CPU kernel read out of bounds and return uninitialized garbage instead of raising.

- Added a `_validate_matching_shape` helper in `xrspatial/utils.py` that raises a clear ValueError when a companion raster's shape does not match the primary grid.
- Wired it into the five affected MFD functions: `flow_path_mfd` (start_points), `watershed_mfd` (pour_points), `hand_mfd` (flow_accum, elevation), `stream_order_mfd` (flow_accum), `stream_link_mfd` (flow_accum). The check runs after the existing 3-D shape validation and before any kernel indexing.

The check lives in the shared public-API entry point, so it guards all four backends (numpy, cupy, dask+numpy, dask+cupy) before dispatch.

Test plan:
- [x] New `test_validate_mfd_companion_shape.py`: each function raises ValueError on a mismatched companion and still runs on a matching one (11 tests).
- [x] Existing MFD suites and the secondary-args validation suite pass (96 tests).
- [x] flake8 clean on changed lines.