### PR TITLE
Fix bounded dask proximity dropping in-range targets on irregular coords

### DIFF
--- a/xrspatial/proximity.py
+++ b/xrspatial/proximity.py
@@ -1533,8 +1533,14 @@ def _process(
         else:
             pad_y, pad_x = _halo_depth(
                 x_coords, y_coords, max_distance, distance_metric)
-            pad_y, pad_x, (raster.data, xs, ys) = _fit_halo_to_chunks(
-                pad_y, pad_x, raster.data, xs, ys)
+            # Fold into the same local ``data`` the map_overlap call uses, not
+            # ``raster.data``: assigning back to ``raster.data`` would both
+            # mutate the caller's input (issue #2847) and leave map_overlap
+            # reading the stale, un-folded array while xs/ys are folded, so
+            # chunking disagrees and in-range targets in adjacent chunks drop
+            # to NaN (issue #2908).
+            pad_y, pad_x, (data, xs, ys) = _fit_halo_to_chunks(
+                pad_y, pad_x, data, xs, ys)
 
         out = da.map_overlap(
             _process_numpy,

--- a/xrspatial/tests/test_proximity.py
+++ b/xrspatial/tests/test_proximity.py
@@ -1530,6 +1530,35 @@ def test_bounded_dask_irregular_coords_matches_numpy(func):
 
 @pytest.mark.skipif(da is None, reason="dask is not installed")
 @pytest.mark.parametrize("func", [proximity, allocation, direction])
+def test_bounded_dask_does_not_mutate_input(func):
+    """Bounded dask must not rebind or rechunk the caller's .data (issue #2908).
+
+    When the halo is deeper than a chunk, the bounded path folds that axis into
+    a single chunk. The fold used to be assigned back to ``raster.data``, which
+    rebound the caller's DataArray (the same mutation issue #2847 guards
+    against) and left map_overlap reading a stale, un-folded array. Sizing the
+    halo at 3 px against width-2 column chunks forces the column-axis fold.
+    """
+    coords = np.array([0, 100, 101, 102, 103, 104, 105, 106], dtype=float)
+    data = np.zeros((8, 8), dtype=np.float64)
+    data[3, 3] = 1.0
+    raster = xr.DataArray(data, dims=['lat', 'lon'])
+    raster['lon'] = coords
+    raster['lat'] = coords
+    raster.data = da.from_array(data, chunks=(4, 2))
+
+    data_before = raster.data
+    chunks_before = raster.data.chunks
+
+    func(raster, x='lon', y='lat', max_distance=2.5).compute()
+
+    assert raster.data is data_before, "bounded dask rebound the input .data"
+    assert raster.data.chunks == chunks_before, \
+        "bounded dask rechunked the input"
+
+
+@pytest.mark.skipif(da is None, reason="dask is not installed")
+@pytest.mark.parametrize("func", [proximity, allocation, direction])
 @pytest.mark.parametrize("shape_name", ["1xN", "Nx1"])
 def test_bounded_dask_single_row_or_col_matches_numpy(func, shape_name):
     """Bounded dask must not crash on 1xN / Nx1 rasters.


### PR DESCRIPTION
Closes #2908

## What

- The bounded dask path of proximity/allocation/direction folded the halo with `_fit_halo_to_chunks` but assigned the folded array back to `raster.data` instead of the local `data` that `map_overlap` actually reads. The call then mixed a stale, un-folded data array with folded `xs`/`ys`, so chunking disagreed and in-range targets in adjacent column chunks dropped to NaN on irregularly spaced coordinates. The same assignment mutated the caller's input DataArray, the mutation issue #2847 already guards against.
- Assign the fold into the local `data`, matching the unbounded branch right above it. One line of behaviour change plus an explanatory comment.

## Backend coverage

- dask+numpy: fixed (this is where the bug lived).
- dask+cupy: already correct; `_process_dask_cupy` folds into a local `raster_data` and passes that to `map_overlap`, so it neither mutated the input nor mismatched chunking. No change needed.
- numpy / cupy: not on this code path.

## Test plan

- [x] `test_bounded_dask_irregular_coords_matches_numpy` passes for proximity, allocation, direction (was failing on all three).
- [x] New `test_bounded_dask_does_not_mutate_input` asserts the caller's `.data` is neither rebound nor rechunked; verified it fails on the pre-fix code.
- [x] Full `test_proximity.py` green (410 passed).

No new public API and no backend-support change, so the user-guide notebook and README feature-matrix steps do not apply. CHANGELOG left untouched.