### PR TITLE
Resolve contours output CRS the same way as polygonize (#2893)

### DIFF
--- a/xrspatial/contour.py
+++ b/xrspatial/contour.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, List, Optional, Sequence, Tuple, Union
 import numpy as np
 import xarray as xr
 
+from .polygonize import _detect_raster_crs
 from .utils import ArrayTypeFunctionMapping, _validate_raster, ngjit
 
 if TYPE_CHECKING:
@@ -653,7 +654,7 @@ def contours(
         if not np.isfinite(vmin) or not np.isfinite(vmax):
             if return_type == "numpy":
                 return []
-            return _to_geopandas([], crs=agg.attrs.get('crs', None))
+            return _to_geopandas([], crs=_detect_raster_crs(agg))
 
         # Exclude exact min/max to avoid tracing along the boundary.
         levels = np.linspace(vmin, vmax, n_levels + 2)[1:-1]
@@ -685,7 +686,7 @@ def contours(
     if return_type == "numpy":
         return results
     elif return_type == "geopandas":
-        crs = agg.attrs.get('crs', None)
+        crs = _detect_raster_crs(agg)
         return _to_geopandas(results, crs=crs)
     else:
         raise ValueError(

--- a/xrspatial/tests/test_contour.py
+++ b/xrspatial/tests/test_contour.py
@@ -751,23 +751,25 @@ class TestCRSPropagation:
         assert isinstance(gdf, gpd.GeoDataFrame)
         assert gdf.crs is None
 
-    @pytest.mark.parametrize("attrs", [
-        {'crs': 'EPSG:5070'},
-        {'crs_wkt': None},  # filled in below with a real WKT
-        {},
+    @staticmethod
+    def _wkt_4326():
+        from pyproj import CRS
+        return {'crs_wkt': CRS.from_epsg(4326).to_wkt()}
+
+    @pytest.mark.parametrize("attrs_factory", [
+        pytest.param(lambda: {'crs': 'EPSG:5070'}, id="crs"),
+        pytest.param(lambda: TestCRSPropagation._wkt_4326(), id="crs_wkt"),
+        pytest.param(lambda: {}, id="no_crs"),
     ])
-    def test_geopandas_crs_matches_detect_raster_crs(self, attrs):
+    def test_geopandas_crs_matches_detect_raster_crs(self, attrs_factory):
         """contours resolves the same CRS polygonize would for one raster."""
         pytest.importorskip("geopandas")
         from pyproj import CRS
 
         from xrspatial.polygonize import _detect_raster_crs
 
-        if 'crs_wkt' in attrs:
-            attrs = {'crs_wkt': CRS.from_epsg(4326).to_wkt()}
-
         agg = self._bare_raster()
-        agg.attrs.update(attrs)
+        agg.attrs.update(attrs_factory())
         gdf = contours(agg, levels=[1.5], return_type="geopandas")
 
         expected = _detect_raster_crs(agg)

--- a/xrspatial/tests/test_contour.py
+++ b/xrspatial/tests/test_contour.py
@@ -703,6 +703,79 @@ class TestCRSPropagation:
         assert isinstance(gdf, gpd.GeoDataFrame)
         assert gdf.crs is None
 
+    # CRS-resolver parity with polygonize (#2893). contours must use the
+    # same resolution order as polygonize._detect_raster_crs:
+    #   attrs['crs'] -> attrs['crs_wkt'] -> raster.rio.crs -> None.
+
+    @staticmethod
+    def _bare_raster():
+        """A peak raster with explicit coords and no CRS metadata."""
+        data = _make_peak()
+        agg = xr.DataArray(data, dims=['y', 'x'])
+        agg['y'] = np.linspace(2.0, 0.0, data.shape[0])
+        agg['x'] = np.linspace(0.0, 2.0, data.shape[1])
+        return agg
+
+    def test_geopandas_crs_from_crs_wkt(self):
+        """A raster with only attrs['crs_wkt'] still georeferences the gdf.
+
+        Previously contours read only attrs['crs'], so a crs_wkt-only raster
+        produced an unprojected GeoDataFrame.
+        """
+        pytest.importorskip("geopandas")
+        from pyproj import CRS
+
+        agg = self._bare_raster()
+        agg.attrs['crs_wkt'] = CRS.from_epsg(5070).to_wkt()
+        gdf = contours(agg, levels=[1.5], return_type="geopandas")
+        assert gdf.crs is not None
+        assert gdf.crs.to_epsg() == 5070
+
+    def test_geopandas_crs_attr_precedence(self):
+        """attrs['crs'] wins over attrs['crs_wkt'] when both are present."""
+        pytest.importorskip("geopandas")
+        from pyproj import CRS
+
+        agg = self._bare_raster()
+        agg.attrs['crs'] = 'EPSG:5070'
+        agg.attrs['crs_wkt'] = CRS.from_epsg(4326).to_wkt()
+        gdf = contours(agg, levels=[1.5], return_type="geopandas")
+        assert gdf.crs is not None
+        assert gdf.crs.to_epsg() == 5070
+
+    def test_geopandas_no_crs_info(self):
+        """A raster with no CRS info yields a GeoDataFrame with crs None."""
+        gpd = pytest.importorskip("geopandas")
+        agg = self._bare_raster()
+        gdf = contours(agg, levels=[1.5], return_type="geopandas")
+        assert isinstance(gdf, gpd.GeoDataFrame)
+        assert gdf.crs is None
+
+    @pytest.mark.parametrize("attrs", [
+        {'crs': 'EPSG:5070'},
+        {'crs_wkt': None},  # filled in below with a real WKT
+        {},
+    ])
+    def test_geopandas_crs_matches_detect_raster_crs(self, attrs):
+        """contours resolves the same CRS polygonize would for one raster."""
+        pytest.importorskip("geopandas")
+        from pyproj import CRS
+
+        from xrspatial.polygonize import _detect_raster_crs
+
+        if 'crs_wkt' in attrs:
+            attrs = {'crs_wkt': CRS.from_epsg(4326).to_wkt()}
+
+        agg = self._bare_raster()
+        agg.attrs.update(attrs)
+        gdf = contours(agg, levels=[1.5], return_type="geopandas")
+
+        expected = _detect_raster_crs(agg)
+        if expected is None:
+            assert gdf.crs is None
+        else:
+            assert gdf.crs == CRS.from_user_input(expected)
+
 
 # ---------------------------------------------------------------------------
 # Non-default dim names: index -> coordinate transform (#2704 audit, Cat 5)


### PR DESCRIPTION
Closes #2893

`contours(..., return_type='geopandas')` read the output CRS only from `agg.attrs['crs']`. The other raster-to-vector function, `polygonize`, uses a fuller resolver, `_detect_raster_crs` (attrs['crs'] -> attrs['crs_wkt'] -> raster.rio.crs -> None). So a raster georeferenced via `crs_wkt` or `rio.crs` would polygonize with a CRS but contour without one.

Now both functions resolve georeferencing the same way:

- contours reuses `polygonize._detect_raster_crs` at both CRS sites in `contour.py` (the all-non-finite early return and the main geopandas return). No import cycle: polygonize does not import contour.
- polygonize is unchanged.

Backend coverage: CRS resolution is backend-independent. The geopandas return path is numpy-only (it builds shapely geometries on the host), so the tests run on numpy.

Test plan:
- crs_wkt-only raster now yields a GeoDataFrame with its CRS set (was None before).
- attrs['crs'] still takes precedence over attrs['crs_wkt'].
- A raster with no CRS info yields crs None.
- Parity: contours(...).crs matches what _detect_raster_crs returns for the same raster.
- Full test_contour.py suite passes (52 tests).