### PR TITLE
Make reproject output-size guard backend-aware (#3046)

### DIFF
--- a/xrspatial/reproject/__init__.py
+++ b/xrspatial/reproject/__init__.py
@@ -936,20 +936,9 @@ def reproject(
     y_desc = _is_y_descending(raster)
     x_desc = _is_x_descending(raster)
 
-    # Compute output grid
-    grid = _compute_output_grid(
-        src_bounds, src_shape, src_crs, tgt_crs,
-        resolution=resolution, bounds=bounds,
-        width=width, height=height,
-        bounds_policy=bounds_policy,
-    )
-    out_bounds = grid['bounds']
-    out_shape = grid['shape']
-
-    # Output coordinates
-    y_coords, x_coords = _make_output_coords(out_bounds, out_shape)
-
-    # Detect backend
+    # Detect backend before computing the output grid so the grid's
+    # output-size guard can tell a lazy dask output (never materialized
+    # in full) from a materializing backend.
     from ..utils import has_dask_array, is_cupy_array
 
     data = raster.data
@@ -993,6 +982,21 @@ def reproject(
             except ImportError:
                 # dask not available -- fall back to streaming
                 _use_streaming = True
+
+    # Compute output grid. A dask output is lazy, so the output-size
+    # guard is skipped for it (peak memory is bounded by chunk size).
+    grid = _compute_output_grid(
+        src_bounds, src_shape, src_crs, tgt_crs,
+        resolution=resolution, bounds=bounds,
+        width=width, height=height,
+        bounds_policy=bounds_policy,
+        lazy_output=is_dask,
+    )
+    out_bounds = grid['bounds']
+    out_shape = grid['shape']
+
+    # Output coordinates
+    y_coords, x_coords = _make_output_coords(out_bounds, out_shape)
 
     # Serialize CRS for pickle safety
     src_wkt = src_crs.to_wkt()

--- a/xrspatial/reproject/_grid.py
+++ b/xrspatial/reproject/_grid.py
@@ -179,7 +179,7 @@ def _transform_boundary(source_crs, target_crs, xs, ys):
 
 def _compute_output_grid(source_bounds, source_shape, source_crs, target_crs,
                          resolution=None, bounds=None, width=None, height=None,
-                         bounds_policy="auto"):
+                         bounds_policy="auto", lazy_output=False):
     """Compute the output raster grid parameters.
 
     Parameters
@@ -200,6 +200,11 @@ def _compute_output_grid(source_bounds, source_shape, source_crs, target_crs,
         How to handle output bounds near projection singularities.
         See :func:`reproject` for the full description. Ignored when
         ``bounds`` is supplied.
+    lazy_output : bool
+        When True, the output will be a lazy dask array that is never
+        materialized in full, so the ``_MAX_OUTPUT_PIXELS`` memory guard
+        is skipped. Leave False for backends that allocate the whole
+        output array (in-memory numpy/cupy, streaming).
 
     Returns
     -------
@@ -436,8 +441,11 @@ def _compute_output_grid(source_bounds, source_shape, source_crs, target_crs,
     # Guard: reject output grids that would exhaust memory.
     # 1 billion pixels ~= 8 GB for a single float64 array, and the
     # reprojection pipeline allocates several arrays of this size.
+    # Lazy dask outputs never materialize the full grid (peak memory is
+    # bounded by the chunk size), so the guard only applies to backends
+    # that allocate the whole output array.
     _MAX_OUTPUT_PIXELS = 1_000_000_000
-    if width * height > _MAX_OUTPUT_PIXELS:
+    if not lazy_output and width * height > _MAX_OUTPUT_PIXELS:
         raise ValueError(
             f"Computed output grid is too large ({width} x {height} = "
             f"{width * height:,} pixels, limit is {_MAX_OUTPUT_PIXELS:,}). "

--- a/xrspatial/tests/test_reproject.py
+++ b/xrspatial/tests/test_reproject.py
@@ -2476,15 +2476,15 @@ class TestSecurityGuards:
         )
         raster.data = da.from_array(raster.values, chunks=(32, 32))
 
-        # Tiny resolution forces >1e9 output pixels; a large chunk_size
-        # keeps the chunk layout small so building the graph stays cheap.
+        # Tiny resolution forces >1e9 output pixels. A modest chunk_size
+        # keeps each computed block small so the test stays cheap.
         out = reproject(raster, target_crs='EPSG:3857',
-                        resolution=2.0, chunk_size=20000)
+                        resolution=2.0, chunk_size=1024)
 
         assert isinstance(out.data, da.Array)
         assert out.shape[0] * out.shape[1] > 1_000_000_000
         # A single block computes without materializing the whole grid.
-        assert out.data.blocks[0, 0].compute().shape == (20000, 20000)
+        assert out.data.blocks[0, 0].compute().shape == (1024, 1024)
 
     def test_numpy_chunk_source_window_guard(self):
         """_reproject_chunk_numpy should return nodata for huge source windows."""

--- a/xrspatial/tests/test_reproject.py
+++ b/xrspatial/tests/test_reproject.py
@@ -2441,6 +2441,51 @@ class TestSecurityGuards:
         )
         assert result['shape'] == (200, 200)
 
+    def test_output_grid_too_large_lazy_output_ok(self):
+        """lazy_output=True bypasses the >1e9 pixel guard (issue #3046)."""
+        from xrspatial.reproject._grid import _compute_output_grid
+        from xrspatial.reproject._crs_utils import _resolve_crs
+
+        src_crs = _resolve_crs(4326)
+        tgt_crs = _resolve_crs(4326)
+
+        # Same grid that raises without lazy_output must now succeed,
+        # because a dask output never materializes the full array.
+        result = _compute_output_grid(
+            source_bounds=(-180, -90, 180, 90),
+            source_shape=(1000, 1000),
+            source_crs=src_crs,
+            target_crs=tgt_crs,
+            resolution=1e-6,  # ~360M cols x 180M rows >> 1e9
+            lazy_output=True,
+        )
+        h, w = result['shape']
+        assert w * h > 1_000_000_000
+
+    @pytest.mark.skipif(not HAS_DASK, reason="dask required")
+    def test_reproject_dask_output_over_limit_stays_lazy(self):
+        """A dask input whose output exceeds 1e9 pixels reprojects lazily
+        instead of raising (issue #3046)."""
+        from xrspatial.reproject import reproject
+
+        raster = _make_raster(
+            np.arange(64 * 64, dtype='float64').reshape(64, 64),
+            crs='EPSG:4326',
+            x_range=(-105, -104),
+            y_range=(39, 40),
+        )
+        raster.data = da.from_array(raster.values, chunks=(32, 32))
+
+        # Tiny resolution forces >1e9 output pixels; a large chunk_size
+        # keeps the chunk layout small so building the graph stays cheap.
+        out = reproject(raster, target_crs='EPSG:3857',
+                        resolution=2.0, chunk_size=20000)
+
+        assert isinstance(out.data, da.Array)
+        assert out.shape[0] * out.shape[1] > 1_000_000_000
+        # A single block computes without materializing the whole grid.
+        assert out.data.blocks[0, 0].compute().shape == (20000, 20000)
+
     def test_numpy_chunk_source_window_guard(self):
         """_reproject_chunk_numpy should return nodata for huge source windows."""
         from xrspatial.reproject import reproject


### PR DESCRIPTION
Closes #3046

`reproject()` computed the output grid and applied the 1-billion-pixel memory guard before it detected the backend, so it treated every backend the same. That blocked dask-backed inputs whose output is lazy and never held in memory all at once.

This moves backend detection ahead of the grid computation and threads a `lazy_output` flag into `_compute_output_grid`. When the output is a lazy dask array the size guard is skipped; for the materializing backends (in-memory numpy, in-memory cupy, the streaming fallback) it stays in force.

- Detect the backend (including large-numpy auto-promotion to dask) before computing the output grid
- Skip the `_MAX_OUTPUT_PIXELS` guard for lazy dask outputs, keep it for materializing backends
- No new public parameter; behavior keys purely on the backend

Backend coverage: numpy and cupy keep the guard; dask+numpy and dask+cupy now produce lazy outputs above the old cap.

Test plan:
- [x] `_compute_output_grid(..., lazy_output=True)` over 1e9 pixels does not raise; default still raises
- [x] dask input forced over 1e9 output pixels reprojects lazily and a single block computes
- [x] full `xrspatial/tests/test_reproject.py` suite passes (425 tests)