### PR TITLE
Fix UnboundLocalError on restore_sentinel in plain-ndarray VRT tiled write (#2969)

### DIFF
--- a/xrspatial/geotiff/_writers/eager.py
+++ b/xrspatial/geotiff/_writers/eager.py
@@ -1240,6 +1240,10 @@ def _write_vrt_tiled(data, vrt_path, *, crs=None, nodata=None,
         res_unit = None
         gdal_meta_xml = None
         extra_tags_list = None
+        # Default to the kwarg default so a plain-ndarray write (which
+        # skips the DataArray branch below) still has a defined value
+        # when it reaches the per-tile ``restore_sentinel=`` pass-through.
+        restore_sentinel = True
 
         if isinstance(data, xr.DataArray):
             raw = data.data

--- a/xrspatial/geotiff/tests/write/test_vrt_atomic.py
+++ b/xrspatial/geotiff/tests/write/test_vrt_atomic.py
@@ -183,3 +183,21 @@ def test_dask_failed_tiled_write_cleans_up(tmp_path, monkeypatch):
     to_geotiff(da, vrt_path, tiled=True, compression='none')
     assert os.path.isfile(vrt_path)
     assert os.path.isdir(tiles_dir)
+
+
+def test_plain_ndarray_tiled_write_round_trips(tmp_path):
+    """A plain ndarray VRT write must not raise UnboundLocalError on
+    ``restore_sentinel`` (issue #2969). The non-DataArray path skips the
+    branch that assigns ``restore_sentinel``, so it has to default to the
+    kwarg default before the per-tile write reads it."""
+    arr = np.arange(256, dtype='float32').reshape(16, 16)
+    vrt_path = str(tmp_path / 'ndarray_2969.vrt')
+
+    to_geotiff(arr, vrt_path, tiled=True, tile_size=16, compression='none')
+
+    assert os.path.isfile(vrt_path)
+    assert os.path.isdir(_tiles_dir_for(vrt_path))
+
+    result = open_geotiff(vrt_path)
+    np.testing.assert_array_almost_equal(
+        np.asarray(result.data).squeeze(), arr, decimal=5)


### PR DESCRIPTION
Closes #2969

## Problem

`to_geotiff` accepts a plain `np.ndarray`, and `.vrt` paths route to `_write_vrt_tiled`. That function only assigned `restore_sentinel` inside the `if isinstance(data, xr.DataArray)` branch. When `data` was a plain ndarray, the `else: raw = data` branch ran and `restore_sentinel` was never set, so the per-tile write raised `UnboundLocalError`.

## Fix

- Initialize `restore_sentinel = True` (the kwarg default) before the `if isinstance(data, xr.DataArray)` branch, so the non-DataArray path has a defined value. This matches the non-VRT write path.
- Add a regression test for a plain-ndarray tiled VRT write that round-trips the data.

## Backend coverage

The change is in the eager writer path. It covers numpy and cupy ndarray inputs to the VRT tiled writer; dask and DataArray inputs were already correct.

## Test plan

- [x] Reproduced the `UnboundLocalError` before the fix
- [x] `test_plain_ndarray_tiled_write_round_trips` passes after the fix
- [x] Existing `test_vrt_atomic.py` suite still passes (6 passed)