### PR TITLE
geotiff: fix flake8/isort style drift in tests and two source imports

### DIFF
--- a/xrspatial/geotiff/__init__.py
+++ b/xrspatial/geotiff/__init__.py
@@ -987,8 +987,7 @@ def open_geotiff(source: str | BinaryIO, *,
     # that kwarg conflict is reported -- the tier rejection wins, which
     # matches refusing the unsupported source before validating kwargs
     # that would not be honoured anyway.
-    from ._validation import _validate_stable_only_remote
-    from ._validation import _validate_stable_only_vrt
+    from ._validation import _validate_stable_only_remote, _validate_stable_only_vrt
     if _is_vrt_source:
         _validate_stable_only_vrt(
             source,

--- a/xrspatial/geotiff/_writers/eager.py
+++ b/xrspatial/geotiff/_writers/eager.py
@@ -34,10 +34,9 @@ from .._geotags import RASTER_PIXEL_IS_AREA, GeoTransform
 from .._nodata import NodataLifecycle as _NL
 from .._runtime import (GeoTIFFFallbackWarning, _geotiff_strict_mode, _gpu_fallback_warning_message,
                         _resolve_spatial_coords)
-from .._validation import (_validate_3d_writer_dims, _validate_gpu_arg,
-                           _validate_no_rotated_affine, _validate_nodata_arg,
-                           _validate_tile_size_arg, _validate_writer_spatial_shape,
-                           validate_write_metadata)
+from .._validation import (_validate_3d_writer_dims, _validate_gpu_arg, _validate_no_rotated_affine,
+                           _validate_nodata_arg, _validate_tile_size_arg,
+                           _validate_writer_spatial_shape, validate_write_metadata)
 from .._writer import _COG_REQUIRES_TILED_MSG, write
 from .gpu import _write_geotiff_gpu
 

--- a/xrspatial/geotiff/tests/attrs/test_contract.py
+++ b/xrspatial/geotiff/tests/attrs/test_contract.py
@@ -32,7 +32,7 @@ import xarray as xr
 
 from xrspatial.geotiff import ConflictingNodataError
 from xrspatial.geotiff import _attrs as _attrs_module
-from xrspatial.geotiff import open_geotiff, _read_vrt, to_geotiff
+from xrspatial.geotiff import _read_vrt, open_geotiff, to_geotiff
 from xrspatial.geotiff._attrs import _ATTRS_CONTRACT_VERSION, _resolve_nodata_attr
 
 from .._helpers.markers import requires_gpu

--- a/xrspatial/geotiff/tests/golden_corpus/test_dask_numpy.py
+++ b/xrspatial/geotiff/tests/golden_corpus/test_dask_numpy.py
@@ -47,10 +47,8 @@ from xrspatial.geotiff import open_geotiff  # noqa: E402
 _OPTIN = {"allow_experimental_codecs": True, "allow_internal_only_jpeg": True}
 
 from xrspatial.geotiff.tests.golden_corpus import generate  # noqa: E402
-from xrspatial.geotiff.tests.golden_corpus._marks import (  # noqa: E402
-    fast_slow_marks_for,
-    optional_dep_marks_for,
-)
+from xrspatial.geotiff.tests.golden_corpus._marks import fast_slow_marks_for  # noqa: E402
+from xrspatial.geotiff.tests.golden_corpus._marks import optional_dep_marks_for  # noqa: E402
 from xrspatial.geotiff.tests.golden_corpus._oracle import compare_to_oracle  # noqa: E402
 
 FIXTURES_DIR = (

--- a/xrspatial/geotiff/tests/golden_corpus/test_eager_numpy.py
+++ b/xrspatial/geotiff/tests/golden_corpus/test_eager_numpy.py
@@ -75,10 +75,8 @@ from xrspatial.geotiff import open_geotiff  # noqa: E402
 _OPTIN = {"allow_experimental_codecs": True, "allow_internal_only_jpeg": True}
 
 from xrspatial.geotiff.tests.golden_corpus import generate  # noqa: E402
-from xrspatial.geotiff.tests.golden_corpus._marks import (  # noqa: E402
-    fast_slow_marks_for,
-    optional_dep_marks_for,
-)
+from xrspatial.geotiff.tests.golden_corpus._marks import fast_slow_marks_for  # noqa: E402
+from xrspatial.geotiff.tests.golden_corpus._marks import optional_dep_marks_for  # noqa: E402
 from xrspatial.geotiff.tests.golden_corpus._oracle import compare_to_oracle  # noqa: E402
 
 FIXTURES_DIR = (

--- a/xrspatial/geotiff/tests/golden_corpus/test_fsspec.py
+++ b/xrspatial/geotiff/tests/golden_corpus/test_fsspec.py
@@ -63,10 +63,8 @@ from xrspatial.geotiff import open_geotiff  # noqa: E402
 _OPTIN = {"allow_experimental_codecs": True, "allow_internal_only_jpeg": True}
 
 from xrspatial.geotiff.tests.golden_corpus import generate  # noqa: E402
-from xrspatial.geotiff.tests.golden_corpus._marks import (  # noqa: E402
-    fast_slow_marks_for,
-    optional_dep_marks_for,
-)
+from xrspatial.geotiff.tests.golden_corpus._marks import fast_slow_marks_for  # noqa: E402
+from xrspatial.geotiff.tests.golden_corpus._marks import optional_dep_marks_for  # noqa: E402
 from xrspatial.geotiff.tests.golden_corpus._oracle import compare_to_oracle  # noqa: E402
 
 FIXTURES_DIR = (

--- a/xrspatial/geotiff/tests/golden_corpus/test_vrt.py
+++ b/xrspatial/geotiff/tests/golden_corpus/test_vrt.py
@@ -33,7 +33,7 @@ import pytest
 pytest.importorskip("yaml")
 rasterio = pytest.importorskip("rasterio")
 
-from xrspatial.geotiff import open_geotiff, build_vrt  # noqa: E402
+from xrspatial.geotiff import build_vrt, open_geotiff  # noqa: E402
 
 # Golden-corpus fixtures span every codec/tier, including the
 # experimental and internal-only ones. Opting in here lets the parity

--- a/xrspatial/geotiff/tests/gpu/test_codec.py
+++ b/xrspatial/geotiff/tests/gpu/test_codec.py
@@ -110,7 +110,7 @@ def test_gpu_write_roundtrip_after_batched_compress_1712(compression):
     """GPU compress path round-trips uncorrupted for deflate + zstd."""
     import cupy
 
-    from xrspatial.geotiff import open_geotiff, _write_geotiff_gpu
+    from xrspatial.geotiff import _write_geotiff_gpu, open_geotiff
 
     rng = np.random.default_rng(seed=1712)
     arr_cpu = rng.random((512, 512), dtype=np.float32)
@@ -138,7 +138,7 @@ def test_gpu_write_zero_tile_edge_case_1712():
     """A 0-tile compress returns an empty list without indexing into None."""
     import cupy
 
-    from xrspatial.geotiff import open_geotiff, _write_geotiff_gpu
+    from xrspatial.geotiff import _write_geotiff_gpu, open_geotiff
 
     arr_gpu = cupy.zeros((32, 32), dtype=cupy.float32)
     darr = xr.DataArray(arr_gpu, dims=["y", "x"])
@@ -1783,7 +1783,7 @@ class TestErrorMessageStable_1933:
     """The GPU error wording matches the eager/dask wording."""
 
     def test_gpu_error_message_matches_eager(self, tmp_path):
-        from xrspatial.geotiff import open_geotiff, _read_geotiff_gpu
+        from xrspatial.geotiff import _read_geotiff_gpu, open_geotiff
 
         arr = np.arange(64, dtype=np.uint32).reshape(8, 8)
         path = tmp_path / "pred3_uint32_msg.tif"

--- a/xrspatial/geotiff/tests/gpu/test_kernels_and_kwargs.py
+++ b/xrspatial/geotiff/tests/gpu/test_kernels_and_kwargs.py
@@ -3078,7 +3078,7 @@ class TestErrorMessageParity_1929:
     """
 
     def test_gpu_vs_cpu_message_matches(self, tmp_path):
-        from xrspatial.geotiff import to_geotiff, _write_geotiff_gpu
+        from xrspatial.geotiff import _write_geotiff_gpu, to_geotiff
 
         out_cpu = str(tmp_path / "cpu_msg_1929.tif")
         out_gpu = str(tmp_path / "gpu_msg_1929.tif")
@@ -3121,7 +3121,7 @@ class TestKwargDefaultParity_1929:
     """
 
     def test_default_is_false_on_all_writers(self):
-        from xrspatial.geotiff import to_geotiff, _write_geotiff_gpu
+        from xrspatial.geotiff import _write_geotiff_gpu, to_geotiff
         from xrspatial.geotiff._writers.eager import _write_vrt_tiled
 
         for fn in (to_geotiff, _write_geotiff_gpu, _write_vrt_tiled):

--- a/xrspatial/geotiff/tests/gpu/test_reader.py
+++ b/xrspatial/geotiff/tests/gpu/test_reader.py
@@ -90,7 +90,7 @@ def multi_band_tiff_1605(tmp_path):
 def test_read_geotiff_gpu_window_matches_eager_1605(single_band_tiff_1605):
     """Direct call: GPU window slice matches CPU eager window slice."""
     path, source_arr = single_band_tiff_1605
-    from xrspatial.geotiff import open_geotiff, _read_geotiff_gpu
+    from xrspatial.geotiff import _read_geotiff_gpu, open_geotiff
 
     window = (2, 4, 12, 14)
 
@@ -126,7 +126,7 @@ def test_open_geotiff_gpu_window_no_longer_silently_dropped_1605(
 def test_read_geotiff_gpu_band_selection_1605(multi_band_tiff_1605):
     """Direct call: band=k returns the kth band as a 2D DataArray."""
     path, source_arr = multi_band_tiff_1605
-    from xrspatial.geotiff import open_geotiff, _read_geotiff_gpu
+    from xrspatial.geotiff import _read_geotiff_gpu, open_geotiff
 
     cpu = open_geotiff(path, band=1)
     gpu = _read_geotiff_gpu(path, band=1)
@@ -158,7 +158,7 @@ def test_open_geotiff_gpu_band_no_longer_silently_dropped_1605(
 def test_read_geotiff_gpu_window_and_band_1605(multi_band_tiff_1605):
     """window + band combine cleanly."""
     path, source_arr = multi_band_tiff_1605
-    from xrspatial.geotiff import open_geotiff, _read_geotiff_gpu
+    from xrspatial.geotiff import _read_geotiff_gpu, open_geotiff
 
     window = (1, 2, 11, 17)
     cpu = open_geotiff(path, window=window, band=0)
@@ -529,7 +529,7 @@ def test_stripped_max_pixels_cap_is_enforced_1732():
 def test_stripped_window_returns_only_window_1732():
     """Windowed read on a stripped file returns the window-sized array
     with coords and transform that match the window origin."""
-    from xrspatial.geotiff import open_geotiff, _read_geotiff_gpu, to_geotiff
+    from xrspatial.geotiff import _read_geotiff_gpu, open_geotiff, to_geotiff
 
     rng = np.random.RandomState(20260512)
     data = rng.randint(0, 200, size=(64, 96)).astype(np.uint8)
@@ -1105,7 +1105,7 @@ def _attrs_subset_2324(da):
 
 def test_sidecar_without_geokeys_attrs_match_cpu_vs_dask_2324(tmp_path):
     """Baseline: CPU eager and dask agree on inherited georef."""
-    from xrspatial.geotiff import open_geotiff, _read_geotiff_dask
+    from xrspatial.geotiff import _read_geotiff_dask, open_geotiff
 
     from ..integration.test_sidecar import _write_pair
 
@@ -1135,7 +1135,7 @@ def test_sidecar_without_geokeys_attrs_match_cpu_vs_dask_2324(tmp_path):
 @_gpu_only
 def test_sidecar_without_geokeys_gpu_matches_cpu_2324(tmp_path):
     """GPU eager georef matches CPU / dask."""
-    from xrspatial.geotiff import open_geotiff, _read_geotiff_gpu
+    from xrspatial.geotiff import _read_geotiff_gpu, open_geotiff
 
     from ..integration.test_sidecar import _write_pair
 
@@ -1161,7 +1161,7 @@ def test_sidecar_without_geokeys_gpu_matches_cpu_2324(tmp_path):
 @_gpu_only
 def test_sidecar_with_own_geokeys_gpu_matches_cpu_2324(tmp_path):
     """GPU path routes a sidecar-owned georef payload to sidecar bytes."""
-    from xrspatial.geotiff import open_geotiff, _read_geotiff_gpu
+    from xrspatial.geotiff import _read_geotiff_gpu, open_geotiff
 
     from ..integration.test_sidecar import _write_pair
 
@@ -1268,7 +1268,7 @@ def test_http_url_returns_cupy_matching_cpu_2161(small_tif_bytes_2161,
     """HTTP URLs route through the CPU decode + GPU upload helper."""
     import cupy
 
-    from xrspatial.geotiff import open_geotiff, _read_geotiff_gpu
+    from xrspatial.geotiff import _read_geotiff_gpu, open_geotiff
 
     payload, arr_ref, _local = small_tif_bytes_2161
     monkeypatch.setenv('XRSPATIAL_GEOTIFF_ALLOW_PRIVATE_HOSTS', '1')
@@ -1298,7 +1298,7 @@ def test_memory_fsspec_uri_returns_cupy_matching_cpu_2161(
     fsspec = pytest.importorskip("fsspec")
     import cupy
 
-    from xrspatial.geotiff import open_geotiff, _read_geotiff_gpu
+    from xrspatial.geotiff import _read_geotiff_gpu, open_geotiff
 
     payload, arr_ref, _local = small_tif_bytes_2161
     fs = fsspec.filesystem("memory")

--- a/xrspatial/geotiff/tests/gpu/test_writer.py
+++ b/xrspatial/geotiff/tests/gpu/test_writer.py
@@ -44,8 +44,8 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from xrspatial.geotiff import (GeoTIFFFallbackWarning, _gpu_decode, open_geotiff, to_geotiff,
-                               _write_geotiff_gpu)
+from xrspatial.geotiff import (GeoTIFFFallbackWarning, _gpu_decode, _write_geotiff_gpu,
+                               open_geotiff, to_geotiff)
 from xrspatial.geotiff._compression import JPEG2000_AVAILABLE, LERC_AVAILABLE, LZ4_AVAILABLE
 from xrspatial.geotiff._geotags import GeoTransform, _epsg_to_wkt
 from xrspatial.geotiff._header import parse_header, parse_ifd

--- a/xrspatial/geotiff/tests/integration/test_dask_pipeline.py
+++ b/xrspatial/geotiff/tests/integration/test_dask_pipeline.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from xrspatial.geotiff import open_geotiff, _read_geotiff_dask, to_geotiff
+from xrspatial.geotiff import _read_geotiff_dask, open_geotiff, to_geotiff
 from xrspatial.geotiff._writer import write
 
 # ----------------------------------------------------------
@@ -455,7 +455,7 @@ def test_dask_overview_level_zero_matches_full_res(tmp_path):
 
 def test_dask_overview_level_one_returns_half_res(tmp_path):
     """``overview_level=1`` materialises the half-resolution overview."""
-    from xrspatial.geotiff import open_geotiff, _read_geotiff_dask
+    from xrspatial.geotiff import _read_geotiff_dask, open_geotiff
 
     rng = np.random.RandomState(0xD0E)
     arr = rng.randint(0, 256, size=(128, 192), dtype=np.uint8)
@@ -477,7 +477,7 @@ def test_dask_overview_level_one_returns_half_res(tmp_path):
 
 def test_dask_overview_level_two_returns_quarter_res(tmp_path):
     """``overview_level=2`` materialises the quarter-resolution overview."""
-    from xrspatial.geotiff import open_geotiff, _read_geotiff_dask
+    from xrspatial.geotiff import _read_geotiff_dask, open_geotiff
 
     rng = np.random.RandomState(0xD0E)
     arr = rng.randint(0, 256, size=(128, 192), dtype=np.uint8)

--- a/xrspatial/geotiff/tests/integration/test_gpu_pipeline.py
+++ b/xrspatial/geotiff/tests/integration/test_gpu_pipeline.py
@@ -80,7 +80,7 @@ def test_open_geotiff_gpu_chunks_int_round_trip(tmp_path):
 
 def test_read_geotiff_gpu_chunks_tuple_round_trip(tmp_path):
     """`_read_geotiff_gpu(chunks=(rh, cw))` accepts tuple chunk specs."""
-    from xrspatial.geotiff import open_geotiff, _read_geotiff_gpu, to_geotiff
+    from xrspatial.geotiff import _read_geotiff_gpu, open_geotiff, to_geotiff
 
     rng = np.random.RandomState(11)
     arr = rng.randint(0, 60_000, (192, 256)).astype(np.uint16)

--- a/xrspatial/geotiff/tests/integration/test_http_sources.py
+++ b/xrspatial/geotiff/tests/integration/test_http_sources.py
@@ -21,11 +21,10 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from xrspatial.geotiff import UnsafeURLError
+from xrspatial.geotiff import UnsafeURLError, _read_geotiff_dask, _read_geotiff_gpu, _read_vrt
 from xrspatial.geotiff import _reader as _reader_mod
 from xrspatial.geotiff import _sources as _sources_mod
-from xrspatial.geotiff import (open_geotiff, _read_geotiff_dask, _read_geotiff_gpu, _read_vrt,
-                               to_geotiff, _write_geotiff_gpu, build_vrt)
+from xrspatial.geotiff import _write_geotiff_gpu, build_vrt, open_geotiff, to_geotiff
 from xrspatial.geotiff._errors import RotatedTransformError
 from xrspatial.geotiff._header import parse_all_ifds, parse_header
 from xrspatial.geotiff._reader import (_FULL_IMAGE_BUDGET_HEADER_SLACK, INITIAL_HTTP_HEADER_BYTES,

--- a/xrspatial/geotiff/tests/parity/test_backend_matrix.py
+++ b/xrspatial/geotiff/tests/parity/test_backend_matrix.py
@@ -71,7 +71,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from xrspatial.geotiff import open_geotiff, _read_vrt, to_geotiff, build_vrt
+from xrspatial.geotiff import _read_vrt, build_vrt, open_geotiff, to_geotiff
 from xrspatial.geotiff._attrs import _finalize_eager_read, _finalize_lazy_read_attrs
 from xrspatial.geotiff._errors import RotatedTransformError, UnparseableCRSError
 

--- a/xrspatial/geotiff/tests/parity/test_finalization.py
+++ b/xrspatial/geotiff/tests/parity/test_finalization.py
@@ -35,8 +35,8 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from xrspatial.geotiff import (open_geotiff, _read_geotiff_dask, _read_geotiff_gpu, _read_vrt,
-                               to_geotiff, build_vrt)
+from xrspatial.geotiff import (_read_geotiff_dask, _read_geotiff_gpu, _read_vrt, build_vrt,
+                               open_geotiff, to_geotiff)
 from xrspatial.geotiff._attrs import (GEOREF_STATUS_CRS_ONLY, GEOREF_STATUS_FULL,
                                       GEOREF_STATUS_NONE, GEOREF_STATUS_ROTATED_DROPPED,
                                       GEOREF_STATUS_TRANSFORM_ONLY)

--- a/xrspatial/geotiff/tests/parity/test_pixel_equality.py
+++ b/xrspatial/geotiff/tests/parity/test_pixel_equality.py
@@ -30,8 +30,8 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from xrspatial.geotiff import (open_geotiff, _read_geotiff_dask, _read_geotiff_gpu, _read_vrt,
-                               to_geotiff, build_vrt)
+from xrspatial.geotiff import (_read_geotiff_dask, _read_geotiff_gpu, _read_vrt, build_vrt,
+                               open_geotiff, to_geotiff)
 
 from .._helpers.markers import gpu_available, requires_gpu, requires_loopback
 

--- a/xrspatial/geotiff/tests/parity/test_reference.py
+++ b/xrspatial/geotiff/tests/parity/test_reference.py
@@ -27,8 +27,8 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from xrspatial.geotiff import (open_geotiff, _read_geotiff_dask, _read_geotiff_gpu, to_geotiff,
-                               _write_geotiff_gpu)
+from xrspatial.geotiff import (_read_geotiff_dask, _read_geotiff_gpu, _write_geotiff_gpu,
+                               open_geotiff, to_geotiff)
 
 from .._helpers.markers import requires_gpu
 

--- a/xrspatial/geotiff/tests/parity/test_signature_contract.py
+++ b/xrspatial/geotiff/tests/parity/test_signature_contract.py
@@ -35,9 +35,8 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from xrspatial.geotiff import (SUPPORTED_FEATURES, build_vrt, open_geotiff, to_geotiff,
-                               _read_geotiff_dask, _read_geotiff_gpu, _read_vrt,
-                               _write_geotiff_gpu)
+from xrspatial.geotiff import (SUPPORTED_FEATURES, _read_geotiff_dask, _read_geotiff_gpu, _read_vrt,
+                               _write_geotiff_gpu, build_vrt, open_geotiff, to_geotiff)
 
 from .._helpers.markers import requires_gpu
 

--- a/xrspatial/geotiff/tests/read/test_basic.py
+++ b/xrspatial/geotiff/tests/read/test_basic.py
@@ -18,8 +18,9 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from xrspatial.geotiff import GeoTIFFFallbackWarning, open_geotiff, to_geotiff
+from xrspatial.geotiff import GeoTIFFFallbackWarning
 from xrspatial.geotiff import build_vrt as _write_vrt_1810
+from xrspatial.geotiff import open_geotiff, to_geotiff
 from xrspatial.geotiff._dtypes import tiff_dtype_to_numpy
 from xrspatial.geotiff._geotags import RASTER_PIXEL_IS_POINT, TAG_GEO_ASCII_PARAMS, extract_geo_info
 from xrspatial.geotiff._header import parse_all_ifds, parse_header

--- a/xrspatial/geotiff/tests/read/test_dtypes.py
+++ b/xrspatial/geotiff/tests/read/test_dtypes.py
@@ -14,7 +14,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from xrspatial.geotiff import open_geotiff, _read_geotiff_dask, to_geotiff
+from xrspatial.geotiff import _read_geotiff_dask, open_geotiff, to_geotiff
 from xrspatial.geotiff._dtypes import (SAMPLE_FORMAT_FLOAT, SAMPLE_FORMAT_INT, SAMPLE_FORMAT_UINT,
                                        tiff_dtype_to_numpy, tiff_storage_dtype)
 

--- a/xrspatial/geotiff/tests/read/test_georef.py
+++ b/xrspatial/geotiff/tests/read/test_georef.py
@@ -40,8 +40,8 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from xrspatial.geotiff import (NonUniformCoordsError, _coords_to_transform, _transform_from_attr,
-                               open_geotiff, _read_vrt, to_geotiff, _write_geotiff_gpu)
+from xrspatial.geotiff import (NonUniformCoordsError, _coords_to_transform, _read_vrt,
+                               _transform_from_attr, _write_geotiff_gpu, open_geotiff, to_geotiff)
 from xrspatial.geotiff._attrs import (_ATTRS_CONTRACT_VERSION, GEOREF_STATUS_CRS_ONLY,
                                       GEOREF_STATUS_FULL, GEOREF_STATUS_NONE,
                                       GEOREF_STATUS_ROTATED_DROPPED, GEOREF_STATUS_TRANSFORM_ONLY,

--- a/xrspatial/geotiff/tests/read/test_nodata.py
+++ b/xrspatial/geotiff/tests/read/test_nodata.py
@@ -33,7 +33,7 @@ import pytest
 import xarray as xr
 
 from xrspatial.geotiff import (GeoTIFFAmbiguousMetadataError, InvalidIntegerNodataError,
-                               open_geotiff, _read_geotiff_dask, _read_vrt, to_geotiff)
+                               _read_geotiff_dask, _read_vrt, open_geotiff, to_geotiff)
 from xrspatial.geotiff._attrs import _finalize_lazy_read_attrs, _validate_read_geo_info
 from xrspatial.geotiff._backends import _gpu_helpers
 from xrspatial.geotiff._errors import MixedBandMetadataError

--- a/xrspatial/geotiff/tests/read/test_tiling.py
+++ b/xrspatial/geotiff/tests/read/test_tiling.py
@@ -33,8 +33,9 @@ import pytest
 import xarray as xr
 
 from xrspatial.geotiff import _decode as _decode_mod
+from xrspatial.geotiff import _read_geotiff_gpu
 from xrspatial.geotiff import _reader as _reader_mod
-from xrspatial.geotiff import open_geotiff, _read_geotiff_gpu, to_geotiff
+from xrspatial.geotiff import open_geotiff, to_geotiff
 from xrspatial.geotiff._compression import COMPRESSION_NONE, unpack_bits
 from xrspatial.geotiff._dtypes import (resolve_bits_per_sample, resolve_sample_format,
                                        tiff_dtype_to_numpy)

--- a/xrspatial/geotiff/tests/release_gates/test_features.py
+++ b/xrspatial/geotiff/tests/release_gates/test_features.py
@@ -49,8 +49,8 @@ import xarray as xr
 from xrspatial.geotiff import (SUPPORTED_FEATURES, GeoTIFFAmbiguousMetadataError,
                                GeoTIFFFallbackWarning, RotatedTransformError,
                                UnsupportedGeoTIFFFeatureError, VRTStableSourcesOnlyError,
-                               open_geotiff, _read_geotiff_dask, _read_vrt, to_geotiff,
-                               _write_geotiff_gpu)
+                               _read_geotiff_dask, _read_vrt, _write_geotiff_gpu, open_geotiff,
+                               to_geotiff)
 from xrspatial.geotiff._attrs import _VALID_COMPRESSIONS
 from xrspatial.geotiff._compression import (packbits_compress, packbits_decompress, zstd_compress,
                                             zstd_decompress)

--- a/xrspatial/geotiff/tests/release_gates/test_stable_features.py
+++ b/xrspatial/geotiff/tests/release_gates/test_stable_features.py
@@ -73,8 +73,8 @@ _requires_rasterio_and_dask = pytest.mark.skipif(
     ),
 )
 
-from xrspatial.geotiff import (SUPPORTED_FEATURES, UnsafeURLError, open_geotiff,  # noqa: E402
-                               _read_geotiff_dask, to_geotiff)
+from xrspatial.geotiff import (SUPPORTED_FEATURES, UnsafeURLError, _read_geotiff_dask,  # noqa: E402
+                               open_geotiff, to_geotiff)
 from xrspatial.geotiff._compression import (COMPRESSION_DEFLATE, COMPRESSION_LZW,  # noqa: E402
                                             COMPRESSION_NONE, COMPRESSION_PACKBITS,
                                             COMPRESSION_ZSTD)

--- a/xrspatial/geotiff/tests/test_polish.py
+++ b/xrspatial/geotiff/tests/test_polish.py
@@ -23,7 +23,7 @@ import warnings
 import numpy as np
 import pytest
 
-from xrspatial.geotiff import _read_geotiff_dask, to_geotiff, build_vrt
+from xrspatial.geotiff import _read_geotiff_dask, build_vrt, to_geotiff
 from xrspatial.geotiff._reader import _MmapCache, read_to_array
 from xrspatial.geotiff._writer import _MAX_OVERVIEW_LEVELS, write
 

--- a/xrspatial/geotiff/tests/test_round_trip.py
+++ b/xrspatial/geotiff/tests/test_round_trip.py
@@ -56,7 +56,7 @@ import xarray as xr
 from hypothesis import HealthCheck, assume, event, given, settings
 from hypothesis import strategies as st
 
-from xrspatial.geotiff import open_geotiff, to_geotiff, build_vrt
+from xrspatial.geotiff import build_vrt, open_geotiff, to_geotiff
 from xrspatial.geotiff._geotags import _NO_GEOREF_KEY, GeoTransform
 from xrspatial.geotiff._writer import write
 

--- a/xrspatial/geotiff/tests/test_security.py
+++ b/xrspatial/geotiff/tests/test_security.py
@@ -134,6 +134,7 @@ class TestDimensionGuard:
         """The suggested chunk side fits under max_pixels for the given
         band count and never exceeds 1024."""
         from xrspatial.geotiff._layout import _suggest_chunk_side
+
         # Default budget: capped at 1024.
         assert _suggest_chunk_side(1_000_000_000, 1) == 1024
         # Tight budget: 100 pixels, 1 band -> side 10.
@@ -148,6 +149,7 @@ class TestDimensionGuard:
     def test_gb_hint_helper_rounds_to_two_decimals(self):
         """_gb_hint formats bytes/pixel * count as a ~X.XX GB string."""
         from xrspatial.geotiff._layout import _gb_hint
+
         # No dtype: 1 billion pixels * 4 bytes (float32 default) ->
         # 4.00 GB hint, matching MAX_PIXELS_DEFAULT's docstring.
         assert _gb_hint(1_000_000_000) == "~4.00 GB at 4 bytes/pixel"

--- a/xrspatial/geotiff/tests/test_stable_only_bbox_ordering_2869.py
+++ b/xrspatial/geotiff/tests/test_stable_only_bbox_ordering_2869.py
@@ -31,9 +31,8 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from xrspatial.geotiff import (RemoteStableSourcesOnlyError,
-                               VRTStableSourcesOnlyError, open_geotiff,
-                               to_geotiff)
+from xrspatial.geotiff import (RemoteStableSourcesOnlyError, VRTStableSourcesOnlyError,
+                               open_geotiff, to_geotiff)
 from xrspatial.geotiff.tests._helpers.tiff_builders import make_minimal_tiff
 
 fsspec = pytest.importorskip("fsspec")

--- a/xrspatial/geotiff/tests/test_stable_only_remote_2821.py
+++ b/xrspatial/geotiff/tests/test_stable_only_remote_2821.py
@@ -22,7 +22,7 @@ import numpy as np
 import pytest
 
 from xrspatial.geotiff import (GeoTIFFAmbiguousMetadataError, RemoteStableSourcesOnlyError,
-                               open_geotiff, _read_geotiff_dask, _read_geotiff_gpu)
+                               _read_geotiff_dask, _read_geotiff_gpu, open_geotiff)
 from xrspatial.geotiff.tests._helpers.tiff_builders import make_minimal_tiff
 
 fsspec = pytest.importorskip("fsspec")

--- a/xrspatial/geotiff/tests/unit/test_geotags.py
+++ b/xrspatial/geotiff/tests/unit/test_geotags.py
@@ -253,8 +253,6 @@ def _build_tiff_with_transformation_tag(matrix_16: tuple) -> bytes:
     No ModelPixelScale or ModelTiepoint -- the reader has to use the
     transformation tag.
     """
-    import struct
-
     bo = '<'
     width, height = 2, 2
     pixels = np.zeros((height, width), dtype=np.uint8)
@@ -405,8 +403,6 @@ def _build_tiff_with_tiepoint_only(tiepoint_6: tuple) -> bytes:
     pixel_height is stored as -sy, so the resulting transform has
     pixel_width == 1.0 and pixel_height == -1.0.
     """
-    import struct
-
     bo = '<'
     width, height = 2, 2
     pixels = np.zeros((height, width), dtype=np.uint8)
@@ -829,5 +825,3 @@ def test_open_geotiff_accepts_consistent_geographic(tmp_path):
     da = open_geotiff(str(path))
     assert da.shape == (4, 4)
     assert da.attrs.get('crs') == 4326
-
-

--- a/xrspatial/geotiff/tests/unit/test_input_validation.py
+++ b/xrspatial/geotiff/tests/unit/test_input_validation.py
@@ -33,8 +33,8 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from xrspatial.geotiff import (_header, open_geotiff, _read_geotiff_dask, to_geotiff,
-                               _write_geotiff_gpu)
+from xrspatial.geotiff import (_header, _read_geotiff_dask, _write_geotiff_gpu, open_geotiff,
+                               to_geotiff)
 from xrspatial.geotiff._coords import coords_to_transform
 from xrspatial.geotiff._dtypes import LONG, SHORT
 from xrspatial.geotiff._header import (MAX_PIXEL_ARRAY_COUNT, TAG_BITS_PER_SAMPLE, TAG_COLORMAP,

--- a/xrspatial/geotiff/tests/unit/test_metadata.py
+++ b/xrspatial/geotiff/tests/unit/test_metadata.py
@@ -21,15 +21,14 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from .._geotiff_fixtures import write_minimal_tiff
-
 import xrspatial.geotiff as geotiff_pkg
 from xrspatial.geotiff import (ConflictingCRSError, GeoTIFFAmbiguousMetadataError,
-                               MixedBandMetadataError, _runtime)
+                               MixedBandMetadataError, _read_geotiff_dask, _read_vrt, _runtime)
 from xrspatial.geotiff import _validation as _validation_mod
-from xrspatial.geotiff import open_geotiff, _read_geotiff_dask, _read_vrt, to_geotiff
-from xrspatial.geotiff._attrs import (_ATTRS_CONTRACT_VERSION, GeoTIFFMetadata, _resolve_nodata_attr,
-                                      attrs_to_metadata, geo_info_to_metadata, metadata_to_attrs)
+from xrspatial.geotiff import open_geotiff, to_geotiff
+from xrspatial.geotiff._attrs import (_ATTRS_CONTRACT_VERSION, GeoTIFFMetadata,
+                                      _resolve_nodata_attr, attrs_to_metadata, geo_info_to_metadata,
+                                      metadata_to_attrs)
 from xrspatial.geotiff._errors import (ConflictingNodataError, InvalidCRSCodeError,
                                        NonUniformCoordsError, RotatedTransformError,
                                        UnparseableCRSError)
@@ -46,6 +45,8 @@ from xrspatial.geotiff._validation import (_check_read_rotated_transform,
                                            unregister_write_metadata_check, validate_read_metadata,
                                            validate_write_metadata)
 from xrspatial.geotiff._writer import write
+
+from .._geotiff_fixtures import write_minimal_tiff
 
 # =============================================================================
 # Section: Ambiguous metadata hooks
@@ -1443,7 +1444,6 @@ def _da(*, coords=None, attrs=None, shape=(4, 4)):
 
 
 def _write_minimal_tiff_with_wkt(path: str, wkt: str) -> None:
-    ascii_buf = bytearray((wkt + '|').encode('ascii'))
     gkd = [1, 1, 0, 1, 1026, 34737, len(wkt) + 1, 0]
     write_minimal_tiff(path, geokeys=gkd, geo_ascii=wkt)
 

--- a/xrspatial/geotiff/tests/unit/test_photometric.py
+++ b/xrspatial/geotiff/tests/unit/test_photometric.py
@@ -47,7 +47,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from xrspatial.geotiff import GeoTIFFFallbackWarning, open_geotiff, to_geotiff, _write_geotiff_gpu
+from xrspatial.geotiff import GeoTIFFFallbackWarning, _write_geotiff_gpu, open_geotiff, to_geotiff
 from xrspatial.geotiff._header import TAG_PHOTOMETRIC, TAG_SAMPLE_FORMAT, parse_header
 
 tifffile = pytest.importorskip("tifffile")

--- a/xrspatial/geotiff/tests/unit/test_signatures.py
+++ b/xrspatial/geotiff/tests/unit/test_signatures.py
@@ -62,9 +62,9 @@ import xarray as xr
 
 import xrspatial.geotiff as g
 import xrspatial.geotiff._compression as comp_mod
-from xrspatial.geotiff import (GeoTIFFFallbackWarning, _geotiff_strict_mode, _wkt_to_epsg,
-                               open_geotiff, _read_geotiff_dask, _read_geotiff_gpu, _read_vrt,
-                               to_geotiff, _write_geotiff_gpu, build_vrt)
+from xrspatial.geotiff import (GeoTIFFFallbackWarning, _geotiff_strict_mode, _read_geotiff_dask,
+                               _read_geotiff_gpu, _read_vrt, _wkt_to_epsg, _write_geotiff_gpu,
+                               build_vrt, open_geotiff, to_geotiff)
 from xrspatial.geotiff._attrs import (_COMPRESSION_TAG_TO_NAME, _validate_read_codec_optin,
                                       _validate_write_rich_tag_optin)
 from xrspatial.geotiff._compression import (_HAVE_LIBDEFLATE, COMPRESSION_DEFLATE, COMPRESSION_LZ4,

--- a/xrspatial/geotiff/tests/vrt/test_metadata.py
+++ b/xrspatial/geotiff/tests/vrt/test_metadata.py
@@ -31,8 +31,8 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from xrspatial.geotiff import (GeoTIFFFallbackWarning, MixedBandMetadataError, open_geotiff,
-                               _read_geotiff_dask, _read_vrt, to_geotiff, build_vrt)
+from xrspatial.geotiff import (GeoTIFFFallbackWarning, MixedBandMetadataError, _read_geotiff_dask,
+                               _read_vrt, build_vrt, open_geotiff, to_geotiff)
 from xrspatial.geotiff._attrs import GEOREF_STATUS_FULL, GEOREF_STATUS_TRANSFORM_ONLY
 from xrspatial.geotiff._errors import VRTUnsupportedError
 from xrspatial.geotiff._geotags import GeoTransform

--- a/xrspatial/geotiff/tests/vrt/test_missing_sources.py
+++ b/xrspatial/geotiff/tests/vrt/test_missing_sources.py
@@ -33,7 +33,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from xrspatial.geotiff import GeoTIFFFallbackWarning, open_geotiff, _read_vrt, to_geotiff
+from xrspatial.geotiff import GeoTIFFFallbackWarning, _read_vrt, open_geotiff, to_geotiff
 from xrspatial.geotiff._vrt import read_vrt as _internal_read_vrt
 
 PRESENT_FILL = 7.0

--- a/xrspatial/geotiff/tests/vrt/test_parity.py
+++ b/xrspatial/geotiff/tests/vrt/test_parity.py
@@ -36,7 +36,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from xrspatial.geotiff import open_geotiff, _read_geotiff_dask, _read_vrt, to_geotiff
+from xrspatial.geotiff import _read_geotiff_dask, _read_vrt, open_geotiff, to_geotiff
 from xrspatial.geotiff._attrs import (GEOREF_STATUS_CRS_ONLY, GEOREF_STATUS_FULL,
                                       GEOREF_STATUS_NONE, GEOREF_STATUS_ROTATED_DROPPED,
                                       GEOREF_STATUS_TRANSFORM_ONLY)

--- a/xrspatial/geotiff/tests/vrt/test_source_opt_ins_2672.py
+++ b/xrspatial/geotiff/tests/vrt/test_source_opt_ins_2672.py
@@ -20,7 +20,7 @@ import warnings
 import numpy as np
 import pytest
 
-from xrspatial.geotiff import GeoTIFFFallbackWarning, open_geotiff, _read_vrt
+from xrspatial.geotiff import GeoTIFFFallbackWarning, _read_vrt, open_geotiff
 from xrspatial.geotiff._errors import InvalidIntegerNodataError, RotatedTransformError
 
 # Reuse the existing hand-rolled TIFF builders so this suite shares one

--- a/xrspatial/geotiff/tests/write/test_basic.py
+++ b/xrspatial/geotiff/tests/write/test_basic.py
@@ -34,9 +34,11 @@ import numpy as np
 import pytest
 import xarray as xr
 
+from xrspatial.geotiff import _read_vrt
 from xrspatial.geotiff import _vrt as _vrt_module
+from xrspatial.geotiff import _write_geotiff_gpu
 from xrspatial.geotiff import _writer as writer_mod
-from xrspatial.geotiff import open_geotiff, _read_vrt, to_geotiff, _write_geotiff_gpu, build_vrt
+from xrspatial.geotiff import build_vrt, open_geotiff, to_geotiff
 from xrspatial.geotiff._compression import COMPRESSION_NONE
 from xrspatial.geotiff._geotags import GeoTransform
 from xrspatial.geotiff._header import TAG_PHOTOMETRIC, parse_header, parse_ifd
@@ -1106,7 +1108,7 @@ def test_writer_trio_all_accept_crs_kwarg():
     output extension never has to special-case the kwarg name."""
     import inspect
 
-    from xrspatial.geotiff import to_geotiff, _write_geotiff_gpu, build_vrt
+    from xrspatial.geotiff import _write_geotiff_gpu, build_vrt, to_geotiff
 
     for fn in (to_geotiff, _write_geotiff_gpu, build_vrt):
         sig = inspect.signature(fn)

--- a/xrspatial/geotiff/tests/write/test_bigtiff.py
+++ b/xrspatial/geotiff/tests/write/test_bigtiff.py
@@ -515,8 +515,8 @@ def test_overhead_matches_actual_emitted_size_via_writer_1905(tmp_path):
 import inspect  # noqa: E402
 import re  # noqa: E402
 
-from xrspatial.geotiff import to_geotiff as _to_geotiff_1683  # noqa: E402
 from xrspatial.geotiff import _write_geotiff_gpu as _write_geotiff_gpu_1683  # noqa: E402
+from xrspatial.geotiff import to_geotiff as _to_geotiff_1683  # noqa: E402
 
 
 def _documented_params_1683(fn) -> list[str]:

--- a/xrspatial/geotiff/tests/write/test_nodata.py
+++ b/xrspatial/geotiff/tests/write/test_nodata.py
@@ -27,7 +27,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from xrspatial.geotiff import open_geotiff, _read_geotiff_dask, _read_vrt, to_geotiff, build_vrt
+from xrspatial.geotiff import _read_geotiff_dask, _read_vrt, build_vrt, open_geotiff, to_geotiff
 from xrspatial.geotiff._attrs import _resolve_nodata_attr
 from xrspatial.geotiff._geotags import GeoTransform, _parse_nodata_str, build_geo_tags
 from xrspatial.geotiff._reader import _int_nodata_in_range, _resolve_masked_fill


### PR DESCRIPTION
Closes #2970.

The geotiff subpackage has no flake8 or isort check in CI, so style drift had piled up. Running the project's configured tooling (setup.cfg: flake8 `max-line-length=100`, isort `line_length=100`) found a small set of issues, all confirmed by the tools. The 33 source files were already clean except for two import blocks.

## What changed

- Cat 3 (pyflakes F-codes): removed dead test code.
  - `tests/unit/test_geotags.py`: dropped two redundant local `import struct` statements (F811) so the single module-level import is the one in use (clears F401).
  - `tests/unit/test_metadata.py`: removed the unused local `ascii_buf` (F841).
- Cat 1 (E501): `tests/unit/test_metadata.py` over-length import reflowed by isort.
- Cat 2 (W391): trailing blank line at the end of `tests/unit/test_geotags.py`.
- Cat 4 (isort): import ordering in `__init__.py` and `_writers/eager.py`, plus about 40 test files, normalized to the configured profile.

## No behavioural change

Cat 1/2/4 are formatting only. The Cat 3 removals delete code that the tools confirm is never executed (dead imports and an unused local), so runtime is unchanged.

One detail worth flagging: three golden_corpus test files have imports below module-level setup that carry `# noqa: E402`. isort split those into one-per-line, which dropped the noqa from the second line, so I re-added `# noqa: E402` to keep flake8 quiet on the intentional late import. isort is stable and idempotent after that.

## Scope

No black/autopep8/ruff-format, no config widening. Fixes limited to what flake8 + isort report.

## Test plan

- [x] `flake8 xrspatial/geotiff/` reports 0
- [x] `isort --check-only xrspatial/geotiff/` clean and idempotent
- [x] `pytest xrspatial/geotiff/tests/unit/test_geotags.py xrspatial/geotiff/tests/unit/test_metadata.py` (171 passed)
- [x] patched golden_corpus files collect and import cleanly

Found by `/sweep-style`.