### PR TITLE
Reject fills the output dtype cannot represent exactly

### DIFF
--- a/xrspatial/rasterize.py
+++ b/xrspatial/rasterize.py
@@ -3039,13 +3039,16 @@ def rasterize(
         length ``len(columns)`` as its ``props`` argument.
     fill : float, default np.nan
         Value for pixels not covered by any geometry.  When ``dtype``
-        resolves to an integer type (either via the ``dtype`` argument or
-        via ``like`` carrying an integer dtype), the default NaN fill is
-        rejected with ``ValueError`` because NaN has no integer
-        representation and the cast would silently land on a
-        platform-specific sentinel with no ``_FillValue`` attr to mark
-        it; pass an explicit integer sentinel (e.g. ``fill=0`` or
-        ``fill=-9999``) or use a floating dtype.
+        resolves to an integer or boolean type (either via the ``dtype``
+        argument or via ``like``), a fill the dtype cannot represent
+        exactly is rejected with ``ValueError``.  This covers NaN into an
+        integer dtype (which would land on a platform sentinel), an
+        out-of-range integer (``fill=-9999`` into ``uint8`` wraps to
+        241), and any non-False value into ``bool`` (which collapses to
+        ``True``).  Without the guard the burned array and its emitted
+        ``nodata`` / ``_FillValue`` attrs would disagree.  Pass a fill the
+        dtype can hold (e.g. ``fill=0`` or ``fill=-9999`` for integers,
+        ``fill=False`` for bool) or use a floating dtype.
     dtype : numpy dtype, optional
         Data type of the output array.  Defaults to np.float64, or
         to the dtype of ``like`` if provided.
@@ -3338,37 +3341,52 @@ def rasterize(
     else:
         final_dtype = np.float64
 
-    # Reject NaN fill against an integer output dtype.  Without this guard
-    # the final ``astype(int_dtype)`` silently coerces NaN to either 0
-    # (unsigned) or ``np.iinfo(dtype).min`` (signed), and the rasterizer
-    # emits no ``_FillValue`` / ``nodata`` / ``nodatavals`` attr to mark
-    # the unwritten pixels.  Downstream consumers (geotiff writer,
-    # rioxarray masks) have no sentinel to key off and treat unwritten
-    # cells as valid data -- a metadata-propagation failure surfaced by
-    # the metadata sweep (issue #2504).
+    # Reject a fill that the output dtype cannot represent exactly.  Every
+    # backend casts its float64 work buffer with ``astype(final_dtype)`` at
+    # the end (``_run_numpy`` etc.), and the attrs block below stores the
+    # original ``fill`` verbatim.  When the cast changes the value, the
+    # array and its ``nodata`` / ``_FillValue`` / ``nodatavals`` attrs
+    # disagree, so downstream consumers (geotiff writer, rioxarray masks)
+    # mask the wrong pixels or treat unwritten cells as valid data -- a
+    # metadata-propagation failure surfaced by the metadata sweep
+    # (issues #2504, #3054).  Failure modes guarded here:
+    #   * NaN fill into an integer dtype -> coerced to 0 / INT_MIN.
+    #   * out-of-range integer fill (fill=-9999 into uint8 -> 241).
+    #   * any non-False fill into bool (fill=NaN -> True everywhere).
+    # ``np.issubdtype(bool_, np.integer)`` is False, so bool needs the
+    # explicit round-trip test below rather than the old integer-only
+    # check.
     #
     # Checked before any host / device allocation so the error surfaces
     # cleanly regardless of backend (numpy, cupy, dask+numpy, dask+cupy).
     # It runs after ``_check_output_dimensions`` because the
     # width/height/resolution guard reports a more actionable diagnostic
     # for oversized grids; both checks land before the allocator either
-    # way.
+    # way.  Float dtypes are left alone: NaN is representable and ordinary
+    # float rounding is expected, not a metadata lie.
     final_dtype_np = np.dtype(final_dtype)
-    try:
-        fill_is_nan_for_dtype_check = (
-            isinstance(fill, (float, np.floating))
-            and np.isnan(float(fill)))
-    except (TypeError, ValueError):
-        fill_is_nan_for_dtype_check = False
-    if (fill_is_nan_for_dtype_check
-            and np.issubdtype(final_dtype_np, np.integer)):
-        raise ValueError(
-            f"fill=NaN cannot be represented in integer dtype "
-            f"{final_dtype_np}: the cast would silently coerce NaN to a "
-            f"dtype-specific sentinel (0 for unsigned, INT_MIN for signed) "
-            f"with no _FillValue attr to mark unwritten pixels. Pass an "
-            f"explicit integer fill (e.g. fill=0 or fill=-9999) or use a "
-            f"floating dtype.")
+    if (np.issubdtype(final_dtype_np, np.integer)
+            or final_dtype_np == np.bool_):
+        try:
+            fill_arr = np.array(fill)
+            with warnings.catch_warnings():
+                # NaN -> int casts warn; we are probing for exactly that.
+                warnings.simplefilter('ignore', RuntimeWarning)
+                cast_back = fill_arr.astype(
+                    final_dtype_np).astype(fill_arr.dtype)
+            representable = bool(np.array_equal(fill_arr, cast_back))
+        except (TypeError, ValueError):
+            representable = False
+        if not representable:
+            raise ValueError(
+                f"fill={fill!r} cannot be represented exactly in output "
+                f"dtype {final_dtype_np}: the final cast would silently "
+                f"change it (e.g. NaN -> 0/INT_MIN, an out-of-range int -> "
+                f"a wrapped value, any non-False value -> True for bool), "
+                f"leaving the burned array and its nodata/_FillValue attrs "
+                f"in disagreement. Pass a fill the dtype can hold (e.g. "
+                f"fill=0 or fill=-9999 for integers, fill=False for bool) "
+                f"or use a floating dtype.")
 
     # For GPU paths, resolve string merge names to GPU (merge_fn,
     # should_write_fn) pairs.  User callables are paired with the

--- a/xrspatial/rasterize.py
+++ b/xrspatial/rasterize.py
@@ -3375,7 +3375,11 @@ def rasterize(
                 cast_back = fill_arr.astype(
                     final_dtype_np).astype(fill_arr.dtype)
             representable = bool(np.array_equal(fill_arr, cast_back))
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, OverflowError):
+            # A fill too large for the dtype's C type (e.g. an int wider
+            # than the platform long) overflows the cast rather than
+            # round-tripping; that is exactly a value the dtype cannot
+            # hold, so treat it as non-representable.
             representable = False
         if not representable:
             raise ValueError(

--- a/xrspatial/tests/test_rasterize_coverage_2026_05_17.py
+++ b/xrspatial/tests/test_rasterize_coverage_2026_05_17.py
@@ -574,7 +574,7 @@ class TestIntegerDtypeNanFill:
 
     def test_int32_dtype_with_default_nan_fill_raises(self):
         """NaN fill against int32 dtype raises with a clear pointer."""
-        with pytest.raises(ValueError, match="fill=NaN cannot be represented"):
+        with pytest.raises(ValueError, match="cannot be represented"):
             rasterize([(box(0, 0, 3, 3), 7.0)],
                       width=5, height=5, bounds=(0, 0, 5, 5),
                       dtype=np.int32)

--- a/xrspatial/tests/test_rasterize_fill_dtype_3054.py
+++ b/xrspatial/tests/test_rasterize_fill_dtype_3054.py
@@ -79,6 +79,20 @@ def test_out_of_range_int_fill_raises_numpy(dt, fill):
 
 
 @skip_no_shapely
+def test_huge_int_fill_raises_cleanly():
+    """A fill wider than the platform C long is rejected, not crashed on.
+
+    ``np.array(2**100)`` is an object array whose ``astype(<int>)`` raises
+    ``OverflowError`` rather than ``ValueError``; the guard catches it so
+    the user sees the same actionable message instead of a stray
+    ``OverflowError``.
+    """
+    with pytest.raises(ValueError, match="cannot be represented"):
+        rasterize(_square(), width=10, height=10, bounds=(0, 0, 10, 10),
+                  fill=2 ** 100, dtype=np.int64)
+
+
+@skip_no_shapely
 @skip_no_dask
 def test_out_of_range_int_fill_raises_dask_numpy():
     with pytest.raises(ValueError, match="cannot be represented"):

--- a/xrspatial/tests/test_rasterize_fill_dtype_3054.py
+++ b/xrspatial/tests/test_rasterize_fill_dtype_3054.py
@@ -1,0 +1,168 @@
+"""Regression coverage for issue #3054 (metadata sweep).
+
+``rasterize()`` casts its float64 work buffer to the output dtype at the
+end of every backend, while the attrs block stores the original ``fill``
+verbatim.  Two cases used to slip past the old NaN-only-integer guard and
+leave the burned array disagreeing with its ``nodata`` / ``_FillValue`` /
+``nodatavals`` attrs:
+
+  * An out-of-range integer fill: ``dtype=np.uint8, fill=-9999`` burned
+    241 but advertised -9999.
+  * A boolean dtype: ``np.issubdtype(np.bool_, np.integer)`` is False, so
+    ``dtype=np.bool_, fill=np.nan`` slipped through, turning every
+    unwritten pixel into ``True`` with no nodata attrs at all.
+
+The guard now rejects any fill the output dtype cannot represent exactly
+(integer overflow and boolean included).  These tests pin that across all
+four backends so a refactor that re-introduces the silent cast surfaces
+in CI.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+try:
+    from shapely.geometry import box
+    has_shapely = True
+except ImportError:
+    has_shapely = False
+
+try:
+    import cupy  # noqa: F401
+    has_cupy = True
+except ImportError:
+    has_cupy = False
+
+try:
+    import dask.array  # noqa: F401
+    has_dask = True
+except ImportError:
+    has_dask = False
+
+try:
+    from numba import cuda
+    has_cuda = has_cupy and cuda.is_available()
+except Exception:
+    has_cuda = False
+
+if has_shapely:
+    from xrspatial.rasterize import rasterize
+
+skip_no_shapely = pytest.mark.skipif(
+    not has_shapely, reason="shapely not installed")
+skip_no_dask = pytest.mark.skipif(
+    not has_dask, reason="dask not installed")
+skip_no_cuda = pytest.mark.skipif(
+    not has_cuda, reason="CUDA / CuPy not available")
+
+
+def _square():
+    return [(box(2, 2, 8, 8), 1.0)]
+
+
+# --------------------------------------------------------------------------
+# Out-of-range integer fill (the uint8 / -9999 -> 241 reproduction).
+# --------------------------------------------------------------------------
+
+@skip_no_shapely
+@pytest.mark.parametrize("dt,fill", [
+    (np.uint8, -9999),
+    (np.uint8, 256),
+    (np.int8, 200),
+    (np.uint16, -1),
+])
+def test_out_of_range_int_fill_raises_numpy(dt, fill):
+    with pytest.raises(ValueError, match="cannot be represented"):
+        rasterize(_square(), width=10, height=10, bounds=(0, 0, 10, 10),
+                  fill=fill, dtype=dt)
+
+
+@skip_no_shapely
+@skip_no_dask
+def test_out_of_range_int_fill_raises_dask_numpy():
+    with pytest.raises(ValueError, match="cannot be represented"):
+        rasterize(_square(), width=10, height=10, bounds=(0, 0, 10, 10),
+                  fill=-9999, dtype=np.uint8, chunks=5)
+
+
+@skip_no_shapely
+@skip_no_cuda
+def test_out_of_range_int_fill_raises_cupy():
+    with pytest.raises(ValueError, match="cannot be represented"):
+        rasterize(_square(), width=10, height=10, bounds=(0, 0, 10, 10),
+                  fill=-9999, dtype=np.uint8, use_cuda=True)
+
+
+@skip_no_shapely
+@skip_no_cuda
+@skip_no_dask
+def test_out_of_range_int_fill_raises_dask_cupy():
+    with pytest.raises(ValueError, match="cannot be represented"):
+        rasterize(_square(), width=10, height=10, bounds=(0, 0, 10, 10),
+                  fill=-9999, dtype=np.uint8, use_cuda=True, chunks=5)
+
+
+@skip_no_shapely
+def test_in_range_int_fill_round_trips():
+    """A fill the dtype can hold is burned and advertised consistently."""
+    r = rasterize(_square(), width=10, height=10, bounds=(0, 0, 10, 10),
+                  fill=200, dtype=np.uint8)
+    assert r.dtype == np.uint8
+    assert r.values[0, 0] == 200
+    assert r.attrs.get('nodata') == 200
+    assert r.attrs.get('_FillValue') == 200
+    assert r.attrs.get('nodatavals') == (200,)
+
+
+# --------------------------------------------------------------------------
+# Boolean dtype (NaN -> True everywhere, no nodata attrs).
+# --------------------------------------------------------------------------
+
+@skip_no_shapely
+@pytest.mark.parametrize("fill", [np.nan, 2, -1])
+def test_bool_dtype_unrepresentable_fill_raises_numpy(fill):
+    with pytest.raises(ValueError, match="cannot be represented"):
+        rasterize(_square(), width=10, height=10, bounds=(0, 0, 10, 10),
+                  fill=fill, dtype=np.bool_)
+
+
+@skip_no_shapely
+@skip_no_dask
+def test_bool_dtype_nan_fill_raises_dask_numpy():
+    with pytest.raises(ValueError, match="cannot be represented"):
+        rasterize(_square(), width=10, height=10, bounds=(0, 0, 10, 10),
+                  fill=np.nan, dtype=np.bool_, chunks=5)
+
+
+@skip_no_shapely
+@skip_no_cuda
+def test_bool_dtype_nan_fill_raises_cupy():
+    with pytest.raises(ValueError, match="cannot be represented"):
+        rasterize(_square(), width=10, height=10, bounds=(0, 0, 10, 10),
+                  fill=np.nan, dtype=np.bool_, use_cuda=True)
+
+
+@skip_no_shapely
+@skip_no_cuda
+@skip_no_dask
+def test_bool_dtype_nan_fill_raises_dask_cupy():
+    with pytest.raises(ValueError, match="cannot be represented"):
+        rasterize(_square(), width=10, height=10, bounds=(0, 0, 10, 10),
+                  fill=np.nan, dtype=np.bool_, use_cuda=True, chunks=5)
+
+
+@skip_no_shapely
+@pytest.mark.parametrize("fill", [False, True, 0, 1])
+def test_bool_dtype_representable_fill_round_trips(fill):
+    """``fill=False``/``True`` (and 0/1) are exact for bool and accepted."""
+    r = rasterize(_square(), width=10, height=10, bounds=(0, 0, 10, 10),
+                  fill=fill, dtype=np.bool_)
+    assert r.dtype == np.bool_
+    assert bool(r.values[0, 0]) == bool(fill)
+    # Non-False fill emits the nodata triplet; False is falsy so the
+    # existing ``if not fill_is_nan``/``nodata`` block keys off the value
+    # exactly like any other sentinel.
+    assert r.attrs.get('nodata') == fill
+    assert r.attrs.get('_FillValue') == fill
+    assert r.attrs.get('nodatavals') == (fill,)

--- a/xrspatial/tests/test_rasterize_nan_int_fill_2504.py
+++ b/xrspatial/tests/test_rasterize_nan_int_fill_2504.py
@@ -59,7 +59,7 @@ INT_DTYPES = [np.int8, np.int16, np.int32, np.int64,
 @pytest.mark.parametrize("dt", INT_DTYPES)
 def test_int_dtype_default_nan_fill_raises_numpy(dt):
     """Numpy backend: ``dtype=<int>`` + default ``fill=np.nan`` raises."""
-    with pytest.raises(ValueError, match="fill=NaN cannot be represented"):
+    with pytest.raises(ValueError, match="cannot be represented"):
         rasterize([(box(2, 2, 8, 8), 1.0)],
                   width=10, height=10, bounds=(0, 0, 10, 10),
                   dtype=dt)
@@ -74,7 +74,7 @@ def test_like_int_dtype_default_nan_fill_raises_numpy(dt):
     like = xr.DataArray(
         np.zeros((10, 10), dtype=dt), dims=['y', 'x'],
         coords={'y': y, 'x': x}, attrs={'crs': 'EPSG:32610'})
-    with pytest.raises(ValueError, match="fill=NaN cannot be represented"):
+    with pytest.raises(ValueError, match="cannot be represented"):
         rasterize([(box(2, 2, 8, 8), 1.0)], like=like)
 
 
@@ -82,7 +82,7 @@ def test_like_int_dtype_default_nan_fill_raises_numpy(dt):
 @skip_no_dask
 def test_int_dtype_default_nan_fill_raises_dask_numpy():
     """Dask+numpy backend trips the guard before graph construction."""
-    with pytest.raises(ValueError, match="fill=NaN cannot be represented"):
+    with pytest.raises(ValueError, match="cannot be represented"):
         rasterize([(box(2, 2, 8, 8), 1.0)],
                   width=10, height=10, bounds=(0, 0, 10, 10),
                   dtype=np.int32, chunks=5)
@@ -92,7 +92,7 @@ def test_int_dtype_default_nan_fill_raises_dask_numpy():
 @skip_no_cuda
 def test_int_dtype_default_nan_fill_raises_cupy():
     """CuPy backend trips the guard before any device allocation."""
-    with pytest.raises(ValueError, match="fill=NaN cannot be represented"):
+    with pytest.raises(ValueError, match="cannot be represented"):
         rasterize([(box(2, 2, 8, 8), 1.0)],
                   width=10, height=10, bounds=(0, 0, 10, 10),
                   dtype=np.int32, use_cuda=True)
@@ -103,7 +103,7 @@ def test_int_dtype_default_nan_fill_raises_cupy():
 @skip_no_dask
 def test_int_dtype_default_nan_fill_raises_dask_cupy():
     """Dask+CuPy backend trips the guard before any device allocation."""
-    with pytest.raises(ValueError, match="fill=NaN cannot be represented"):
+    with pytest.raises(ValueError, match="cannot be represented"):
         rasterize([(box(2, 2, 8, 8), 1.0)],
                   width=10, height=10, bounds=(0, 0, 10, 10),
                   dtype=np.int32, use_cuda=True, chunks=5)
@@ -142,7 +142,7 @@ def test_float_dtype_default_nan_fill_unaffected():
 @skip_no_shapely
 def test_int_dtype_explicit_nan_fill_also_raises():
     """``fill=np.nan`` passed explicitly trips the same guard."""
-    with pytest.raises(ValueError, match="fill=NaN cannot be represented"):
+    with pytest.raises(ValueError, match="cannot be represented"):
         rasterize([(box(2, 2, 8, 8), 1.0)],
                   width=10, height=10, bounds=(0, 0, 10, 10),
                   fill=np.nan, dtype=np.int32)
@@ -157,7 +157,7 @@ def test_int_dtype_numpy_typed_nan_fill_raises():
     guard normalises through ``float()`` then ``np.isnan`` to catch
     every NaN flavour.
     """
-    with pytest.raises(ValueError, match="fill=NaN cannot be represented"):
+    with pytest.raises(ValueError, match="cannot be represented"):
         rasterize([(box(2, 2, 8, 8), 1.0)],
                   width=10, height=10, bounds=(0, 0, 10, 10),
                   fill=np.float32(np.nan), dtype=np.int32)


### PR DESCRIPTION
Closes #3054

`rasterize()` casts its float64 work buffer to the output dtype at the end of every backend, while the attrs block stores the original `fill` verbatim. The old guard only caught `fill=NaN` against integer dtypes, so two cases slipped through and left the burned array disagreeing with its `nodata`/`_FillValue`/`nodatavals` attrs:

- `dtype=np.uint8, fill=-9999` burned an actual fill of 241 but advertised -9999.
- `dtype=np.bool_, fill=np.nan` turned every unwritten pixel into `True` with no nodata attrs (since `np.issubdtype(np.bool_, np.integer)` is False, bool dodged the integer-only guard).

## Change

- Replace the NaN-only-integer guard with a round-trip representability test: for integer and boolean output dtypes, reject any fill that changes value when cast to the dtype and back. Float dtypes are left alone (NaN is representable, ordinary rounding is expected).
- Update the `fill` docstring to describe the broadened guard.
- Relax the #2504 regression match strings to the shared `"cannot be represented"` substring.

## Backend coverage

The guard runs before any host/device allocation, so it fires identically on numpy, cupy, dask+numpy, and dask+cupy. New tests parametrize the out-of-range-int and bool cases across all four (cupy/dask paths skip when unavailable).

## Test plan

- [x] New regression tests in `test_rasterize_fill_dtype_3054.py` pass
- [x] Existing #2504 guard tests still pass
- [x] `test_rasterize.py` full suite passes (249 passed, 2 skipped)
- [x] flake8 clean on changed files