### PR TITLE
Add coregister=True to open_geotiff: mask_and_scale + reproject + match grid

### DIFF
--- a/xrspatial/accessor.py
+++ b/xrspatial/accessor.py
@@ -167,8 +167,56 @@ def _resolve_resampling(resampling, result):
     return 'nearest' if categorical else 'bilinear'
 
 
+def _axis_res(coord, n, obj, axis):
+    """Resolution (cell size) for one axis of the caller's grid.
+
+    With 2+ cells it is the centre spacing. A single-cell axis cannot
+    give a spacing, so fall back to the caller's ``attrs['res']`` or
+    ``attrs['transform']`` pixel size, and raise if neither is present.
+    """
+    if n >= 2:
+        return abs(float(coord[-1]) - float(coord[0])) / (n - 1)
+    res = obj.attrs.get('res')
+    if res is not None:
+        return abs(float(res[0] if axis == 'x' else res[1]))
+    transform = obj.attrs.get('transform')
+    if transform is not None:
+        return abs(float(transform[0] if axis == 'x' else transform[4]))
+    raise ValueError(
+        f"coregister cannot infer {axis} resolution for a single-cell "
+        f"template; use a template with 2+ cells along {axis}, or set "
+        f"attrs['res'] / attrs['transform']"
+    )
+
+
+def _caller_grid(obj):
+    """Edge bounds + shape that make :func:`reproject` reproduce the
+    caller's exact pixel centres.
+
+    Returns ``((left, bottom, right, top), width, height)``. ``reproject``
+    emits pixel-centre coords ``linspace(left+res/2, right-res/2, W)``, so
+    bounds offset half a pixel outside the caller's centre extent map the
+    output cells back onto the caller's coordinates.
+
+    Assumes a regular grid with ``x`` ascending and ``y`` descending (the
+    convention ``_open_geotiff_windowed`` already works in); resolution is
+    the centre spacing. An irregular or descending-``x`` template would
+    not line up cell-for-cell.
+    """
+    y = obj.coords['y'].values
+    x = obj.coords['x'].values
+    width, height = len(x), len(y)
+    res_x = _axis_res(x, width, obj, 'x')
+    res_y = _axis_res(y, height, obj, 'y')
+    x_lo, x_hi = float(min(x[0], x[-1])), float(max(x[0], x[-1]))
+    y_lo, y_hi = float(min(y[0], y[-1])), float(max(y[0], y[-1]))
+    bounds = (x_lo - res_x / 2, y_lo - res_y / 2,
+              x_hi + res_x / 2, y_hi + res_y / 2)
+    return bounds, width, height
+
+
 def _open_geotiff_windowed(obj, source, *, auto_reproject=False,
-                           resampling='auto', **kwargs):
+                           coregister=False, resampling='auto', **kwargs):
     """Shared implementation for ``.xrs.open_geotiff`` on DataArray and
     Dataset.
 
@@ -198,6 +246,22 @@ def _open_geotiff_windowed(obj, source, *, auto_reproject=False,
             f"got {resampling!r}"
         )
 
+    if coregister:
+        gpu_requested = (
+            kwargs.get('gpu', False)
+            or _classify_backend(obj) in ("cupy", "dask+cupy")
+        )
+        is_vrt = str(source).lower().endswith('.vrt')
+        if gpu_requested or is_vrt:
+            raise ValueError(
+                "coregister=True applies mask_and_scale, which is not "
+                "supported with gpu=True or .vrt sources. Read on CPU, "
+                "or pass coregister=False."
+            )
+        # coregister implies a masked-and-scaled read; this overrides an
+        # explicit mask_and_scale=False.
+        kwargs['mask_and_scale'] = True
+
     if 'y' not in obj.coords or 'x' not in obj.coords:
         raise ValueError(
             "Caller must have 'y' and 'x' coordinates to compute a "
@@ -221,7 +285,7 @@ def _open_geotiff_windowed(obj, source, *, auto_reproject=False,
         and not caller_crs.equals(file_crs)
     )
 
-    if crs_mismatch and not auto_reproject:
+    if crs_mismatch and not (auto_reproject or coregister):
         raise ValueError(
             f"CRS mismatch: caller has {caller_crs_raw!r} but file has "
             f"EPSG:{file_crs_raw}. Pass auto_reproject=True to project "
@@ -265,13 +329,42 @@ def _open_geotiff_windowed(obj, source, *, auto_reproject=False,
 
     result = open_geotiff(source, window=window, **kwargs)
 
-    if crs_mismatch:
+    # A masked read replaces the nodata sentinel with NaN but leaves
+    # attrs['nodata'] as the raw sentinel; tell reproject the holes are
+    # NaN so it does not resample them as ordinary values.
+    nodata_arg = float('nan') if result.attrs.get('masked_nodata') else None
+
+    if coregister:
+        from .reproject import reproject
+        target_crs = caller_crs if caller_crs is not None else file_crs
+        if target_crs is None:
+            raise ValueError(
+                "coregister=True needs a CRS: set attrs['crs'] on the "
+                "caller or read a file that declares one"
+            )
+        # A file that declares no CRS is treated as already in the
+        # caller's CRS, so coregister stays a pure resample instead of
+        # failing reproject's source-CRS detection.
+        source_crs = file_crs if file_crs is not None else target_crs
+        bounds, width_out, height_out = _caller_grid(obj)
+        result = reproject(
+            result,
+            target_crs=target_crs,
+            source_crs=source_crs,
+            bounds=bounds,
+            width=width_out,
+            height=height_out,
+            resampling=_resolve_resampling(resampling, result),
+            nodata=nodata_arg,
+        )
+    elif crs_mismatch:
         from .reproject import reproject
         result = reproject(
             result,
             target_crs=caller_crs,
             source_crs=file_crs,
             resampling=_resolve_resampling(resampling, result),
+            nodata=nodata_arg,
         )
 
     return result
@@ -813,7 +906,7 @@ class XrsSpatialDataArrayAccessor:
         return to_geotiff(self._obj, path, **kwargs)
 
     def open_geotiff(self, source, *, auto_reproject=False,
-                     resampling='auto', **kwargs):
+                     coregister=False, resampling='auto', **kwargs):
         """Read a GeoTIFF windowed to this DataArray's spatial extent.
 
         Uses ``self``'s ``y``/``x`` coordinates to compute a pixel window
@@ -833,18 +926,31 @@ class XrsSpatialDataArrayAccessor:
             then reprojects the result back to ``self``'s CRS via
             :func:`xrspatial.reproject.reproject` so the returned
             DataArray lines up with ``self``.
+        coregister : bool
+            If True, read the file masked and scaled
+            (``mask_and_scale=True``), reproject into ``self``'s CRS, and
+            resample onto ``self``'s exact grid, so the result shares
+            ``self``'s ``y``/``x`` coordinates and shape. The grid snap
+            happens even when the CRS already matches. ``mask_and_scale``
+            is unsupported with ``gpu=True`` or ``.vrt`` sources, so
+            ``coregister=True`` raises ``ValueError`` there, and it
+            overrides an explicit ``mask_and_scale=False``. The resample
+            mode follows ``resampling``. This is the heavier counterpart
+            of ``auto_reproject``, which keeps the file's native
+            resolution.
         resampling : {'auto', 'nearest', 'bilinear', 'cubic'}
-            Resampling mode for the ``auto_reproject`` reproject step;
-            ignored when no reprojection happens. ``'auto'`` (default)
-            picks ``'nearest'`` for categorical rasters (a paletted
-            colormap is present, or the data has an integer dtype) and
-            ``'bilinear'`` otherwise. Note an integer-typed continuous
-            DEM (e.g. int16 elevation) is treated as categorical under
-            ``'auto'``; pass ``resampling='bilinear'`` for those.
-            Conversely, an integer raster read with a nodata sentinel is
-            promoted to float on read, so a categorical raster that
-            carries nodata and no colormap resolves to ``'bilinear'``;
-            pass ``resampling='nearest'`` for those.
+            Resampling mode for the ``auto_reproject`` / ``coregister``
+            reproject step; ignored when no reprojection happens.
+            ``'auto'`` (default) picks ``'nearest'`` for categorical
+            rasters (a paletted colormap is present, or the data has an
+            integer dtype) and ``'bilinear'`` otherwise. Note an
+            integer-typed continuous DEM (e.g. int16 elevation) is
+            treated as categorical under ``'auto'``; pass
+            ``resampling='bilinear'`` for those. Conversely, an integer
+            raster read with a nodata sentinel is promoted to float on
+            read, so a categorical raster that carries nodata and no
+            colormap resolves to ``'bilinear'``; pass
+            ``resampling='nearest'`` for those.
         **kwargs
             Forwarded to :func:`xrspatial.geotiff.open_geotiff` (except
             ``window=``, which is computed automatically).
@@ -852,13 +958,14 @@ class XrsSpatialDataArrayAccessor:
         Returns
         -------
         xr.DataArray
-            The windowed portion of the GeoTIFF, in ``self``'s CRS when
-            ``auto_reproject`` reprojection occurred and otherwise in the
-            file's native CRS.
+            The windowed portion of the GeoTIFF. In ``self``'s CRS when
+            ``auto_reproject`` reprojection occurred, on ``self``'s exact
+            grid when ``coregister`` is set, and otherwise in the file's
+            native CRS.
         """
         return _open_geotiff_windowed(
             self._obj, source, auto_reproject=auto_reproject,
-            resampling=resampling, **kwargs
+            coregister=coregister, resampling=resampling, **kwargs
         )
 
     # ---- Chunking ----
@@ -1325,7 +1432,7 @@ class XrsSpatialDatasetAccessor:
         )
 
     def open_geotiff(self, source, *, auto_reproject=False, var=None,
-                     resampling='auto', **kwargs):
+                     coregister=False, resampling='auto', **kwargs):
         """Read a GeoTIFF windowed to this Dataset's spatial extent.
 
         Uses the Dataset's ``y``/``x`` coordinates to compute a pixel
@@ -1348,18 +1455,29 @@ class XrsSpatialDatasetAccessor:
         var : str or None
             Data variable used for backend inference and CRS lookup. If
             None, picks the first 2D variable with ``y``/``x`` dims.
+        coregister : bool
+            If True, read the file masked and scaled
+            (``mask_and_scale=True``), reproject into the Dataset's CRS,
+            and resample onto the Dataset's exact grid, so the result
+            shares the Dataset's ``y``/``x`` coordinates and shape. The
+            grid snap happens even when the CRS already matches.
+            ``mask_and_scale`` is unsupported with ``gpu=True`` or
+            ``.vrt`` sources, so ``coregister=True`` raises ``ValueError``
+            there, and it overrides an explicit ``mask_and_scale=False``.
+            The resample mode follows ``resampling``.
         resampling : {'auto', 'nearest', 'bilinear', 'cubic'}
-            Resampling mode for the ``auto_reproject`` reproject step;
-            ignored when no reprojection happens. ``'auto'`` (default)
-            picks ``'nearest'`` for categorical rasters (a paletted
-            colormap is present, or the data has an integer dtype) and
-            ``'bilinear'`` otherwise. Note an integer-typed continuous
-            DEM (e.g. int16 elevation) is treated as categorical under
-            ``'auto'``; pass ``resampling='bilinear'`` for those.
-            Conversely, an integer raster read with a nodata sentinel is
-            promoted to float on read, so a categorical raster that
-            carries nodata and no colormap resolves to ``'bilinear'``;
-            pass ``resampling='nearest'`` for those.
+            Resampling mode for the ``auto_reproject`` / ``coregister``
+            reproject step; ignored when no reprojection happens.
+            ``'auto'`` (default) picks ``'nearest'`` for categorical
+            rasters (a paletted colormap is present, or the data has an
+            integer dtype) and ``'bilinear'`` otherwise. Note an
+            integer-typed continuous DEM (e.g. int16 elevation) is
+            treated as categorical under ``'auto'``; pass
+            ``resampling='bilinear'`` for those. Conversely, an integer
+            raster read with a nodata sentinel is promoted to float on
+            read, so a categorical raster that carries nodata and no
+            colormap resolves to ``'bilinear'``; pass
+            ``resampling='nearest'`` for those.
         **kwargs
             Forwarded to :func:`xrspatial.geotiff.open_geotiff` (except
             ``window=``, which is computed automatically).
@@ -1382,7 +1500,7 @@ class XrsSpatialDatasetAccessor:
             rep.attrs = {**rep.attrs, 'crs': ds.attrs['crs']}
         return _open_geotiff_windowed(
             rep, source, auto_reproject=auto_reproject,
-            resampling=resampling, **kwargs
+            coregister=coregister, resampling=resampling, **kwargs
         )
 
     # ---- Chunking ----

--- a/xrspatial/tests/test_open_geotiff_coregister.py
+++ b/xrspatial/tests/test_open_geotiff_coregister.py
@@ -1,0 +1,231 @@
+"""Tests for ``.xrs.open_geotiff(coregister=True)`` (issue #3069 -
+mask_and_scale + reproject + resample onto the caller's exact grid)."""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from xrspatial.accessor import _caller_grid
+from xrspatial.geotiff import to_geotiff
+
+
+# ---------------------------------------------------------------------------
+# _caller_grid unit tests
+# ---------------------------------------------------------------------------
+
+def test_caller_grid_reconstructs_centers():
+    # reproject emits linspace(left+res/2, right-res/2, W); the bounds
+    # _caller_grid returns must map those back onto the caller's coords.
+    x = np.linspace(-100.0, -95.0, 6)
+    y = np.linspace(45.0, 40.0, 6)
+    da = xr.DataArray(np.zeros((6, 6)), dims=['y', 'x'],
+                      coords={'y': y, 'x': x})
+    (left, bottom, right, top), W, H = _caller_grid(da)
+    res_x = (right - left) / W
+    res_y = (top - bottom) / H
+    ox = np.linspace(left + res_x / 2, right - res_x / 2, W)
+    oy = np.linspace(top - res_y / 2, bottom + res_y / 2, H)
+    assert np.allclose(ox, x)
+    assert np.allclose(oy, y)
+    assert (W, H) == (6, 6)
+
+
+def test_caller_grid_single_cell_needs_resolution():
+    da = xr.DataArray(np.zeros((1, 1)), dims=['y', 'x'],
+                      coords={'y': [44.0], 'x': [-97.0]})
+    with pytest.raises(ValueError, match="single-cell"):
+        _caller_grid(da)
+    # with a transform it can infer the cell size
+    da.attrs['transform'] = (0.01, 0, -97.0, 0, -0.01, 44.0)
+    (left, bottom, right, top), W, H = _caller_grid(da)
+    assert (W, H) == (1, 1)
+    assert np.isclose(right - left, 0.01)
+
+
+# ---------------------------------------------------------------------------
+# Helpers: build a file + a template on a different grid
+# ---------------------------------------------------------------------------
+
+def _file_4326(tmp_path, dtype, name, nodata=None):
+    height, width = 30, 30
+    arr = np.arange(height * width, dtype=dtype).reshape(height, width)
+    y = np.linspace(45.5, 44.5, height)
+    x = np.linspace(-120.5, -119.5, width)
+    attrs = {'crs': 4326}
+    if nodata is not None:
+        attrs['nodata'] = nodata
+        # place the sentinel in the centre so it falls inside the
+        # template's windowed footprint (which covers the interior)
+        arr[14:17, 14:17] = nodata
+    da = xr.DataArray(arr, dims=['y', 'x'],
+                      coords={'y': y, 'x': x}, attrs=attrs)
+    path = str(tmp_path / name)
+    to_geotiff(da, path, compression='none')
+    return path
+
+
+def _template_3857(n=6):
+    from pyproj import Transformer
+    tr = Transformer.from_crs(4326, 3857, always_xy=True)
+    x0, y0 = tr.transform(-120.25, 45.25)
+    x1, y1 = tr.transform(-119.75, 44.75)
+    return xr.DataArray(
+        np.zeros((n, n), dtype=np.float32),
+        dims=['y', 'x'],
+        coords={'y': np.linspace(max(y0, y1), min(y0, y1), n),
+                'x': np.linspace(min(x0, x1), max(x0, x1), n)},
+        attrs={'crs': 3857},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Exact grid match
+# ---------------------------------------------------------------------------
+
+def test_coregister_matches_grid_crs_mismatch(tmp_path):
+    path = _file_4326(tmp_path, np.float32, 'cg_mismatch.tif')
+    template = _template_3857(6)
+    out = template.xrs.open_geotiff(path, coregister=True)
+    assert out.shape == template.shape
+    assert np.allclose(out.coords['x'].values, template.coords['x'].values)
+    assert np.allclose(out.coords['y'].values, template.coords['y'].values)
+
+
+def test_coregister_matches_grid_same_crs(tmp_path):
+    # Same CRS but a coarser, offset template: coregister still snaps.
+    path = _file_4326(tmp_path, np.float32, 'cg_samecrs.tif')
+    template = xr.DataArray(
+        np.zeros((5, 5), dtype=np.float32),
+        dims=['y', 'x'],
+        coords={'y': np.linspace(45.3, 44.7, 5),
+                'x': np.linspace(-120.3, -119.7, 5)},
+        attrs={'crs': 4326},
+    )
+    out = template.xrs.open_geotiff(path, coregister=True)
+    assert out.shape == template.shape
+    assert np.allclose(out.coords['x'].values, template.coords['x'].values)
+    assert np.allclose(out.coords['y'].values, template.coords['y'].values)
+
+
+def test_coregister_crs_less_file(tmp_path):
+    # A file with a transform but no CRS is treated as already in the
+    # template's CRS: coregister resamples onto the template grid rather
+    # than failing reproject's source-CRS detection.
+    height, width = 20, 20
+    arr = np.arange(height * width, dtype=np.float32).reshape(height, width)
+    y = np.linspace(45.5, 44.5, height)
+    x = np.linspace(-120.5, -119.5, width)
+    # no 'crs' attr -> to_geotiff writes a transform-only (CRS-less) file
+    da = xr.DataArray(arr, dims=['y', 'x'], coords={'y': y, 'x': x})
+    path = str(tmp_path / 'cg_nocrs.tif')
+    to_geotiff(da, path, compression='none')
+
+    template = xr.DataArray(
+        np.zeros((8, 8), dtype=np.float32),
+        dims=['y', 'x'],
+        coords={'y': np.linspace(45.3, 44.7, 8),
+                'x': np.linspace(-120.3, -119.7, 8)},
+        attrs={'crs': 4326},
+    )
+    out = template.xrs.open_geotiff(path, coregister=True)
+    assert out.shape == template.shape
+    assert np.allclose(out.coords['x'].values, template.coords['x'].values)
+    assert np.allclose(out.coords['y'].values, template.coords['y'].values)
+
+
+def test_coregister_dask_template(tmp_path):
+    path = _file_4326(tmp_path, np.float32, 'cg_dask.tif')
+    template = _template_3857(6).chunk({'y': 3, 'x': 3})
+    out = template.xrs.open_geotiff(path, coregister=True)
+    assert np.allclose(out.coords['x'].values, template.coords['x'].values)
+    assert np.allclose(out.coords['y'].values, template.coords['y'].values)
+
+
+# ---------------------------------------------------------------------------
+# mask_and_scale
+# ---------------------------------------------------------------------------
+
+def test_coregister_forwards_mask_and_scale(tmp_path, monkeypatch):
+    # coregister must read with mask_and_scale=True. Spy on the real
+    # open_geotiff and confirm the kwarg, then delegate.
+    path = _file_4326(tmp_path, np.float32, 'cg_ms.tif')
+    template = _template_3857(6)
+
+    import xrspatial.geotiff as gt
+    real = gt.open_geotiff
+    seen = {}
+
+    def spy(src, **kw):
+        seen['mask_and_scale'] = kw.get('mask_and_scale')
+        return real(src, **kw)
+
+    monkeypatch.setattr(gt, 'open_geotiff', spy)
+    template.xrs.open_geotiff(path, coregister=True)
+    assert seen['mask_and_scale'] is True
+
+
+def test_coregister_masks_nodata_to_nan(tmp_path):
+    # Coregister onto a template that matches the file grid, so the
+    # masked sentinel cells map one-to-one to output NaNs (no resample
+    # blending to hide the hole).
+    height, width = 20, 20
+    arr = np.arange(height * width, dtype=np.int16).reshape(height, width)
+    arr[8:12, 8:12] = -9999
+    y = np.linspace(45.5, 44.5, height)
+    x = np.linspace(-120.5, -119.5, width)
+    da = xr.DataArray(arr, dims=['y', 'x'], coords={'y': y, 'x': x},
+                      attrs={'crs': 4326, 'nodata': -9999})
+    path = str(tmp_path / 'cg_nodata.tif')
+    to_geotiff(da, path, compression='none')
+
+    template = xr.DataArray(
+        np.zeros((height, width), dtype=np.float32),
+        dims=['y', 'x'], coords={'y': y, 'x': x}, attrs={'crs': 4326},
+    )
+    out = template.xrs.open_geotiff(path, coregister=True, resampling='nearest')
+    vals = np.asarray(out.data)
+    assert np.issubdtype(vals.dtype, np.floating)
+    assert np.isnan(vals).any()
+
+
+# ---------------------------------------------------------------------------
+# resampling reuse
+# ---------------------------------------------------------------------------
+
+def test_coregister_categorical_preserves_class_ids(tmp_path):
+    # Integer class raster (no nodata, no scale) -> 'auto' uses nearest,
+    # so coregistered output holds only original class IDs.
+    classes = np.array([10, 20, 30, 40], dtype=np.int16)
+    height, width = 30, 30
+    block = np.tile(classes, (height, width // classes.size + 1))[:, :width]
+    y = np.linspace(45.5, 44.5, height)
+    x = np.linspace(-120.5, -119.5, width)
+    da = xr.DataArray(block.astype(np.int16), dims=['y', 'x'],
+                      coords={'y': y, 'x': x}, attrs={'crs': 4326})
+    path = str(tmp_path / 'cg_classes.tif')
+    to_geotiff(da, path, compression='none')
+
+    out = _template_3857(6).xrs.open_geotiff(path, coregister=True)
+    vals = np.asarray(out.data)
+    finite = vals[np.isfinite(vals)]
+    assert finite.size > 0
+    assert np.isin(finite, classes).all()
+
+
+# ---------------------------------------------------------------------------
+# gpu / vrt guard
+# ---------------------------------------------------------------------------
+
+def test_coregister_gpu_guard(tmp_path):
+    path = _file_4326(tmp_path, np.float32, 'cg_gpu.tif')
+    template = _template_3857(6)
+    with pytest.raises(ValueError, match="not supported with gpu"):
+        template.xrs.open_geotiff(path, coregister=True, gpu=True)
+
+
+def test_coregister_vrt_guard(tmp_path):
+    # The guard fires before any read, so the .vrt need not exist.
+    template = _template_3857(6)
+    with pytest.raises(ValueError, match="not supported with gpu"):
+        template.xrs.open_geotiff('nonexistent.vrt', coregister=True)


### PR DESCRIPTION
`coregister=True` runs mask_and_scale, reproject, and grid matching in a single `open_geotiff` call.

This re-targets work that was already reviewed and merged in #3070 — but #3070's base was set to `issue-3067` instead of `main`, so the commit never made it onto `main`. This branch cherry-picks that commit (`7ced24a8`) onto `main`; it applies with no conflicts and all 11 tests in `test_open_geotiff_coregister.py` pass.

No code changes from #3070.