### PR TITLE
Add pack=True to to_geotiff: the inverse of mask_and_scale (#3064)

### DIFF
--- a/docs/source/user_guide/attrs_contract.rst
+++ b/docs/source/user_guide/attrs_contract.rst
@@ -114,6 +114,12 @@ write.
        float-because-masked from float-because-promoted, which a
        ``masked_nodata`` lookup alone cannot disambiguate. See issue
        #2135.
+   * - ``mask_and_scale_dtype``
+     - str
+     - Integer source dtype name (e.g. ``"int8"``), set only when a
+       ``mask_and_scale=True`` read promoted an integer array to float.
+       ``to_geotiff(pack=True)`` reads it to reverse the promotion and
+       restore the on-disk dtype. Added in contract v5 (issue #3064).
    * - ``raster_type``
      - str
      - ``'point'`` when the file declares ``RasterPixelIsPoint``;
@@ -142,7 +148,7 @@ write.
        ``ResolutionUnit`` ids 1, 2, 3).
    * - ``_xrspatial_geotiff_contract``
      - int
-     - Contract version. Currently ``4``. See `Versioning`_.
+     - Contract version. Currently ``5``. See `Versioning`_.
    * - ``_xrspatial_no_georef``
      - bool
      - Stamped ``True`` on reads of files with no GeoTIFF transform
@@ -376,3 +382,12 @@ canonical tier. The attr surfaces the rotated 6-tuple from
 so callers can recover the rotated mapping. The writer drops it on
 round-trip until ``to_geotiff`` learns to emit
 ``ModelTransformationTag`` (issue #2115 follow-up).
+
+Contract v5 (issue #3064) added the ``mask_and_scale_dtype`` attr to
+the canonical tier. The attr records the integer source dtype when a
+``mask_and_scale=True`` read promoted the array to float, so
+``to_geotiff(pack=True)`` can reverse the scale / offset, fill NaN back
+to the nodata sentinel, and restore the on-disk dtype. The packed file
+keeps its ``SCALE`` / ``OFFSET`` tags, so reopening it with
+``mask_and_scale=True`` unpacks to the same values instead of scaling a
+second time.

--- a/xrspatial/geotiff/_attrs.py
+++ b/xrspatial/geotiff/_attrs.py
@@ -25,7 +25,7 @@ is present, and pass-through keys are kept when the writer can
 reconstruct them from canonical state.
 
 The contract version is recorded in ``attrs['_xrspatial_geotiff_contract']``
-(currently ``4``). Consumers can branch on this integer if the tier
+(currently ``5``). Consumers can branch on this integer if the tier
 split changes in a future release.
 
 Canonical (xrspatial owns these; round-trip stable):

--- a/xrspatial/geotiff/_attrs.py
+++ b/xrspatial/geotiff/_attrs.py
@@ -76,6 +76,11 @@ Canonical (xrspatial owns these; round-trip stable):
   passed an explicit ``dtype=`` kwarg. Records that a post-mask cast
   happened so consumers can tell float-because-masked from
   float-because-promoted.
+- ``mask_and_scale_dtype`` (#3064, contract v5): string dtype name of
+  the integer source (e.g. ``"int8"``), only emitted when masking
+  and / or ``mask_and_scale`` promoted an integer array to float on
+  read. ``to_geotiff(pack=True)`` reads it to reverse the promotion and
+  restore the on-disk dtype.
 - ``raster_type``: ``'area'`` (implicit / RasterPixelIsArea) or ``'point'``
   (explicit / RasterPixelIsPoint).
 - ``georef_status``: one of ``'full'``, ``'transform_only'``, ``'crs_only'``,
@@ -547,7 +552,12 @@ _TIFF_SHORT = 3
 # writer drops it on round-trip until ``to_geotiff`` grows a
 # ``ModelTransformationTag`` emit path. Existing keys keep their pre-v4
 # shape.
-_ATTRS_CONTRACT_VERSION = 4
+#
+# Version 5 adds ``attrs['mask_and_scale_dtype']``: the integer source
+# dtype recorded when ``mask_nodata`` / ``mask_and_scale`` promoted the
+# array to float on read. ``to_geotiff(pack=True)`` reads it to restore
+# the on-disk dtype. Existing keys keep their pre-v5 shape.
+_ATTRS_CONTRACT_VERSION = 5
 
 
 # Canonical ``attrs['georef_status']`` values. One attr
@@ -1645,6 +1655,79 @@ def _extract_scale_offset(gdal_metadata, band=None, *, malformed=False):
     return scale, offset
 
 
+def _pack(data):
+    """Re-pack a ``mask_and_scale=True`` read for writing -- inverse of
+    :func:`_extract_scale_offset`'s forward direction.
+
+    Reverses the scale / offset applied on read (``(data - add_offset) /
+    scale_factor``), fills NaN back to the declared nodata sentinel, and
+    casts to the integer source dtype recorded in
+    ``attrs['mask_and_scale_dtype']`` (falling back to the dtype of
+    ``attrs['nodata']`` for arrays read by an xrspatial release predating
+    contract v5). Returns a new DataArray; ``data`` is left untouched.
+
+    The SCALE / OFFSET GDAL_METADATA tags are kept: the written file stores
+    the raw packed integers and re-declares the scale, so reopening with
+    ``mask_and_scale=True`` unpacks to the same values rather than scaling a
+    second time. (The double-scale bug the round-trip caveat warns about
+    comes from writing the *already-scaled* floats with the tags still on;
+    reversing the scale first, as here, makes keeping the tags correct.)
+
+    Raises ``ValueError`` when ``data`` carries no mask_and_scale state to
+    reverse, or when an integer dtype must be restored but NaN pixels are
+    present with no declared sentinel to fill them.
+    """
+    attrs = dict(data.attrs)
+    scale = attrs.get('scale_factor', 1.0)
+    offset = attrs.get('add_offset', 0.0)
+    target = attrs.get('mask_and_scale_dtype')
+    nodata = _resolve_nodata_attr(attrs)
+
+    if ('scale_factor' not in attrs and target is None
+            and not attrs.get('masked_nodata')):
+        raise ValueError(
+            "pack=True but the array carries no mask_and_scale state to "
+            "reverse (no scale_factor / mask_and_scale_dtype / "
+            "masked_nodata). It was not produced by "
+            "open_geotiff(mask_and_scale=True).")
+
+    out = (data - offset) / scale
+
+    if target is None and nodata is not None:
+        # Best-effort recovery for pre-v5 reads: the sentinel is stored in
+        # the source dtype, so its width is the source width.
+        target = np.asarray(nodata).dtype.name
+    tgt = np.dtype(target) if target is not None else np.dtype(str(out.dtype))
+
+    if tgt.kind in ('i', 'u'):
+        if nodata is None:
+            # ``isnull().any()`` forces a compute on dask; only reached on
+            # the error path where no sentinel exists to fill the holes.
+            if bool(out.isnull().any()):
+                raise ValueError(
+                    f"pack=True: cannot restore integer dtype {tgt.name}: "
+                    "NaN pixels are present but no nodata sentinel is "
+                    "declared to fill them.")
+        else:
+            out = out.fillna(nodata)
+        out = out.round()
+
+    out = out.astype(tgt)
+
+    # Drop the read-side lifecycle attrs that describe the now-reversed
+    # transform. The SCALE / OFFSET GDAL_METADATA stays so the packed file
+    # still declares how to unpack. ``masked_nodata`` flips to False: the
+    # buffer now carries the literal sentinel, not NaN.
+    for key in ('scale_factor', 'add_offset', 'mask_and_scale_dtype'):
+        attrs.pop(key, None)
+    if 'masked_nodata' in attrs:
+        attrs['masked_nodata'] = False
+
+    out.attrs = attrs
+    out.name = data.name
+    return out
+
+
 def _finalize_eager_read(
     arr,
     *,
@@ -1718,6 +1801,11 @@ def _finalize_eager_read(
     # AND masks the nodata sentinel to NaN), so fold it into the mask gate.
     effective_mask = mask_nodata or mask_and_scale
 
+    # Remember the source dtype before masking / scaling can promote an
+    # integer buffer to float so ``to_geotiff(pack=True)`` can restore it
+    # (issue #3064). Stamped below only when the promotion actually ran.
+    pre_promote_dtype = np.dtype(str(arr.dtype))
+
     # Apply the nodata-to-NaN mask (or compute pixels_present
     # without rewriting if masking is off). Skipped entirely when
     # the source declared no sentinel.
@@ -1741,6 +1829,16 @@ def _finalize_eager_read(
             arr = arr * scale + offset
             attrs['scale_factor'] = scale
             attrs['add_offset'] = offset
+
+    # Record the integer source dtype when ``mask_and_scale`` promoted it to
+    # float, so ``to_geotiff(pack=True)`` can re-pack the decoded array
+    # (issue #3064). Scoped to ``mask_and_scale`` reads (not a plain
+    # ``masked`` read) since ``pack`` is the inverse of ``mask_and_scale``;
+    # the attr name says as much. Checked before the caller ``dtype=`` cast
+    # so it captures the on-disk dtype, not the caller's requested cast.
+    if (mask_and_scale and pre_promote_dtype.kind != 'f'
+            and np.dtype(str(arr.dtype)).kind == 'f'):
+        attrs['mask_and_scale_dtype'] = pre_promote_dtype.name
 
     # Caller-requested dtype cast (post-mask so the integer
     # promotion above runs first). ``_validate_dtype_cast`` lives in

--- a/xrspatial/geotiff/_backends/dask.py
+++ b/xrspatial/geotiff/_backends/dask.py
@@ -529,6 +529,21 @@ def _read_geotiff_dask(source: str, *,
         allow_unparseable_crs=allow_unparseable_crs,
     )
 
+    # Record the integer source dtype when a *real* ``mask_and_scale``
+    # transform -- masking a fittable sentinel, here, or a non-identity
+    # scale / offset, in the block below -- promotes the array to float, so
+    # ``to_geotiff(pack=True)`` can re-pack (issue #3064). Scoped to
+    # ``mask_and_scale`` (not a plain ``masked`` read) to mirror the eager
+    # path. Keys off the real transform, not the graph's ``effective_dtype``,
+    # which over-promotes a bare ``mask_and_scale`` read of an int source
+    # with no scale / offset and no sentinel (a pre-existing eager/dask dtype
+    # gap, left untouched here).
+    if (mask_and_scale
+            and file_dtype.kind in ('u', 'i')
+            and nodata is not None
+            and lifecycle.sentinel_fits_buffer):
+        attrs['mask_and_scale_dtype'] = file_dtype.name
+
     if isinstance(chunks, int):
         ch_h = ch_w = chunks
     else:
@@ -641,6 +656,10 @@ def _read_geotiff_dask(source: str, *,
             dask_arr = dask_arr * scale + offset
             attrs['scale_factor'] = scale
             attrs['add_offset'] = offset
+            # A non-identity scale / offset is the other real transform that
+            # promotes an int source to float (issue #3064).
+            if file_dtype.kind != 'f':
+                attrs.setdefault('mask_and_scale_dtype', file_dtype.name)
 
     # ``parse_coordinates=False`` drops the x / y coordinate arrays (the
     # transform / crs attrs still carry georeferencing); the band coord is

--- a/xrspatial/geotiff/_backends/dask.py
+++ b/xrspatial/geotiff/_backends/dask.py
@@ -421,18 +421,34 @@ def _read_geotiff_dask(source: str, *,
     nodata_attr = lifecycle.raw_sentinel  # original sentinel for attrs['nodata']
     nodata = lifecycle.effective_sentinel  # post-MinIsWhite for masking
 
+    # ``mask_and_scale`` reads need the scale / offset up front: the dtype
+    # decision below must know whether the transform is real -- a non-identity
+    # scale / offset, or a fittable sentinel to mask -- before declaring the
+    # graph dtype. A bare ``mask_and_scale`` read of an int source with no
+    # scale / offset and no fittable sentinel stays integer, matching the
+    # eager path (issue #3066). Extracted once here and reused when the
+    # scaling is applied lazily below.
+    ms_scale, ms_offset = 1.0, 0.0
+    if mask_and_scale:
+        from .._attrs import _extract_scale_offset
+        ms_scale, ms_offset = _extract_scale_offset(
+            getattr(geo_info, 'gdal_metadata', None), band=band,
+            malformed=getattr(geo_info, 'gdal_metadata_malformed', False))
+
     # Nodata masking promotes integer arrays to float64 (for NaN).
     # The lifecycle's ``sentinel_fits_buffer`` already encapsulates the
-    # finite / integer / in-range gates, so the
-    # promotion fires iff the helper says the sentinel is comparable.
+    # finite / integer / in-range gates, so the promotion fires iff the
+    # helper says the sentinel is comparable. ``mask_and_scale`` masks the
+    # sentinel too, so it shares this gate.
     effective_dtype = file_dtype
-    if (mask_nodata
+    if ((mask_nodata or mask_and_scale)
             and file_dtype.kind in ('u', 'i')
             and lifecycle.sentinel_fits_buffer):
         effective_dtype = np.dtype('float64')
-    # ``mask_and_scale`` applies ``data * scale + offset`` (and masks), which
-    # promotes any integer source to float regardless of the sentinel.
-    if mask_and_scale and file_dtype.kind != 'f':
+    # A non-identity scale / offset promotes any integer source to float
+    # even when no sentinel is present.
+    if (mask_and_scale and file_dtype.kind != 'f'
+            and (ms_scale != 1.0 or ms_offset != 0.0)):
         effective_dtype = np.dtype('float64')
 
     if dtype is not None:
@@ -534,10 +550,9 @@ def _read_geotiff_dask(source: str, *,
     # scale / offset, in the block below -- promotes the array to float, so
     # ``to_geotiff(pack=True)`` can re-pack (issue #3064). Scoped to
     # ``mask_and_scale`` (not a plain ``masked`` read) to mirror the eager
-    # path. Keys off the real transform, not the graph's ``effective_dtype``,
-    # which over-promotes a bare ``mask_and_scale`` read of an int source
-    # with no scale / offset and no sentinel (a pre-existing eager/dask dtype
-    # gap, left untouched here).
+    # path. ``effective_dtype`` now agrees with this gate (issue #3066), so a
+    # bare ``mask_and_scale`` read of an int source with no scale / offset and
+    # no sentinel stays integer and records nothing.
     if (mask_and_scale
             and file_dtype.kind in ('u', 'i')
             and nodata is not None
@@ -645,21 +660,17 @@ def _read_geotiff_dask(source: str, *,
     dask_arr = da.concatenate(dask_rows, axis=0)
 
     # ``mask_and_scale``: apply ``data * scale + offset`` lazily on the
-    # assembled dask array. The per-chunk mask above already promoted the
-    # graph to float and replaced sentinels with NaN.
-    if mask_and_scale:
-        from .._attrs import _extract_scale_offset
-        scale, offset = _extract_scale_offset(
-            getattr(geo_info, 'gdal_metadata', None), band=band,
-            malformed=getattr(geo_info, 'gdal_metadata_malformed', False))
-        if scale != 1.0 or offset != 0.0:
-            dask_arr = dask_arr * scale + offset
-            attrs['scale_factor'] = scale
-            attrs['add_offset'] = offset
-            # A non-identity scale / offset is the other real transform that
-            # promotes an int source to float (issue #3064).
-            if file_dtype.kind != 'f':
-                attrs.setdefault('mask_and_scale_dtype', file_dtype.name)
+    # assembled dask array, reusing the scale / offset extracted up front.
+    # The per-chunk mask above already promoted the graph to float and
+    # replaced sentinels with NaN.
+    if mask_and_scale and (ms_scale != 1.0 or ms_offset != 0.0):
+        dask_arr = dask_arr * ms_scale + ms_offset
+        attrs['scale_factor'] = ms_scale
+        attrs['add_offset'] = ms_offset
+        # A non-identity scale / offset is the other real transform that
+        # promotes an int source to float (issue #3064).
+        if file_dtype.kind != 'f':
+            attrs.setdefault('mask_and_scale_dtype', file_dtype.name)
 
     # ``parse_coordinates=False`` drops the x / y coordinate arrays (the
     # transform / crs attrs still carry georeferencing); the band coord is

--- a/xrspatial/geotiff/_writers/eager.py
+++ b/xrspatial/geotiff/_writers/eager.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from typing import BinaryIO
 
 from .._attrs import (_EXPERIMENTAL_CODECS, _LEVEL_RANGES, _VALID_COMPRESSIONS, _extract_rich_tags,
-                      _resolve_nodata_attr, _should_restore_nan_sentinel)
+                      _pack, _resolve_nodata_attr, _should_restore_nan_sentinel)
 from .._backends._gpu_helpers import _is_gpu_data
 from .._coords import _BAND_DIM_NAMES, ROTATION_SHEAR_TOL, _has_no_georef_marker
 from .._coords import require_transform_for_georeferenced as _require_transform_for_georeferenced
@@ -61,7 +61,8 @@ def to_geotiff(data: xr.DataArray | np.ndarray,
                allow_internal_only_jpeg: bool = False,
                allow_experimental_codecs: bool = False,
                allow_unparseable_crs: bool = False,
-               drop_rotation: bool = False) -> str | BinaryIO:
+               drop_rotation: bool = False,
+               pack: bool = False) -> str | BinaryIO:
     """Write data as a GeoTIFF or Cloud Optimized GeoTIFF.
 
     Release-contract tier (see
@@ -338,6 +339,19 @@ def to_geotiff(data: xr.DataArray | np.ndarray,
         impossible without an explicit signal. ``drop_rotation=True``
         accepts the loss and lets the write proceed; consumers reading
         the output will see an axis-aligned, non-rotated TIFF.
+    pack : bool, default False
+        [advanced] Inverse of ``open_geotiff(mask_and_scale=True)``. Re-pack
+        a decoded float array before writing: reverse the scale / offset
+        recorded on ``attrs['scale_factor']`` / ``attrs['add_offset']``,
+        fill NaN back to the nodata sentinel, and cast to the integer source
+        dtype recorded on ``attrs['mask_and_scale_dtype']`` (contract v5).
+        The output stores the raw packed integers and keeps the
+        SCALE / OFFSET GDAL_METADATA, so reopening it with
+        ``mask_and_scale=True`` unpacks to the original values instead of
+        scaling a second time. Raises ``ValueError`` for a bare array (no
+        attrs) or one that never went through a ``mask_and_scale`` read. The
+        dtype falls back to the ``attrs['nodata']`` width for arrays read
+        before contract v5.
 
     Returns
     -------
@@ -374,6 +388,18 @@ def to_geotiff(data: xr.DataArray | np.ndarray,
     from .._reader import _coerce_path
 
     path = _coerce_path(path)
+
+    # ``pack``: inverse of ``open_geotiff(mask_and_scale=True)``. Reverse
+    # the scale / offset, restore the recorded integer source dtype, fill
+    # NaN back to the nodata sentinel, and drop the SCALE / OFFSET tags so
+    # the written file round-trips cleanly. Run before any dispatch (GPU /
+    # VRT / streaming / eager) so every write path sees the re-packed array.
+    if pack:
+        if not isinstance(data, xr.DataArray):
+            raise ValueError(
+                "pack=True requires a DataArray carrying mask_and_scale "
+                "attrs; got a bare array with no metadata to reverse.")
+        data = _pack(data)
 
     # Reject bool / np.bool_ nodata up front. ``bool`` is a subclass of
     # ``int`` in Python, so a typo like ``nodata=True`` slips past every

--- a/xrspatial/geotiff/_writers/eager.py
+++ b/xrspatial/geotiff/_writers/eager.py
@@ -390,10 +390,11 @@ def to_geotiff(data: xr.DataArray | np.ndarray,
     path = _coerce_path(path)
 
     # ``pack``: inverse of ``open_geotiff(mask_and_scale=True)``. Reverse
-    # the scale / offset, restore the recorded integer source dtype, fill
-    # NaN back to the nodata sentinel, and drop the SCALE / OFFSET tags so
-    # the written file round-trips cleanly. Run before any dispatch (GPU /
-    # VRT / streaming / eager) so every write path sees the re-packed array.
+    # the scale / offset, restore the recorded integer source dtype, and fill
+    # NaN back to the nodata sentinel. The SCALE / OFFSET tags are kept (see
+    # ``_pack``) so the re-packed file unpacks cleanly on the next
+    # ``mask_and_scale`` read. Run before any dispatch (GPU / VRT / streaming
+    # / eager) so every write path sees the re-packed array.
     if pack:
         if not isinstance(data, xr.DataArray):
             raise ValueError(

--- a/xrspatial/geotiff/_writers/gpu.py
+++ b/xrspatial/geotiff/_writers/gpu.py
@@ -78,6 +78,7 @@ def _write_geotiff_gpu(data: xr.DataArray | cupy.ndarray | np.ndarray,
                        allow_experimental_codecs: bool = False,
                        allow_unparseable_crs: bool = False,
                        drop_rotation: bool = False,
+                       pack: bool = False,
                        ) -> str | BinaryIO:
     """Write a CuPy-backed DataArray as a GeoTIFF with GPU compression.
 
@@ -255,6 +256,11 @@ def _write_geotiff_gpu(data: xr.DataArray | cupy.ndarray | np.ndarray,
         ``False`` refuses the write with ``ValueError``; the GPU
         writer does not emit a ``ModelTransformationTag`` either, so
         the silent-loss surface is identical on both backends.
+    pack : bool, default False
+        [advanced] No-op on the GPU writer: it exists for signature
+        parity with ``to_geotiff``, which applies the ``pack`` re-pack
+        transform before dispatching here. See ``to_geotiff`` for the
+        behaviour.
 
     Returns
     -------
@@ -442,6 +448,10 @@ def _write_geotiff_gpu(data: xr.DataArray | cupy.ndarray | np.ndarray,
     # the kwarg exists for API parity with to_geotiff so callers can pass
     # the same kwargs to both entry points without filtering.
     del streaming_buffer_bytes
+    # ``pack`` is likewise a no-op here: ``to_geotiff`` applies the
+    # re-pack transform before dispatching to this writer, so the kwarg
+    # only needs to exist for signature parity (#3064).
+    del pack
     try:
         import cupy
     except ImportError:

--- a/xrspatial/geotiff/tests/attrs/test_contract.py
+++ b/xrspatial/geotiff/tests/attrs/test_contract.py
@@ -840,10 +840,13 @@ def test_version_constant_is_current():
 
     Contract v3 added ``attrs['georef_status']`` to the canonical tier.
     Contract v4 added ``attrs['rotated_affine']`` for the
-    ``allow_rotated=True`` opt-in path. Bumping past 4 should be paired
-    with a docs update and a sibling test for the new key.
+    ``allow_rotated=True`` opt-in path. Contract v5 added
+    ``attrs['mask_and_scale_dtype']`` (the integer source dtype recorded
+    on a ``mask_and_scale`` read, for ``to_geotiff(pack=True)``). Bumping
+    past 5 should be paired with a docs update and a sibling test for the
+    new key.
     """
-    assert _ATTRS_CONTRACT_VERSION == 4
+    assert _ATTRS_CONTRACT_VERSION == 5
 
 
 def test_version_module_docstring_matches_constant():

--- a/xrspatial/geotiff/tests/read/test_mask_and_scale_dtype_parity_3066.py
+++ b/xrspatial/geotiff/tests/read/test_mask_and_scale_dtype_parity_3066.py
@@ -1,0 +1,64 @@
+"""Eager/dask dtype parity for ``mask_and_scale`` reads (#3066).
+
+The dask reader used to promote any integer source to float64 for
+``mask_and_scale=True`` regardless of whether a scale/offset or a fittable
+nodata sentinel was present, while the eager reader kept the integer dtype
+when there was nothing to transform. These tests pin the two paths to the
+same dtype (and values) across the relevant cases.
+"""
+import numpy as np
+import pytest
+import xarray as xr
+
+from xrspatial.geotiff import open_geotiff, to_geotiff
+
+
+def _write(path, data, *, nodata=None, scale=None, offset=None):
+    h, w = data.shape
+    attrs = {"crs": 4326}
+    if nodata is not None:
+        attrs["nodata"] = nodata
+    if scale is not None or offset is not None:
+        attrs["gdal_metadata"] = {
+            "SCALE": str(scale if scale is not None else 1.0),
+            "OFFSET": str(offset if offset is not None else 0.0),
+        }
+    to_geotiff(
+        xr.DataArray(
+            data, dims=("y", "x"),
+            coords={"y": np.arange(h, 0, -1) - 0.5, "x": np.arange(w) + 0.5},
+            attrs=attrs),
+        path)
+    return path
+
+
+_DATA = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.uint8)
+
+
+@pytest.mark.parametrize(
+    "label, nodata, scale, offset, expected_dtype",
+    [
+        # Nothing to mask or scale: stays integer on both paths (the #3066 fix).
+        ("bare", None, None, None, "uint8"),
+        # Fittable sentinel: masking promotes on both paths.
+        ("masked", 6, None, None, "float64"),
+        # Non-identity scale/offset: scaling promotes on both paths.
+        ("scaled", None, 2.0, 10.0, "float64"),
+        # Both: promotes on both paths.
+        ("masked_scaled", 6, 2.0, 10.0, "float64"),
+    ],
+)
+def test_eager_dask_dtype_parity(tmp_path, label, nodata, scale, offset,
+                                 expected_dtype):
+    path = _write(
+        tmp_path / f"src_{label}_3066.tif", _DATA,
+        nodata=nodata, scale=scale, offset=offset)
+
+    eager = open_geotiff(path, mask_and_scale=True)
+    lazy = open_geotiff(path, mask_and_scale=True, chunks=2)
+
+    assert str(eager.dtype) == expected_dtype
+    assert str(lazy.dtype) == expected_dtype
+    np.testing.assert_allclose(
+        np.asarray(eager.data), np.asarray(lazy.data.compute()),
+        equal_nan=True)

--- a/xrspatial/geotiff/tests/write/test_pack_3064.py
+++ b/xrspatial/geotiff/tests/write/test_pack_3064.py
@@ -1,0 +1,170 @@
+"""``to_geotiff(pack=True)`` -- the inverse of ``mask_and_scale=True`` (#3064).
+
+A ``mask_and_scale=True`` read promotes an integer raster to float64,
+applies the GDAL SCALE/OFFSET, and masks the nodata sentinel to NaN.
+``pack=True`` reverses that on write: it un-scales, fills NaN back to the
+sentinel, and restores the integer source dtype recorded on
+``attrs['mask_and_scale_dtype']``. The SCALE/OFFSET tags are kept so the
+re-packed file unpacks to the same values on the next ``mask_and_scale``
+read rather than double-scaling.
+
+``mask_and_scale`` is a CPU eager + dask read feature (GPU/VRT reject it),
+so the round-trip is exercised on numpy and dask.
+"""
+import numpy as np
+import pytest
+import xarray as xr
+
+from xrspatial.geotiff import open_geotiff, to_geotiff
+
+
+def _write_int_tiff(path, data, *, nodata=None, scale=None, offset=None):
+    """Write ``data`` (an integer ndarray) as a GeoTIFF, optionally carrying
+    a nodata sentinel and GDAL SCALE/OFFSET packing metadata."""
+    h, w = data.shape
+    attrs = {"crs": 4326}
+    if nodata is not None:
+        attrs["nodata"] = nodata
+    if scale is not None or offset is not None:
+        attrs["gdal_metadata"] = {
+            "SCALE": str(scale if scale is not None else 1.0),
+            "OFFSET": str(offset if offset is not None else 0.0),
+        }
+    da = xr.DataArray(
+        data,
+        dims=("y", "x"),
+        coords={"y": np.arange(h, 0, -1) - 0.5, "x": np.arange(w) + 0.5},
+        attrs=attrs,
+    )
+    to_geotiff(da, path)
+    return path
+
+
+def _reopen(path, chunks):
+    return (open_geotiff(path, mask_and_scale=True) if chunks is None
+            else open_geotiff(path, mask_and_scale=True, chunks=chunks))
+
+
+# ---------------------------------------------------------------------------
+# Round trip: no scale/offset (the int8 + nodata case from the issue)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("chunks", [None, 2], ids=["numpy", "dask"])
+def test_pack_restores_int8_no_scale(tmp_path, chunks):
+    """int8 + nodata, read with mask_and_scale, packs back to int8."""
+    data = np.array([[1, 2, -128], [4, 5, 6]], dtype=np.int8)
+    src = _write_int_tiff(tmp_path / "src_int8_3064.tif", data, nodata=-128)
+
+    decoded = _reopen(src, chunks)
+    assert decoded.dtype == np.float64
+    assert decoded.attrs.get("mask_and_scale_dtype") == "int8"
+
+    out = str(tmp_path / "out_int8_3064.tif")
+    decoded.xrs.to_geotiff(out, pack=True)
+
+    back = open_geotiff(out)
+    assert str(back.dtype) == "int8"
+    np.testing.assert_array_equal(back.data, data)
+
+
+@pytest.mark.parametrize("chunks", [None, 2], ids=["numpy", "dask"])
+def test_pack_restores_uint16_no_scale(tmp_path, chunks):
+    data = np.array([[10, 20, 65535], [40, 50, 60]], dtype=np.uint16)
+    src = _write_int_tiff(tmp_path / "src_u16_3064.tif", data, nodata=65535)
+
+    decoded = _reopen(src, chunks)
+    out = str(tmp_path / "out_u16_3064.tif")
+    decoded.xrs.to_geotiff(out, pack=True)
+
+    back = open_geotiff(out)
+    assert str(back.dtype) == "uint16"
+    np.testing.assert_array_equal(back.data, data)
+
+
+# ---------------------------------------------------------------------------
+# Round trip: with SCALE/OFFSET -- the file must unpack, not double-scale
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("chunks", [None, 2], ids=["numpy", "dask"])
+def test_pack_with_scale_offset_round_trip(tmp_path, chunks):
+    data = np.array([[1, 2, 3], [4, 5, 255]], dtype=np.uint8)
+    src = _write_int_tiff(
+        tmp_path / "src_so_3064.tif", data, nodata=255, scale=2.0, offset=10.0)
+
+    decoded = _reopen(src, chunks)
+    # unpacked values: data * 2 + 10, sentinel -> NaN
+    assert decoded.attrs.get("mask_and_scale_dtype") == "uint8"
+
+    out = str(tmp_path / "out_so_3064.tif")
+    decoded.xrs.to_geotiff(out, pack=True)
+
+    # Raw read: the stored integers round-trip exactly.
+    raw = open_geotiff(out)
+    assert str(raw.dtype) == "uint8"
+    np.testing.assert_array_equal(raw.data, data)
+
+    # The SCALE/OFFSET tags are kept, so a mask_and_scale read of the packed
+    # file reproduces the original decoded values rather than scaling twice.
+    eager_decoded = open_geotiff(src, mask_and_scale=True)
+    repacked_decoded = open_geotiff(out, mask_and_scale=True)
+    np.testing.assert_allclose(
+        repacked_decoded.data, eager_decoded.data, equal_nan=True)
+
+
+# ---------------------------------------------------------------------------
+# Read-side attr: recorded for mask_and_scale, not for a plain masked read
+# ---------------------------------------------------------------------------
+
+
+def test_mask_and_scale_dtype_recorded_eager_dask_match(tmp_path):
+    data = np.array([[1, 2, 255], [4, 5, 6]], dtype=np.uint8)
+    src = _write_int_tiff(tmp_path / "src_attr_3064.tif", data, nodata=255)
+
+    eager = open_geotiff(src, mask_and_scale=True)
+    lazy = open_geotiff(src, mask_and_scale=True, chunks=2)
+    assert eager.attrs.get("mask_and_scale_dtype") == "uint8"
+    assert (eager.attrs.get("mask_and_scale_dtype")
+            == lazy.attrs.get("mask_and_scale_dtype"))
+
+
+def test_mask_and_scale_dtype_absent_on_plain_masked_read(tmp_path):
+    """A plain ``masked=True`` read (not mask_and_scale) does not stamp the
+    attr; ``pack`` is the inverse of ``mask_and_scale`` specifically."""
+    data = np.array([[1, 2, 255], [4, 5, 6]], dtype=np.uint8)
+    src = _write_int_tiff(tmp_path / "src_masked_3064.tif", data, nodata=255)
+
+    masked = open_geotiff(src, masked=True)
+    assert masked.dtype == np.float64  # masking still promotes
+    assert "mask_and_scale_dtype" not in masked.attrs
+
+
+def test_contract_version_is_5(tmp_path):
+    src = _write_int_tiff(
+        tmp_path / "src_ver_3064.tif",
+        np.array([[1, 2], [3, 4]], dtype=np.uint8))
+    da = open_geotiff(src)
+    assert da.attrs["_xrspatial_geotiff_contract"] == 5
+
+
+# ---------------------------------------------------------------------------
+# Guards
+# ---------------------------------------------------------------------------
+
+
+def test_pack_rejects_bare_array(tmp_path):
+    arr = np.zeros((2, 2), dtype=np.float64)
+    with pytest.raises(ValueError, match="pack=True requires a DataArray"):
+        to_geotiff(arr, str(tmp_path / "x_3064.tif"), pack=True)
+
+
+def test_pack_rejects_array_without_mask_and_scale_state(tmp_path):
+    da = xr.DataArray(
+        np.ones((2, 2), dtype=np.float64),
+        dims=("y", "x"),
+        coords={"y": [1.5, 0.5], "x": [0.5, 1.5]},
+        attrs={"crs": 4326},
+    )
+    with pytest.raises(ValueError, match="no mask_and_scale state"):
+        da.xrs.to_geotiff(str(tmp_path / "y_3064.tif"), pack=True)


### PR DESCRIPTION
Closes #3064

Adds `pack=True` to `to_geotiff` as the inverse of `open_geotiff(mask_and_scale=True)`. A `mask_and_scale` read promotes an integer raster to float64, applies the GDAL SCALE/OFFSET, and masks the nodata sentinel to NaN; `pack=True` reverses that so the file round-trips back to its integer encoding without the user reconstructing it by hand.

## What it does
- Read side records the integer source dtype on a new canonical attr `mask_and_scale_dtype` when `mask_and_scale` promoted the array to float (attrs contract v4 -> v5), on both the eager and dask paths.
- `to_geotiff(pack=True)` runs a `_pack` transform before any write-path dispatch: reverse `(data - add_offset) / scale_factor`, fill NaN back to the nodata sentinel, round, and cast to the recorded dtype.
- The SCALE/OFFSET GDAL_METADATA is kept, not dropped. Because the float values are un-scaled first, the packed integer file unpacks to the original values on the next `mask_and_scale` read instead of double-scaling. (My first pass dropped the tags, which silently changed the stored values' meaning; the test for the round-trip identity caught it.)

## Scope notes
- The dtype is recorded only for `mask_and_scale` reads, not plain `masked=True` reads, matching the attr name and the feature. Recording it on every masked read broke existing masked round-trip attr-stability tests, since writing a masked float array changes the on-disk dtype.
- Surfaced (but did not fix) a pre-existing eager/dask gap: a bare `mask_and_scale` read of an int source with no scale/offset and no sentinel returns int on eager but float64 on dask. The attr recording keys off the real transform, not the dask graph's promoted dtype, so the new attr stays consistent across backends.
- `pack` is a no-op on the GPU writer (the transform runs before dispatch); it exists there only for signature parity.

## Backends
numpy and dask. `mask_and_scale` is a CPU eager + dask read feature (GPU/VRT reject it), so the round-trip is exercised on those two.

## Test plan
- [x] int8 and uint16 round trips (numpy + dask)
- [x] SCALE/OFFSET round trip: raw reopen matches the source, and a `mask_and_scale` reopen reproduces the original decode (no double-scale)
- [x] eager/dask `mask_and_scale_dtype` parity
- [x] guards: bare array and no-mask_and_scale-state arrays raise
- [x] contract-version pin and docstring gates bumped to v5
- [x] full geotiff suite green (6247 passed); flake8 + isort clean

Also closes #3066 (eager/dask mask_and_scale dtype parity), surfaced during this PR's review: the dask reader no longer over-promotes a bare mask_and_scale read of an int source with no scale/offset and no sentinel to float64.