### PR TITLE
Surface chunked VRT decode-time hole gap under missing_sources='warn' (#2989)

### DIFF
--- a/docs/source/reference/geotiff.rst
+++ b/docs/source/reference/geotiff.rst
@@ -510,6 +510,20 @@ integer bands without a sentinel). ``XRSPATIAL_GEOTIFF_STRICT=1``
 forces the raise in ``'warn'`` mode too, so CI environments can enforce
 fail-fast behavior globally.
 
+Under chunked dispatch (``chunks=`` set), ``attrs['vrt_holes']`` records
+statically-detectable missing-file holes only (#2989). A source file
+that exists but fails to decode at compute time -- corrupt, truncated,
+or a codec error -- reads as a hole in the per-chunk worker and emits a
+:class:`xrspatial.geotiff.GeoTIFFFallbackWarning` then, but cannot be
+reduced back onto the parent DataArray's ``attrs['vrt_holes']`` without
+eagerly decoding every source (which would defeat lazy reading). So the
+chunked ``attrs['vrt_holes']`` is a lower bound, not the eager reader's
+exhaustive list. The chunked ``'warn'`` path emits one
+``GeoTIFFFallbackWarning`` up front when the requested window touches any
+existing source, so do not treat the absence of ``attrs['vrt_holes']``
+as proof of a complete mosaic. Use ``missing_sources='raise'`` to fail
+closed if you need a hard guarantee.
+
 BigTIFF COG (issue #2303)
 =========================
 

--- a/xrspatial/geotiff/_backends/vrt.py
+++ b/xrspatial/geotiff/_backends/vrt.py
@@ -222,6 +222,17 @@ def _read_vrt(source: str, *,
         sentinel (or zero on integer bands without a sentinel).
         ``XRSPATIAL_GEOTIFF_STRICT=1`` forces a raise across the whole
         module regardless of this kwarg.
+        Under chunked dispatch (``chunks=`` set) ``attrs['vrt_holes']``
+        records statically-detectable missing-file holes only. A source
+        file that exists but fails to decode at compute time (corrupt,
+        truncated, or codec error) surfaces as a per-chunk
+        ``GeoTIFFFallbackWarning`` and does NOT appear in
+        ``attrs['vrt_holes']``; recording it would require eagerly
+        decoding every source, which defeats lazy reading. The chunked
+        ``'warn'`` path emits one ``GeoTIFFFallbackWarning`` up front
+        when the requested window touches any existing source, so do not
+        treat the absence of ``attrs['vrt_holes']`` as proof of a
+        complete mosaic.
     band_nodata : {'first', None}, optional
         [advanced] Opt-out for the fail-closed mixed-band-metadata
         check. ``None`` (the default) rejects a VRT
@@ -1165,9 +1176,13 @@ def _read_vrt_chunked(source, *, window, band, name, chunks, gpu, dtype,
     # under chunked dispatch each per-task decode catches its own
     # missing source and warns, but those records cannot be reduced
     # back onto the parent DataArray without an extra synchronisation
-    # pass. The parse-time existence sweep catches the dominant
-    # missing-file case before scheduling and lets callers branch on
-    # ``"vrt_holes" in da.attrs`` exactly as with the eager reader.
+    # pass (or an eager decode of every source, which would defeat lazy
+    # reading). The parse-time existence sweep catches the dominant
+    # missing-file case before scheduling, but a source that exists yet
+    # fails to decode is invisible here -- so the chunked
+    # ``attrs['vrt_holes']`` is a lower bound, not the eager reader's
+    # exhaustive list. The lenient-path heads-up warning below tells the
+    # caller as much before they treat the attr as a completeness check.
     # Empty list is omitted so the attr only appears when a hole is
     # actually present. Each entry mirrors the eager schema:
     # ``{'source', 'band', 'dst_rect', 'error'}``.
@@ -1252,6 +1267,62 @@ def _read_vrt_chunked(source, *, window, band, name, chunks, gpu, dtype,
             f"and warns at compute time. "
             f"{len(chunked_holes)} missing source(s) total."
         )
+
+    # Build-time heads-up for the lenient ``'warn'`` path (issue #2989).
+    # ``chunked_holes`` above only records sources whose backing file is
+    # missing on disk -- the parse-time ``os.path.exists`` sweep cannot
+    # tell whether a file that *does* exist will decode. A source that is
+    # present but corrupt / truncated / codec-failing reads as a hole at
+    # compute time and gets warned from the per-chunk worker task, but
+    # that record cannot be reduced back onto this parent DataArray's
+    # ``attrs['vrt_holes']`` without an eager decode of every source,
+    # which would defeat lazy reading. So ``attrs['vrt_holes']`` on a
+    # chunked read is a lower bound: it lists statically-detectable
+    # missing-file holes only. Callers that branch on
+    # ``"vrt_holes" in da.attrs`` as a completeness check would otherwise
+    # treat a corrupt-source mosaic as whole. Emit one
+    # ``GeoTIFFFallbackWarning`` up front whenever the requested window
+    # touches a source whose file exists (i.e. one that could fail at
+    # decode time) so the caller learns the attr is not authoritative
+    # before they compute. Suppressed when no in-window source exists on
+    # disk (nothing can decode-fail) so the warning only fires when the
+    # gap is reachable.
+    if missing_sources == 'warn':
+        decode_capable = False
+        for band_idx, vrt_band in enumerate(vrt.bands):
+            if band is not None and band_idx != band:
+                continue
+            for src in vrt_band.sources:
+                dst = src.dst_rect
+                if not (
+                    dst.x_off + dst.x_size > win_c0
+                    and dst.x_off < win_c0 + full_w
+                    and dst.y_off + dst.y_size > win_r0
+                    and dst.y_off < win_r0 + full_h
+                ):
+                    continue
+                if _os.path.exists(src.filename):
+                    decode_capable = True
+                    break
+            if decode_capable:
+                break
+        if decode_capable:
+            import warnings
+
+            from .._runtime import GeoTIFFFallbackWarning
+            warnings.warn(
+                "Chunked VRT read under missing_sources='warn': "
+                "attrs['vrt_holes'] lists only statically-detectable "
+                "missing-file holes. A source file that exists but fails "
+                "to decode at compute time (corrupt / truncated / codec "
+                "error) surfaces as a per-chunk GeoTIFFFallbackWarning "
+                "and will NOT appear in attrs['vrt_holes']. Do not treat "
+                "the absence of attrs['vrt_holes'] as proof of a complete "
+                "mosaic; watch the compute-time warning stream or set "
+                "missing_sources='raise' to fail closed.",
+                GeoTIFFFallbackWarning,
+                stacklevel=2,
+            )
 
     # Route attrs assembly through
     # ``_finalize_lazy_read_attrs`` so the VRT chunked path shares the

--- a/xrspatial/geotiff/_backends/vrt.py
+++ b/xrspatial/geotiff/_backends/vrt.py
@@ -1186,7 +1186,14 @@ def _read_vrt_chunked(source, *, window, band, name, chunks, gpu, dtype,
     # Empty list is omitted so the attr only appears when a hole is
     # actually present. Each entry mirrors the eager schema:
     # ``{'source', 'band', 'dst_rect', 'error'}``.
+    # ``decode_capable`` (issue #2989) tracks whether any in-window source
+    # exists on disk. A present source can still fail to decode at compute
+    # time, and that decode-time hole cannot be reduced back onto this
+    # parent DataArray's ``attrs['vrt_holes']`` (see the lenient-path
+    # heads-up warning below). It is set in this same pass so we walk the
+    # source list once rather than re-scanning it just to compute the flag.
     chunked_holes: list[dict] = []
+    decode_capable = False
     for band_idx, vrt_band in enumerate(vrt.bands):
         # When ``band`` is restricted, the per-chunk decode never touches
         # bands outside the selection, so a missing source on an
@@ -1202,23 +1209,24 @@ def _read_vrt_chunked(source, *, window, band, name, chunks, gpu, dtype,
         if band is not None and band_idx != band:
             continue
         for src in vrt_band.sources:
-            if not _os.path.exists(src.filename):
-                # Skip holes that fall entirely outside the requested
-                # window. Each chunk task only decodes sources that
-                # intersect its destination rect, so a missing source
-                # outside the window never gets touched and the eager
-                # path with the same window would also not raise.
-                # ``win_r0/win_c0`` are the row/col origin of the
-                # requested window in the VRT's destination coordinate
-                # space and ``full_h/full_w`` are its size.
-                dst = src.dst_rect
-                if not (
-                    dst.x_off + dst.x_size > win_c0
-                    and dst.x_off < win_c0 + full_w
-                    and dst.y_off + dst.y_size > win_r0
-                    and dst.y_off < win_r0 + full_h
-                ):
-                    continue
+            # Skip sources that fall entirely outside the requested
+            # window. Each chunk task only decodes sources that intersect
+            # its destination rect, so a source outside the window never
+            # gets touched -- it can neither be a reachable hole nor a
+            # decode-capable tile. ``win_r0/win_c0`` are the row/col origin
+            # of the requested window in the VRT's destination coordinate
+            # space and ``full_h/full_w`` are its size.
+            dst = src.dst_rect
+            if not (
+                dst.x_off + dst.x_size > win_c0
+                and dst.x_off < win_c0 + full_w
+                and dst.y_off + dst.y_size > win_r0
+                and dst.y_off < win_r0 + full_h
+            ):
+                continue
+            if _os.path.exists(src.filename):
+                decode_capable = True
+            else:
                 chunked_holes.append({
                     'source': src.filename,
                     'band': vrt_band.band_num,
@@ -1284,45 +1292,27 @@ def _read_vrt_chunked(source, *, window, band, name, chunks, gpu, dtype,
     # ``GeoTIFFFallbackWarning`` up front whenever the requested window
     # touches a source whose file exists (i.e. one that could fail at
     # decode time) so the caller learns the attr is not authoritative
-    # before they compute. Suppressed when no in-window source exists on
-    # disk (nothing can decode-fail) so the warning only fires when the
-    # gap is reachable.
-    if missing_sources == 'warn':
-        decode_capable = False
-        for band_idx, vrt_band in enumerate(vrt.bands):
-            if band is not None and band_idx != band:
-                continue
-            for src in vrt_band.sources:
-                dst = src.dst_rect
-                if not (
-                    dst.x_off + dst.x_size > win_c0
-                    and dst.x_off < win_c0 + full_w
-                    and dst.y_off + dst.y_size > win_r0
-                    and dst.y_off < win_r0 + full_h
-                ):
-                    continue
-                if _os.path.exists(src.filename):
-                    decode_capable = True
-                    break
-            if decode_capable:
-                break
-        if decode_capable:
-            import warnings
+    # before they compute. ``decode_capable`` was computed in the static
+    # sweep above. It is False when no in-window source exists on disk
+    # (nothing can decode-fail), which suppresses the warning so it only
+    # fires when the gap is reachable.
+    if missing_sources == 'warn' and decode_capable:
+        import warnings
 
-            from .._runtime import GeoTIFFFallbackWarning
-            warnings.warn(
-                "Chunked VRT read under missing_sources='warn': "
-                "attrs['vrt_holes'] lists only statically-detectable "
-                "missing-file holes. A source file that exists but fails "
-                "to decode at compute time (corrupt / truncated / codec "
-                "error) surfaces as a per-chunk GeoTIFFFallbackWarning "
-                "and will NOT appear in attrs['vrt_holes']. Do not treat "
-                "the absence of attrs['vrt_holes'] as proof of a complete "
-                "mosaic; watch the compute-time warning stream or set "
-                "missing_sources='raise' to fail closed.",
-                GeoTIFFFallbackWarning,
-                stacklevel=2,
-            )
+        from .._runtime import GeoTIFFFallbackWarning
+        warnings.warn(
+            "Chunked VRT read under missing_sources='warn': "
+            "attrs['vrt_holes'] lists only statically-detectable "
+            "missing-file holes. A source file that exists but fails "
+            "to decode at compute time (corrupt / truncated / codec "
+            "error) surfaces as a per-chunk GeoTIFFFallbackWarning "
+            "and will NOT appear in attrs['vrt_holes']. Do not treat "
+            "the absence of attrs['vrt_holes'] as proof of a complete "
+            "mosaic; watch the compute-time warning stream or set "
+            "missing_sources='raise' to fail closed.",
+            GeoTIFFFallbackWarning,
+            stacklevel=2,
+        )
 
     # Route attrs assembly through
     # ``_finalize_lazy_read_attrs`` so the VRT chunked path shares the

--- a/xrspatial/geotiff/tests/vrt/test_missing_sources.py
+++ b/xrspatial/geotiff/tests/vrt/test_missing_sources.py
@@ -880,3 +880,153 @@ class TestRaiseAtBuildStrictMode:
         vrt_path = _raise_make_horizontal_partial_vrt(str(tmp_path))
         result = _read_vrt(vrt_path, chunks=4, missing_sources="warn")
         assert "vrt_holes" in result.attrs
+
+
+# ===========================================================================
+# Chunked decode-time holes are under-reported in attrs['vrt_holes'] (#2989).
+#
+# The chunked path's parse-time ``os.path.exists`` sweep only records
+# missing-file holes. A source that exists on disk but fails to decode
+# (corrupt / truncated / codec error) reads as a hole at compute time and
+# is warned from the per-chunk worker, but cannot be reduced back onto the
+# parent DataArray's ``attrs['vrt_holes']``. Recording it would require an
+# eager decode of every source, defeating lazy reading. The chunked
+# ``'warn'`` path emits a build-time heads-up warning so callers do not
+# treat ``attrs['vrt_holes']`` as a completeness check.
+# ===========================================================================
+
+
+def _make_corrupt_source_vrt_2989(tmp_path: str) -> tuple[str, str, str]:
+    """2-source VRT ``[ present | corrupt ]`` laid out 4x8.
+
+    Both ``<SourceFilename>`` paths exist on disk, so the parse-time
+    ``os.path.exists`` sweep finds no holes. The right tile is a present
+    GeoTIFF whose body has been overwritten with garbage so it fails to
+    decode at compute time.
+
+    Returns ``(vrt_path, present_src, corrupt_src)``.
+    """
+    present = _raise_write_present_source(
+        tmp_path, "src_2989_present.tif", 7.0,
+    )
+    corrupt = _raise_write_present_source(
+        tmp_path, "src_2989_corrupt.tif", 9.0,
+    )
+    # Keep the TIFF header (first 8 bytes) so path/format sniffing still
+    # treats it as a TIFF, then clobber the rest so the IFD / tile decode
+    # raises one of the caught (OSError, ValueError, struct.error, codec)
+    # families inside the per-source read.
+    with open(corrupt, "r+b") as f:
+        head = f.read(8)
+        f.seek(0)
+        f.truncate()
+        f.write(head)
+        f.write(b"\x00" * 64)
+
+    vrt_path = os.path.join(tmp_path, "partial_2989_corrupt.vrt")
+    with open(vrt_path, "w") as f:
+        f.write(
+            '<VRTDataset rasterXSize="8" rasterYSize="4">\n'
+            '<GeoTransform>0.0, 1.0, 0.0, 0.0, 0.0, -1.0</GeoTransform>\n'
+            '<VRTRasterBand dataType="Float32" band="1">\n'
+            '<SimpleSource>\n'
+            f'<SourceFilename relativeToVRT="0">{present}</SourceFilename>\n'
+            '<SourceBand>1</SourceBand>\n'
+            '<SrcRect xOff="0" yOff="0" xSize="4" ySize="4"/>\n'
+            '<DstRect xOff="0" yOff="0" xSize="4" ySize="4"/>\n'
+            '</SimpleSource>\n'
+            '<SimpleSource>\n'
+            f'<SourceFilename relativeToVRT="0">{corrupt}</SourceFilename>\n'
+            '<SourceBand>1</SourceBand>\n'
+            '<SrcRect xOff="0" yOff="0" xSize="4" ySize="4"/>\n'
+            '<DstRect xOff="4" yOff="0" xSize="4" ySize="4"/>\n'
+            '</SimpleSource>\n'
+            '</VRTRasterBand>\n'
+            '</VRTDataset>\n'
+        )
+    return vrt_path, present, corrupt
+
+
+class TestChunkedDecodeTimeHoleHeadsUp:
+    """Chunked ``'warn'`` build-time heads-up about decode-time holes."""
+
+    def test_corrupt_source_absent_from_vrt_holes_at_build(self, tmp_path):
+        """A present-but-corrupt source is not recorded in
+        ``attrs['vrt_holes']`` at build (it passes ``os.path.exists``)."""
+        vrt_path, _, corrupt = _make_corrupt_source_vrt_2989(str(tmp_path))
+        with pytest.warns(GeoTIFFFallbackWarning):
+            da = _read_vrt(vrt_path, chunks=4, missing_sources="warn")
+        holes = da.attrs.get("vrt_holes", [])
+        assert all(
+            not h["source"].endswith("src_2989_corrupt.tif") for h in holes
+        ), (
+            "corrupt-but-existing source must not appear in the build-time "
+            "attrs['vrt_holes'] (it passes the os.path.exists sweep)"
+        )
+
+    def test_build_time_heads_up_warning_fires(self, tmp_path):
+        """The chunked ``'warn'`` path warns up front that
+        ``attrs['vrt_holes']`` excludes decode-time holes."""
+        vrt_path, _, _ = _make_corrupt_source_vrt_2989(str(tmp_path))
+        with pytest.warns(
+            GeoTIFFFallbackWarning,
+            match="statically-detectable",
+        ):
+            _read_vrt(vrt_path, chunks=4, missing_sources="warn")
+
+    def test_compute_time_warning_for_corrupt_source(self, tmp_path):
+        """Computing the chunk over the corrupt tile warns at decode."""
+        vrt_path, _, corrupt = _make_corrupt_source_vrt_2989(str(tmp_path))
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            da = _read_vrt(vrt_path, chunks=4, missing_sources="warn")
+        with pytest.warns(GeoTIFFFallbackWarning) as record:
+            da.compute()
+        msgs = [str(w.message) for w in record]
+        assert any("src_2989_corrupt.tif" in m for m in msgs), (
+            "the per-chunk decode of a corrupt source must warn at "
+            f"compute time; got {msgs!r}"
+        )
+
+    def test_no_heads_up_when_all_sources_missing(self, tmp_path):
+        """When no in-window source exists on disk, nothing can decode-fail,
+        so the heads-up warning is suppressed (only the missing-file holes
+        are recorded in attrs)."""
+        vrt_path = _raise_make_horizontal_partial_vrt(str(tmp_path))
+        # The present tile makes one in-window source exist, so the
+        # heads-up should still fire here; pin that it does, then pin the
+        # all-missing case below where it should not.
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            da = _read_vrt(vrt_path, chunks=4, missing_sources="warn")
+        assert "vrt_holes" in da.attrs
+
+        all_missing = os.path.join(str(tmp_path), "all_missing_2989.vrt")
+        with open(all_missing, "w") as f:
+            f.write(
+                '<VRTDataset rasterXSize="2" rasterYSize="2">\n'
+                '<GeoTransform>0.0, 1.0, 0.0, 0.0, 0.0, -1.0</GeoTransform>\n'
+                '<VRTRasterBand dataType="Float32" band="1">\n'
+                '<SimpleSource>\n'
+                '<SourceFilename relativeToVRT="0">'
+                f'{os.path.join(str(tmp_path), "gone_2989.tif")}'
+                '</SourceFilename>\n'
+                '<SourceBand>1</SourceBand>\n'
+                '<SrcRect xOff="0" yOff="0" xSize="2" ySize="2"/>\n'
+                '<DstRect xOff="0" yOff="0" xSize="2" ySize="2"/>\n'
+                '</SimpleSource>\n'
+                '</VRTRasterBand>\n'
+                '</VRTDataset>\n'
+            )
+        with warnings.catch_warnings(record=True) as rec:
+            warnings.simplefilter("always")
+            _read_vrt(all_missing, chunks=2, missing_sources="warn")
+        heads_up = [
+            w for w in rec
+            if isinstance(w.message, GeoTIFFFallbackWarning)
+            and "statically-detectable" in str(w.message)
+        ]
+        assert not heads_up, (
+            "no in-window source exists on disk, so nothing can "
+            "decode-fail and the heads-up warning must be suppressed"
+        )


### PR DESCRIPTION
Closes #2989

## What

The chunked VRT path pre-populates `attrs['vrt_holes']` from a parse-time `os.path.exists` sweep, which only catches sources whose backing file is missing. A source that exists but fails to decode at compute time (corrupt, truncated, codec error) reads as a hole inside the per-chunk worker and is warned there, but that record cannot be reduced back onto the parent DataArray's attrs without eagerly decoding every source. Eager decode would defeat lazy reading, so it is off the table.

This PR makes the gap explicit instead of silent:

- Documents `attrs['vrt_holes']` under chunked dispatch as a lower bound (statically-detectable missing-file holes only), in the `_read_vrt` docstring, the inline static-sweep comment, and `docs/source/reference/geotiff.rst`.
- Emits one `GeoTIFFFallbackWarning` up front under `missing_sources='warn'` when the requested window touches an existing (decode-capable) source, so a caller cannot treat the absence of the attr as proof of a complete mosaic. The warning is suppressed when no in-window source exists on disk, since nothing can decode-fail in that case.

No behavior change for `missing_sources='raise'` (still fails closed up front on missing files) or for the eager path.

## Backend coverage

VRT reads are CPU/dask only and do not go through the GPU decoder pipeline; the warning lands on the chunked dispatcher shared by dask+numpy and dask+cupy. No numpy/cupy eager-path change.

## Test plan

- [x] Present-but-corrupt source is absent from build-time `attrs['vrt_holes']`
- [x] Build-time heads-up `GeoTIFFFallbackWarning` fires under chunked `'warn'`
- [x] Corrupt source still warns at compute time
- [x] Heads-up suppressed when no in-window source exists on disk
- [x] Full `xrspatial/geotiff/tests/vrt/` suite green (502 passed)