### PR TITLE
geotiff: fail closed on malformed GDAL_METADATA XML under mask_and_scale

### DIFF
--- a/xrspatial/geotiff/_attrs.py
+++ b/xrspatial/geotiff/_attrs.py
@@ -1580,6 +1580,10 @@ def _extract_scale_offset(gdal_metadata, band=None, *, malformed=False):
     as if no scaling were declared.
     """
     scale, offset = 1.0, 0.0
+    # Check ``malformed`` before the empty-dict short-circuit below: an
+    # unparseable payload yields ``gdal_metadata == {}``, so a guard that
+    # returned the identity default on an empty dict first would silence
+    # the rejection. Keep this check at the top.
     if malformed:
         raise MalformedScaleOffsetError(
             "GDAL_METADATA XML is malformed and could not be parsed. "

--- a/xrspatial/geotiff/_attrs.py
+++ b/xrspatial/geotiff/_attrs.py
@@ -1549,7 +1549,7 @@ def _apply_eager_nodata_mask(arr, *, mask_sentinel, mask_nodata):
     return arr, nodata_pixels_present
 
 
-def _extract_scale_offset(gdal_metadata, band=None):
+def _extract_scale_offset(gdal_metadata, band=None, *, malformed=False):
     """Pull SCALE / OFFSET from parsed GDAL_METADATA for ``mask_and_scale``.
 
     Returns ``(scale, offset)`` floats, defaulting to ``(1.0, 0.0)`` when the
@@ -1571,8 +1571,22 @@ def _extract_scale_offset(gdal_metadata, band=None):
     Raises :class:`MalformedScaleOffsetError` when a ``SCALE`` or ``OFFSET``
     item is present but does not parse as a float. An absent key keeps the
     1.0 / 0.0 identity default.
+
+    ``malformed=True`` signals that the source carried a GDAL_METADATA XML
+    payload that did not parse (see :func:`_parse_gdal_metadata_strict`).
+    Because the unparseable payload could have declared a scale / offset
+    that is now lost, ``mask_and_scale`` fails closed with a
+    :class:`MalformedScaleOffsetError` rather than reading the raw pixels
+    as if no scaling were declared.
     """
     scale, offset = 1.0, 0.0
+    if malformed:
+        raise MalformedScaleOffsetError(
+            "GDAL_METADATA XML is malformed and could not be parsed. "
+            "mask_and_scale=True cannot honour the scale / offset it may "
+            "declare, so the read is refused rather than returning raw, "
+            "unscaled pixels."
+        )
     if not gdal_metadata:
         return scale, offset
 
@@ -1715,7 +1729,8 @@ def _finalize_eager_read(
     # mask path raises (scaling promotes to float).
     if mask_and_scale:
         scale, offset = _extract_scale_offset(
-            getattr(geo_info, 'gdal_metadata', None), band=band)
+            getattr(geo_info, 'gdal_metadata', None), band=band,
+            malformed=getattr(geo_info, 'gdal_metadata_malformed', False))
         if scale != 1.0 or offset != 0.0:
             if arr.dtype.kind != 'f':
                 arr = arr.astype(np.float64)

--- a/xrspatial/geotiff/_backends/dask.py
+++ b/xrspatial/geotiff/_backends/dask.py
@@ -635,7 +635,8 @@ def _read_geotiff_dask(source: str, *,
     if mask_and_scale:
         from .._attrs import _extract_scale_offset
         scale, offset = _extract_scale_offset(
-            getattr(geo_info, 'gdal_metadata', None), band=band)
+            getattr(geo_info, 'gdal_metadata', None), band=band,
+            malformed=getattr(geo_info, 'gdal_metadata_malformed', False))
         if scale != 1.0 or offset != 0.0:
             dask_arr = dask_arr * scale + offset
             attrs['scale_factor'] = scale

--- a/xrspatial/geotiff/_geotags.py
+++ b/xrspatial/geotiff/_geotags.py
@@ -173,6 +173,11 @@ class GeoInfo:
     # and {(name, band): value} for per-band items.  Raw XML also kept.
     gdal_metadata: dict | None = None
     gdal_metadata_xml: str | None = None
+    # True when ``gdal_metadata_xml`` was present but did not parse as
+    # well-formed XML. ``mask_and_scale`` reads use this to fail closed
+    # instead of silently treating the unparseable metadata as "no
+    # scale / offset" and reading the raw pixels.
+    gdal_metadata_malformed: bool = False
     # Extra TIFF tags not managed by the writer (pass-through on round-trip)
     # List of (tag_id, type_id, count, raw_value) tuples.
     extra_tags: list | None = None
@@ -185,16 +190,23 @@ class GeoInfo:
     geokeys: dict[int, int | float | str] = field(default_factory=dict)
 
 
-def _parse_gdal_metadata(xml_str: str) -> dict:
-    """Parse GDALMetadata XML into a flat dict.
+def _parse_gdal_metadata_strict(xml_str: str) -> tuple[dict, bool]:
+    """Parse GDALMetadata XML, reporting whether the payload was malformed.
 
-    Dataset-level items are stored as ``{name: value}``.
-    Per-band items are stored as ``{(name, band_int): value}``.
+    Returns ``(result, malformed)``. ``result`` is the flat dict described
+    by :func:`_parse_gdal_metadata`. ``malformed`` is ``True`` when the
+    payload could not be parsed as XML (an :class:`xml.etree.ElementTree.
+    ParseError`), so a caller honouring the metadata (``mask_and_scale``)
+    can fail closed instead of reading the raw pixels as if no scale /
+    offset were declared. A DOCTYPE rejection (billion-laughs guard) does
+    NOT set the flag: that payload is dropped on purpose and the read
+    proceeds without the non-essential metadata.
     """
     import xml.etree.ElementTree as ET
 
     from ._safe_xml import safe_fromstring
     result = {}
+    malformed = False
     try:
         # GDALMetadata XML rides inside TIFF tag 42112; a crafted file
         # can carry a billion-laughs payload there, so refuse DOCTYPEs
@@ -208,12 +220,31 @@ def _parse_gdal_metadata(xml_str: str) -> dict:
                 result[(name, int(sample))] = text
             else:
                 result[name] = text
-    except (ET.ParseError, ValueError):
+    except ET.ParseError:
+        # The payload is present but is not well-formed XML. We still
+        # return an empty dict so reads that ignore GDAL_METADATA keep
+        # working, but we flag the failure so ``mask_and_scale`` can
+        # reject it rather than silently reading unscaled pixels.
+        malformed = True
+    except ValueError:
         # ValueError surfaces from safe_fromstring when the payload
         # carries a DOCTYPE. GDALMetadata is non-essential metadata, so
-        # we silently drop it rather than failing the whole read --
-        # matches the existing ParseError fallback.
+        # we silently drop it rather than failing the whole read.
         pass
+    return result, malformed
+
+
+def _parse_gdal_metadata(xml_str: str) -> dict:
+    """Parse GDALMetadata XML into a flat dict.
+
+    Dataset-level items are stored as ``{name: value}``.
+    Per-band items are stored as ``{(name, band_int): value}``.
+
+    Malformed or DOCTYPE-bearing payloads are dropped, returning ``{}``.
+    Callers that need to distinguish a malformed payload from an absent
+    one use :func:`_parse_gdal_metadata_strict`.
+    """
+    result, _ = _parse_gdal_metadata_strict(xml_str)
     return result
 
 
@@ -995,9 +1026,11 @@ def extract_geo_info(ifd: IFD, data: bytes | memoryview,
 
     # Parse GDALMetadata XML (tag 42112)
     gdal_metadata = None
+    gdal_metadata_malformed = False
     gdal_metadata_xml = ifd.gdal_metadata
     if gdal_metadata_xml is not None:
-        gdal_metadata = _parse_gdal_metadata(gdal_metadata_xml)
+        gdal_metadata, gdal_metadata_malformed = _parse_gdal_metadata_strict(
+            gdal_metadata_xml)
 
     # Extract palette colormap (Photometric=3, tag 320)
     colormap = None
@@ -1106,6 +1139,7 @@ def extract_geo_info(ifd: IFD, data: bytes | memoryview,
         crs_wkt=crs_wkt,
         gdal_metadata=gdal_metadata,
         gdal_metadata_xml=gdal_metadata_xml,
+        gdal_metadata_malformed=gdal_metadata_malformed,
         extra_tags=extra_tags,
         image_description=image_description,
         extra_samples=extra_samples,
@@ -1288,6 +1322,7 @@ def extract_geo_info_with_overview_inheritance(
     if (info.gdal_metadata_xml is None
             and base_info.gdal_metadata_xml is not None):
         info.gdal_metadata_xml = base_info.gdal_metadata_xml
+        info.gdal_metadata_malformed = base_info.gdal_metadata_malformed
     if info.x_resolution is None and base_info.x_resolution is not None:
         info.x_resolution = base_info.x_resolution
     if info.y_resolution is None and base_info.y_resolution is not None:

--- a/xrspatial/geotiff/tests/read/test_rioxarray_compat_2961.py
+++ b/xrspatial/geotiff/tests/read/test_rioxarray_compat_2961.py
@@ -269,6 +269,55 @@ def test_malformed_scale_ignored_without_mask_and_scale(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# malformed GDAL_METADATA XML rejection (#2998)
+# ---------------------------------------------------------------------------
+
+def _malformed_xml_tiff(path):
+    """uint8 raster whose GDAL_METADATA tag holds non-well-formed XML.
+
+    The writer escapes every SCALE/OFFSET value it serialises, so a
+    malformed payload has to be injected through the raw
+    ``gdal_metadata_xml`` writer kwarg (gated behind the rich-tag opt-in).
+    The unclosed ``<Item>`` makes ``ET.fromstring`` raise ``ParseError``.
+    """
+    data = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.uint8)
+    da = xr.DataArray(
+        data,
+        dims=("y", "x"),
+        coords={"y": [0.5, 1.5], "x": [0.5, 1.5, 2.5]},
+        attrs={
+            "crs": 4326,
+            "gdal_metadata_xml": (
+                '<GDALMetadata><Item name="SCALE">2.0</GDALMetadata>'
+            ),
+        },
+    )
+    to_geotiff(da, path, allow_experimental_codecs=True)
+    return path
+
+
+def test_mask_and_scale_malformed_xml_raises(tmp_path):
+    """Malformed GDAL_METADATA XML fails closed under mask_and_scale."""
+    path = _malformed_xml_tiff(str(tmp_path / "t2998_bad_xml.tif"))
+    with pytest.raises(MalformedScaleOffsetError, match="XML"):
+        open_geotiff(path, mask_and_scale=True)
+
+
+def test_mask_and_scale_malformed_xml_dask_raises(tmp_path):
+    path = _malformed_xml_tiff(str(tmp_path / "t2998_bad_xml_dask.tif"))
+    with pytest.raises(MalformedScaleOffsetError, match="XML"):
+        open_geotiff(path, mask_and_scale=True, chunks=2)
+
+
+def test_malformed_xml_ignored_without_mask_and_scale(tmp_path):
+    """Without mask_and_scale the XML is never parsed for scale/offset."""
+    path = _malformed_xml_tiff(str(tmp_path / "t2998_no_ms.tif"))
+    out = open_geotiff(path)
+    assert out.dtype == np.uint8
+    np.testing.assert_array_equal(out.data, [[1, 2, 3], [4, 5, 6]])
+
+
+# ---------------------------------------------------------------------------
 # parse_coordinates
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #2998

## What

Under `mask_and_scale=True`, a GeoTIFF whose `GDAL_METADATA` tag holds non-well-formed XML now fails closed with `MalformedScaleOffsetError` instead of reading raw, unscaled pixels. `_parse_gdal_metadata()` caught `ET.ParseError` and returned `{}`, which `_extract_scale_offset()` then read as identity scaling. A scale/offset hidden inside a corrupt XML payload was lost silently. PRs #2988 / #2992 closed the same risk for malformed numeric SCALE/OFFSET; this covers the XML container itself.

- `_parse_gdal_metadata_strict()` returns `(dict, malformed)`. `_parse_gdal_metadata()` keeps its dict-only contract by discarding the flag, so the existing callers and the DOCTYPE/billion-laughs security drop are unchanged (that payload is still refused silently, on purpose).
- `GeoInfo.gdal_metadata_malformed` carries the flag to the consumer and is inherited by overview IFDs alongside the XML.
- `_extract_scale_offset()` raises `MalformedScaleOffsetError` when the flag is set.

## Backend coverage

The rejection lands on both `mask_and_scale` consumer sites: the eager path (`_finalize_eager_read`, used by numpy / cupy / GPU) and the dask path. numpy, cupy, dask+numpy, and dask+cupy all route through one of the two.

## Test plan

- [x] Eager read of malformed XML raises `MalformedScaleOffsetError`
- [x] Dask read (`chunks=2`) of malformed XML raises `MalformedScaleOffsetError`
- [x] Read without `mask_and_scale` is unchanged (no rejection)
- [x] Existing DOCTYPE security test still returns `{}` (silent drop)
- [x] Full geotiff suite green (6206 passed, 81 skipped, 1 xfailed)