### PR TITLE
Name the calling function in the unit-mismatch warning (#2782)

### DIFF
--- a/xrspatial/aspect.py
+++ b/xrspatial/aspect.py
@@ -442,7 +442,7 @@ def aspect(agg: xr.DataArray,
     _validate_boundary(boundary)
 
     if method == 'planar':
-        warn_if_unit_mismatch(agg)
+        warn_if_unit_mismatch(agg, func_name='aspect')
         cellsize_x, cellsize_y = get_dataarray_resolution(agg)
         mapper = ArrayTypeFunctionMapping(
             numpy_func=_run_numpy,

--- a/xrspatial/tests/test_aspect.py
+++ b/xrspatial/tests/test_aspect.py
@@ -511,6 +511,14 @@ def test_planar_warns_on_degree_coords_meter_elevation():
         aspect(raster)  # method='planar' is the default
 
 
+def test_planar_warning_names_aspect_not_slope():
+    # The shared warning helper defaults to naming `slope`; aspect must pass
+    # its own name so the advice is not misleading. Regression for #2782.
+    raster = _degree_coord_meter_elevation_raster()
+    with pytest.warns(UserWarning, match="before calling `aspect`"):
+        aspect(raster)
+
+
 def test_planar_no_warn_on_projected_meter_coords():
     raster = _projected_meter_raster()
     with warnings.catch_warnings():

--- a/xrspatial/tests/test_utils.py
+++ b/xrspatial/tests/test_utils.py
@@ -54,6 +54,36 @@ def test_warn_if_unit_mismatch_degrees_horizontal_elevation_vertical(monkeypatch
         utils.warn_if_unit_mismatch(da)
 
 
+def test_warn_if_unit_mismatch_func_name_in_message(monkeypatch):
+    """
+    The warning text names the calling function so an aspect() caller is not
+    told to fix their `slope` call. Default stays `slope` for back-compat.
+    Regression for issue #2782.
+    """
+    data = np.linspace(0, 999, 10 * 10, dtype=float).reshape(10, 10)
+    y = np.linspace(5.0, 5.0025, 10)
+    x = np.linspace(-74.93, -74.9275, 10)
+    da_2782 = xr.DataArray(
+        data,
+        dims=("y", "x"),
+        coords={"y": y, "x": x},
+        attrs={"units": "m"},
+    )
+
+    def fake_get_dataarray_resolution(arr):
+        return float(x[1] - x[0]), float(y[1] - y[0])
+
+    monkeypatch.setattr(
+        utils, "get_dataarray_resolution", fake_get_dataarray_resolution
+    )
+
+    with pytest.warns(UserWarning, match="before calling `slope`"):
+        utils.warn_if_unit_mismatch(da_2782)
+
+    with pytest.warns(UserWarning, match="before calling `aspect`"):
+        utils.warn_if_unit_mismatch(da_2782, func_name="aspect")
+
+
 def test_warn_if_unit_mismatch_no_warning_for_projected_like_grid(monkeypatch):
     """
     If coordinates look like projected linear units (e.g., meters) and values

--- a/xrspatial/utils.py
+++ b/xrspatial/utils.py
@@ -949,7 +949,7 @@ def _infer_vertical_unit_type(agg):
     return "unknown"
 
 
-def warn_if_unit_mismatch(agg: xr.DataArray) -> None:
+def warn_if_unit_mismatch(agg: xr.DataArray, func_name: str = "slope") -> None:
     """
     Heuristic check for horizontal vs vertical unit mismatch.
 
@@ -958,6 +958,14 @@ def warn_if_unit_mismatch(agg: xr.DataArray) -> None:
     - elevation values in meters/feet
 
     Emits a UserWarning if a likely mismatch is detected.
+
+    Parameters
+    ----------
+    agg : xarray.DataArray
+        Input raster to inspect.
+    func_name : str, default="slope"
+        Name of the calling function. Used only to make the warning text
+        refer to the operation the user actually called (e.g. ``aspect``).
     """
     try:
         cellsize_x, cellsize_y = get_dataarray_resolution(agg)
@@ -996,8 +1004,10 @@ def warn_if_unit_mismatch(agg: xr.DataArray) -> None:
             "xrspatial: input DataArray appears to have coordinates in degrees "
             "but elevation values in a linear unit (e.g. meters/feet). "
             "Slope/aspect operations expect horizontal distances in the same "
-            "units as vertical. Consider reprojecting to a projected CRS with "
-            "meter-based coordinates before calling `slope`.",
+            "units as vertical, and away from the equator the degree-to-meter "
+            "ratio differs between the x and y axes, which skews the result. "
+            "Consider reprojecting to a projected CRS with meter-based "
+            f"coordinates before calling `{func_name}`.",
             UserWarning,
         )
 


### PR DESCRIPTION
Closes #2782.

The decision the issue asked for (whether `aspect()` should call `warn_if_unit_mismatch` on its planar branch) was already made in #2839: aspect's planar path calls the helper. The leftover footgun is that the shared warning text was hard-coded to say "before calling `slope`", so an `aspect()` caller was told to fix a slope call they never made.

- Add an optional `func_name` argument to `warn_if_unit_mismatch` so the message names the operation the user actually called. Default stays `slope`, so slope's wording is unchanged.
- Have `aspect()` pass `func_name='aspect'`.
- Extend the message to mention the anisotropy effect called out in the issue: away from the equator the degree-to-meter ratio differs between the x and y axes, which skews the computed aspect direction.

This is a warning-message change in a private helper. No public API, no new function, and no backend support change, so it applies to all backends equally (the warning fires in the shared planar dispatch before backend selection).

Test plan:
- [x] `warn_if_unit_mismatch` names `slope` by default and `aspect` when passed `func_name='aspect'` (test_utils.py)
- [x] `aspect()` planar path emits a warning that names `aspect` (test_aspect.py)
- [x] Existing slope/aspect/utils warning tests still pass (message stem unchanged)