### PR TITLE
viewshed: warn and document dask Tier C divergence from exact sweep

### DIFF
--- a/docs/source/reference/dask_laziness.rst
+++ b/docs/source/reference/dask_laziness.rst
@@ -154,7 +154,10 @@ Visibility
      - Notes
    * - ``viewshed``
      - Fully materialized
-     - Sweepline algorithm needs random access
+     - Sweepline needs random access. Grids that exceed memory (no
+       ``max_distance``) use an approximate out-of-core sweep that does
+       not match the exact result and emits a ``UserWarning``; set
+       ``max_distance`` for exact results.
    * - ``line_of_sight``
      - Fully materialized
      - Extracts 1D transect via ``.compute()``

--- a/setup.cfg
+++ b/setup.cfg
@@ -113,6 +113,7 @@ filterwarnings =
     ignore:cost_distance. max_cost is infinite:UserWarning:xrspatial
     ignore:surface_distance. max_distance is infinite:UserWarning:xrspatial
     ignore:proximity. target coordinates exceed:ResourceWarning:xrspatial
+    ignore:viewshed. grid exceeds memory:UserWarning:xrspatial
     ignore:Covariance of the parameters could not be estimated:scipy.optimize.OptimizeWarning
     ignore:'oneOf' deprecated:DeprecationWarning:matplotlib
     ignore:'parseString' deprecated:DeprecationWarning:matplotlib

--- a/xrspatial/tests/test_viewshed.py
+++ b/xrspatial/tests/test_viewshed.py
@@ -420,6 +420,63 @@ def test_viewshed_dask_distance_sweep_target_elev():
             err_msg="Tier C angles diverge too far from numpy reference")
 
 
+def test_viewshed_dask_tier_c_warns_and_quantifies_divergence():
+    """Tier C (out-of-core distance sweep) is an approximate visibility
+    model that does not match the exact numpy sweep cell-for-cell.
+
+    Pins the documented contract for issue #2872:
+    1. A UserWarning is emitted when the Tier C path runs, so users feeding
+       large dask rasters into downstream visibility logic are not silently
+       misled.
+    2. The visibility-mask divergence vs the exact sweep is real and
+       material on rough terrain (not "minor near occluded boundaries").
+    """
+    from unittest.mock import patch
+
+    ny, nx = 20, 20
+    rng = np.random.RandomState(42)
+    terrain = rng.rand(ny, nx) * 10.0
+    xs = np.arange(nx, dtype=float)
+    ys = np.arange(ny, dtype=float)
+    obs_x, obs_y = 10.0, 10.0
+
+    # Exact numpy reference.
+    raster_np = xa.DataArray(terrain.copy(), coords=dict(x=xs, y=ys),
+                             dims=["y", "x"])
+    v_np = viewshed(raster_np, x=obs_x, y=obs_y)
+
+    # Force Tier C: shrink the memory budget so Tier B (full compute + R2)
+    # is skipped but the output-grid guard still passes.
+    raster_da = xa.DataArray(
+        da.from_array(terrain.copy(), chunks=(10, 10)),
+        coords=dict(x=xs, y=ys), dims=["y", "x"])
+    with patch('xrspatial.viewshed._available_memory_bytes',
+               return_value=10_000):
+        with pytest.warns(UserWarning,
+                          match="approximate visibility model"):
+            v_dask = viewshed(raster_da, x=obs_x, y=obs_y)
+
+    exact_mask = v_np.values != INVISIBLE
+    tier_c_mask = v_dask.values != INVISIBLE
+    mismatches = int((exact_mask != tier_c_mask).sum())
+
+    # The exact and Tier C masks must agree on the observer cell.
+    obs_r, obs_c = 10, 10
+    assert v_dask.values[obs_r, obs_c] == 180.0
+    assert v_np.values[obs_r, obs_c] == 180.0
+
+    # Document the divergence: this is the bug being pinned. On this seed
+    # the two models disagree on dozens of cells, well beyond "minor near
+    # occluded boundaries". If a future change makes Tier C exact, this
+    # assertion should be tightened to parity instead.
+    assert mismatches > 0, (
+        "Tier C is expected to diverge from the exact sweep on rough "
+        "terrain; if it now matches, update this test to assert parity")
+    assert mismatches >= 10, (
+        f"Tier C divergence ({mismatches} cells) is expected to be "
+        f"material on this random terrain, not minor")
+
+
 def test_viewshed_cpu_memory_guard():
     """_viewshed_cpu should refuse rasters that would blow past RAM.
 

--- a/xrspatial/tests/test_viewshed.py
+++ b/xrspatial/tests/test_viewshed.py
@@ -466,15 +466,22 @@ def test_viewshed_dask_tier_c_warns_and_quantifies_divergence():
     assert v_np.values[obs_r, obs_c] == 180.0
 
     # Document the divergence: this is the bug being pinned. On this seed
-    # the two models disagree on dozens of cells, well beyond "minor near
-    # occluded boundaries". If a future change makes Tier C exact, this
-    # assertion should be tightened to parity instead.
+    # the two models disagree on 25 of 400 cells (~6%), well beyond "minor
+    # near occluded boundaries". The assertion uses 10 as a floor below the
+    # observed 25 to stay robust against small implementation drift. If a
+    # future change makes Tier C exact, this assertion should be tightened
+    # to parity instead.
     assert mismatches > 0, (
         "Tier C is expected to diverge from the exact sweep on rough "
         "terrain; if it now matches, update this test to assert parity")
     assert mismatches >= 10, (
-        f"Tier C divergence ({mismatches} cells) is expected to be "
-        f"material on this random terrain, not minor")
+        f"Tier C divergence ({mismatches} cells, observed 25) is expected "
+        f"to be material on this random terrain, not minor")
+
+    # Note: cumulative_viewshed calls viewshed once per observer, so the
+    # Tier C warning can fire on each call. Python's default warning filter
+    # dedupes by (message, category, module, lineno), so it surfaces once
+    # per process rather than once per observer.
 
 
 def test_viewshed_cpu_memory_guard():

--- a/xrspatial/viewshed.py
+++ b/xrspatial/viewshed.py
@@ -1,3 +1,4 @@
+import warnings
 from collections import OrderedDict
 from math import atan, atan2, fabs
 from math import pi as PI
@@ -1668,15 +1669,26 @@ def viewshed(raster: xarray.DataArray,
       mesh of the terrain. The mesh discretisation can introduce small
       angular errors (typically < 0.03 degrees for visible cells).
     - **Dask**: When ``max_distance`` is set or the grid fits in memory,
-      the exact CPU algorithm is used on the relevant window. For very
-      large grids that exceed memory, a horizon-profile distance-sweep
-      algorithm is used instead. This algorithm discretises angles and
-      may produce minor visibility differences near the boundary of
-      occluded regions.
+      the exact CPU algorithm is used on the relevant window, so results
+      match the numpy backend. For very large grids that exceed memory
+      and have no ``max_distance``, an out-of-core horizon-profile
+      distance-sweep algorithm is used instead. This is a different,
+      approximate visibility model from the exact GRASS sweep, and the
+      two do **not** agree cell-for-cell. On rough terrain the visibility
+      mask can differ for a substantial fraction of cells (measured at up
+      to ~20% on small random rasters), with both false positives and
+      false negatives relative to the exact sweep. The error is geometric
+      and does not shrink with finer angle discretisation. When this path
+      runs, :func:`viewshed` emits a ``UserWarning`` so the approximation
+      is not silent. If you need results that match the exact sweep on a
+      large dask raster, set ``max_distance`` to restrict the analysis to
+      a window that fits in memory.
 
-    Both backends agree on which cells are visible vs invisible in the
-    vast majority of cases, but the reported vertical angles may differ
-    by a small amount near cell boundaries.
+    The CPU and GPU backends, and the dask exact-window path, agree on
+    which cells are visible vs invisible in the vast majority of cases;
+    reported vertical angles may differ by a small amount near cell
+    boundaries. The dask out-of-core distance sweep is the exception
+    described above.
 
     Examples
     --------
@@ -2225,6 +2237,22 @@ def _viewshed_dask(raster, x, y, observer_elev, target_elev, name='viewshed'):
                                 dims=raster.dims, attrs=raster.attrs)
 
     # --- Tier C: out-of-core distance sweep (CPU only) ---
+    # This path uses a horizon-profile distance sweep, an approximate
+    # visibility model that does not match the exact GRASS sweep used by
+    # the numpy/Tier-B backends. On rough terrain the visibility mask can
+    # differ for a substantial fraction of cells. Warn so the divergence
+    # is not silent (see issue #2872).
+    warnings.warn(
+        "viewshed: grid exceeds memory and no max_distance is set, so the "
+        "dask out-of-core horizon-profile distance sweep is used. This is "
+        "an approximate visibility model and does NOT match the exact "
+        "numpy sweep cell-for-cell; the mask can differ for a substantial "
+        "fraction of cells on rough terrain. Set max_distance to restrict "
+        "the analysis to a window that fits in memory for exact results.",
+        UserWarning,
+        stacklevel=3,
+    )
+
     output_bytes = height * width * 8
     if output_bytes > 0.8 * avail:
         raise MemoryError(


### PR DESCRIPTION
Closes #2872

## What

The dask out-of-core "Tier C" fallback in `viewshed()` (`_viewshed_dask`, distance-sweep path) is a horizon-profile distance sweep. It is a different, approximate visibility model from the exact GRASS r.viewshed event sweep used by the numpy backend and the dask Tier-B (in-memory compute) path. The docstring described it as producing only "minor visibility differences near the boundary of occluded regions," which understates the problem: on rough terrain the visibility mask can differ for a substantial fraction of cells, with both false positives and false negatives.

I investigated whether Tier C could be made exact. It cannot, short of reimplementing the exact event sweep out-of-core. The divergence is geometric, not an angle-resolution artifact: raising the bin count from 360 to 500000 leaves the mismatch count unchanged. Making it exact would mean streaming the GRASS red-black status structure across chunks, which is a major new subsystem and defeats the reason Tier C exists (the exact algorithm's working set does not fit when the grid exceeds memory).

So this PR takes option (b) from the issue: make the contract honest and stop the silent divergence.

## Changes

- Emit a `UserWarning` when the Tier C path runs, so large dask rasters do not silently feed approximate visibility into downstream logic.
- Correct the `viewshed` docstring and the dask laziness reference table to state the real accuracy contract and point users to `max_distance` for exact results on large grids.
- Add a test that asserts the warning fires and quantifies the mask divergence vs the exact numpy sweep (pins the documented behavior; if Tier C is ever made exact, the test flags that it should switch to a parity assertion).
- Add a `filterwarnings` ignore for the new warning so the two existing Tier C tests stay quiet.

## Backend coverage

Affects the dask backends only (dask+numpy and dask+cupy take the same Tier C path; dask+cupy converts chunks to numpy before the sweep). numpy and cupy backends are unchanged. No new public API and no change to backend support, so the README matrix and user-guide notebook are unchanged.

## Test plan

- [x] `pytest xrspatial/tests/test_viewshed.py` (64 passed, 1 xfailed)
- [x] New test asserts the `UserWarning` and a material (>= 10 cell) mask divergence on a 20x20 random terrain
- [x] flake8 clean on the touched files
