### PR TITLE
Drop zero-length contour geometry at exact-level corners

### DIFF
--- a/xrspatial/contour.py
+++ b/xrspatial/contour.py
@@ -209,7 +209,10 @@ def _emit_seg(r, c, tl, tr, bl, br, level, edge_a, edge_b,
     # happens the interpolation parameter lands on the corner and both
     # endpoints can collapse onto the same point, producing a zero-length
     # segment.  Drop those here so no zero-length / single-point geometry
-    # reaches stitching or GeoDataFrame output.
+    # reaches stitching or GeoDataFrame output.  Exact float equality is
+    # intended: a real collapse computes both endpoints from the same corner
+    # value and yields bit-identical coordinates, while near-equal endpoints
+    # are genuine short segments and must be kept.
     if r0 == r1 and c0 == c1:
         return
 
@@ -571,7 +574,10 @@ def _to_geopandas(results, crs=None):
 
     records = []
     for level, coords in results:
-        if len(coords) >= 2:
+        # Require at least two distinct vertices.  _stitch_segments already
+        # drops single-point polylines, but guard here too so the geopandas
+        # path never emits a zero-length / invalid LineString on its own.
+        if _has_distinct_points(coords, 10):
             # coords are (row, col); convert to (x, y) = (col, row)
             geom = LineString(coords[:, ::-1])
             records.append({'level': level, 'geometry': geom})

--- a/xrspatial/contour.py
+++ b/xrspatial/contour.py
@@ -204,6 +204,15 @@ def _emit_seg(r, c, tl, tr, bl, br, level, edge_a, edge_b,
         r1 = float(r) + t
         c1 = float(c)
 
+    # Degenerate-segment policy: corners are classified with ``>= level``,
+    # so a corner exactly equal to the level is treated as above.  When that
+    # happens the interpolation parameter lands on the corner and both
+    # endpoints can collapse onto the same point, producing a zero-length
+    # segment.  Drop those here so no zero-length / single-point geometry
+    # reaches stitching or GeoDataFrame output.
+    if r0 == r1 and c0 == c1:
+        return
+
     seg_rows[idx, 0] = r0
     seg_rows[idx, 1] = r1
     seg_cols[idx, 0] = c0
@@ -277,9 +286,26 @@ def _stitch_segments(seg_rows, seg_cols, n_segs):
                     break
 
         coords = np.column_stack([line_r, line_c])
-        lines.append(coords)
+        # Drop polylines that collapse to a single distinct point.  A line
+        # with fewer than two distinct vertices has zero length and produces
+        # an invalid LineString downstream.
+        if _has_distinct_points(coords, DECIMALS):
+            lines.append(coords)
 
     return lines
+
+
+def _has_distinct_points(coords, decimals):
+    """Return True if a polyline has at least two distinct vertices."""
+    if len(coords) < 2:
+        return False
+    r0 = round(coords[0, 0], decimals)
+    c0 = round(coords[0, 1], decimals)
+    for i in range(1, len(coords)):
+        if round(coords[i, 0], decimals) != r0 or \
+                round(coords[i, 1], decimals) != c0:
+            return True
+    return False
 
 
 def _extend_line(line_r, line_c, direction, rows, cols, used, endpoint_map,
@@ -607,6 +633,14 @@ def contours(
     is an inherently sequential graph traversal.  For Dask inputs,
     each chunk is processed independently and results are merged,
     keeping peak memory proportional to chunk size.
+
+    Corners are classified with ``>= level``, so a corner exactly equal
+    to the level is treated as above it.  This can make a traced segment
+    collapse onto a single point.  Such degenerate (zero-length or
+    single-distinct-point) segments and polylines are dropped before
+    output, so no zero-length or invalid geometry reaches the numpy or
+    geopandas result.  The rule is applied identically across the numpy,
+    cupy, dask+numpy, and dask+cupy backends.
 
     Examples
     --------

--- a/xrspatial/tests/test_contour.py
+++ b/xrspatial/tests/test_contour.py
@@ -756,3 +756,116 @@ class TestNonDefaultDims:
         for (lvl_a, c_a), (lvl_b, c_b) in zip(r_yx, r_ll):
             assert lvl_a == lvl_b
             np.testing.assert_allclose(c_a, c_b)
+
+
+# ---------------------------------------------------------------------------
+# Degenerate geometry at exact-level corners (issue #2892)
+# ---------------------------------------------------------------------------
+
+def _make_checkerboard(n=4, lo=0.0, hi=1.0):
+    """n x n checkerboard alternating between lo and hi."""
+    board = np.indices((n, n)).sum(axis=0) % 2
+    return np.where(board == 0, lo, hi).astype(np.float64)
+
+
+def _assert_no_degenerate_numpy(result):
+    """Every numpy polyline has at least two distinct vertices, no repeats."""
+    for level, coords in result:
+        # No two consecutive points are identical.
+        if len(coords) >= 2:
+            diffs = np.abs(np.diff(coords, axis=0)).sum(axis=1)
+            assert np.all(diffs > 0), (
+                f"repeated consecutive point at level {level}: {coords}"
+            )
+        # At least two distinct vertices (non-zero extent).
+        distinct = np.unique(np.round(coords, 10), axis=0)
+        assert len(distinct) >= 2, (
+            f"single-point polyline at level {level}: {coords}"
+        )
+
+
+def _assert_no_degenerate_geopandas(gdf):
+    """No geometry is zero-length or invalid in Shapely."""
+    for geom in gdf.geometry:
+        assert geom.length > 0, f"zero-length geometry: {geom.wkt}"
+        assert geom.is_valid, f"invalid geometry: {geom.wkt}"
+
+
+class TestDegenerateExactLevel:
+    """A corner exactly equal to the level must not poison the output.
+
+    Corners are classified with ``>= level`` (treated as above), so the
+    fix is to drop the zero-length / single-point segments that would
+    otherwise collapse onto that corner.  The rule must hold identically
+    on every backend.
+    """
+
+    def test_checkerboard_numpy_no_zero_length(self):
+        data = _make_checkerboard(4, lo=0.0, hi=1.0)
+        agg = create_test_raster(data, backend='numpy')
+        result = contours(agg, levels=[1.0])
+        _assert_no_degenerate_numpy(result)
+
+    def test_checkerboard_numpy_geopandas_valid(self):
+        pytest.importorskip("geopandas")
+        data = _make_checkerboard(4, lo=0.0, hi=1.0)
+        agg = create_test_raster(data, backend='numpy')
+        gdf = contours(agg, levels=[1.0], return_type="geopandas")
+        _assert_no_degenerate_geopandas(gdf)
+
+    def test_checkerboard_equality_consistent(self):
+        """The level lands on every 'hi' corner; orientation must not matter.
+
+        Two checkerboards that differ only by which phase carries the
+        exact-level value must both yield clean (degenerate-free) output.
+        """
+        for lo, hi in [(0.0, 1.0), (1.0, 2.0), (2.0, 1.0)]:
+            data = _make_checkerboard(4, lo=lo, hi=hi)
+            agg = create_test_raster(data, backend='numpy')
+            result = contours(agg, levels=[1.0])
+            _assert_no_degenerate_numpy(result)
+
+    @dask_array_available
+    def test_checkerboard_dask_no_zero_length(self):
+        data = _make_checkerboard(4, lo=0.0, hi=1.0)
+        agg = create_test_raster(data, backend='dask+numpy', chunks=(2, 2))
+        result = contours(agg, levels=[1.0])
+        _assert_no_degenerate_numpy(result)
+
+    @dask_array_available
+    def test_checkerboard_dask_geopandas_valid(self):
+        pytest.importorskip("geopandas")
+        data = _make_checkerboard(4, lo=0.0, hi=1.0)
+        agg = create_test_raster(data, backend='dask+numpy', chunks=(2, 2))
+        gdf = contours(agg, levels=[1.0], return_type="geopandas")
+        _assert_no_degenerate_geopandas(gdf)
+
+    @dask_array_available
+    def test_checkerboard_numpy_matches_dask(self):
+        """numpy and dask agree that the checkerboard yields no geometry."""
+        data = _make_checkerboard(4, lo=0.0, hi=1.0)
+        np_agg = create_test_raster(data, backend='numpy')
+        dk_agg = create_test_raster(
+            data, backend='dask+numpy', chunks=(2, 2)
+        )
+        np_res = contours(np_agg, levels=[1.0])
+        dk_res = contours(dk_agg, levels=[1.0])
+        _assert_no_degenerate_numpy(np_res)
+        _assert_no_degenerate_numpy(dk_res)
+        assert len(np_res) == len(dk_res)
+
+    def test_genuine_contour_survives(self):
+        """The degenerate filter must not drop real crossings.
+
+        A ramp that crosses the level mid-edge still produces a valid,
+        non-zero-length contour.
+        """
+        pytest.importorskip("geopandas")
+        data = _make_ramp(ny=5, nx=6)
+        agg = create_test_raster(data, backend='numpy')
+        result = contours(agg, levels=[2.5])
+        assert len(result) > 0
+        _assert_no_degenerate_numpy(result)
+        gdf = contours(agg, levels=[2.5], return_type="geopandas")
+        assert len(gdf) > 0
+        _assert_no_degenerate_geopandas(gdf)


### PR DESCRIPTION
Closes #2892

## Problem

`contours()` classifies corners with `>= level`, so a corner exactly equal to the level is treated as above it. When that happens the marching-squares interpolation lands the crossing on the corner, and both endpoints of a segment can collapse onto the same point. The result is a zero-length segment that becomes an invalid LineString (`is_valid == False`, length 0) once it reaches the GeoDataFrame.

A 4x4 checkerboard of 0 and 1 at `level=1.0` produced 8 such zero-length geometries.

## Fix

Filter degenerate geometry in the backend-agnostic stitching/output layer, so both `return_type="numpy"` and `return_type="geopandas"` stay clean:

- `_emit_seg` skips writing a segment when its two endpoints are identical (zero length).
- `_stitch_segments` drops any polyline that collapses to a single distinct point.
- The policy is documented in the `contours()` docstring.

Corners are still classified with `>= level` (equality counts as above), and that rule is applied the same way every time. Genuine mid-edge crossings are untouched.

## Backends

The fix lives in shared Python helpers that all four backends route through (`_emit_seg`, `_stitch_segments`), so numpy, cupy, dask+numpy, and dask+cupy get the same behavior.

## Test plan

- [x] Checkerboard at `level=1.0` produces no zero-length segments and no invalid LineStrings (numpy and dask)
- [x] No repeated consecutive points in emitted geometries
- [x] Equality semantics consistent across checkerboard phase variants
- [x] Genuine ramp crossing still produces valid contours (regression guard)
- [x] Existing contour tests still pass (53 total, 7 new)