### PR TITLE
Validate regular grid spacing in viewshed (#2789)

### DIFF
--- a/xrspatial/tests/test_viewshed.py
+++ b/xrspatial/tests/test_viewshed.py
@@ -1077,3 +1077,68 @@ def test_viewshed_does_not_mutate_cupy_input():
     assert isinstance(raster.data, cp.ndarray)
     assert raster.dtype == np.dtype("int16")
     np.testing.assert_array_equal(raster.data.get(), before)
+
+
+# -------------------------------------------------------------------
+# Regular-grid validation (#2789)
+# -------------------------------------------------------------------
+
+def _build_grid_2789(backend, xs, ys):
+    """5x5 raster with a single peak, given explicit x/y coordinates."""
+    arr = np.zeros((len(ys), len(xs)), dtype="float64")
+    arr[2, 2] = 5.0
+    if backend == "cupy":
+        import cupy as cp
+        arr = cp.asarray(arr)
+    elif backend == "dask":
+        arr = da.from_array(arr, chunks=(3, 3))
+    return xa.DataArray(arr, coords=dict(x=xs, y=ys), dims=["y", "x"])
+
+
+@pytest.mark.parametrize("backend", ["numpy", "dask"])
+def test_viewshed_irregular_x_raises(backend):
+    """Non-uniform x spacing must raise a clear ValueError naming the axis."""
+    ys = np.arange(5, dtype=float)
+    xs = np.array([0.0, 1.0, 2.0, 5.0, 6.0])  # gap between index 2 and 3
+    raster = _build_grid_2789(backend, xs, ys)
+    with pytest.raises(ValueError, match="x coordinates are not uniformly spaced"):
+        viewshed(raster, x=2, y=2, observer_elev=2)
+
+
+@pytest.mark.parametrize("backend", ["numpy", "dask"])
+def test_viewshed_irregular_y_raises(backend):
+    """Non-uniform y spacing must raise a clear ValueError naming the axis."""
+    xs = np.arange(5, dtype=float)
+    ys = np.array([0.0, 1.0, 2.0, 5.0, 6.0])
+    raster = _build_grid_2789(backend, xs, ys)
+    with pytest.raises(ValueError, match="y coordinates are not uniformly spaced"):
+        viewshed(raster, x=2, y=2, observer_elev=2)
+
+
+@pytest.mark.parametrize("backend", ["numpy", "dask"])
+def test_viewshed_irregular_with_max_distance_raises(backend):
+    """The windowed (max_distance) path is validated too (#2789)."""
+    ys = np.arange(5, dtype=float)
+    xs = np.array([0.0, 1.0, 2.0, 5.0, 6.0])
+    raster = _build_grid_2789(backend, xs, ys)
+    with pytest.raises(ValueError, match="x coordinates are not uniformly spaced"):
+        viewshed(raster, x=2, y=2, observer_elev=2, max_distance=10)
+
+
+@pytest.mark.parametrize("backend", ["numpy", "dask"])
+def test_viewshed_regular_grid_passes(backend):
+    """A regularly spaced grid must not be rejected by the validation."""
+    xs = np.arange(5, dtype=float)
+    ys = np.arange(5, dtype=float)
+    raster = _build_grid_2789(backend, xs, ys)
+    result = viewshed(raster, x=2, y=2, observer_elev=2)
+    general_output_checks(raster, result)
+
+
+def test_viewshed_float_roundoff_regular_grid_passes():
+    """Coordinates from linspace carry float roundoff but are still regular."""
+    xs = np.linspace(-20, 20, 5)
+    ys = np.linspace(-20, 20, 5)
+    raster = _build_grid_2789("numpy", xs, ys)
+    # Should not raise despite the diffs not being bit-identical.
+    viewshed(raster, x=0, y=0, observer_elev=2)

--- a/xrspatial/viewshed.py
+++ b/xrspatial/viewshed.py
@@ -1630,6 +1630,40 @@ def _viewshed_cpu(
     return visibility
 
 
+def _validate_regular_grid(raster: xarray.DataArray) -> None:
+    """Reject rasters whose x/y coordinates are not uniformly spaced.
+
+    The viewshed sweep derives a single constant cell resolution per axis
+    from the coordinate endpoints (``(end - start) / (n - 1)``). That is
+    only correct when the coordinates are monotonic and evenly spaced. On
+    an irregular grid the endpoint-derived resolution does not match the
+    real cell sizes, so every distance and vertical angle comes out wrong.
+    Validate the requirement here and fail loudly instead of returning a
+    silently incorrect result.
+    """
+    for axis in ('y', 'x'):
+        index = raster.indexes.get(axis)
+        if index is None:
+            continue
+        coords = np.asarray(index.values, dtype=np.float64)
+        if coords.size < 3:
+            # 0, 1 or 2 points have no interior spacing to compare.
+            continue
+        diffs = np.diff(coords)
+        expected = (coords[-1] - coords[0]) / (coords.size - 1)
+        # Tolerance scales with the expected spacing so it is unit-agnostic
+        # (degrees, metres, ...). A flat absolute floor handles expected == 0.
+        tol = 1e-6 * abs(expected) + 1e-9
+        if not np.all(np.abs(diffs - expected) <= tol):
+            raise ValueError(
+                f"viewshed requires a regularly spaced grid, but the {axis} "
+                f"coordinates are not uniformly spaced. Expected a constant "
+                f"spacing of {expected} between consecutive {axis} values. "
+                f"Resample the raster onto a regular grid before calling "
+                f"viewshed."
+            )
+
+
 def viewshed(raster: xarray.DataArray,
              x: Union[int, float],
              y: Union[int, float],
@@ -1679,6 +1713,13 @@ def viewshed(raster: xarray.DataArray,
 
     Notes
     -----
+    The input raster must be on a regularly spaced grid: the x and y
+    coordinates each have to be monotonic and uniformly spaced. The sweep
+    derives a single constant cell resolution per axis from the coordinate
+    endpoints, so an irregular grid would yield physically wrong distances
+    and vertical angles. :func:`viewshed` raises ``ValueError`` naming the
+    offending axis when the grid is not uniform.
+
     The CPU (numpy), GPU (cupy with RTX), and dask backends use
     different algorithms and may produce slightly different results for
     the same input.
@@ -1748,6 +1789,7 @@ def viewshed(raster: xarray.DataArray,
 
     """
     _validate_raster(raster, func_name='viewshed', name='raster')
+    _validate_regular_grid(raster)
 
     # --- max_distance: validate, then extract spatial window for any backend ---
     if max_distance is not None:


### PR DESCRIPTION
Closes #2789

## What

The viewshed sweep derives one constant cell resolution per axis from the coordinate endpoints (`(end - start) / (n - 1)`). That is only correct when the grid is uniformly spaced. On an irregular grid the derived resolution did not match the real cell sizes, so distances and vertical angles came out physically wrong with no warning.

- Add a `_validate_regular_grid` helper that checks the x and y coordinates are monotonic and uniformly spaced within a small (unit-scaled) tolerance.
- Call it once at the top of the public `viewshed()`, so the CPU, windowed (`max_distance`), and dask dispatch paths are all covered.
- Raise a `ValueError` that names the offending axis and the expected uniform spacing.
- Document the regular-grid requirement in the `viewshed()` docstring.

A coordinate-aware rewrite of the sweep is out of scope; this just makes the existing assumption explicit and enforced.

## Backend coverage

Validation runs in the shared `viewshed()` entry point using `raster.indexes`, so it applies to numpy, cupy, dask+numpy, and dask+cupy alike before any backend-specific dispatch.

## Test plan

- [x] Irregular x and irregular y each raise `ValueError` naming the axis (numpy and dask)
- [x] The windowed `max_distance` path is validated too
- [x] A regularly spaced grid still runs and passes `general_output_checks`
- [x] `linspace` float roundoff is accepted (not a false positive)
- [x] Full `test_viewshed.py` suite: 96 passed, 1 skipped (cupy-only)