### PR TITLE
geotiff: reject malformed SCALE/OFFSET under mask_and_scale

### DIFF
--- a/docs/source/reference/geotiff.rst
+++ b/docs/source/reference/geotiff.rst
@@ -201,6 +201,13 @@ this section is the brief.
   nodata sentinels raises ``MixedBandMetadataError`` by default. Pass
   ``band_nodata='first'`` to opt back into the legacy flatten-to-band-0
   behaviour; see ``xrspatial/geotiff/tests/vrt/test_metadata.py``.
+* Malformed scale/offset. Under ``mask_and_scale=True`` the read applies
+  the source's ``SCALE`` / ``OFFSET`` from ``GDAL_METADATA``. A key that
+  is present but does not parse as a float (for example ``SCALE="abc"``)
+  raises ``MalformedScaleOffsetError`` (a ``GeoTIFFAmbiguousMetadataError``
+  subclass) rather than falling back to the 1.0 / 0.0 default and reading
+  the raw pixels as clean. An absent key keeps the identity default; see
+  ``xrspatial/geotiff/tests/read/test_rioxarray_compat_2961.py``.
 
 The lifecycle is locked end-to-end by
 ``xrspatial/geotiff/tests/read/test_nodata.py``.

--- a/xrspatial/geotiff/__init__.py
+++ b/xrspatial/geotiff/__init__.py
@@ -67,7 +67,8 @@ from ._coords import \
 from ._crs import _resolve_crs_to_wkt, _wkt_to_epsg  # noqa: F401
 from ._errors import (ConflictingCRSError, ConflictingNodataError, DuplicateIFDTagError,
                       GeoTIFFAmbiguousMetadataError, InconsistentGeoKeysError, InvalidCRSCodeError,
-                      InvalidIntegerNodataError, MixedBandMetadataError,
+                      InvalidIntegerNodataError, MalformedScaleOffsetError,
+                      MixedBandMetadataError,
                       NonRepresentableEPSGCRSError, NonUniformCoordsError,
                       RemoteStableSourcesOnlyError, RotatedTransformError, UnknownCRSModelTypeError,
                       UnparseableCRSError, UnsupportedGeoTIFFFeatureError,
@@ -116,6 +117,7 @@ __all__ = [
     'InconsistentGeoKeysError',
     'InvalidCRSCodeError',
     'InvalidIntegerNodataError',
+    'MalformedScaleOffsetError',
     'MixedBandMetadataError',
     'NonRepresentableEPSGCRSError',
     'NonUniformCoordsError',

--- a/xrspatial/geotiff/__init__.py
+++ b/xrspatial/geotiff/__init__.py
@@ -67,8 +67,7 @@ from ._coords import \
 from ._crs import _resolve_crs_to_wkt, _wkt_to_epsg  # noqa: F401
 from ._errors import (ConflictingCRSError, ConflictingNodataError, DuplicateIFDTagError,
                       GeoTIFFAmbiguousMetadataError, InconsistentGeoKeysError, InvalidCRSCodeError,
-                      InvalidIntegerNodataError, MalformedScaleOffsetError,
-                      MixedBandMetadataError,
+                      InvalidIntegerNodataError, MalformedScaleOffsetError, MixedBandMetadataError,
                       NonRepresentableEPSGCRSError, NonUniformCoordsError,
                       RemoteStableSourcesOnlyError, RotatedTransformError, UnknownCRSModelTypeError,
                       UnparseableCRSError, UnsupportedGeoTIFFFeatureError,

--- a/xrspatial/geotiff/_attrs.py
+++ b/xrspatial/geotiff/_attrs.py
@@ -164,7 +164,8 @@ import xarray as xr
 from ._coords import coords_from_geo_info as _coords_from_geo_info
 from ._coords import resolve_georef as _resolve_georef
 from ._coords import transform_tuple_from_pixel_geometry as _transform_tuple_from_pixel_geometry
-from ._errors import ConflictingNodataError, _distinct_per_band_nodatavals_msg
+from ._errors import (ConflictingNodataError, MalformedScaleOffsetError,
+                      _distinct_per_band_nodatavals_msg)
 from ._geotags import (_NO_GEOREF_KEY, GEOKEY_GEOGRAPHIC_TYPE, GEOKEY_MODEL_TYPE,
                        GEOKEY_PROJECTED_CS_TYPE, RASTER_PIXEL_IS_AREA, RASTER_PIXEL_IS_POINT)
 
@@ -1537,22 +1538,36 @@ def _extract_scale_offset(gdal_metadata):
     values are preferred; band 0's per-band values are the fallback. A single
     pair is applied to the whole array, so a source with differing per-band
     scale / offset is read with band 0's values (documented limitation).
+
+    Raises :class:`MalformedScaleOffsetError` when a ``SCALE`` or
+    ``OFFSET`` item is present but does not parse as a float. An absent
+    key keeps the 1.0 / 0.0 identity default.
     """
     scale, offset = 1.0, 0.0
     if not gdal_metadata:
         return scale, offset
 
-    def _num(keys, default):
+    def _num(label, keys, default):
+        # A key being absent is legitimate (the source carries no
+        # scale / offset): fall back to the identity default. A key that
+        # is present but unparseable is rejected -- ``mask_and_scale``
+        # asked us to honour the metadata, so a malformed value must not
+        # be silently dropped and the raw pixels read as if clean.
         for k in keys:
             if k in gdal_metadata:
+                raw = gdal_metadata[k]
                 try:
-                    return float(gdal_metadata[k])
+                    return float(raw)
                 except (TypeError, ValueError):
-                    return default
+                    raise MalformedScaleOffsetError(
+                        f"GDAL_METADATA {label} is not a number: {raw!r}. "
+                        "mask_and_scale=True cannot honour a malformed "
+                        f"{label}."
+                    ) from None
         return default
 
-    scale = _num(['SCALE', ('SCALE', 0)], 1.0)
-    offset = _num(['OFFSET', ('OFFSET', 0)], 0.0)
+    scale = _num('SCALE', ['SCALE', ('SCALE', 0)], 1.0)
+    offset = _num('OFFSET', ['OFFSET', ('OFFSET', 0)], 0.0)
     return scale, offset
 
 

--- a/xrspatial/geotiff/_errors.py
+++ b/xrspatial/geotiff/_errors.py
@@ -22,7 +22,8 @@ Hierarchy::
         ├── MixedBandMetadataError
         ├── ConflictingCRSError
         ├── ConflictingNodataError
-        └── InconsistentGeoKeysError
+        ├── InconsistentGeoKeysError
+        └── MalformedScaleOffsetError
 """
 from __future__ import annotations
 

--- a/xrspatial/geotiff/_errors.py
+++ b/xrspatial/geotiff/_errors.py
@@ -191,6 +191,26 @@ class InvalidIntegerNodataError(GeoTIFFAmbiguousMetadataError):
     """
 
 
+class MalformedScaleOffsetError(GeoTIFFAmbiguousMetadataError):
+    """A present SCALE / OFFSET item cannot be parsed as a float.
+
+    Raised under ``mask_and_scale=True`` when the source's GDAL_METADATA
+    carries a ``SCALE`` or ``OFFSET`` item whose value does not parse as
+    a float (for example ``SCALE="abc"``). ``mask_and_scale`` asks the
+    reader to honour the scale / offset metadata, so a malformed value
+    that would otherwise fall back to the 1.0 / 0.0 default is rejected
+    rather than silently dropped -- the raw, unscaled pixels would
+    otherwise flow downstream and the file would look clean.
+
+    An absent key is not an error: a source that declares no scale /
+    offset is read with the 1.0 / 0.0 identity transform as before.
+
+    Subclasses :class:`GeoTIFFAmbiguousMetadataError` (and therefore
+    ``ValueError``) so existing ``except ValueError`` callers keep
+    catching the case.
+    """
+
+
 class VRTStableSourcesOnlyError(GeoTIFFAmbiguousMetadataError):
     """VRT source opened under ``stable_only=True``.
 
@@ -324,6 +344,7 @@ __all__ = [
     "InconsistentGeoKeysError",
     "InvalidCRSCodeError",
     "InvalidIntegerNodataError",
+    "MalformedScaleOffsetError",
     "MixedBandMetadataError",
     "NonRepresentableEPSGCRSError",
     "NonUniformCoordsError",

--- a/xrspatial/geotiff/tests/read/test_rioxarray_compat_2961.py
+++ b/xrspatial/geotiff/tests/read/test_rioxarray_compat_2961.py
@@ -15,8 +15,8 @@ import pytest
 import xarray as xr
 
 from xrspatial.geotiff import (
-    _build_vrt, _read_geotiff_dask, _read_geotiff_gpu, _read_vrt,
-    open_geotiff, to_geotiff)
+    MalformedScaleOffsetError, _build_vrt, _read_geotiff_dask,
+    _read_geotiff_gpu, _read_vrt, open_geotiff, to_geotiff)
 from xrspatial.geotiff._runtime import GeoTIFFFallbackWarning
 from xrspatial.geotiff.tests._helpers.markers import requires_gpu
 
@@ -218,6 +218,54 @@ def test_mask_and_scale_int_dtype_raises(tmp_path):
     path = _scale_offset_tiff(str(tmp_path / "t2961_ms_int.tif"))
     with pytest.raises(ValueError):
         open_geotiff(path, mask_and_scale=True, dtype="uint8")
+
+
+# ---------------------------------------------------------------------------
+# malformed SCALE/OFFSET rejection (#2987)
+# ---------------------------------------------------------------------------
+
+def _malformed_scale_tiff(path, scale="abc", offset="0"):
+    """uint8 raster carrying an unparseable SCALE/OFFSET in GDAL_METADATA."""
+    data = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.uint8)
+    da = xr.DataArray(
+        data,
+        dims=("y", "x"),
+        coords={"y": [0.5, 1.5], "x": [0.5, 1.5, 2.5]},
+        attrs={
+            "crs": 4326,
+            "gdal_metadata": {"SCALE": scale, "OFFSET": offset},
+        },
+    )
+    to_geotiff(da, path)
+    return path
+
+
+def test_mask_and_scale_malformed_scale_raises(tmp_path):
+    """A present-but-unparseable SCALE fails closed under mask_and_scale."""
+    path = _malformed_scale_tiff(str(tmp_path / "t2987_bad_scale.tif"))
+    with pytest.raises(MalformedScaleOffsetError, match="SCALE"):
+        open_geotiff(path, mask_and_scale=True)
+
+
+def test_mask_and_scale_malformed_offset_raises(tmp_path):
+    path = _malformed_scale_tiff(
+        str(tmp_path / "t2987_bad_offset.tif"), scale="1", offset="xyz")
+    with pytest.raises(MalformedScaleOffsetError, match="OFFSET"):
+        open_geotiff(path, mask_and_scale=True)
+
+
+def test_mask_and_scale_malformed_scale_dask_raises(tmp_path):
+    path = _malformed_scale_tiff(str(tmp_path / "t2987_bad_scale_dask.tif"))
+    with pytest.raises(MalformedScaleOffsetError, match="SCALE"):
+        open_geotiff(path, mask_and_scale=True, chunks=2)
+
+
+def test_malformed_scale_ignored_without_mask_and_scale(tmp_path):
+    """Without mask_and_scale the metadata is never read, so no rejection."""
+    path = _malformed_scale_tiff(str(tmp_path / "t2987_no_ms.tif"))
+    out = open_geotiff(path)
+    assert out.dtype == np.uint8
+    np.testing.assert_array_equal(out.data, [[1, 2, 3], [4, 5, 6]])
 
 
 # ---------------------------------------------------------------------------

--- a/xrspatial/geotiff/tests/read/test_rioxarray_compat_2961.py
+++ b/xrspatial/geotiff/tests/read/test_rioxarray_compat_2961.py
@@ -14,9 +14,8 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from xrspatial.geotiff import (
-    MalformedScaleOffsetError, _build_vrt, _read_geotiff_dask,
-    _read_geotiff_gpu, _read_vrt, open_geotiff, to_geotiff)
+from xrspatial.geotiff import (MalformedScaleOffsetError, _build_vrt, _read_geotiff_dask,
+                               _read_geotiff_gpu, _read_vrt, open_geotiff, to_geotiff)
 from xrspatial.geotiff._runtime import GeoTIFFFallbackWarning
 from xrspatial.geotiff.tests._helpers.markers import requires_gpu
 

--- a/xrspatial/geotiff/tests/release_gates/test_features.py
+++ b/xrspatial/geotiff/tests/release_gates/test_features.py
@@ -2830,6 +2830,10 @@ class TestPublicAPI:
             # GDAL_NODATA against an integer source dtype, replacing the
             # legacy silent no-op.
             'InvalidIntegerNodataError',
+            # Read-side fail-closed on a present-but-unparseable SCALE /
+            # OFFSET under mask_and_scale, replacing the legacy silent
+            # fall-back to the 1.0 / 0.0 default (issue #2987).
+            'MalformedScaleOffsetError',
             'MixedBandMetadataError',
             # Writer rejects compound EPSG codes that cannot be
             # represented in a single GeographicType / ProjectedCSType


### PR DESCRIPTION
Closes #2987

`_extract_scale_offset` returned the 1.0 / 0.0 identity default whenever a `SCALE` or `OFFSET` value failed to parse as a float, so a malformed item read the same as a missing one. Under `mask_and_scale=True` the caller asked the reader to honour the metadata, and the silent fallback let the raw unscaled pixels through as if the file were clean.

Changes:

- `_extract_scale_offset` now raises the new `MalformedScaleOffsetError` (a `GeoTIFFAmbiguousMetadataError`/`ValueError` subclass) when a SCALE or OFFSET key is present but unparseable. An absent key still returns the identity default, so a source with no scale/offset reads as before.
- The error names the offending key and value.
- Added the error to the geotiff package exports and a note to the reference docs.

Both `mask_and_scale` call sites (eager `_finalize_eager_read` and the dask backend) reach `_extract_scale_offset` during graph assembly, so the rejection fires before compute on both. Reads without `mask_and_scale` never touch the metadata and are unaffected.

Test plan:

- [x] `test_mask_and_scale_malformed_scale_raises` / `_offset_raises` (eager)
- [x] `test_mask_and_scale_malformed_scale_dask_raises` (dask)
- [x] `test_malformed_scale_ignored_without_mask_and_scale` (no opt-in, no rejection)
- [x] Existing `test_rioxarray_compat_2961.py` suite still green (29 passed)