### PR TITLE
geotiff: accumulate GPU overview mean in float64 for CPU byte parity (#2983)

### DIFF
--- a/xrspatial/geotiff/_gpu_decode.py
+++ b/xrspatial/geotiff/_gpu_decode.py
@@ -3251,7 +3251,16 @@ def _block_reduce_2d_gpu(arr2d, method, nodata=None):
                         mask, cupy.float64('nan'), blocks)
 
     if method == 'mean':
-        result = cupy.nanmean(blocks, axis=(1, 3))
+        # Accumulate the block mean in float64 then downcast on the final
+        # ``astype(arr2d.dtype)`` below, matching the CPU kernel
+        # (``_reduce2x2_mean`` in ``_overview_kernels``) which sums into a
+        # float64 Python accumulator. Without ``dtype=cupy.float64`` a
+        # float32 ``blocks`` array makes ``cupy.nanmean`` accumulate in
+        # float32, so the GPU and CPU writers emit different overview bytes
+        # for float32 rasters (the GPU writer documents byte parity with
+        # the CPU writer). float64 input already accumulates in float64 on
+        # both paths, so this only changes the float32 result.
+        result = cupy.nanmean(blocks, axis=(1, 3), dtype=cupy.float64)
     elif method == 'min':
         result = cupy.nanmin(blocks, axis=(1, 3))
     elif method == 'max':

--- a/xrspatial/geotiff/tests/gpu/test_writer.py
+++ b/xrspatial/geotiff/tests/gpu/test_writer.py
@@ -1512,6 +1512,38 @@ def test_gpu_writer_overview_uses_make_overview_gpu_fresh_buffer_1948():
         )
 
 
+@_gpu_only
+@pytest.mark.parametrize("shape", [(64, 64), (33, 65), (128, 128)])
+@pytest.mark.parametrize("method", ["mean", "min", "max", "median"])
+def test_gpu_overview_reduce_byte_matches_cpu_2983(shape, method):
+    """GPU ``_block_reduce_2d_gpu`` matches the CPU reducer byte-for-byte.
+
+    The GPU writer documents byte parity with the CPU writer for
+    overviews. ``mean`` on float32 used to diverge because
+    ``cupy.nanmean`` accumulated in float32 while the CPU kernel
+    accumulates in float64 (issue #2983); the GPU mean now passes
+    ``dtype=cupy.float64`` so both downcast a float64 accumulator to
+    float32 on store. ``min`` / ``max`` / ``median`` are exact and were
+    already byte-identical; they ride along to guard against regressions.
+    """
+    import cupy
+
+    from xrspatial.geotiff._gpu_decode import _block_reduce_2d_gpu
+
+    h, w = shape
+    rng = np.random.default_rng(2983)
+    arr = (rng.standard_normal((h, w)).astype(np.float32) * 1000.0)
+
+    cpu = _block_reduce_2d(arr, method)
+    gpu = _block_reduce_2d_gpu(cupy.asarray(arr), method).get()
+
+    assert cpu.dtype == gpu.dtype == np.float32
+    assert cpu.tobytes() == gpu.tobytes(), (
+        f"GPU overview {method!r} diverges from CPU on float32 "
+        f"{shape}: {(cpu != gpu).sum()} of {cpu.size} pixels differ"
+    )
+
+
 # ===========================================================================
 # Section 7: overview_resampling='mode' + compression_level kwarg
 # (was test_gpu_writer_overview_mode_and_compression_level_1740.py)


### PR DESCRIPTION
Closes #2983

- `_block_reduce_2d_gpu` (`xrspatial/geotiff/_gpu_decode.py`) ran `cupy.nanmean` on a float32 `blocks` array, so the mean accumulated in float32. The CPU kernel accumulates in float64 and downcasts on store, so the two writers emitted different overview bytes for float32 rasters. That broke the GPU writer's documented byte-parity contract.
- Pass `dtype=cupy.float64` to the `nanmean` call so the GPU also downcasts a float64 accumulator on the existing final `astype`. `min` / `max` / `median` are exact and unchanged; float64 input was already correct on both paths.

Backend coverage: GPU (cupy) only. The change is isolated to the GPU overview reducer; the CPU and dask paths are untouched and serve as the reference.

Test plan:
- [x] New `test_gpu_overview_reduce_byte_matches_cpu_2983` asserts CPU/GPU byte parity for mean/min/max/median across 64x64, odd 33x65, and 128x128 float32 inputs
- [x] Confirmed the test fails on the `mean` cases without the fix and passes with it
- [x] Existing GPU overview / COG tests still pass