### PR TITLE
Remove stale external-overview skips on dask/fsspec/GPU golden-corpus backends

### DIFF
--- a/xrspatial/geotiff/tests/golden_corpus/test_dask_gpu.py
+++ b/xrspatial/geotiff/tests/golden_corpus/test_dask_gpu.py
@@ -82,11 +82,12 @@ _DASK_GPU_SKIPS: dict[str, str] = {}
 # xrspatial reader. The base-IFD parity check still runs; the
 # overview-level loop driven by ``candidate_factory`` is skipped for
 # these ids. See the eager module for the rationale.
-_OVERVIEW_READER_GAPS: dict[str, str] = {
-    "overview_external_ovr_uint16": (
-        "External .ovr sidecar reader is not implemented in xrspatial."
-    ),
-}
+#
+# Empty now that the dask+GPU reader resolves the sibling ``.tif.ovr``
+# pyramid through the shared ``_sidecar`` discovery the eager numpy
+# backend uses, so the overview-level comparison runs for
+# ``overview_external_ovr_uint16`` on this backend too.
+_OVERVIEW_READER_GAPS: dict[str, str] = {}
 
 _INTENTIONAL_SKIPS: dict[str, str] = {
     "nodata_miniswhite_uint8": (

--- a/xrspatial/geotiff/tests/golden_corpus/test_dask_numpy.py
+++ b/xrspatial/geotiff/tests/golden_corpus/test_dask_numpy.py
@@ -78,11 +78,12 @@ _DASK_SKIPS: dict[str, str] = {}
 # xrspatial reader. The base-IFD parity check still runs; the
 # overview-level loop driven by ``candidate_factory`` is skipped for
 # these ids. See the eager module for the rationale.
-_OVERVIEW_READER_GAPS: dict[str, str] = {
-    "overview_external_ovr_uint16": (
-        "External .ovr sidecar reader is not implemented in xrspatial."
-    ),
-}
+#
+# Empty now that the dask reader resolves the sibling ``.tif.ovr``
+# pyramid through the shared ``_sidecar`` discovery the eager numpy
+# backend uses, so the overview-level comparison runs for
+# ``overview_external_ovr_uint16`` on this backend too.
+_OVERVIEW_READER_GAPS: dict[str, str] = {}
 
 _INTENTIONAL_SKIPS: dict[str, str] = {
     "nodata_miniswhite_uint8": (

--- a/xrspatial/geotiff/tests/golden_corpus/test_fsspec.py
+++ b/xrspatial/geotiff/tests/golden_corpus/test_fsspec.py
@@ -84,13 +84,7 @@ _FSSPEC_SKIPS: dict[str, str] = {}
 # xrspatial reader. The base-IFD parity check still runs; the
 # overview-level loop driven by ``candidate_factory`` is skipped for
 # these ids. See the eager module for the rationale.
-_OVERVIEW_READER_GAPS: dict[str, str] = {
-    "overview_external_ovr_uint16": (
-        "External .ovr sidecar reader is not implemented in xrspatial. "
-        "The base IFD still parity-checks; the overview levels live in "
-        "a sibling .tif.ovr that the reader does not open."
-    ),
-}
+_OVERVIEW_READER_GAPS: dict[str, str] = {}
 
 _INTENTIONAL_SKIPS: dict[str, str] = {
     "nodata_miniswhite_uint8": (
@@ -202,6 +196,18 @@ def test_fsspec_parity(manifest_entry: dict, memory_fs_clean) -> None:
     with open(path, "rb") as f:
         payload = f.read()
     url = _serve_via_memory(payload, fixture_id)
+
+    # When the fixture ships a sibling ``.tif.ovr`` sidecar, push it
+    # into the memory filesystem under the matching URL so the reader's
+    # fsspec sidecar discovery (``_probe_fsspec`` -> ``load_sidecar``)
+    # can resolve the external overview levels. Without this the memory
+    # filesystem holds only the base ``.tif`` and ``overview_level>=1``
+    # fails as out of range, which is a test-harness gap rather than a
+    # reader limitation.
+    sidecar_path = path.parent / f"{path.name}.ovr"
+    if sidecar_path.exists():
+        with open(sidecar_path, "rb") as f:
+            memory_fs_clean.pipe(f"/corpus/{fixture_id}.tif.ovr", f.read())
 
     candidate = open_geotiff(url, **_OPTIN)
     # When the fixture carries pyramid overviews, hand the oracle a

--- a/xrspatial/geotiff/tests/golden_corpus/test_fsspec.py
+++ b/xrspatial/geotiff/tests/golden_corpus/test_fsspec.py
@@ -146,6 +146,13 @@ def _serve_via_memory(payload: bytes, fixture_id: str) -> str:
     Returns the ``memory:///corpus/<fixture_id>.tif`` URL the reader
     should open. The three-slash form is required: ``memory://`` writes
     must use a path beginning with ``/`` or fsspec rejects them.
+
+    When the fixture ships a sibling ``.tif.ovr`` sidecar on disk, push
+    it under the matching ``.tif.ovr`` URL so the reader's fsspec
+    sidecar discovery (``_probe_fsspec`` -> ``load_sidecar``) can resolve
+    the external overview levels. Without it the memory filesystem holds
+    only the base ``.tif`` and ``overview_level>=1`` fails as out of
+    range, which is a test-harness gap rather than a reader limitation.
     """
     fs = fsspec.filesystem("memory")
     url = f"memory:///corpus/{fixture_id}.tif"
@@ -153,6 +160,9 @@ def _serve_via_memory(payload: bytes, fixture_id: str) -> str:
     # filesystems; ``test_cloud_read_byte_limit_1928.py`` uses the
     # same pattern.
     fs.pipe(f"/corpus/{fixture_id}.tif", payload)
+    sidecar_path = FIXTURES_DIR / f"{fixture_id}.tif.ovr"
+    if sidecar_path.exists():
+        fs.pipe(f"/corpus/{fixture_id}.tif.ovr", sidecar_path.read_bytes())
     return url
 
 
@@ -196,18 +206,6 @@ def test_fsspec_parity(manifest_entry: dict, memory_fs_clean) -> None:
     with open(path, "rb") as f:
         payload = f.read()
     url = _serve_via_memory(payload, fixture_id)
-
-    # When the fixture ships a sibling ``.tif.ovr`` sidecar, push it
-    # into the memory filesystem under the matching URL so the reader's
-    # fsspec sidecar discovery (``_probe_fsspec`` -> ``load_sidecar``)
-    # can resolve the external overview levels. Without this the memory
-    # filesystem holds only the base ``.tif`` and ``overview_level>=1``
-    # fails as out of range, which is a test-harness gap rather than a
-    # reader limitation.
-    sidecar_path = path.parent / f"{path.name}.ovr"
-    if sidecar_path.exists():
-        with open(sidecar_path, "rb") as f:
-            memory_fs_clean.pipe(f"/corpus/{fixture_id}.tif.ovr", f.read())
 
     candidate = open_geotiff(url, **_OPTIN)
     # When the fixture carries pyramid overviews, hand the oracle a

--- a/xrspatial/geotiff/tests/golden_corpus/test_gpu.py
+++ b/xrspatial/geotiff/tests/golden_corpus/test_gpu.py
@@ -84,11 +84,12 @@ _GPU_SKIPS: dict[str, str] = {}
 # xrspatial reader. The base-IFD parity check still runs; the
 # overview-level loop driven by ``candidate_factory`` is skipped for
 # these ids. See the eager module for the rationale.
-_OVERVIEW_READER_GAPS: dict[str, str] = {
-    "overview_external_ovr_uint16": (
-        "External .ovr sidecar reader is not implemented in xrspatial."
-    ),
-}
+#
+# Empty now that the GPU reader resolves the sibling ``.tif.ovr``
+# pyramid through the shared ``_sidecar`` discovery the eager numpy
+# backend uses, so the overview-level comparison runs for
+# ``overview_external_ovr_uint16`` on this backend too.
+_OVERVIEW_READER_GAPS: dict[str, str] = {}
 
 # Fixtures whose codec is not implemented on the GPU read path and
 # legitimately need to fall back to CPU. The test routes these through


### PR DESCRIPTION
Closes #3024

## What

The golden-corpus dask, fsspec, GPU, and dask+GPU parity modules listed `overview_external_ovr_uint16` in `_OVERVIEW_READER_GAPS`, which switched off the overview-level oracle comparison and ran only the base-IFD check. The reader has external `.ovr` sidecar discovery (`_sidecar.py`) shared across backends, so these gates were stale.

- Removed the `overview_external_ovr_uint16` entry from `_OVERVIEW_READER_GAPS` in all four modules. The overview-level comparison now runs and passes.
- For fsspec, also pushed the sibling `.tif.ovr` into the `memory://` filesystem so the reader's fsspec sidecar discovery (`_probe_fsspec` -> `load_sidecar`) can resolve the external overview levels. Without it the memory filesystem held only the base `.tif` and `overview_level>=1` failed as out of range. That was a test-harness gap, not a reader limitation.

## Backends

Test-only change. All four backends (dask+numpy, fsspec, GPU/cupy, dask+GPU) run and pass the overview comparison in the dev environment used here, which has a working CUDA device. Eager numpy already had its gap cleared.

## Test plan

- [x] `test_dask_numpy_parity[overview_external_ovr_uint16]` passes
- [x] `test_fsspec_parity[overview_external_ovr_uint16]` passes
- [x] `test_gpu_parity[overview_external_ovr_uint16]` passes
- [x] `test_dask_gpu_parity[overview_external_ovr_uint16]` passes
- [x] Full golden-corpus suite for the four modules: 127 passed, 9 skipped
- [x] `test_taxonomy_ids_are_in_manifest` passes in each module