### PR TITLE
Add tests for all-NaN auto-levels RuntimeWarning regression (#2795)

### DIFF
--- a/xrspatial/tests/test_contour.py
+++ b/xrspatial/tests/test_contour.py
@@ -1,3 +1,4 @@
+import warnings
 import numpy as np
 import pytest
 import xarray as xr
@@ -122,7 +123,6 @@ class TestNaNHandling:
 
     def test_all_nan_auto_levels_no_warning(self):
         """All-NaN raster with auto levels must not emit RuntimeWarning (#2795)."""
-        import warnings
         data = np.full((4, 4), np.nan, dtype=np.float64)
         agg = create_test_raster(data, backend='numpy')
         with warnings.catch_warnings(record=True) as w:
@@ -138,7 +138,6 @@ class TestNaNHandling:
     @dask_array_available
     def test_all_nan_auto_levels_no_warning_dask(self):
         """All-NaN dask raster with auto levels must not emit RuntimeWarning (#2795)."""
-        import warnings
         data = np.full((4, 4), np.nan, dtype=np.float64)
         agg = create_test_raster(data, backend='dask+numpy', chunks=(2, 2))
         with warnings.catch_warnings(record=True) as w:
@@ -154,7 +153,6 @@ class TestNaNHandling:
     @cuda_and_cupy_available
     def test_all_nan_auto_levels_no_warning_cupy(self):
         """All-NaN cupy raster with auto levels must not emit RuntimeWarning (#2795)."""
-        import warnings
         data = np.full((4, 4), np.nan, dtype=np.float64)
         agg = create_test_raster(data, backend='cupy')
         with warnings.catch_warnings(record=True) as w:
@@ -171,7 +169,6 @@ class TestNaNHandling:
     @cuda_and_cupy_available
     def test_all_nan_auto_levels_no_warning_dask_cupy(self):
         """All-NaN dask+cupy raster with auto levels must not emit RuntimeWarning (#2795)."""
-        import warnings
         data = np.full((4, 4), np.nan, dtype=np.float64)
         agg = create_test_raster(data, backend='dask+cupy', chunks=(2, 2))
         with warnings.catch_warnings(record=True) as w:

--- a/xrspatial/tests/test_contour.py
+++ b/xrspatial/tests/test_contour.py
@@ -120,6 +120,70 @@ class TestNaNHandling:
         result = contours(agg, levels=[0.0])
         assert result == []
 
+    def test_all_nan_auto_levels_no_warning(self):
+        """All-NaN raster with auto levels must not emit RuntimeWarning (#2795)."""
+        import warnings
+        data = np.full((4, 4), np.nan, dtype=np.float64)
+        agg = create_test_raster(data, backend='numpy')
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = contours(agg)
+            assert result == []
+            runtime_warnings = [x for x in w if issubclass(x.category, RuntimeWarning)]
+            assert len(runtime_warnings) == 0, (
+                f"RuntimeWarning emitted on all-NaN auto-level path: "
+                f"{[str(x.message) for x in runtime_warnings]}"
+            )
+
+    @dask_array_available
+    def test_all_nan_auto_levels_no_warning_dask(self):
+        """All-NaN dask raster with auto levels must not emit RuntimeWarning (#2795)."""
+        import warnings
+        data = np.full((4, 4), np.nan, dtype=np.float64)
+        agg = create_test_raster(data, backend='dask+numpy', chunks=(2, 2))
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = contours(agg)
+            assert result == []
+            runtime_warnings = [x for x in w if issubclass(x.category, RuntimeWarning)]
+            assert len(runtime_warnings) == 0, (
+                f"RuntimeWarning emitted on all-NaN dask auto-level path: "
+                f"{[str(x.message) for x in runtime_warnings]}"
+            )
+
+    @cuda_and_cupy_available
+    def test_all_nan_auto_levels_no_warning_cupy(self):
+        """All-NaN cupy raster with auto levels must not emit RuntimeWarning (#2795)."""
+        import warnings
+        data = np.full((4, 4), np.nan, dtype=np.float64)
+        agg = create_test_raster(data, backend='cupy')
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = contours(agg)
+            assert result == []
+            runtime_warnings = [x for x in w if issubclass(x.category, RuntimeWarning)]
+            assert len(runtime_warnings) == 0, (
+                f"RuntimeWarning emitted on all-NaN cupy auto-level path: "
+                f"{[str(x.message) for x in runtime_warnings]}"
+            )
+
+    @dask_array_available
+    @cuda_and_cupy_available
+    def test_all_nan_auto_levels_no_warning_dask_cupy(self):
+        """All-NaN dask+cupy raster with auto levels must not emit RuntimeWarning (#2795)."""
+        import warnings
+        data = np.full((4, 4), np.nan, dtype=np.float64)
+        agg = create_test_raster(data, backend='dask+cupy', chunks=(2, 2))
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = contours(agg)
+            assert result == []
+            runtime_warnings = [x for x in w if issubclass(x.category, RuntimeWarning)]
+            assert len(runtime_warnings) == 0, (
+                f"RuntimeWarning emitted on all-NaN dask+cupy auto-level path: "
+                f"{[str(x.message) for x in runtime_warnings]}"
+            )
+
     def test_partial_nan(self):
         """Contours skip quads with NaN corners."""
         data = _make_ramp(ny=5, nx=6)


### PR DESCRIPTION
Closes xarray-contrib/xarray-spatial#2795.

- Add test coverage for `contours()` on all-NaN rasters with auto level selection, verifying no RuntimeWarning is emitted.
- Tests cover numpy, dask+numpy, cupy, and dask+cupy backends.

The warning suppression was already in place (commit 58a44c3), but lacked explicit test coverage to prevent regression.

**Backend coverage:**
- numpy: tested
- dask+numpy: tested
- cupy: tested (skipped when cupy unavailable)
- dask+cupy: tested (skipped when cupy unavailable)

**Test checklist:**
- [x] All-NaN numpy raster with auto levels returns empty, no RuntimeWarning
- [x] All-NaN dask raster with auto levels returns empty, no RuntimeWarning
- [x] All-NaN cupy/dask+cupy tests included (skipped without GPU)
- [x] Existing contour tests still pass