### PR TITLE
Validate return_type before data work in contours() (#2891)

### DIFF
--- a/xrspatial/contour.py
+++ b/xrspatial/contour.py
@@ -693,6 +693,8 @@ def contours(
         crs = agg.attrs.get('crs', None)
         return _to_geopandas(results, crs=crs)
     else:
+        # Unreachable: return_type is validated at the top of the function.
+        # Kept as a defensive guard.
         raise ValueError(
             f"Invalid return_type '{return_type}'. "
             "Allowed values are 'numpy' and 'geopandas'."

--- a/xrspatial/contour.py
+++ b/xrspatial/contour.py
@@ -616,6 +616,11 @@ def contours(
     >>> level, coords = lines[0]
     """
     _validate_raster(agg, func_name='contours', name='agg', ndim=2)
+    if return_type not in ("numpy", "geopandas"):
+        raise ValueError(
+            f"Invalid return_type '{return_type}'. "
+            "Allowed values are 'numpy' and 'geopandas'."
+        )
     if agg.shape[0] < 2 or agg.shape[1] < 2:
         raise ValueError(
             "Input raster must have at least 2 rows and 2 columns"

--- a/xrspatial/tests/test_contour.py
+++ b/xrspatial/tests/test_contour.py
@@ -282,6 +282,46 @@ class TestEdgeCases:
         with pytest.raises(TypeError, match="xarray.DataArray"):
             contours(data, levels=[0.5])
 
+    def test_invalid_return_type_rejected(self):
+        """A bad return_type raises ValueError for a normal raster."""
+        data = _make_ramp(ny=5, nx=6)
+        agg = create_test_raster(data, backend='numpy')
+        with pytest.raises(ValueError, match="Invalid return_type"):
+            contours(agg, levels=[2.5], return_type="bad")
+
+    def test_invalid_return_type_rejected_all_nan(self):
+        """A bad return_type raises even on the all-non-finite path.
+
+        Previously the all-non-finite early return handed back an empty
+        GeoDataFrame for any non-'numpy' value instead of raising.
+        """
+        data = np.full((4, 4), np.nan, dtype=np.float64)
+        agg = create_test_raster(data, backend='numpy')
+        with pytest.raises(ValueError, match="Invalid return_type"):
+            contours(agg, return_type="bad")
+
+    def test_invalid_return_type_checked_before_data_work(self):
+        """return_type is validated before level computation / extraction.
+
+        A degenerate all-NaN raster (which would otherwise take the
+        early-return path) still raises on the bad argument.
+        """
+        data = np.full((4, 4), np.nan, dtype=np.float64)
+        agg = create_test_raster(data, backend='numpy')
+        with pytest.raises(ValueError, match="Invalid return_type"):
+            contours(agg, levels=[0.5], return_type="bad")
+
+    def test_valid_return_types_accepted(self):
+        """The two valid return_type values still work."""
+        data = _make_ramp(ny=5, nx=6)
+        agg = create_test_raster(data, backend='numpy')
+        result = contours(agg, levels=[2.5], return_type="numpy")
+        assert isinstance(result, list)
+
+        gpd = pytest.importorskip("geopandas")
+        gdf = contours(agg, levels=[2.5], return_type="geopandas")
+        assert isinstance(gdf, gpd.GeoDataFrame)
+
 
 # ---------------------------------------------------------------------------
 # Segment stitching


### PR DESCRIPTION
Closes #2891

`contours()` only checked `return_type` at the end of its dispatch chain.
The all-non-finite early return (`contour.py:653-656`) ran before that
check, so any non-`"numpy"` value fell through to the GeoDataFrame branch:
`contours(all_nan, return_type="bad")` handed back an empty GeoDataFrame
instead of raising.

- Add an explicit `return_type` check right after `_validate_raster`, before
  any level computation or extraction. Bad values raise `ValueError` with the
  same wording the late branch already used.
- The late `else: raise` stays in place but is now unreachable for bad values;
  the legitimate numpy/geopandas dispatch is untouched.

Backend coverage: pure validation at the DataArray boundary, so it applies
across numpy / cupy / dask+numpy / dask+cupy without backend-specific code.

Test plan:
- [x] `return_type="bad"` raises on a normal raster
- [x] `return_type="bad"` raises on the all-non-finite path (the silent case)
- [x] validation fires before data work on a degenerate all-NaN raster
- [x] `"numpy"` and `"geopandas"` still work
- [x] full `test_contour.py` passes (50 tests)