### PR TITLE
Reject to_geotiff(compression=None) with a clear TypeError (#2978)

### DIFF
--- a/xrspatial/geotiff/_writer.py
+++ b/xrspatial/geotiff/_writer.py
@@ -178,8 +178,9 @@ def _validate_lowlevel_write_kwargs(*,
     ----------
     compression : str or other
         Codec name. Validated against :data:`_VALID_COMPRESSIONS` and
-        the JPEG-in-TIFF opt-in gate. Non-string values are not
-        rejected here; ``_compression_tag`` raises downstream.
+        the JPEG-in-TIFF opt-in gate. Non-string values (including
+        ``None``) are rejected here with ``TypeError`` so they never
+        reach ``_compression_tag``'s ``.lower()`` (#2978).
     allow_internal_only_jpeg : bool
         If False (the default), ``compression='jpeg'`` is rejected
         because the encoder writes JFIF tiles without the
@@ -212,11 +213,13 @@ def _validate_lowlevel_write_kwargs(*,
             raise ValueError(
                 f"Unknown compression {compression!r} (in {entry_point}). "
                 f"Valid options: {list(_VALID_COMPRESSIONS)}.")
-    elif compression is not None:
-        # Unreachable from ``to_geotiff`` (which only forwards ``str``
-        # or the default), but direct callers can hit this. Without the
+    else:
+        # ``None`` and every other non-string value land here. Without the
         # explicit guard the downstream ``compression.lower()`` would
-        # surface as ``AttributeError`` instead of a typed error.
+        # surface as ``AttributeError`` instead of a typed error. ``None``
+        # is rejected rather than aliased to ``'none'``: the contract is
+        # ``compression: str`` (use the ``'none'`` string to disable
+        # compression) (#2978).
         raise TypeError(
             f"compression must be a str (in {entry_point}); "
             f"got {type(compression).__name__}.")

--- a/xrspatial/geotiff/_writers/eager.py
+++ b/xrspatial/geotiff/_writers/eager.py
@@ -496,13 +496,16 @@ def to_geotiff(data: xr.DataArray | np.ndarray,
     # Up-front validation: catch bad compression names before they reach
     # any of the deeper write paths (streaming, GPU, VRT, COG) where the
     # error surfaces from _compression_tag with a less obvious traceback.
-    if not isinstance(compression, str) and compression is not None:
+    if not isinstance(compression, str):
         # The string block below validates bad NAMES, but a non-string
         # ``compression`` skips it entirely and later lands in
         # ``compression.lower()`` during compression_level validation,
         # surfacing as ``AttributeError`` instead of a typed error.
-        # Reject the bad TYPE here with the same shape as the low-level
-        # writer's guard in ``_writer.py``.
+        # ``None`` is included: the contract is ``compression: str`` (use
+        # the ``'none'`` string to disable compression), so ``None`` is
+        # rejected here rather than aliased (#2978). Reject the bad TYPE
+        # with the same shape as the low-level writer's guard in
+        # ``_writer.py``.
         raise TypeError(
             f"compression must be a str (in to_geotiff); "
             f"got {type(compression).__name__}.")

--- a/xrspatial/geotiff/tests/write/test_basic.py
+++ b/xrspatial/geotiff/tests/write/test_basic.py
@@ -188,6 +188,26 @@ class TestWriteInvalidInput:
         to_geotiff(arr, str(tmp_path / 'tmp_2975_deflate.tif'),
                    compression='deflate', compression_level=6)
 
+    def test_to_geotiff_none_compression_typeerror(self, tmp_path):
+        # Regression for #2978: ``compression=None`` was exempted from the
+        # #2975 type guard, so it fell through to ``_compression_tag`` and
+        # surfaced as a raw ``AttributeError: 'NoneType' object has no
+        # attribute 'lower'``. The contract is ``compression: str`` (use the
+        # ``'none'`` string to disable compression), so ``None`` is rejected
+        # with the same ``TypeError`` as any other non-string type.
+        arr = np.zeros((4, 4), dtype=np.float32)
+        path = str(tmp_path / 'tmp_2978_none.tif')
+        with pytest.raises(TypeError, match="compression must be a str"):
+            to_geotiff(arr, path, compression=None)
+
+    def test_write_none_compression_typeerror(self, tmp_path):
+        # The low-level writer's guard rejects ``None`` for direct callers
+        # too, so it can never reach ``_compression_tag`` (#2978).
+        arr = np.zeros((4, 4), dtype=np.float32)
+        path = str(tmp_path / 'tmp_2978_none_lowlevel.tif')
+        with pytest.raises(TypeError, match="compression must be a str"):
+            write(arr, path, compression=None)
+
 
 # -------------------------------------------------------------------------
 # Section: writer dtype x compression matrix


### PR DESCRIPTION
## Summary

`to_geotiff(arr, path, compression=None)` raised a raw `AttributeError: 'NoneType' object has no attribute 'lower'` from `_compression_tag`. The type guards added in #2977 reject non-string compression but exempted `None`, so it fell through to the downstream `.lower()` call.

The documented contract is `compression: str` (default `'zstd'`), with the `'none'` string used to disable compression. `None` was never a supported value, so this rejects it with the same `TypeError` as any other non-string type rather than aliasing it to `'none'`.

- Dropped the `None` exemption from the public `to_geotiff` boundary guard (`_writers/eager.py`) and the low-level writer guard (`_writer.py`).
- Updated the stale `_validate_lowlevel_write_kwargs` docstring that claimed non-string values were not rejected.

Closes #2978.

## Backend coverage

Validation-layer change at the write entry points, so it is backend-agnostic: numpy, cupy, dask+numpy, and dask+cupy all route through the same guards.

## Test plan

- [x] `compression=None` raises `TypeError` at the public `to_geotiff` boundary
- [x] `compression=None` raises `TypeError` at the low-level `write` boundary
- [x] Existing non-string type-guard tests and valid-compression writes still pass
- [x] `pytest xrspatial/geotiff/tests/write/` green