### PR TITLE
Reject cyclic MFD fraction grids instead of returning wrong results or hanging

### DIFF
--- a/xrspatial/hydro/flow_accumulation_mfd.py
+++ b/xrspatial/hydro/flow_accumulation_mfd.py
@@ -163,6 +163,7 @@ def _flow_accum_mfd_cpu(fractions, height, width):
     valid = np.zeros((height, width), dtype=np.int8)
 
     # Pass 1: initialise
+    n_valid = 0
     for r in range(height):
         for c in range(width):
             v = fractions[0, r, c]
@@ -171,6 +172,7 @@ def _flow_accum_mfd_cpu(fractions, height, width):
             else:
                 valid[r, c] = 1
                 accum[r, c] = 1.0
+                n_valid += 1
 
     # Pass 2: compute in-degrees
     for r in range(height):
@@ -216,6 +218,15 @@ def _flow_accum_mfd_cpu(fractions, height, width):
                             queue_r[tail] = nr
                             queue_c[tail] = nc
                             tail += 1
+
+    # If a cycle remains, some valid cells never reached in_degree 0 and
+    # were never dequeued.  head counts the cells processed by the BFS.
+    if head < n_valid:
+        raise ValueError(
+            "flow_accumulation_mfd: the MFD fraction grid contains a cycle "
+            "(some cells never reach zero in-degree).  The input must be a "
+            "directed acyclic graph, as produced by flow_direction_mfd."
+        )
 
     return accum
 
@@ -402,12 +413,14 @@ def _flow_accum_mfd_tile_kernel(fractions, h, w,
     valid = np.zeros((h, w), dtype=np.int8)
 
     # Initialise
+    n_valid = 0
     for r in range(h):
         for c in range(w):
             v = fractions[0, r, c]
             if v == v:  # not NaN
                 valid[r, c] = 1
                 accum[r, c] = 1.0
+                n_valid += 1
             else:
                 accum[r, c] = np.nan
 
@@ -474,6 +487,14 @@ def _flow_accum_mfd_tile_kernel(fractions, h, w,
                         queue_r[tail] = nr
                         queue_c[tail] = nc
                         tail += 1
+
+    # A cycle within this tile leaves some valid cells undequeued.
+    if head < n_valid:
+        raise ValueError(
+            "flow_accumulation_mfd: the MFD fraction grid contains a cycle "
+            "(some cells never reach zero in-degree).  The input must be a "
+            "directed acyclic graph, as produced by flow_direction_mfd."
+        )
 
     return accum
 

--- a/xrspatial/hydro/flow_length_mfd.py
+++ b/xrspatial/hydro/flow_length_mfd.py
@@ -174,12 +174,14 @@ def _flow_length_mfd_downstream_cpu(fractions, H, W, cellsize_x, cellsize_y):
     flow_len = np.empty((H, W), dtype=np.float64)
 
     # Init
+    n_valid = 0
     for r in range(H):
         for c in range(W):
             v = fractions[0, r, c]
             if v == v:  # not NaN
                 valid[r, c] = 1
                 flow_len[r, c] = 0.0
+                n_valid += 1
             else:
                 flow_len[r, c] = np.nan
 
@@ -223,6 +225,15 @@ def _flow_length_mfd_downstream_cpu(fractions, H, W, cellsize_x, cellsize_y):
                         order_c[tail] = nc
                         tail += 1
 
+    # If a cycle remains, fewer than n_valid cells made it into the
+    # topological order.  The MFD grid must be a DAG.
+    if tail < n_valid:
+        raise ValueError(
+            "flow_length_mfd: the MFD fraction grid contains a cycle "
+            "(some cells never reach zero in-degree).  The input must be a "
+            "directed acyclic graph, as produced by flow_direction_mfd."
+        )
+
     # Reverse pass: outlets -> divides
     for i in range(tail - 1, -1, -1):
         r = order_r[i]
@@ -257,12 +268,14 @@ def _flow_length_mfd_upstream_cpu(fractions, H, W, cellsize_x, cellsize_y):
     valid = np.zeros((H, W), dtype=np.int8)
     flow_len = np.empty((H, W), dtype=np.float64)
 
+    n_valid = 0
     for r in range(H):
         for c in range(W):
             v = fractions[0, r, c]
             if v == v:
                 valid[r, c] = 1
                 flow_len[r, c] = 0.0
+                n_valid += 1
             else:
                 flow_len[r, c] = np.nan
 
@@ -310,6 +323,15 @@ def _flow_length_mfd_upstream_cpu(fractions, H, W, cellsize_x, cellsize_y):
                         queue_c[tail] = nc
                         tail += 1
 
+    # If a cycle remains, fewer than n_valid cells were dequeued.  head
+    # counts processed cells; the MFD grid must be a DAG.
+    if head < n_valid:
+        raise ValueError(
+            "flow_length_mfd: the MFD fraction grid contains a cycle "
+            "(some cells never reach zero in-degree).  The input must be a "
+            "directed acyclic graph, as produced by flow_direction_mfd."
+        )
+
     return flow_len
 
 
@@ -353,12 +375,14 @@ def _flow_length_mfd_downstream_tile(fractions, h, w, cellsize_x, cellsize_y,
     flow_len = np.empty((h, w), dtype=np.float64)
 
     # Init
+    n_valid = 0
     for r in range(h):
         for c in range(w):
             v = fractions[0, r, c]
             if v == v:
                 valid[r, c] = 1
                 flow_len[r, c] = 0.0
+                n_valid += 1
             else:
                 flow_len[r, c] = np.nan
 
@@ -401,6 +425,14 @@ def _flow_length_mfd_downstream_tile(fractions, h, w, cellsize_x, cellsize_y,
                         order_r[tail] = nr
                         order_c[tail] = nc
                         tail += 1
+
+    # A cycle within this tile leaves some valid cells out of the order.
+    if tail < n_valid:
+        raise ValueError(
+            "flow_length_mfd: the MFD fraction grid contains a cycle "
+            "(some cells never reach zero in-degree).  The input must be a "
+            "directed acyclic graph, as produced by flow_direction_mfd."
+        )
 
     # Reverse pass
     for i in range(tail - 1, -1, -1):
@@ -470,12 +502,14 @@ def _flow_length_mfd_upstream_tile(fractions, h, w, cellsize_x, cellsize_y,
     valid = np.zeros((h, w), dtype=np.int8)
     flow_len = np.empty((h, w), dtype=np.float64)
 
+    n_valid = 0
     for r in range(h):
         for c in range(w):
             v = fractions[0, r, c]
             if v == v:
                 valid[r, c] = 1
                 flow_len[r, c] = 0.0
+                n_valid += 1
             else:
                 flow_len[r, c] = np.nan
 
@@ -544,6 +578,14 @@ def _flow_length_mfd_upstream_tile(fractions, h, w, cellsize_x, cellsize_y,
                         queue_r[tail] = nr
                         queue_c[tail] = nc
                         tail += 1
+
+    # A cycle within this tile leaves some valid cells undequeued.
+    if head < n_valid:
+        raise ValueError(
+            "flow_length_mfd: the MFD fraction grid contains a cycle "
+            "(some cells never reach zero in-degree).  The input must be a "
+            "directed acyclic graph, as produced by flow_direction_mfd."
+        )
 
     return flow_len
 

--- a/xrspatial/hydro/flow_path_mfd.py
+++ b/xrspatial/hydro/flow_path_mfd.py
@@ -165,8 +165,21 @@ def _flow_path_mfd_cpu(fractions, start_points, H, W):
                 continue
             label = v
             cr, cc = r, c
+            # A dominant-neighbor path through a DAG visits each cell at
+            # most once, so it cannot exceed H*W steps.  If it does, the
+            # fraction grid contains a cycle.
+            steps = 0
+            max_steps = H * W
             while True:
                 out[cr, cc] = label
+                steps += 1
+                if steps > max_steps:
+                    raise ValueError(
+                        "flow_path_mfd: the MFD fraction grid contains a "
+                        "cycle; a traced path revisited cells and did not "
+                        "terminate.  The input must be a directed acyclic "
+                        "graph, as produced by flow_direction_mfd."
+                    )
                 # Check if cell is valid
                 chk = fractions[0, cr, cc]
                 if chk != chk:  # NaN → nodata
@@ -294,9 +307,20 @@ def _flow_path_mfd_dask(fractions_data, start_points_data, chunks_y, chunks_x):
     dy_arr = [0, 1, 1, 1, 0, -1, -1, -1]
     dx_arr = [1, 1, 0, -1, -1, -1, 0, 1]
 
+    max_steps = H * W
+
     for r, c, label in points:
         cr, cc = r, c
+        steps = 0
         while True:
+            steps += 1
+            if steps > max_steps:
+                raise ValueError(
+                    "flow_path_mfd: the MFD fraction grid contains a cycle; "
+                    "a traced path revisited cells and did not terminate.  "
+                    "The input must be a directed acyclic graph, as produced "
+                    "by flow_direction_mfd."
+                )
             if _buf_len >= len(_buf_rows):
                 new_cap = len(_buf_rows) * 2
                 _new_rows = np.empty(new_cap, dtype=np.int64)

--- a/xrspatial/hydro/tests/test_flow_accumulation_mfd.py
+++ b/xrspatial/hydro/tests/test_flow_accumulation_mfd.py
@@ -414,3 +414,41 @@ class TestMemoryGuard:
         ):
             with pytest.raises(MemoryError, match="dask"):
                 flow_accumulation_mfd(mfd)
+
+
+def _make_cyclic_mfd(backend='numpy', chunks=(8, 2, 2)):
+    """MFD fractions with a 2-cell horizontal cycle in the top row.
+
+    Row 0: (0,0) flows E into (0,1); (0,1) flows W into (0,0).
+    Row 1: both cells flow S off the grid so they are not in the cycle.
+    """
+    fracs = np.zeros((8, 2, 2), dtype=np.float64)
+    fracs[0, 0, 0] = 1.0  # (0,0) -> E
+    fracs[4, 0, 1] = 1.0  # (0,1) -> W  (closes the cycle)
+    fracs[2, 1, 0] = 1.0  # (1,0) -> S off grid
+    fracs[2, 1, 1] = 1.0  # (1,1) -> S off grid
+    da_obj = xr.DataArray(
+        fracs,
+        dims=('neighbor', 'y', 'x'),
+        coords={'y': [1.0, 0.0], 'x': [0.0, 1.0]},
+    )
+    if backend == 'dask':
+        dask = pytest.importorskip('dask.array')
+        da_obj = xr.DataArray(
+            dask.from_array(fracs, chunks=chunks),
+            dims=da_obj.dims, coords=da_obj.coords)
+    return da_obj
+
+
+class TestFlowAccumulationMFDCycleDetection:
+    """A cyclic fraction grid must raise rather than return wrong values."""
+
+    def test_numpy_cycle_raises(self):
+        mfd = _make_cyclic_mfd(backend='numpy')
+        with pytest.raises(ValueError, match="cycle"):
+            flow_accumulation_mfd(mfd)
+
+    def test_dask_cycle_raises(self):
+        mfd = _make_cyclic_mfd(backend='dask')
+        with pytest.raises(ValueError, match="cycle"):
+            flow_accumulation_mfd(mfd).data.compute()

--- a/xrspatial/hydro/tests/test_flow_length_mfd.py
+++ b/xrspatial/hydro/tests/test_flow_length_mfd.py
@@ -491,3 +491,35 @@ class TestMemoryGuard:
         ):
             with pytest.raises(MemoryError, match="GPU working memory"):
                 flow_length_mfd(raster, direction='downstream')
+
+
+def _cyclic_fractions():
+    """2x2 fractions with a 2-cell horizontal cycle in the top row.
+
+    (0,0) -> E into (0,1); (0,1) -> W into (0,0).  Bottom row flows
+    S off grid, so only the top row forms the cycle.
+    """
+    fracs = np.zeros((8, 2, 2), dtype=np.float64)
+    fracs[0, 0, 0] = 1.0  # (0,0) -> E
+    fracs[4, 0, 1] = 1.0  # (0,1) -> W  (closes the cycle)
+    fracs[2, 1, 0] = 1.0  # (1,0) -> S off grid
+    fracs[2, 1, 1] = 1.0  # (1,1) -> S off grid
+    return fracs
+
+
+class TestFlowLengthMFDCycleDetection:
+    """A cyclic fraction grid must raise rather than return wrong values."""
+
+    @pytest.mark.parametrize('direction', ['downstream', 'upstream'])
+    def test_numpy_cycle_raises(self, direction):
+        raster = _make_mfd_raster(_cyclic_fractions(), backend='numpy')
+        with pytest.raises(ValueError, match="cycle"):
+            flow_length_mfd(raster, direction=direction)
+
+    @pytest.mark.parametrize('direction', ['downstream', 'upstream'])
+    def test_dask_cycle_raises(self, direction):
+        pytest.importorskip('dask.array')
+        raster = _make_mfd_raster(
+            _cyclic_fractions(), backend='dask', chunks=(2, 2))
+        with pytest.raises(ValueError, match="cycle"):
+            flow_length_mfd(raster, direction=direction).data.compute()

--- a/xrspatial/hydro/tests/test_flow_path_mfd.py
+++ b/xrspatial/hydro/tests/test_flow_path_mfd.py
@@ -340,3 +340,41 @@ def test_numpy_equals_dask_cupy():
 
     np.testing.assert_allclose(
         np_result.data, dcp_result.data.compute().get(), equal_nan=True)
+
+
+def _make_cyclic_fractions():
+    """2x2 fractions with a 2-cell horizontal cycle in the top row.
+
+    A dominant-neighbor trace from (0,0) would loop forever without a
+    step cap: (0,0) -> E (0,1) -> W (0,0) -> ...
+    """
+    fracs = np.zeros((8, 2, 2), dtype=np.float64)
+    fracs[0, 0, 0] = 1.0  # (0,0) -> E
+    fracs[4, 0, 1] = 1.0  # (0,1) -> W  (closes the cycle)
+    fracs[2, 1, 0] = 1.0
+    fracs[2, 1, 1] = 1.0
+    return fracs
+
+
+def test_numpy_cycle_raises():
+    """A start point inside a cycle must raise, not hang."""
+    fracs = _make_cyclic_fractions()
+    sp = np.full((2, 2), np.nan)
+    sp[0, 0] = 1.0
+    fd = _make_mfd_raster(fracs, backend='numpy')
+    sp_da = create_test_raster(sp.astype(np.float64), backend='numpy')
+    with pytest.raises(ValueError, match="cycle"):
+        flow_path_mfd(fd, sp_da)
+
+
+def test_dask_cycle_raises():
+    """Dask path must also raise on a cycle rather than loop forever."""
+    pytest.importorskip('dask.array')
+    fracs = _make_cyclic_fractions()
+    sp = np.full((2, 2), np.nan)
+    sp[0, 0] = 1.0
+    fd = _make_mfd_raster(fracs, backend='dask', chunks=(2, 2))
+    sp_da = create_test_raster(
+        sp.astype(np.float64), backend='dask', chunks=(2, 2))
+    with pytest.raises(ValueError, match="cycle"):
+        flow_path_mfd(fd, sp_da).data.compute()


### PR DESCRIPTION
Closes #2866

The MFD flow functions assume their fraction grid is a DAG but never check it. A hand-built or user-supplied grid with a cycle slipped through: `flow_accumulation_mfd` and `flow_length_mfd` returned wrong numbers (cells in the cycle kept their initial value), and `flow_path_mfd` looped forever.

## Changes

- `flow_accumulation_mfd` and `flow_length_mfd`: after the Kahn traversal, compare the processed-cell count against the valid-cell count. If a cycle left some cells with nonzero in-degree, raise a `ValueError` naming the problem. Applied to the eager CPU kernels and the dask tile kernels (downstream and upstream).
- `flow_path_mfd`: the dominant-neighbor trace now caps at `H*W` steps. A path through a DAG visits each cell at most once, so exceeding that bound means a cycle. Applied to the CPU `while True` loop and the dask tracing loop. Both raise instead of spinning.

## Backend coverage

The cycle guard runs on numpy, dask+numpy, and dask+cupy (the cupy and dask+cupy paths route through the same CPU/tile kernels). cupy follows the CPU kernel as well.

## Test plan

- [x] New `ValueError` tests for a 2-cell cycle on numpy and dask, for all three functions and both flow_length directions
- [x] Existing 82 MFD tests still pass (90 total with the new ones)
- [x] Confirmed a valid `flow_direction_mfd` grid still computes on every backend