### PR TITLE
geotiff: write VRT index atomically via temp-then-rename (#2965)

### DIFF
--- a/xrspatial/geotiff/_vrt.py
+++ b/xrspatial/geotiff/_vrt.py
@@ -2242,7 +2242,13 @@ def write_vrt(vrt_path: str, source_files: list[str], *,
     lines.append('</VRTDataset>')
 
     xml = '\n'.join(lines) + '\n'
-    with open(vrt_path, 'w') as f:
-        f.write(xml)
+    # Write the index atomically: a temp file in the destination
+    # directory followed by ``os.replace``. The tiled writer promotes the
+    # tile directory before this call, so a direct in-place write here is
+    # the last non-atomic step and an interrupted write would leave a
+    # partial ``.vrt`` pointing at a complete tile set. ``_write_bytes``
+    # already implements the temp-then-rename pattern for local paths.
+    from ._writer import _write_bytes
+    _write_bytes(xml.encode('utf-8'), vrt_path)
 
     return vrt_path

--- a/xrspatial/geotiff/tests/write/test_basic.py
+++ b/xrspatial/geotiff/tests/write/test_basic.py
@@ -1526,6 +1526,78 @@ def test_compatible_sources_succeed(tmp_path):
     assert os.path.exists(vrt)
 
 
+def test_write_vrt_leaves_no_temp_file(tmp_path):
+    """A successful write_vrt leaves the final .vrt and no stray temp
+    files in the destination directory (issue #2965)."""
+    d = _unique_dir(tmp_path, "atomic_clean")
+    a = os.path.join(d, "a.tif")
+    b = os.path.join(d, "b.tif")
+    _write_tif(a, h=4, w=4, dtype=np.float32)
+    _write_tif(b, h=4, w=4, dtype=np.float32, origin_x=4.0)
+    vrt = os.path.join(d, "out.vrt")
+    _priv_write_vrt(vrt, [a, b])
+    assert os.path.exists(vrt)
+    # No leftover temp artifacts from the temp-then-rename write.
+    leftovers = glob.glob(os.path.join(d, "*.tmp")) + glob.glob(
+        os.path.join(d, "*.tmp*"))
+    assert leftovers == [], f"temp files not cleaned up: {leftovers}"
+
+
+def test_write_vrt_no_partial_file_on_write_failure(tmp_path, monkeypatch):
+    """If the index write fails mid-flight, no partial .vrt is left at
+    the final path (issue #2965). The write goes to a temp file in the
+    destination directory and is os.replace'd into place, so a failure
+    before the rename never publishes a truncated index."""
+    d = _unique_dir(tmp_path, "atomic_fail")
+    a = os.path.join(d, "a.tif")
+    b = os.path.join(d, "b.tif")
+    _write_tif(a, h=4, w=4, dtype=np.float32)
+    _write_tif(b, h=4, w=4, dtype=np.float32, origin_x=4.0)
+    vrt = os.path.join(d, "out.vrt")
+
+    # Force the atomic helper to blow up while writing the temp file,
+    # before any rename onto the final path could happen.
+    def boom(file_bytes, path):
+        raise OSError("simulated disk-full during VRT index write")
+
+    # write_vrt imports _write_bytes locally from _writer at call time,
+    # so patching the source module is what intercepts the call.
+    monkeypatch.setattr(writer_mod, "_write_bytes", boom)
+
+    with pytest.raises(OSError, match="simulated disk-full"):
+        _priv_write_vrt(vrt, [a, b])
+
+    # The final path must not exist as a partial file.
+    assert not os.path.exists(vrt)
+
+
+def test_write_vrt_failure_preserves_existing_file(tmp_path, monkeypatch):
+    """A failed re-write leaves any pre-existing .vrt at the final path
+    untouched rather than truncating it (issue #2965)."""
+    d = _unique_dir(tmp_path, "atomic_preserve")
+    a = os.path.join(d, "a.tif")
+    b = os.path.join(d, "b.tif")
+    _write_tif(a, h=4, w=4, dtype=np.float32)
+    _write_tif(b, h=4, w=4, dtype=np.float32, origin_x=4.0)
+    vrt = os.path.join(d, "out.vrt")
+
+    # First write succeeds and produces a valid index.
+    _priv_write_vrt(vrt, [a, b])
+    original = open(vrt, "rb").read()
+    assert original
+
+    def boom(file_bytes, path):
+        raise OSError("simulated failure during VRT rewrite")
+
+    monkeypatch.setattr(writer_mod, "_write_bytes", boom)
+    with pytest.raises(OSError, match="simulated failure"):
+        _priv_write_vrt(vrt, [a, b])
+
+    # The original index is intact (the temp-then-rename never published
+    # a partial file over it).
+    assert open(vrt, "rb").read() == original
+
+
 def test_pixel_size_within_tolerance_accepted(tmp_path):
     d = _unique_dir(tmp_path, "tol")
     a = os.path.join(d, "a.tif")

--- a/xrspatial/geotiff/tests/write/test_basic.py
+++ b/xrspatial/geotiff/tests/write/test_basic.py
@@ -1583,7 +1583,8 @@ def test_write_vrt_failure_preserves_existing_file(tmp_path, monkeypatch):
 
     # First write succeeds and produces a valid index.
     _priv_write_vrt(vrt, [a, b])
-    original = open(vrt, "rb").read()
+    with open(vrt, "rb") as f:
+        original = f.read()
     assert original
 
     def boom(file_bytes, path):
@@ -1595,7 +1596,8 @@ def test_write_vrt_failure_preserves_existing_file(tmp_path, monkeypatch):
 
     # The original index is intact (the temp-then-rename never published
     # a partial file over it).
-    assert open(vrt, "rb").read() == original
+    with open(vrt, "rb") as f:
+        assert f.read() == original
 
 
 def test_pixel_size_within_tolerance_accepted(tmp_path):


### PR DESCRIPTION
Closes #2965

`write_vrt` in `xrspatial/geotiff/_vrt.py` wrote the final `.vrt` in place with `open(vrt_path, 'w')`. A crash, a full disk, or an interrupted write between `open` and the finished `write` could leave a truncated index at the final path.

The tiled writer makes this worse. `_write_vrt_tiled` promotes the staging tile directory to its final name with an atomic `os.replace` and only then writes the index, so the index was the last non-atomic step. A partial index would point at a complete, fully-promoted tile set, and a reader that picks it up sees a valid tile directory behind a malformed index.

## Change

Route the index write through the existing `_write_bytes` helper in `_writer.py`. It writes to a temp file in the destination directory and `os.replace`s it into place. The temp file lives on the same filesystem as the destination, so the rename stays atomic. No new temp-then-rename code.

## Backend coverage

Not applicable. `write_vrt` writes a filesystem index, it is not a backend-dispatched array op. The behavior is the same on every platform: `os.replace` is atomic on POSIX and is the standard atomic-rename primitive on Windows for same-directory targets.

## Notes

`_write_bytes` names its temp file with a `.tif.tmp` suffix. That suffix is cosmetic for a VRT, the file is renamed to the real `.vrt` immediately and is only visible if the process dies mid-write, so I left the shared helper alone rather than reshaping it for one caller.

## Test plan

- [x] `test_write_vrt_leaves_no_temp_file`: a successful write leaves the `.vrt` and no `.tmp` artifacts in the directory.
- [x] `test_write_vrt_no_partial_file_on_write_failure`: a forced failure during the write leaves no partial `.vrt` at the final path.
- [x] `test_write_vrt_failure_preserves_existing_file`: a failed rewrite leaves a pre-existing `.vrt` byte-for-byte intact.
- [x] Existing VRT write, metadata, nodata, and tiled-writer suites pass unchanged.
