### PR TITLE
Fix contours() docstring overstating Dask peak-memory guarantee

### DIFF
--- a/xrspatial/contour.py
+++ b/xrspatial/contour.py
@@ -9,6 +9,7 @@
 # levels, making it well suited to Dask chunking and GPU execution.
 
 import warnings
+from itertools import chain
 from typing import TYPE_CHECKING, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -401,12 +402,7 @@ def _contours_dask(data, levels):
         r_off += rsize
 
     chunk_results = dask.compute(*all_results)
-
-    merged = []
-    for chunk_lines in chunk_results:
-        merged.extend(chunk_lines)
-
-    return _deduplicate_by_level(merged)
+    return _deduplicate_by_level(chain.from_iterable(chunk_results))
 
 
 def _contours_dask_cupy(data, levels):
@@ -433,12 +429,7 @@ def _contours_dask_cupy(data, levels):
         r_off += rsize
 
     chunk_results = dask.compute(*all_results)
-
-    merged = []
-    for chunk_lines in chunk_results:
-        merged.extend(chunk_lines)
-
-    return _deduplicate_by_level(merged)
+    return _deduplicate_by_level(chain.from_iterable(chunk_results))
 
 
 def _process_chunk_numpy(chunk_data, levels, r_offset, c_offset):
@@ -605,8 +596,10 @@ def contours(
     CuPy and Dask+CuPy arrays are accepted as input.  Data is
     transferred to CPU for the tracing step because segment stitching
     is an inherently sequential graph traversal.  For Dask inputs,
-    each chunk is processed independently and results are merged,
-    keeping peak memory proportional to chunk size.
+    chunking bounds the per-chunk scan buffers, but the global merge
+    step materializes all contour segments at once to stitch polylines
+    across chunk boundaries, so peak memory scales with total contour
+    complexity rather than chunk size.
 
     Examples
     --------

--- a/xrspatial/contour.py
+++ b/xrspatial/contour.py
@@ -9,7 +9,6 @@
 # levels, making it well suited to Dask chunking and GPU execution.
 
 import warnings
-from itertools import chain
 from typing import TYPE_CHECKING, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
@@ -402,7 +401,12 @@ def _contours_dask(data, levels):
         r_off += rsize
 
     chunk_results = dask.compute(*all_results)
-    return _deduplicate_by_level(chain.from_iterable(chunk_results))
+
+    merged = []
+    for chunk_lines in chunk_results:
+        merged.extend(chunk_lines)
+
+    return _deduplicate_by_level(merged)
 
 
 def _contours_dask_cupy(data, levels):
@@ -429,7 +433,12 @@ def _contours_dask_cupy(data, levels):
         r_off += rsize
 
     chunk_results = dask.compute(*all_results)
-    return _deduplicate_by_level(chain.from_iterable(chunk_results))
+
+    merged = []
+    for chunk_lines in chunk_results:
+        merged.extend(chunk_lines)
+
+    return _deduplicate_by_level(merged)
 
 
 def _process_chunk_numpy(chunk_data, levels, r_offset, c_offset):

--- a/xrspatial/tests/test_contour.py
+++ b/xrspatial/tests/test_contour.py
@@ -757,23 +757,3 @@ class TestNonDefaultDims:
             assert lvl_a == lvl_b
             np.testing.assert_allclose(c_a, c_b)
 
-
-# ---------------------------------------------------------------------------
-# Docstring wording: the Dask memory description must be accurate (#2787)
-# ---------------------------------------------------------------------------
-
-class TestDocstringWording:
-
-    def test_dask_memory_wording_pinned(self):
-        """Docstring does not overstate Dask peak-memory guarantee.
-
-        Regression guard for #2787: the docstring should accurately
-        describe that chunking bounds per-chunk scan buffers but the
-        global merge materialises all segments.
-        """
-        doc = contours.__doc__
-        assert doc is not None
-
-        assert "keeping peak memory proportional to chunk size" not in doc
-        assert "peak memory scales with total contour" in doc
-        assert "chunk size" in doc

--- a/xrspatial/tests/test_contour.py
+++ b/xrspatial/tests/test_contour.py
@@ -756,3 +756,24 @@ class TestNonDefaultDims:
         for (lvl_a, c_a), (lvl_b, c_b) in zip(r_yx, r_ll):
             assert lvl_a == lvl_b
             np.testing.assert_allclose(c_a, c_b)
+
+
+# ---------------------------------------------------------------------------
+# Docstring wording: the Dask memory description must be accurate (#2787)
+# ---------------------------------------------------------------------------
+
+class TestDocstringWording:
+
+    def test_dask_memory_wording_pinned(self):
+        """Docstring does not overstate Dask peak-memory guarantee.
+
+        Regression guard for #2787: the docstring should accurately
+        describe that chunking bounds per-chunk scan buffers but the
+        global merge materialises all segments.
+        """
+        doc = contours.__doc__
+        assert doc is not None
+
+        assert "keeping peak memory proportional to chunk size" not in doc
+        assert "peak memory scales with total contour" in doc
+        assert "chunk size" in doc


### PR DESCRIPTION
## Summary

Closes #2787. The `contours()` docstring in `xrspatial/contour.py` tells Dask users:

> For Dask inputs, each chunk is processed independently and results are merged, keeping peak memory proportional to chunk size.

The implementation does not deliver that guarantee. The global merge step (`_deduplicate_by_level`) materialises all contour segments at once to stitch polylines across chunk boundaries, so peak memory scales with total contour complexity, not chunk size. Cross-chunk stitching inherently needs all segments for a level in memory simultaneously.

## Change

`xrspatial/contour.py` — corrected the Notes section to accurately describe the memory trade-off.

## Testing

No behavioural changes — the fix edits only a docstring.