### PR TITLE
Pick reproject resampling by raster type in open_geotiff(auto_reproject=True) (#3067)

### DIFF
--- a/xrspatial/accessor.py
+++ b/xrspatial/accessor.py
@@ -146,7 +146,29 @@ def _bbox_edge_samples(x_min, y_min, x_max, y_max, n_per_side=20):
     return xs, ys
 
 
-def _open_geotiff_windowed(obj, source, *, auto_reproject=False, **kwargs):
+_RESAMPLING_CHOICES = ('auto', 'nearest', 'bilinear', 'cubic')
+
+
+def _resolve_resampling(resampling, result):
+    """Resolve an ``'auto'`` resampling choice for the reproject step.
+
+    ``'auto'`` picks ``'nearest'`` for categorical rasters (a paletted
+    colormap is present, or the data has an integer dtype) and
+    ``'bilinear'`` otherwise. Any explicit mode is returned unchanged
+    for :func:`xrspatial.reproject.reproject` to validate.
+    """
+    if resampling != 'auto':
+        return resampling
+    import numpy as np
+    categorical = (
+        result.attrs.get('colormap') is not None
+        or np.issubdtype(result.dtype, np.integer)
+    )
+    return 'nearest' if categorical else 'bilinear'
+
+
+def _open_geotiff_windowed(obj, source, *, auto_reproject=False,
+                           resampling='auto', **kwargs):
     """Shared implementation for ``.xrs.open_geotiff`` on DataArray and
     Dataset.
 
@@ -169,6 +191,12 @@ def _open_geotiff_windowed(obj, source, *, auto_reproject=False, **kwargs):
     """
     from .geotiff import open_geotiff, _read_geo_info, _extent_to_window
     from .utils import _classify_backend
+
+    if resampling not in _RESAMPLING_CHOICES:
+        raise ValueError(
+            f"resampling must be one of {list(_RESAMPLING_CHOICES)}, "
+            f"got {resampling!r}"
+        )
 
     if 'y' not in obj.coords or 'x' not in obj.coords:
         raise ValueError(
@@ -243,6 +271,7 @@ def _open_geotiff_windowed(obj, source, *, auto_reproject=False, **kwargs):
             result,
             target_crs=caller_crs,
             source_crs=file_crs,
+            resampling=_resolve_resampling(resampling, result),
         )
 
     return result
@@ -783,7 +812,8 @@ class XrsSpatialDataArrayAccessor:
         from .geotiff import to_geotiff
         return to_geotiff(self._obj, path, **kwargs)
 
-    def open_geotiff(self, source, *, auto_reproject=False, **kwargs):
+    def open_geotiff(self, source, *, auto_reproject=False,
+                     resampling='auto', **kwargs):
         """Read a GeoTIFF windowed to this DataArray's spatial extent.
 
         Uses ``self``'s ``y``/``x`` coordinates to compute a pixel window
@@ -803,6 +833,14 @@ class XrsSpatialDataArrayAccessor:
             then reprojects the result back to ``self``'s CRS via
             :func:`xrspatial.reproject.reproject` so the returned
             DataArray lines up with ``self``.
+        resampling : {'auto', 'nearest', 'bilinear', 'cubic'}
+            Resampling mode for the ``auto_reproject`` reproject step;
+            ignored when no reprojection happens. ``'auto'`` (default)
+            picks ``'nearest'`` for categorical rasters (a paletted
+            colormap is present, or the data has an integer dtype) and
+            ``'bilinear'`` otherwise. Note an integer-typed continuous
+            DEM (e.g. int16 elevation) is treated as categorical under
+            ``'auto'``; pass ``resampling='bilinear'`` for those.
         **kwargs
             Forwarded to :func:`xrspatial.geotiff.open_geotiff` (except
             ``window=``, which is computed automatically).
@@ -815,7 +853,8 @@ class XrsSpatialDataArrayAccessor:
             file's native CRS.
         """
         return _open_geotiff_windowed(
-            self._obj, source, auto_reproject=auto_reproject, **kwargs
+            self._obj, source, auto_reproject=auto_reproject,
+            resampling=resampling, **kwargs
         )
 
     # ---- Chunking ----
@@ -1281,7 +1320,8 @@ class XrsSpatialDatasetAccessor:
             "Dataset has no variable with 'y' and 'x' dimensions to write"
         )
 
-    def open_geotiff(self, source, *, auto_reproject=False, var=None, **kwargs):
+    def open_geotiff(self, source, *, auto_reproject=False, var=None,
+                     resampling='auto', **kwargs):
         """Read a GeoTIFF windowed to this Dataset's spatial extent.
 
         Uses the Dataset's ``y``/``x`` coordinates to compute a pixel
@@ -1304,6 +1344,14 @@ class XrsSpatialDatasetAccessor:
         var : str or None
             Data variable used for backend inference and CRS lookup. If
             None, picks the first 2D variable with ``y``/``x`` dims.
+        resampling : {'auto', 'nearest', 'bilinear', 'cubic'}
+            Resampling mode for the ``auto_reproject`` reproject step;
+            ignored when no reprojection happens. ``'auto'`` (default)
+            picks ``'nearest'`` for categorical rasters (a paletted
+            colormap is present, or the data has an integer dtype) and
+            ``'bilinear'`` otherwise. Note an integer-typed continuous
+            DEM (e.g. int16 elevation) is treated as categorical under
+            ``'auto'``; pass ``resampling='bilinear'`` for those.
         **kwargs
             Forwarded to :func:`xrspatial.geotiff.open_geotiff` (except
             ``window=``, which is computed automatically).
@@ -1325,7 +1373,8 @@ class XrsSpatialDatasetAccessor:
             rep = rep.copy()
             rep.attrs = {**rep.attrs, 'crs': ds.attrs['crs']}
         return _open_geotiff_windowed(
-            rep, source, auto_reproject=auto_reproject, **kwargs
+            rep, source, auto_reproject=auto_reproject,
+            resampling=resampling, **kwargs
         )
 
     # ---- Chunking ----

--- a/xrspatial/accessor.py
+++ b/xrspatial/accessor.py
@@ -841,6 +841,10 @@ class XrsSpatialDataArrayAccessor:
             ``'bilinear'`` otherwise. Note an integer-typed continuous
             DEM (e.g. int16 elevation) is treated as categorical under
             ``'auto'``; pass ``resampling='bilinear'`` for those.
+            Conversely, an integer raster read with a nodata sentinel is
+            promoted to float on read, so a categorical raster that
+            carries nodata and no colormap resolves to ``'bilinear'``;
+            pass ``resampling='nearest'`` for those.
         **kwargs
             Forwarded to :func:`xrspatial.geotiff.open_geotiff` (except
             ``window=``, which is computed automatically).
@@ -1352,6 +1356,10 @@ class XrsSpatialDatasetAccessor:
             ``'bilinear'`` otherwise. Note an integer-typed continuous
             DEM (e.g. int16 elevation) is treated as categorical under
             ``'auto'``; pass ``resampling='bilinear'`` for those.
+            Conversely, an integer raster read with a nodata sentinel is
+            promoted to float on read, so a categorical raster that
+            carries nodata and no colormap resolves to ``'bilinear'``;
+            pass ``resampling='nearest'`` for those.
         **kwargs
             Forwarded to :func:`xrspatial.geotiff.open_geotiff` (except
             ``window=``, which is computed automatically).

--- a/xrspatial/tests/test_open_geotiff_resampling.py
+++ b/xrspatial/tests/test_open_geotiff_resampling.py
@@ -1,0 +1,148 @@
+"""Tests for the ``resampling`` parameter of ``.xrs.open_geotiff``
+(issue #3067 - auto-pick resampling for the auto_reproject step)."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from xrspatial.accessor import _resolve_resampling
+from xrspatial.geotiff import to_geotiff
+
+
+# ---------------------------------------------------------------------------
+# _resolve_resampling unit tests (no file IO)
+# ---------------------------------------------------------------------------
+
+def _da(dtype, colormap=None):
+    da = xr.DataArray(np.zeros((2, 2), dtype=dtype), dims=['y', 'x'])
+    if colormap is not None:
+        da.attrs['colormap'] = colormap
+    return da
+
+
+def test_auto_float_no_colormap_picks_bilinear():
+    assert _resolve_resampling('auto', _da('float32')) == 'bilinear'
+
+
+def test_auto_integer_picks_nearest():
+    assert _resolve_resampling('auto', _da('int16')) == 'nearest'
+    assert _resolve_resampling('auto', _da('uint8')) == 'nearest'
+
+
+def test_auto_float_with_colormap_picks_nearest():
+    assert _resolve_resampling('auto', _da('float32', colormap=(1, 2, 3))) \
+        == 'nearest'
+
+
+@pytest.mark.parametrize('mode', ['nearest', 'bilinear', 'cubic'])
+def test_explicit_mode_returned_unchanged(mode):
+    # explicit modes ignore the data characteristics entirely
+    assert _resolve_resampling(mode, _da('int16')) == mode
+    assert _resolve_resampling(mode, _da('float32')) == mode
+
+
+# ---------------------------------------------------------------------------
+# End-to-end forwarding into reproject(), via a spy
+# ---------------------------------------------------------------------------
+
+def _mismatch_template_and_file(tmp_path, dtype, name):
+    """File in EPSG:4326, caller template in EPSG:3857 over same box."""
+    height, width = 30, 30
+    arr = np.arange(height * width, dtype=dtype).reshape(height, width)
+    y = np.linspace(45.5, 44.5, height)
+    x = np.linspace(-120.5, -119.5, width)
+    file_da = xr.DataArray(
+        arr, dims=['y', 'x'], coords={'y': y, 'x': x}, attrs={'crs': 4326},
+    )
+    path = str(tmp_path / name)
+    to_geotiff(file_da, path, compression='none')
+
+    from pyproj import Transformer
+    tr = Transformer.from_crs(4326, 3857, always_xy=True)
+    x0, y0 = tr.transform(-120.25, 45.25)
+    x1, y1 = tr.transform(-119.75, 44.75)
+    template = xr.DataArray(
+        np.zeros((6, 6), dtype=np.float32),
+        dims=['y', 'x'],
+        coords={'y': np.linspace(max(y0, y1), min(y0, y1), 6),
+                'x': np.linspace(min(x0, x1), max(x0, x1), 6)},
+        attrs={'crs': 3857},
+    )
+    return template, path
+
+
+@pytest.fixture
+def reproject_spy(monkeypatch):
+    """Patch reproject() to record its resampling kwarg and echo input."""
+    calls = {}
+
+    def _spy(raster, *args, **kwargs):
+        calls['resampling'] = kwargs.get('resampling')
+        calls['count'] = calls.get('count', 0) + 1
+        return raster
+
+    # ``xrspatial.reproject`` the attribute is the function (it shadows the
+    # submodule), but ``_open_geotiff_windowed`` does ``from .reproject
+    # import reproject``, which resolves through the submodule. Patch the
+    # attribute on the submodule object from sys.modules.
+    import importlib
+    rmod = importlib.import_module('xrspatial.reproject')
+    monkeypatch.setattr(rmod, 'reproject', _spy)
+    return calls
+
+
+def test_auto_float_forwards_bilinear(tmp_path, reproject_spy):
+    template, path = _mismatch_template_and_file(
+        tmp_path, np.float32, 'rs3067_float.tif')
+    template.xrs.open_geotiff(path, auto_reproject=True)
+    assert reproject_spy['resampling'] == 'bilinear'
+
+
+def test_auto_integer_forwards_nearest(tmp_path, reproject_spy):
+    template, path = _mismatch_template_and_file(
+        tmp_path, np.int16, 'rs3067_int.tif')
+    template.xrs.open_geotiff(path, auto_reproject=True)
+    assert reproject_spy['resampling'] == 'nearest'
+
+
+def test_explicit_override_forwarded(tmp_path, reproject_spy):
+    template, path = _mismatch_template_and_file(
+        tmp_path, np.int16, 'rs3067_override.tif')
+    template.xrs.open_geotiff(path, auto_reproject=True, resampling='cubic')
+    assert reproject_spy['resampling'] == 'cubic'
+
+
+# ---------------------------------------------------------------------------
+# Validation and no-op behaviour
+# ---------------------------------------------------------------------------
+
+def test_invalid_resampling_raises(tmp_path):
+    template, path = _mismatch_template_and_file(
+        tmp_path, np.float32, 'rs3067_bad.tif')
+    with pytest.raises(ValueError, match="resampling must be one of"):
+        template.xrs.open_geotiff(path, auto_reproject=True,
+                                  resampling='bogus')
+
+
+def test_no_reproject_when_crs_matches(tmp_path, reproject_spy):
+    # Caller and file share CRS: no reproject, resampling unused.
+    height, width = 12, 12
+    arr = np.arange(height * width, dtype=np.float32).reshape(height, width)
+    y = np.linspace(45.5, 44.5, height)
+    x = np.linspace(-120.5, -119.5, width)
+    file_da = xr.DataArray(
+        arr, dims=['y', 'x'], coords={'y': y, 'x': x}, attrs={'crs': 4326},
+    )
+    path = str(tmp_path / 'rs3067_match.tif')
+    to_geotiff(file_da, path, compression='none')
+
+    template = xr.DataArray(
+        np.zeros((6, 6), dtype=np.float32),
+        dims=['y', 'x'],
+        coords={'y': y[3:9], 'x': x[3:9]},
+        attrs={'crs': 4326},
+    )
+    # passing resampling here is accepted and simply ignored
+    template.xrs.open_geotiff(path, auto_reproject=True, resampling='nearest')
+    assert reproject_spy.get('count', 0) == 0

--- a/xrspatial/tests/test_open_geotiff_resampling.py
+++ b/xrspatial/tests/test_open_geotiff_resampling.py
@@ -113,6 +113,31 @@ def test_explicit_override_forwarded(tmp_path, reproject_spy):
     assert reproject_spy['resampling'] == 'cubic'
 
 
+def test_categorical_real_reproject_preserves_class_ids(tmp_path):
+    # End-to-end (no spy): an integer class raster reprojected under
+    # 'auto' uses nearest, so every output value is an original class ID
+    # rather than an averaged in-between value.
+    classes = np.array([10, 20, 30, 40], dtype=np.int16)
+    template, path = _mismatch_template_and_file(
+        tmp_path, np.int16, 'rs3067_classids.tif')
+    # Rewrite the file with only a few distinct class values
+    height, width = 30, 30
+    y = np.linspace(45.5, 44.5, height)
+    x = np.linspace(-120.5, -119.5, width)
+    block = np.tile(classes, (height, width // classes.size + 1))[:, :width]
+    file_da = xr.DataArray(
+        block.astype(np.int16), dims=['y', 'x'],
+        coords={'y': y, 'x': x}, attrs={'crs': 4326},
+    )
+    to_geotiff(file_da, path, compression='none')
+
+    result = template.xrs.open_geotiff(path, auto_reproject=True)
+    vals = np.asarray(result.data)
+    finite = vals[np.isfinite(vals)]
+    assert finite.size > 0
+    assert np.isin(finite, classes).all()
+
+
 # ---------------------------------------------------------------------------
 # Validation and no-op behaviour
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #3067

## What

`open_geotiff(auto_reproject=True)` reprojected the windowed read back to the caller's CRS with no `resampling=` argument, so `reproject()` always used its `'bilinear'` default. Bilinear is fine for continuous data but averages class IDs in categorical rasters, producing classes that do not exist.

This adds a `resampling` parameter to both `open_geotiff` accessor methods (DataArray and Dataset), defaulting to `'auto'`:

- `'auto'` picks `'nearest'` for categorical rasters (a paletted colormap is present, or the data has an integer dtype) and `'bilinear'` otherwise.
- Explicit `'nearest'`, `'bilinear'`, or `'cubic'` pass straight through to `reproject()`.
- Resolution happens in the accessor layer (`_resolve_resampling`), so only concrete modes reach `reproject()`. `reproject()` itself is untouched.
- The value is validated early, so a bad mode fails before any read.

Documented caveat: an integer-typed continuous DEM (such as int16 elevation) is treated as categorical under `'auto'`. Pass `resampling='bilinear'` for those.

## Backend coverage

The change sits in the accessor dispatch layer and only chooses the string handed to `reproject()`, which already supports numpy, cupy, dask+numpy, and dask+cupy. `result.dtype` and `result.attrs` read the same way across all four.

## Test plan

- [x] `_resolve_resampling` unit tests: float to bilinear, integer to nearest, colormap to nearest, explicit modes unchanged
- [x] End-to-end spy: auto float forwards bilinear, auto integer forwards nearest, explicit override forwarded
- [x] Invalid mode raises ValueError before any read
- [x] No reproject when CRS matches (resampling ignored)
- [x] Existing open_geotiff / auto_reproject tests still pass