### PR TITLE
Guard rasterize() against geometry/like CRS mismatch (#3058)

### DIFF
--- a/xrspatial/rasterize.py
+++ b/xrspatial/rasterize.py
@@ -2742,13 +2742,16 @@ def _run_dask_cupy(geometries, props_array, bounds, height, width, fill,
 # ---------------------------------------------------------------------------
 
 def _parse_input(geometries, column=None, columns=None):
-    """Normalise input to (geometry_list, props_array, bounds).
+    """Normalise input to (geometry_list, props_array, bounds, crs).
 
     Returns
     -------
     geom_list : list of shapely geometries
     props_array : (N, P) float64 array of property values
     bounds : tuple or None
+    crs : the GeoDataFrame's ``.crs`` (any pyproj-parseable value) or
+        ``None``.  Only a GeoDataFrame exposes a CRS; the
+        ``(geometry, value)`` iterable path always returns ``None``.
     """
     # Handle dask-geopandas by materializing eagerly.  Geometry data is
     # typically much smaller than the output raster, so this is fine.
@@ -2782,7 +2785,7 @@ def _parse_input(geometries, column=None, columns=None):
                     column = numeric_cols[0]
                 props_array = geometries[column].values.astype(
                     np.float64).reshape(-1, 1)
-            return geom_list, props_array, total_bounds
+            return geom_list, props_array, total_bounds, geometries.crs
     except ImportError:
         pass
 
@@ -2798,13 +2801,13 @@ def _parse_input(geometries, column=None, columns=None):
 
     if not geom_list:
         props_array = np.empty((0, 1), dtype=np.float64)
-        return geom_list, props_array, None
+        return geom_list, props_array, None, None
 
     props_array = np.array(value_list, dtype=np.float64).reshape(-1, 1)
 
     # Bounds computation is deferred: return None here and let the
     # caller compute bboxes only when bounds are actually needed.
-    return geom_list, props_array, None
+    return geom_list, props_array, None, None
 
 
 def _check_uniform_axis(axis_name, coords, expected_step):
@@ -2973,6 +2976,84 @@ def _extract_grid_from_like(like):
     )
 
 
+def _like_crs(like):
+    """Detect the CRS of a ``like`` template DataArray, or ``None``.
+
+    Mirrors the resolution order in
+    ``xrspatial.polygonize._detect_raster_crs`` so a template carries the
+    same CRS into rasterize that polygonize would read back out:
+
+    1. ``like.attrs['crs']`` (xrspatial.geotiff convention)
+    2. ``like.attrs['crs_wkt']``
+    3. the ``spatial_ref`` non-dim coord's ``crs_wkt`` / ``spatial_ref``
+       attr (rioxarray's georeference coord)
+    4. ``like.rio.crs`` (rioxarray, if installed)
+    5. ``None``
+
+    The raw value is returned (string / int / WKT / pyproj.CRS) so the
+    caller normalizes it the same way the geometry CRS is normalized.
+    """
+    crs_attr = like.attrs.get('crs')
+    if crs_attr is not None:
+        return crs_attr
+
+    crs_wkt = like.attrs.get('crs_wkt')
+    if crs_wkt is not None:
+        return crs_wkt
+
+    if 'spatial_ref' in like.coords:
+        sr_attrs = like.coords['spatial_ref'].attrs
+        sr_crs = sr_attrs.get('crs_wkt') or sr_attrs.get('spatial_ref')
+        if sr_crs is not None:
+            return sr_crs
+
+    try:
+        rio_crs = like.rio.crs
+        if rio_crs is not None:
+            return rio_crs
+    except Exception:
+        pass
+
+    return None
+
+
+def _check_crs_match(geom_crs, like_crs):
+    """Raise ``ValueError`` if ``geom_crs`` and ``like_crs`` disagree.
+
+    Both values are normalized through ``pyproj.CRS`` so an int EPSG
+    code, an ``"EPSG:xxxx"`` string, a WKT string, and a ``pyproj.CRS``
+    instance describing the same system all compare equal.  When either
+    side is ``None`` (no CRS to compare) the check is a no-op -- this
+    keeps CRS-less geometry lists and templates working unchanged.  An
+    unparseable value on either side raises ``ValueError`` rather than
+    silently disabling the guard.
+    """
+    if geom_crs is None or like_crs is None:
+        return
+
+    from pyproj import CRS as _PyprojCRS
+    from pyproj.exceptions import CRSError
+
+    def _norm(value, label):
+        try:
+            return _PyprojCRS(value)
+        except CRSError as e:
+            raise ValueError(
+                f"{label} CRS {value!r} is not a valid CRS: {e}"
+            ) from e
+
+    g = _norm(geom_crs, 'geometry')
+    t = _norm(like_crs, "'like' template")
+    if not g.equals(t):
+        raise ValueError(
+            f"CRS mismatch: geometries are in {geom_crs!r} but the "
+            f"'like' template is in {like_crs!r}. Reproject the "
+            f"geometries to match the template, or pass check_crs=False "
+            f"to rasterize onto the template grid anyway (the output "
+            f"will inherit the template CRS without reprojection)."
+        )
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -2994,6 +3075,7 @@ def rasterize(
     merge: Union[str, Callable] = 'last',
     chunks: Optional[Union[int, Tuple[int, int]]] = None,
     max_pixels: int = MAX_PIXELS_DEFAULT,
+    check_crs: bool = True,
 ) -> xr.DataArray:
     """Rasterize vector geometries into a 2D DataArray.
 
@@ -3117,6 +3199,17 @@ def rasterize(
         function raises ``ValueError`` before any host or device
         allocation if the cap is exceeded.  Raise this explicitly when
         rasterizing a legitimately large grid.
+    check_crs : bool, default True
+        When ``geometries`` is a GeoDataFrame with a ``.crs`` and ``like``
+        is a template that carries a CRS (via ``attrs['crs']``,
+        ``attrs['crs_wkt']``, a ``spatial_ref`` coord, or ``rio.crs``),
+        compare the two and raise ``ValueError`` if they disagree.  This
+        prevents silently burning, say, an EPSG:4326 GeoDataFrame onto an
+        EPSG:3857 template and handing back a raster mislabeled with the
+        template CRS.  The geometries are never reprojected; reproject
+        them yourself to match the template.  Pass ``check_crs=False`` to
+        skip the comparison (the output still inherits the template CRS).
+        The check is a no-op when either side lacks a CRS.
 
     Returns
     -------
@@ -3213,8 +3306,15 @@ def rasterize(
         like_x_descending = grid.x_descending
 
     # Parse input geometries
-    geom_list, props_array, inferred_bounds = _parse_input(
+    geom_list, props_array, inferred_bounds, geom_crs = _parse_input(
         geometries, column=column, columns=columns)
+
+    # Guard against silently burning geometries onto a template in a
+    # different CRS.  The output inherits the template CRS (attrs /
+    # spatial_ref coord) but the geometry coords are never reprojected,
+    # so a mismatch yields an authoritative-looking but wrong raster.
+    if check_crs and geom_crs is not None and like is not None:
+        _check_crs_match(geom_crs, _like_crs(like))
 
     # Resolve bounds: explicit > like > inferred from geometries
     final_bounds = bounds

--- a/xrspatial/rasterize.py
+++ b/xrspatial/rasterize.py
@@ -3012,6 +3012,11 @@ def _like_crs(like):
         if rio_crs is not None:
             return rio_crs
     except Exception:
+        # Broad on purpose (matches polygonize._detect_raster_crs):
+        # ``.rio`` raises AttributeError when rioxarray is not installed,
+        # and rio.crs can raise on a malformed georeference.  Either way
+        # we treat the template as having no detectable CRS and let the
+        # earlier attrs/spatial_ref paths be the source of truth.
         pass
 
     return None
@@ -3045,9 +3050,15 @@ def _check_crs_match(geom_crs, like_crs):
     g = _norm(geom_crs, 'geometry')
     t = _norm(like_crs, "'like' template")
     if not g.equals(t):
+        # Prefer a compact "EPSG:xxxx" label over the raw value, whose
+        # repr is a multi-line WKT block for a pyproj/geopandas CRS.
+        # Fall back to the CRS name when no EPSG code is available.
+        def _label(crs):
+            epsg = crs.to_epsg()
+            return f"EPSG:{epsg}" if epsg is not None else crs.name
         raise ValueError(
-            f"CRS mismatch: geometries are in {geom_crs!r} but the "
-            f"'like' template is in {like_crs!r}. Reproject the "
+            f"CRS mismatch: geometries are in {_label(g)} but the "
+            f"'like' template is in {_label(t)}. Reproject the "
             f"geometries to match the template, or pass check_crs=False "
             f"to rasterize onto the template grid anyway (the output "
             f"will inherit the template CRS without reprojection)."

--- a/xrspatial/tests/test_rasterize_crs_mismatch_3058.py
+++ b/xrspatial/tests/test_rasterize_crs_mismatch_3058.py
@@ -92,6 +92,20 @@ class TestCrsMismatch:
                 column='value',
             )
 
+    def test_mismatch_message_is_compact(self):
+        # The error labels each side with a short "EPSG:xxxx" rather than
+        # the multi-line pyproj CRS repr.
+        with pytest.raises(ValueError) as exc:
+            rasterize(
+                _gdf(crs='EPSG:4326'),
+                like=_make_like(crs_attr='EPSG:3857'),
+                column='value',
+            )
+        msg = str(exc.value)
+        assert 'EPSG:4326' in msg
+        assert 'EPSG:3857' in msg
+        assert '\n' not in msg
+
     def test_check_crs_false_bypasses(self):
         # Opt out: the (wrong) template CRS still propagates, no raise.
         result = rasterize(

--- a/xrspatial/tests/test_rasterize_crs_mismatch_3058.py
+++ b/xrspatial/tests/test_rasterize_crs_mismatch_3058.py
@@ -1,0 +1,228 @@
+"""Issue #3058: rasterize() must not silently burn geometries onto a
+``like`` template in a different CRS.
+
+Before the fix, ``_parse_input`` discarded ``gdf.crs`` and the output
+inherited the template CRS (via ``attrs['crs']`` / the ``spatial_ref``
+coord) with no reprojection, producing an authoritative-looking but
+wrong raster.  ``check_crs=True`` (default) now compares both sides and
+raises ``ValueError`` on mismatch; ``check_crs=False`` opts out.
+"""
+import numpy as np
+import pytest
+import xarray as xr
+
+try:
+    from shapely.geometry import box
+    has_shapely = True
+except ImportError:
+    has_shapely = False
+
+if has_shapely:
+    from xrspatial.rasterize import rasterize
+
+try:
+    import geopandas as gpd
+    has_geopandas = True
+except ImportError:
+    has_geopandas = False
+
+try:
+    import dask.array as da  # noqa: F401
+    has_dask = True
+except ImportError:
+    has_dask = False
+
+try:
+    import cupy  # noqa: F401
+    from numba import cuda
+    has_cuda = cuda.is_available()
+except Exception:
+    has_cuda = False
+
+pytestmark = [
+    pytest.mark.skipif(not has_shapely, reason="shapely not installed"),
+    pytest.mark.skipif(not has_geopandas, reason="geopandas not installed"),
+]
+
+
+def _make_like(crs_attr=None, crs_wkt=None, spatial_ref_wkt=None,
+               width=10, height=10):
+    """2D template with georeferenced coords, optionally CRS-tagged.
+
+    ``crs_attr`` sets ``attrs['crs']``; ``crs_wkt`` sets
+    ``attrs['crs_wkt']``; ``spatial_ref_wkt`` attaches a rioxarray-style
+    ``spatial_ref`` non-dim coord carrying ``crs_wkt``.
+    """
+    x = np.linspace(0.5, width - 0.5, width)
+    y = np.linspace(height - 0.5, 0.5, height)
+    da_ = xr.DataArray(
+        np.zeros((height, width)), dims=['y', 'x'],
+        coords={'y': y, 'x': x},
+    )
+    if crs_attr is not None:
+        da_.attrs['crs'] = crs_attr
+    if crs_wkt is not None:
+        da_.attrs['crs_wkt'] = crs_wkt
+    if spatial_ref_wkt is not None:
+        da_ = da_.assign_coords(spatial_ref=0)
+        da_['spatial_ref'].attrs['crs_wkt'] = spatial_ref_wkt
+    return da_
+
+
+def _gdf(crs=None):
+    return gpd.GeoDataFrame(
+        {'value': [1.0]}, geometry=[box(2, 2, 6, 6)], crs=crs,
+    )
+
+
+class TestCrsMismatch:
+    def test_matching_crs_attr_ok(self):
+        result = rasterize(
+            _gdf(crs='EPSG:4326'),
+            like=_make_like(crs_attr='EPSG:4326'),
+            column='value',
+        )
+        assert result.attrs.get('crs') == 'EPSG:4326'
+
+    def test_mismatch_crs_attr_raises(self):
+        with pytest.raises(ValueError, match='CRS mismatch'):
+            rasterize(
+                _gdf(crs='EPSG:4326'),
+                like=_make_like(crs_attr='EPSG:3857'),
+                column='value',
+            )
+
+    def test_check_crs_false_bypasses(self):
+        # Opt out: the (wrong) template CRS still propagates, no raise.
+        result = rasterize(
+            _gdf(crs='EPSG:4326'),
+            like=_make_like(crs_attr='EPSG:3857'),
+            column='value',
+            check_crs=False,
+        )
+        assert result.attrs.get('crs') == 'EPSG:3857'
+
+    def test_int_vs_string_epsg_equivalent(self):
+        # gdf.crs as int 4326 vs template "EPSG:4326" string must match.
+        result = rasterize(
+            _gdf(crs=4326),
+            like=_make_like(crs_attr='EPSG:4326'),
+            column='value',
+        )
+        assert result is not None
+
+    def test_crs_wkt_attr_used(self):
+        from pyproj import CRS
+        wkt = CRS('EPSG:3857').to_wkt()
+        with pytest.raises(ValueError, match='CRS mismatch'):
+            rasterize(
+                _gdf(crs='EPSG:4326'),
+                like=_make_like(crs_wkt=wkt),
+                column='value',
+            )
+
+    def test_spatial_ref_coord_used(self):
+        from pyproj import CRS
+        wkt = CRS('EPSG:3857').to_wkt()
+        with pytest.raises(ValueError, match='CRS mismatch'):
+            rasterize(
+                _gdf(crs='EPSG:4326'),
+                like=_make_like(spatial_ref_wkt=wkt),
+                column='value',
+            )
+
+    def test_no_geometry_crs_is_noop(self):
+        # GeoDataFrame without a CRS: nothing to compare, no raise.
+        result = rasterize(
+            _gdf(crs=None),
+            like=_make_like(crs_attr='EPSG:3857'),
+            column='value',
+        )
+        assert result.attrs.get('crs') == 'EPSG:3857'
+
+    def test_no_like_crs_is_noop(self):
+        # Template carries no CRS: nothing to compare, no raise.
+        result = rasterize(
+            _gdf(crs='EPSG:4326'),
+            like=_make_like(),
+            column='value',
+        )
+        assert result is not None
+
+    def test_no_like_at_all_is_noop(self):
+        # No template -> no CRS comparison path is taken.
+        result = rasterize(
+            _gdf(crs='EPSG:4326'), width=10, height=10, column='value',
+        )
+        assert result is not None
+
+    def test_iterable_input_has_no_crs(self):
+        # (geometry, value) iterable exposes no CRS, so the check is a
+        # no-op even against a CRS-tagged template.
+        result = rasterize(
+            [(box(2, 2, 6, 6), 1.0)],
+            like=_make_like(crs_attr='EPSG:3857'),
+        )
+        assert result.attrs.get('crs') == 'EPSG:3857'
+
+    def test_invalid_crs_value_surfaces(self):
+        # An unparseable CRS on either side must raise rather than
+        # silently disable the guard.  Exercise the comparison helper
+        # directly with a malformed template CRS value.
+        from xrspatial.rasterize import _check_crs_match
+        with pytest.raises(ValueError, match='not a valid CRS'):
+            _check_crs_match('EPSG:4326', 'not-a-real-crs')
+
+    def test_check_skipped_when_either_side_none(self):
+        # The helper is a no-op when either side lacks a CRS.
+        from xrspatial.rasterize import _check_crs_match
+        _check_crs_match(None, 'EPSG:3857')
+        _check_crs_match('EPSG:4326', None)
+        _check_crs_match(None, None)
+
+
+class TestCrsMismatchBackends:
+    """The CRS guard runs before backend dispatch, so it must fire the
+    same way for dask and cupy outputs.
+    """
+
+    @pytest.mark.skipif(not has_dask, reason="dask not installed")
+    def test_mismatch_raises_dask(self):
+        with pytest.raises(ValueError, match='CRS mismatch'):
+            rasterize(
+                _gdf(crs='EPSG:4326'),
+                like=_make_like(crs_attr='EPSG:3857'),
+                column='value',
+                chunks=5,
+            )
+
+    @pytest.mark.skipif(not has_dask, reason="dask not installed")
+    def test_match_ok_dask(self):
+        result = rasterize(
+            _gdf(crs='EPSG:4326'),
+            like=_make_like(crs_attr='EPSG:4326'),
+            column='value',
+            chunks=5,
+        )
+        assert result.chunks is not None
+        assert result.attrs.get('crs') == 'EPSG:4326'
+
+    @pytest.mark.skipif(not has_cuda, reason="CUDA / CuPy not available")
+    def test_mismatch_raises_cupy(self):
+        with pytest.raises(ValueError, match='CRS mismatch'):
+            rasterize(
+                _gdf(crs='EPSG:4326'),
+                like=_make_like(crs_attr='EPSG:3857'),
+                column='value',
+                use_cuda=True,
+            )
+
+    @pytest.mark.skipif(not has_cuda, reason="CUDA / CuPy not available")
+    def test_match_ok_cupy(self):
+        result = rasterize(
+            _gdf(crs='EPSG:4326'),
+            like=_make_like(crs_attr='EPSG:4326'),
+            column='value',
+            use_cuda=True,
+        )
+        assert result.attrs.get('crs') == 'EPSG:4326'


### PR DESCRIPTION
Closes #3058

## What

`rasterize(geometries, like=template)` no longer silently burns geometries onto a template in a different CRS.

- `_parse_input` now returns the GeoDataFrame's `.crs` instead of dropping it.
- A new `_like_crs` helper reads the template CRS (`attrs['crs']`, `attrs['crs_wkt']`, the `spatial_ref` coord, or `rio.crs`), matching `polygonize._detect_raster_crs`.
- When both sides carry a CRS, `rasterize` normalizes them through pyproj and raises `ValueError` on mismatch. A new `check_crs=True` parameter (default) gates this; `check_crs=False` opts out.

## Why

`_parse_input` discarded `gdf.crs` while `_extract_grid_from_like` propagated the template CRS onto the output. So an EPSG:4326 GeoDataFrame rasterized onto an EPSG:3857 template came back tagged EPSG:3857, with no reprojection and no warning. It looked authoritative but was wrong.

The geometries are never reprojected; reproject them to match the template, or pass `check_crs=False` to burn onto the template grid anyway.

## Backend coverage

The guard runs before backend dispatch, so it behaves the same for numpy, cupy, dask+numpy, and dask+cupy. Tests cover the numpy path plus the dask and cupy paths.

## Test plan

- [x] Matching CRS passes; mismatched CRS raises; `check_crs=False` bypasses
- [x] CRS read from `attrs['crs']`, `attrs['crs_wkt']`, and the `spatial_ref` coord
- [x] No-op when either side lacks a CRS, and for the `(geometry, value)` iterable path
- [x] int EPSG vs `"EPSG:xxxx"` string compare equal
- [x] Invalid CRS value raises instead of disabling the guard
- [x] Existing rasterize suite still green (215 passed)