### PR TITLE
Reject large integer burn values that float64 cannot hold exactly (#3056)

### DIFF
--- a/xrspatial/rasterize.py
+++ b/xrspatial/rasterize.py
@@ -3048,7 +3048,14 @@ def rasterize(
         ``fill=-9999``) or use a floating dtype.
     dtype : numpy dtype, optional
         Data type of the output array.  Defaults to np.float64, or
-        to the dtype of ``like`` if provided.
+        to the dtype of ``like`` if provided.  When this resolves to an
+        integer type, burn values are validated against the float64 safe
+        integer range: the rasterizer computes in float64, so a value
+        with magnitude above ``2**53 - 1`` cannot be cast back to an
+        exact integer (e.g. ``2**53 + 1`` would land on ``2**53``).  Such
+        a value is rejected with ``ValueError`` rather than silently
+        rounded; use a floating dtype to burn identifiers larger than
+        that.
     all_touched : bool, default False
         If True, every pixel a polygon boundary passes through is
         burned in addition to the normal center-fill, using a

--- a/xrspatial/rasterize.py
+++ b/xrspatial/rasterize.py
@@ -3370,6 +3370,39 @@ def rasterize(
             f"explicit integer fill (e.g. fill=0 or fill=-9999) or use a "
             f"floating dtype.")
 
+    # Reject burn values that float64 cannot hold exactly when the output
+    # dtype is integer.  ``_parse_input`` casts every burn value to float64
+    # (props_array is float64, GeoDataFrame columns go through
+    # ``.astype(np.float64)``, and ``(geom, value)`` pairs go through
+    # ``float()``), and the whole rasterize pipeline computes in float64
+    # before the final ``astype(int_dtype)``.  Integers with magnitude above
+    # 2**53 - 1 (the IEEE-754 "max safe integer") are not exactly
+    # representable, so an ID like ``2**53 + 1`` silently lands on
+    # ``2**53`` -- off by one -- by the time it reaches the output.  Zone
+    # IDs, parcel IDs, and uint64 identifiers are exactly the values that
+    # exceed this range, so a silent round is a correctness failure rather
+    # than a rounding nicety.  Reject up front with the offending value
+    # named, mirroring the NaN-fill guard above.  Float dtypes are
+    # unaffected: the float64 value is what the user asked to store.
+    #
+    # Checked before any host / device allocation so the error surfaces
+    # cleanly across all four backends (numpy, cupy, dask+numpy, dask+cupy).
+    if (np.issubdtype(final_dtype_np, np.integer)
+            and props_array.size > 0):
+        max_safe_int = 2.0 ** 53 - 1
+        finite = np.isfinite(props_array)
+        unsafe = finite & (np.abs(props_array) > max_safe_int)
+        if unsafe.any():
+            bad_value = float(props_array[unsafe].flat[0])
+            raise ValueError(
+                f"burn value {bad_value!r} exceeds the range of integers "
+                f"that float64 can represent exactly (|value| > 2**53 - 1 "
+                f"= {int(max_safe_int)}). rasterize() computes in float64, "
+                f"so casting to integer dtype {final_dtype_np} would "
+                f"silently round it (e.g. 2**53 + 1 lands on 2**53). Use a "
+                f"floating output dtype, or pass values within the safe "
+                f"integer range.")
+
     # For GPU paths, resolve string merge names to GPU (merge_fn,
     # should_write_fn) pairs.  User callables are paired with the
     # always-write predicate (matches the public 3-arg signature).

--- a/xrspatial/tests/test_rasterize_int_precision_3056.py
+++ b/xrspatial/tests/test_rasterize_int_precision_3056.py
@@ -1,0 +1,214 @@
+"""Regression coverage for issue #3056.
+
+``rasterize()`` computes in float64 and only casts to the requested
+``dtype`` at the end.  ``_parse_input`` also casts every burn value to
+float64 up front (props_array is float64, GeoDataFrame columns go through
+``.astype(np.float64)``, and ``(geom, value)`` pairs go through
+``float()``).  Integers with magnitude above ``2**53 - 1`` are not exactly
+representable in float64, so an ID like ``2**53 + 1`` used to silently land
+on ``2**53`` -- off by one -- whenever the output dtype was an integer
+type.  Zone IDs, parcel IDs, and uint64 identifiers are exactly the values
+that exceed this range.
+
+The fix rejects such burn values up front with a ``ValueError`` that names
+the offending value, mirroring the NaN-fill-vs-integer-dtype guard.  These
+tests pin that behaviour across all four backends, and confirm safe-range
+integers and float dtypes are unaffected.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import xarray as xr
+
+try:
+    from shapely.geometry import box
+    has_shapely = True
+except ImportError:
+    has_shapely = False
+
+try:
+    import cupy  # noqa: F401
+    has_cupy = True
+except ImportError:
+    has_cupy = False
+
+try:
+    import dask.array  # noqa: F401
+    has_dask = True
+except ImportError:
+    has_dask = False
+
+try:
+    import geopandas as gpd
+    has_geopandas = True
+except ImportError:
+    has_geopandas = False
+
+try:
+    from numba import cuda
+    has_cuda = has_cupy and cuda.is_available()
+except Exception:
+    has_cuda = False
+
+if has_shapely:
+    from xrspatial.rasterize import rasterize
+
+skip_no_shapely = pytest.mark.skipif(
+    not has_shapely, reason="shapely not installed")
+skip_no_dask = pytest.mark.skipif(
+    not has_dask, reason="dask not installed")
+skip_no_geopandas = pytest.mark.skipif(
+    not has_geopandas, reason="geopandas not installed")
+skip_no_cuda = pytest.mark.skipif(
+    not has_cuda, reason="CUDA / CuPy not available")
+
+# First integer that float64 cannot represent exactly.  float(UNSAFE) ==
+# 2**53, so the burned value would be off by one without the guard.
+UNSAFE = 2 ** 53 + 1
+# Largest integer float64 holds exactly; must pass through untouched.
+MAX_SAFE = 2 ** 53 - 1
+
+_MATCH = "exceeds the range of integers that float64 can represent"
+
+
+@skip_no_shapely
+def test_repro_unsafe_int_raises_numpy():
+    """The issue reproduction raises instead of returning an off-by-one."""
+    with pytest.raises(ValueError, match=_MATCH):
+        rasterize([(box(0, 0, 5, 5), UNSAFE)],
+                  width=4, height=4, bounds=(0, 0, 5, 5),
+                  fill=0, dtype=np.int64)
+
+
+@skip_no_shapely
+@pytest.mark.parametrize("dt", [np.int64, np.uint64])
+def test_unsafe_int_raises_for_64bit_dtypes(dt):
+    """int64 and uint64 outputs both reject the unsafe value."""
+    with pytest.raises(ValueError, match=_MATCH):
+        rasterize([(box(0, 0, 5, 5), UNSAFE)],
+                  width=4, height=4, bounds=(0, 0, 5, 5),
+                  fill=0, dtype=dt)
+
+
+@skip_no_shapely
+def test_negative_unsafe_int_raises():
+    """The magnitude check catches large negative values too."""
+    with pytest.raises(ValueError, match=_MATCH):
+        rasterize([(box(0, 0, 5, 5), -UNSAFE)],
+                  width=4, height=4, bounds=(0, 0, 5, 5),
+                  fill=0, dtype=np.int64)
+
+
+@skip_no_shapely
+def test_error_names_offending_value():
+    """The message reports the offending value so users can find it."""
+    with pytest.raises(ValueError, match=r"9007199254740992"):
+        rasterize([(box(0, 0, 5, 5), UNSAFE)],
+                  width=4, height=4, bounds=(0, 0, 5, 5),
+                  fill=0, dtype=np.int64)
+
+
+@skip_no_shapely
+def test_max_safe_int_burns_exactly_numpy():
+    """2**53 - 1 is exactly representable and must round-trip untouched."""
+    r = rasterize([(box(0, 0, 5, 5), MAX_SAFE)],
+                  width=4, height=4, bounds=(0, 0, 5, 5),
+                  fill=0, dtype=np.int64)
+    assert r.dtype == np.int64
+    assert int(r.values[0, 0]) == MAX_SAFE
+
+
+@skip_no_shapely
+def test_small_int_unaffected():
+    """Ordinary small integer IDs are not touched by the guard."""
+    r = rasterize([(box(0, 0, 5, 5), 42)],
+                  width=4, height=4, bounds=(0, 0, 5, 5),
+                  fill=0, dtype=np.int32)
+    assert int(r.values[0, 0]) == 42
+
+
+@skip_no_shapely
+def test_float_dtype_accepts_unsafe_value():
+    """Float outputs are unaffected: the float64 value is what was asked for."""
+    r = rasterize([(box(0, 0, 5, 5), float(UNSAFE))],
+                  width=4, height=4, bounds=(0, 0, 5, 5),
+                  fill=np.nan, dtype=np.float64)
+    assert r.dtype == np.float64
+    # float64 already collapses UNSAFE to 2**53; that is the documented
+    # float behaviour, not a rasterize defect, so no error is raised.
+    assert r.values[0, 0] == float(UNSAFE)
+
+
+@skip_no_shapely
+def test_like_integer_dtype_trips_guard():
+    """An integer-dtype ``like`` template trips the same guard."""
+    x = np.linspace(0.5, 4.5, 5)
+    y = np.linspace(4.5, 0.5, 5)
+    like = xr.DataArray(
+        np.zeros((5, 5), dtype=np.int64), dims=['y', 'x'],
+        coords={'y': y, 'x': x})
+    with pytest.raises(ValueError, match=_MATCH):
+        rasterize([(box(0, 0, 5, 5), UNSAFE)], like=like, fill=0)
+
+
+@skip_no_shapely
+@skip_no_geopandas
+def test_geodataframe_column_path_trips_guard():
+    """The GeoDataFrame ``column`` burn path trips the guard."""
+    gdf = gpd.GeoDataFrame({'zone': [UNSAFE]}, geometry=[box(0, 0, 5, 5)])
+    with pytest.raises(ValueError, match=_MATCH):
+        rasterize(gdf, width=4, height=4, bounds=(0, 0, 5, 5),
+                  column='zone', fill=0, dtype=np.int64)
+
+
+@skip_no_shapely
+@skip_no_geopandas
+def test_geodataframe_columns_path_trips_guard():
+    """The multi-column ``columns`` burn path trips the guard."""
+    gdf = gpd.GeoDataFrame(
+        {'a': [UNSAFE], 'b': [1]}, geometry=[box(0, 0, 5, 5)])
+    with pytest.raises(ValueError, match=_MATCH):
+        rasterize(gdf, width=4, height=4, bounds=(0, 0, 5, 5),
+                  columns=['a', 'b'], fill=0, dtype=np.int64, merge='sum')
+
+
+@skip_no_shapely
+@skip_no_dask
+def test_unsafe_int_raises_dask_numpy():
+    """Dask+numpy backend trips the guard before graph construction."""
+    with pytest.raises(ValueError, match=_MATCH):
+        rasterize([(box(0, 0, 5, 5), UNSAFE)],
+                  width=4, height=4, bounds=(0, 0, 5, 5),
+                  fill=0, dtype=np.int64, chunks=2)
+
+
+@skip_no_shapely
+@skip_no_dask
+def test_max_safe_int_burns_exactly_dask_numpy():
+    """Safe-range value round-trips on the dask+numpy backend too."""
+    r = rasterize([(box(0, 0, 5, 5), MAX_SAFE)],
+                  width=4, height=4, bounds=(0, 0, 5, 5),
+                  fill=0, dtype=np.int64, chunks=2)
+    assert int(r.compute().values[0, 0]) == MAX_SAFE
+
+
+@skip_no_shapely
+@skip_no_cuda
+def test_unsafe_int_raises_cupy():
+    """CuPy backend trips the guard before any device allocation."""
+    with pytest.raises(ValueError, match=_MATCH):
+        rasterize([(box(0, 0, 5, 5), UNSAFE)],
+                  width=4, height=4, bounds=(0, 0, 5, 5),
+                  fill=0, dtype=np.int64, use_cuda=True)
+
+
+@skip_no_shapely
+@skip_no_cuda
+@skip_no_dask
+def test_unsafe_int_raises_dask_cupy():
+    """Dask+CuPy backend trips the guard before any device allocation."""
+    with pytest.raises(ValueError, match=_MATCH):
+        rasterize([(box(0, 0, 5, 5), UNSAFE)],
+                  width=4, height=4, bounds=(0, 0, 5, 5),
+                  fill=0, dtype=np.int64, use_cuda=True, chunks=2)


### PR DESCRIPTION
Closes #3056

## Problem

`rasterize()` computes in float64 and casts burn values to float64 at parse time. Integers above 2**53 - 1 are not exactly representable in float64, so a large integer ID burned into an integer-dtype raster was silently rounded. The reproduction burned 2**53 + 1 with dtype=np.int64 and got 9007199254740992 back instead of 9007199254740993. Zone IDs, parcel IDs, and uint64 identifiers fall in this range.

## Fix

Reject burn values whose magnitude exceeds the float64 safe-integer limit (2**53 - 1) when the output dtype is an integer type. The guard raises a ValueError naming the offending value, placed next to the existing NaN-fill-vs-integer-dtype guard. It runs before any host or device allocation, so it fires identically across all four backends. Float output dtypes are unaffected: the float64 value is what the user asked to store.

This is the reject approach rather than threading integer props through the whole pipeline. The internal computation is float64 end to end, so preserving exact integers throughout would be a much larger change.

## Backend coverage

numpy, cupy, dask+numpy, dask+cupy. The check sits in the shared front-end before backend dispatch, so all four trip it the same way.

## Test plan

- [x] Reproduction value now raises instead of returning an off-by-one
- [x] int64 and uint64 dtypes both reject the unsafe value
- [x] Negative large values rejected (magnitude check)
- [x] 2**53 - 1 (max safe integer) burns exactly on numpy and dask
- [x] Small integer IDs unaffected
- [x] Float output dtype accepts the value unchanged
- [x] `like` with integer dtype trips the guard
- [x] GeoDataFrame column and columns burn paths trip the guard
- [x] dask+numpy backend; cupy / dask+cupy tests gated on CUDA
- [x] Existing rasterize suite still green (233 passed, 2 skipped)