### PR TITLE
Fix contours() border collar on integer dask input (#3020)

### DIFF
--- a/xrspatial/contour.py
+++ b/xrspatial/contour.py
@@ -400,6 +400,21 @@ def _contours_cupy(data, levels):
     return _contours_numpy(cpu_data, levels)
 
 
+def _overlap_for_contours(data):
+    """Add a NaN 1-cell halo to a dask array for marching squares.
+
+    ``boundary=np.nan`` only produces real NaN on float dtypes.  On an
+    integer array NaN can't be stored, so dask fills the halo with the
+    integer minimum, which ``np.isfinite`` accepts.  Those phantom cells
+    then emit spurious crossings that stitch into a border collar (see
+    issue #3020).  Cast non-float input to float64 first so the halo is
+    real NaN, matching the numpy backend which casts in ``_contours_numpy``.
+    """
+    if data.dtype.kind != 'f':
+        data = data.astype(np.float64)
+    return da.overlap.overlap(data, depth={0: 1, 1: 1}, boundary=np.nan)
+
+
 def _contours_dask(data, levels):
     """Dask backend: process each chunk with 1-cell overlap, then merge.
 
@@ -410,7 +425,7 @@ def _contours_dask(data, levels):
     if da is None:
         raise ImportError("Dask is required for chunked contour extraction")
 
-    padded = da.overlap.overlap(data, depth={0: 1, 1: 1}, boundary=np.nan)
+    padded = _overlap_for_contours(data)
     orig_row_chunks = data.chunks[0]
     orig_col_chunks = data.chunks[1]
     padded_blocks = padded.to_delayed()
@@ -445,7 +460,7 @@ def _contours_dask_cupy(data, levels):
     if da is None:
         raise ImportError("Dask is required for chunked contour extraction")
 
-    padded = da.overlap.overlap(data, depth={0: 1, 1: 1}, boundary=np.nan)
+    padded = _overlap_for_contours(data)
     orig_row_chunks = data.chunks[0]
     orig_col_chunks = data.chunks[1]
     padded_blocks = padded.to_delayed()

--- a/xrspatial/tests/test_contour.py
+++ b/xrspatial/tests/test_contour.py
@@ -33,6 +33,23 @@ def _make_peak():
     return data
 
 
+def _segments_by_level(results, decimals=8):
+    """Decompose contour polylines into canonicalized segments per level.
+
+    Each segment is stored with its smaller endpoint first so the result is
+    direction-independent, and segments are sorted for stable comparison
+    across backends.
+    """
+    by_level = defaultdict(list)
+    for level, coords in results:
+        for i in range(len(coords) - 1):
+            p0 = (round(coords[i, 0], decimals), round(coords[i, 1], decimals))
+            p1 = (round(coords[i + 1, 0], decimals),
+                  round(coords[i + 1, 1], decimals))
+            by_level[level].append((min(p0, p1), max(p0, p1)))
+    return {lvl: sorted(segs) for lvl, segs in by_level.items()}
+
+
 # ---------------------------------------------------------------------------
 # Basic correctness
 # ---------------------------------------------------------------------------
@@ -538,23 +555,25 @@ class TestIntegerDtypeCollar:
     _overlap_for_contours.
     """
 
-    def _collect_segments(self, results):
-        return TestBackendEquivalence._collect_segments(self, results)
+    LEVELS = [5.0, 10.0, 15.0]
+    # Cover several integer widths/signedness; the int-min halo fill differs
+    # per dtype, so a phantom crossing would show up regardless.
+    INT_DTYPES = [np.int16, np.int32, np.int64, np.uint8]
 
-    def _int_ramp(self, ny=20, nx=20):
+    def _int_ramp(self, dtype, ny=20, nx=20):
         # Edge columns straddle the levels, so any phantom halo crossing
         # shows up as a frame around the raster.
-        return np.tile(np.arange(nx), (ny, 1)).astype(np.int32)
+        return np.tile(np.arange(nx), (ny, 1)).astype(dtype)
 
     @dask_array_available
-    def test_int_dask_equals_numpy(self):
-        data = self._int_ramp()
-        levels = [5.0, 10.0, 15.0]
+    @pytest.mark.parametrize("dtype", INT_DTYPES)
+    def test_int_dask_equals_numpy(self, dtype):
+        data = self._int_ramp(dtype)
         np_agg = create_test_raster(data, backend='numpy')
         dk_agg = create_test_raster(data, backend='dask+numpy', chunks=(7, 7))
 
-        np_segs = self._collect_segments(contours(np_agg, levels=levels))
-        dk_segs = self._collect_segments(contours(dk_agg, levels=levels))
+        np_segs = _segments_by_level(contours(np_agg, levels=self.LEVELS))
+        dk_segs = _segments_by_level(contours(dk_agg, levels=self.LEVELS))
 
         assert set(np_segs.keys()) == set(dk_segs.keys())
         for lvl in np_segs:
@@ -567,13 +586,12 @@ class TestIntegerDtypeCollar:
         # A collar would push the bounding box out to the raster edges and
         # inflate the total length.
         pytest.importorskip("geopandas")
-        data = self._int_ramp()
-        levels = [5.0, 10.0, 15.0]
+        data = self._int_ramp(np.int32)
         np_agg = create_test_raster(data, backend='numpy')
         dk_agg = create_test_raster(data, backend='dask+numpy', chunks=(7, 7))
 
-        g_np = contours(np_agg, levels=levels, return_type='geopandas')
-        g_dk = contours(dk_agg, levels=levels, return_type='geopandas')
+        g_np = contours(np_agg, levels=self.LEVELS, return_type='geopandas')
+        g_dk = contours(dk_agg, levels=self.LEVELS, return_type='geopandas')
 
         assert g_dk.length.sum() == pytest.approx(g_np.length.sum())
         np.testing.assert_allclose(g_dk.total_bounds, g_np.total_bounds)
@@ -581,13 +599,12 @@ class TestIntegerDtypeCollar:
     @dask_array_available
     @cuda_and_cupy_available
     def test_int_dask_cupy_equals_numpy(self):
-        data = self._int_ramp()
-        levels = [5.0, 10.0, 15.0]
+        data = self._int_ramp(np.int32)
         np_agg = create_test_raster(data, backend='numpy')
         dc_agg = create_test_raster(data, backend='dask+cupy', chunks=(7, 7))
 
-        np_segs = self._collect_segments(contours(np_agg, levels=levels))
-        dc_segs = self._collect_segments(contours(dc_agg, levels=levels))
+        np_segs = _segments_by_level(contours(np_agg, levels=self.LEVELS))
+        dc_segs = _segments_by_level(contours(dc_agg, levels=self.LEVELS))
 
         assert set(np_segs.keys()) == set(dc_segs.keys())
         for lvl in np_segs:

--- a/xrspatial/tests/test_contour.py
+++ b/xrspatial/tests/test_contour.py
@@ -529,6 +529,73 @@ class TestBackendEquivalence:
 
 
 # ---------------------------------------------------------------------------
+# Integer dtype: NaN halo regression (issue #3020)
+# ---------------------------------------------------------------------------
+
+class TestIntegerDtypeCollar:
+    """boundary=np.nan can't fill an integer halo, so dask used to leave a
+    border collar that numpy never produced.  These guard the float cast in
+    _overlap_for_contours.
+    """
+
+    def _collect_segments(self, results):
+        return TestBackendEquivalence._collect_segments(self, results)
+
+    def _int_ramp(self, ny=20, nx=20):
+        # Edge columns straddle the levels, so any phantom halo crossing
+        # shows up as a frame around the raster.
+        return np.tile(np.arange(nx), (ny, 1)).astype(np.int32)
+
+    @dask_array_available
+    def test_int_dask_equals_numpy(self):
+        data = self._int_ramp()
+        levels = [5.0, 10.0, 15.0]
+        np_agg = create_test_raster(data, backend='numpy')
+        dk_agg = create_test_raster(data, backend='dask+numpy', chunks=(7, 7))
+
+        np_segs = self._collect_segments(contours(np_agg, levels=levels))
+        dk_segs = self._collect_segments(contours(dk_agg, levels=levels))
+
+        assert set(np_segs.keys()) == set(dk_segs.keys())
+        for lvl in np_segs:
+            assert np_segs[lvl] == dk_segs[lvl], (
+                f"Integer dask result diverges from numpy at level {lvl}")
+
+    @dask_array_available
+    def test_int_dask_no_border_collar(self):
+        # A vertical ramp at these levels is a set of straight vertical lines.
+        # A collar would push the bounding box out to the raster edges and
+        # inflate the total length.
+        pytest.importorskip("geopandas")
+        data = self._int_ramp()
+        levels = [5.0, 10.0, 15.0]
+        np_agg = create_test_raster(data, backend='numpy')
+        dk_agg = create_test_raster(data, backend='dask+numpy', chunks=(7, 7))
+
+        g_np = contours(np_agg, levels=levels, return_type='geopandas')
+        g_dk = contours(dk_agg, levels=levels, return_type='geopandas')
+
+        assert g_dk.length.sum() == pytest.approx(g_np.length.sum())
+        np.testing.assert_allclose(g_dk.total_bounds, g_np.total_bounds)
+
+    @dask_array_available
+    @cuda_and_cupy_available
+    def test_int_dask_cupy_equals_numpy(self):
+        data = self._int_ramp()
+        levels = [5.0, 10.0, 15.0]
+        np_agg = create_test_raster(data, backend='numpy')
+        dc_agg = create_test_raster(data, backend='dask+cupy', chunks=(7, 7))
+
+        np_segs = self._collect_segments(contours(np_agg, levels=levels))
+        dc_segs = self._collect_segments(contours(dc_agg, levels=levels))
+
+        assert set(np_segs.keys()) == set(dc_segs.keys())
+        for lvl in np_segs:
+            assert np_segs[lvl] == dc_segs[lvl], (
+                f"Integer dask+cupy result diverges from numpy at level {lvl}")
+
+
+# ---------------------------------------------------------------------------
 # Return type: GeoDataFrame
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #3020

## Problem

`contours()` returned different geometry for dask-backed integer rasters than for eager numpy. The dask output drew a rectangular border collar around the whole data extent.

The dask backends call `da.overlap.overlap(data, ..., boundary=np.nan)` to halo each chunk. NaN only fits in float dtypes; on an integer array dask fills the halo with the integer minimum, which `np.isfinite` accepts. Edge cells above a contour level then cross against those phantom corners, and the crossings stitch into a frame. The numpy backend casts to float64 before tracing, so it was never affected.

## Fix

Cast non-float dask input to float64 before the overlap, in a shared `_overlap_for_contours` helper used by both `_contours_dask` and `_contours_dask_cupy`. The halo is then real NaN and matches the numpy backend.

## Backends

- numpy: already correct, unchanged
- cupy: already correct, unchanged (no overlap)
- dask+numpy: fixed
- dask+cupy: fixed

## Test plan

- [x] New `TestIntegerDtypeCollar`: integer dask and dask+cupy results match numpy segment-for-segment; geopandas total length and bounds match numpy (no collar)
- [x] Confirmed the new tests fail before the fix and pass after
- [x] Full `test_contour.py` suite passes (79 tests)