### PR TITLE
Rasterize LinearRing as a line; warn on dropped geometries

### DIFF
--- a/xrspatial/rasterize.py
+++ b/xrspatial/rasterize.py
@@ -4,7 +4,7 @@ Converts vector geometries (GeoDataFrame or list of (geometry, value) pairs)
 to a 2D xr.DataArray.  No GDAL dependency.
 
 - Polygons/MultiPolygons: scanline fill
-- Lines/MultiLineStrings: Bresenham line rasterization
+- Lines/LinearRings/MultiLineStrings: Bresenham line rasterization
 - Points/MultiPoints: direct pixel burn
 
 Supports numpy, cupy, dask+numpy, and dask+cupy backends.
@@ -219,6 +219,36 @@ def _apply_merge(out, written, order, r, c, props, new_idx,
 # Geometry classification (single pass)
 # ---------------------------------------------------------------------------
 
+#: Human-readable names for the shapely type ids the fast path reports.
+_TYPE_ID_NAMES = {
+    0: 'Point', 1: 'LineString', 2: 'LinearRing', 3: 'Polygon',
+    4: 'MultiPoint', 5: 'MultiLineString', 6: 'MultiPolygon',
+    7: 'GeometryCollection',
+}
+
+
+def _warn_dropped_geometries(types):
+    """Warn that non-empty geometries of unsupported types are being dropped.
+
+    ``types`` is an iterable of either shapely type ids (ints, from the
+    vectorized fast path) or ``geom_type`` names (strings, from the recursive
+    slow path).  Names are resolved and de-duplicated so the warning lists each
+    dropped type once.
+    """
+    names = sorted({
+        _TYPE_ID_NAMES.get(int(t), f'type id {int(t)}')
+        if isinstance(t, (int, np.integer)) else str(t)
+        for t in types
+    })
+    warnings.warn(
+        f"rasterize: dropping unsupported non-empty geometr"
+        f"{'y' if len(names) == 1 else 'ies'} of type "
+        f"{', '.join(names)}; only points, lines, and polygons are "
+        f"rasterized.",
+        stacklevel=2,
+    )
+
+
 def _classify_geometries(geometries, props_array):
     """Classify geometries by type in a single pass.
 
@@ -264,16 +294,26 @@ def _classify_geometries(geometries, props_array):
     shapely = _require_shapely()
     type_ids = shapely.get_type_id(geom_arr)
     empty = shapely.is_empty(geom_arr)
-    valid = ~empty
+    # ``get_type_id`` returns -1 for None/missing geometries (which report as
+    # non-empty); treat those as empty so they are skipped like the slow path's
+    # ``geom is None`` guard rather than warned about as an unsupported type.
+    valid = ~empty & (type_ids >= 0)
 
     # Type ID mapping:
     # 0=Point, 1=LineString, 2=LinearRing, 3=Polygon,
     # 4=MultiPoint, 5=MultiLineString, 6=MultiPolygon,
     # 7=GeometryCollection
+    # LinearRing (2) is a closed line; rasterize it like any other line.
     poly_mask = valid & ((type_ids == 3) | (type_ids == 6))
-    line_mask = valid & ((type_ids == 1) | (type_ids == 5))
+    line_mask = valid & ((type_ids == 1) | (type_ids == 2) | (type_ids == 5))
     point_mask = valid & ((type_ids == 0) | (type_ids == 4))
     gc_mask = valid & (type_ids == 7)
+
+    # Warn before dropping any non-empty geometry that matches no bucket, so a
+    # caller never loses data silently.
+    dropped_mask = valid & ~(poly_mask | line_mask | point_mask | gc_mask)
+    if np.any(dropped_mask):
+        _warn_dropped_geometries(np.unique(type_ids[dropped_mask]))
 
     # Fast path: no GeometryCollections (common case)
     if not np.any(gc_mask):
@@ -320,7 +360,7 @@ def _classify_geometries(geometries, props_array):
             poly_ids.append(poly_counter)
             poly_global.append(global_idx)
             poly_counter += 1
-        elif gt in ('LineString', 'MultiLineString'):
+        elif gt in ('LineString', 'LinearRing', 'MultiLineString'):
             line_geoms.append(geom)
             line_prop_rows.append(prop_row)
             line_global.append(global_idx)
@@ -331,6 +371,8 @@ def _classify_geometries(geometries, props_array):
         elif gt == 'GeometryCollection':
             for sub in geom.geoms:
                 _classify_one(sub, prop_row, global_idx)
+        else:
+            _warn_dropped_geometries([gt])
 
     for idx, geom in enumerate(geometries):
         _classify_one(geom, props_array[idx], idx)
@@ -3004,9 +3046,13 @@ def rasterize(
     Supported geometry types:
 
     - **Polygon / MultiPolygon** -- scanline fill
-    - **LineString / MultiLineString** -- Bresenham line rasterization
+    - **LineString / LinearRing / MultiLineString** -- Bresenham line
+      rasterization (a LinearRing burns its closed boundary)
     - **Point / MultiPoint** -- direct pixel burn
     - **GeometryCollection** -- recursively unpacked
+
+    A non-empty geometry of any other type is dropped with a warning rather
+    than silently discarded.
 
     Parameters
     ----------

--- a/xrspatial/tests/test_rasterize_linearring_3055.py
+++ b/xrspatial/tests/test_rasterize_linearring_3055.py
@@ -1,0 +1,196 @@
+"""Issue #3055 -- non-empty LinearRing and other unsupported geometries
+were silently dropped by the rasterizer.
+
+``_classify_geometries`` sorts inputs into polygon / line / point buckets.
+LinearRing (shapely type id 2) matched no bucket, so a non-empty ring came
+back in all three empty buckets and ``rasterize`` returned an all-fill raster
+with no error or warning. This covers:
+
+- LinearRing is now treated as a line on both the fast path and the
+  GeometryCollection slow path.
+- A LinearRing burns the same boundary across the numpy, dask, cupy, and
+  dask+cupy backends (the classifier is shared by all of them).
+- Any remaining non-empty geometry that matches no bucket warns instead of
+  vanishing, while None / empty inputs stay silent.
+"""
+
+import warnings
+
+import numpy as np
+import pytest
+
+try:
+    from shapely.geometry import (
+        LinearRing, LineString, Point, GeometryCollection,
+    )
+    has_shapely = True
+except ImportError:
+    has_shapely = False
+
+if has_shapely:
+    from xrspatial.rasterize import rasterize, _classify_geometries
+
+pytestmark = pytest.mark.skipif(
+    not has_shapely, reason="shapely not installed"
+)
+
+try:
+    import dask.array as da  # noqa: F401
+    has_dask = True
+except Exception:
+    has_dask = False
+
+try:
+    import cupy  # noqa: F401
+    from numba import cuda
+    has_cuda = cuda.is_available()
+except Exception:
+    has_cuda = False
+
+skip_no_dask = pytest.mark.skipif(not has_dask, reason="dask not installed")
+skip_no_cuda = pytest.mark.skipif(
+    not has_cuda, reason="CUDA / CuPy not available")
+
+
+# A square ring whose four edges land on the border pixels of a 5x5 raster.
+_RING = LinearRing([(0.5, 0.5), (0.5, 4.5), (4.5, 4.5), (4.5, 0.5), (0.5, 0.5)])
+
+# Expected burn: the border is 1, the 3x3 interior stays at the fill value.
+_EXPECTED = np.array([
+    [1, 1, 1, 1, 1],
+    [1, 0, 0, 0, 1],
+    [1, 0, 0, 0, 1],
+    [1, 0, 0, 0, 1],
+    [1, 1, 1, 1, 1],
+], dtype=float)
+
+
+def _props(n, p=1):
+    return np.ones((n, p), dtype=np.float64)
+
+
+# ---------------------------------------------------------------------------
+# Classifier: LinearRing routes to the line bucket
+# ---------------------------------------------------------------------------
+
+class TestClassifierLinearRing:
+    def test_fast_path_linearring_is_line(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            (poly, line, point) = _classify_geometries([_RING], _props(1))
+        assert len(line[0]) == 1          # routed to lines
+        assert len(poly[0]) == 0
+        assert len(point[0]) == 0
+        assert w == []                    # no spurious warning
+
+    def test_slow_path_linearring_in_collection(self):
+        # A GeometryCollection forces the recursive slow path.
+        gc = GeometryCollection([
+            LinearRing([(0, 0), (0, 5), (5, 5), (0, 0)]),
+            Point(1, 1),
+        ])
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            (poly, line, point) = _classify_geometries([gc], _props(1))
+        assert len(line[0]) == 1
+        assert len(point[0]) == 1
+        assert w == []
+
+
+# ---------------------------------------------------------------------------
+# Classifier: unsupported non-empty geometries warn, empties stay silent
+# ---------------------------------------------------------------------------
+
+class TestClassifierWarnings:
+    def test_none_geometry_skipped_silently(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            (poly, line, point) = _classify_geometries(
+                [None, Point(2.5, 2.5)], _props(2))
+        # None reports as non-empty with type id -1; it must be skipped like
+        # the slow path's `geom is None` guard, not warned about.
+        assert len(point[0]) == 1
+        assert w == []
+
+    def test_empty_geometry_skipped_silently(self):
+        empty = Point().buffer(0)  # empty polygon
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _classify_geometries([empty, Point(1, 1)], _props(2))
+        assert w == []
+
+    def test_warn_helper_resolves_type_id(self):
+        # Fast path passes shapely type ids (ints); the helper resolves names.
+        from xrspatial.rasterize import _warn_dropped_geometries
+        with pytest.warns(UserWarning, match="GeometryCollection"):
+            _warn_dropped_geometries([7])
+
+    def test_warn_helper_accepts_geom_type_name(self):
+        # Slow path passes geom_type names (strings) straight through.
+        from xrspatial.rasterize import _warn_dropped_geometries
+        with pytest.warns(UserWarning, match="Curve"):
+            _warn_dropped_geometries(["Curve"])
+
+    def test_warn_helper_unknown_id(self):
+        # A type id with no name still warns rather than dropping silently.
+        from xrspatial.rasterize import _warn_dropped_geometries
+        with pytest.warns(UserWarning, match="type id 99"):
+            _warn_dropped_geometries([99])
+
+    def test_fast_path_warns_on_unsupported_type_id(self, monkeypatch):
+        # Simulate a future/unknown non-empty shapely type id (e.g. 8) that
+        # matches no bucket. The fast path must warn, not drop it silently.
+        import sys
+        rasterize_mod = sys.modules["xrspatial.rasterize"]
+        shp = rasterize_mod._require_shapely()
+        monkeypatch.setattr(shp, "get_type_id", lambda arr: np.array([8]))
+        monkeypatch.setattr(shp, "is_empty", lambda arr: np.array([False]))
+        with pytest.warns(UserWarning, match="type id 8"):
+            _classify_geometries([Point(1, 1)], _props(1))
+
+
+# ---------------------------------------------------------------------------
+# End-to-end rasterize across backends
+# ---------------------------------------------------------------------------
+
+class TestRasterizeLinearRing:
+    def test_numpy_burns_ring(self):
+        result = rasterize([(_RING, 1.0)], width=5, height=5,
+                           bounds=(0, 0, 5, 5), fill=0)
+        np.testing.assert_array_equal(result.values, _EXPECTED)
+        # Regression guard: not an all-fill raster.
+        assert np.any(result.values == 1.0)
+
+    def test_numpy_ring_matches_equivalent_line(self):
+        # A LinearRing rasterizes the same as the closed LineString of its
+        # coordinates.
+        line = LineString(list(_RING.coords))
+        ring_r = rasterize([(_RING, 1.0)], width=5, height=5,
+                           bounds=(0, 0, 5, 5), fill=0)
+        line_r = rasterize([(line, 1.0)], width=5, height=5,
+                           bounds=(0, 0, 5, 5), fill=0)
+        np.testing.assert_array_equal(ring_r.values, line_r.values)
+
+    @skip_no_dask
+    def test_dask_burns_ring(self):
+        result = rasterize([(_RING, 1.0)], width=5, height=5,
+                           bounds=(0, 0, 5, 5), fill=0, chunks=3)
+        assert isinstance(result.data, da.Array)
+        np.testing.assert_array_equal(
+            np.asarray(result.data), _EXPECTED)
+
+    @skip_no_cuda
+    def test_cupy_burns_ring(self):
+        result = rasterize([(_RING, 1.0)], width=5, height=5,
+                           bounds=(0, 0, 5, 5), fill=0, use_cuda=True)
+        np.testing.assert_array_equal(result.data.get(), _EXPECTED)
+
+    @skip_no_cuda
+    @skip_no_dask
+    def test_dask_cupy_burns_ring(self):
+        result = rasterize([(_RING, 1.0)], width=5, height=5,
+                           bounds=(0, 0, 5, 5), fill=0,
+                           use_cuda=True, chunks=3)
+        np.testing.assert_array_equal(
+            np.asarray(result.data.map_blocks(lambda b: b.get())),
+            _EXPECTED)


### PR DESCRIPTION
Closes #3055

`_classify_geometries` sorts inputs into polygon / line / point buckets. The line bucket matched only LineString (1) and MultiLineString (5), so a non-empty LinearRing (shapely type id 2) fell through every bucket and disappeared. `rasterize` then returned an all-fill raster with no error or warning.

- Add type id 2 to the fast-path line bucket and the `'LinearRing'` name to the slow-path (GeometryCollection) line branch, so a LinearRing rasterizes as its closed boundary.
- Warn, naming the type, whenever a non-empty geometry matches no bucket, so data is never dropped silently. None / empty geometries stay silent (None reports as non-empty with type id -1, so it is now treated as empty to match the slow path's existing guard).
- Update the `rasterize` docstring to list LinearRing and the new drop-with-warning behavior.

`_classify_geometries` is the single classifier shared by every backend path, so the fix applies to numpy, cupy, dask+numpy, and dask+cupy.

### Test plan
- [x] LinearRing routes to the line bucket on both the fast path and the GeometryCollection slow path
- [x] End-to-end `rasterize` burns a LinearRing boundary and matches the equivalent closed LineString (numpy, dask, cupy, dask+cupy)
- [x] Non-empty unsupported type ids warn; None and empty geometries stay silent
- [x] Full existing rasterize suite passes (586 passed, 2 skipped); flake8 clean