### PR TITLE
Rename open_geotiff mask_and_scale to unpack and add GPU / dask+GPU support

### DIFF
--- a/docs/source/reference/geotiff.rst
+++ b/docs/source/reference/geotiff.rst
@@ -201,7 +201,8 @@ this section is the brief.
   nodata sentinels raises ``MixedBandMetadataError`` by default. Pass
   ``band_nodata='first'`` to opt back into the legacy flatten-to-band-0
   behaviour; see ``xrspatial/geotiff/tests/vrt/test_metadata.py``.
-* Malformed scale/offset. Under ``mask_and_scale=True`` the read applies
+* Malformed scale/offset. Under ``unpack=True`` (formerly
+  ``mask_and_scale=True``) the read applies
   the source's ``SCALE`` / ``OFFSET`` from ``GDAL_METADATA``. A key that
   is present but does not parse as a float (for example ``SCALE="abc"``)
   raises ``MalformedScaleOffsetError`` (a ``GeoTIFFAmbiguousMetadataError``

--- a/docs/source/user_guide/attrs_contract.rst
+++ b/docs/source/user_guide/attrs_contract.rst
@@ -116,10 +116,11 @@ write.
        #2135.
    * - ``mask_and_scale_dtype``
      - str
-     - Integer source dtype name (e.g. ``"int8"``), set only when a
-       ``mask_and_scale=True`` read promoted an integer array to float.
-       ``to_geotiff(pack=True)`` reads it to reverse the promotion and
-       restore the on-disk dtype. Added in contract v5 (issue #3064).
+     - Integer source dtype name (e.g. ``"int8"``), set only when an
+       ``unpack=True`` (formerly ``mask_and_scale=True``) read promoted an
+       integer array to float. ``to_geotiff(pack=True)`` reads it to reverse
+       the promotion and restore the on-disk dtype. The attr keeps its
+       ``mask_and_scale_dtype`` name. Added in contract v5 (issue #3064).
    * - ``raster_type``
      - str
      - ``'point'`` when the file declares ``RasterPixelIsPoint``;
@@ -384,10 +385,11 @@ round-trip until ``to_geotiff`` learns to emit
 ``ModelTransformationTag`` (issue #2115 follow-up).
 
 Contract v5 (issue #3064) added the ``mask_and_scale_dtype`` attr to
-the canonical tier. The attr records the integer source dtype when a
-``mask_and_scale=True`` read promoted the array to float, so
+the canonical tier. The attr records the integer source dtype when an
+``unpack=True`` read promoted the array to float, so
 ``to_geotiff(pack=True)`` can reverse the scale / offset, fill NaN back
 to the nodata sentinel, and restore the on-disk dtype. The packed file
 keeps its ``SCALE`` / ``OFFSET`` tags, so reopening it with
-``mask_and_scale=True`` unpacks to the same values instead of scaling a
-second time.
+``unpack=True`` unpacks to the same values instead of scaling a
+second time. (The read option was renamed from ``mask_and_scale`` to
+``unpack`` in issue #3071; the attr keeps its name.)

--- a/xrspatial/accessor.py
+++ b/xrspatial/accessor.py
@@ -254,13 +254,13 @@ def _open_geotiff_windowed(obj, source, *, auto_reproject=False,
         is_vrt = str(source).lower().endswith('.vrt')
         if gpu_requested or is_vrt:
             raise ValueError(
-                "coregister=True applies mask_and_scale, which is not "
-                "supported with gpu=True or .vrt sources. Read on CPU, "
-                "or pass coregister=False."
+                "coregister=True runs an unpack-and-reproject read that "
+                "runs on CPU only and is not supported with gpu=True or "
+                ".vrt sources. Read on CPU, or pass coregister=False."
             )
-        # coregister implies a masked-and-scaled read; this overrides an
-        # explicit mask_and_scale=False.
-        kwargs['mask_and_scale'] = True
+        # coregister implies an unpacked (scaled + masked) read; this
+        # overrides an explicit unpack=False.
+        kwargs['unpack'] = True
 
     if 'y' not in obj.coords or 'x' not in obj.coords:
         raise ValueError(
@@ -927,16 +927,16 @@ class XrsSpatialDataArrayAccessor:
             :func:`xrspatial.reproject.reproject` so the returned
             DataArray lines up with ``self``.
         coregister : bool
-            If True, read the file masked and scaled
-            (``mask_and_scale=True``), reproject into ``self``'s CRS, and
+            If True, read the file unpacked (``unpack=True``: scaled and
+            masked), reproject into ``self``'s CRS, and
             resample onto ``self``'s exact grid, so the result shares
             ``self``'s ``y``/``x`` coordinates and shape. The grid snap
-            happens even when the CRS already matches. ``mask_and_scale``
-            is unsupported with ``gpu=True`` or ``.vrt`` sources, so
-            ``coregister=True`` raises ``ValueError`` there, and it
-            overrides an explicit ``mask_and_scale=False``. The resample
-            mode follows ``resampling``. This is the heavier counterpart
-            of ``auto_reproject``, which keeps the file's native
+            happens even when the CRS already matches. The
+            unpack-and-reproject read runs on CPU only, so
+            ``coregister=True`` raises ``ValueError`` with ``gpu=True`` or
+            ``.vrt`` sources, and it overrides an explicit ``unpack=False``.
+            The resample mode follows ``resampling``. This is the heavier
+            counterpart of ``auto_reproject``, which keeps the file's native
             resolution.
         resampling : {'auto', 'nearest', 'bilinear', 'cubic'}
             Resampling mode for the ``auto_reproject`` / ``coregister``
@@ -1456,14 +1456,14 @@ class XrsSpatialDatasetAccessor:
             Data variable used for backend inference and CRS lookup. If
             None, picks the first 2D variable with ``y``/``x`` dims.
         coregister : bool
-            If True, read the file masked and scaled
-            (``mask_and_scale=True``), reproject into the Dataset's CRS,
+            If True, read the file unpacked (``unpack=True``: scaled and
+            masked), reproject into the Dataset's CRS,
             and resample onto the Dataset's exact grid, so the result
             shares the Dataset's ``y``/``x`` coordinates and shape. The
-            grid snap happens even when the CRS already matches.
-            ``mask_and_scale`` is unsupported with ``gpu=True`` or
-            ``.vrt`` sources, so ``coregister=True`` raises ``ValueError``
-            there, and it overrides an explicit ``mask_and_scale=False``.
+            grid snap happens even when the CRS already matches. The
+            unpack-and-reproject read runs on CPU only, so
+            ``coregister=True`` raises ``ValueError`` with ``gpu=True`` or
+            ``.vrt`` sources, and it overrides an explicit ``unpack=False``.
             The resample mode follows ``resampling``.
         resampling : {'auto', 'nearest', 'bilinear', 'cubic'}
             Resampling mode for the ``auto_reproject`` / ``coregister``

--- a/xrspatial/geotiff/__init__.py
+++ b/xrspatial/geotiff/__init__.py
@@ -509,7 +509,8 @@ def open_geotiff(source: str | BinaryIO, *,
                  masked: bool = False,
                  mask_nodata: bool = _MASK_NODATA_DEPRECATED_SENTINEL,  # type: ignore[assignment]
                  unpack: bool = False,
-                 mask_and_scale: bool = _MASK_AND_SCALE_DEPRECATED_SENTINEL,  # type: ignore[assignment]
+                 mask_and_scale: bool = (
+                     _MASK_AND_SCALE_DEPRECATED_SENTINEL),  # type: ignore[assignment]
                  parse_coordinates: bool = True,
                  lock: object | None = None,
                  cache: bool = True,

--- a/xrspatial/geotiff/__init__.py
+++ b/xrspatial/geotiff/__init__.py
@@ -76,6 +76,7 @@ from ._geotags import RASTER_PIXEL_IS_AREA, RASTER_PIXEL_IS_POINT, GeoTransform 
 from ._reader import _MAX_CLOUD_BYTES_SENTINEL, CloudSizeLimitError, UnsafeURLError
 from ._reader import read_to_array as _read_to_array
 from ._runtime import (_CRS_WKT_DEPRECATED_SENTINEL, _GPU_DEPRECATED_SENTINEL,  # noqa: F401
+                       _MASK_AND_SCALE_DEPRECATED_SENTINEL,
                        _MASK_NODATA_DEPRECATED_SENTINEL, _MISSING_SOURCES_SENTINEL,
                        _NAME_DEPRECATED_SENTINEL, _ON_GPU_FAILURE_SENTINEL, GeoTIFFFallbackWarning,
                        _geotiff_strict_mode, _gpu_fallback_warning_message)
@@ -507,7 +508,8 @@ def open_geotiff(source: str | BinaryIO, *,
                  band_nodata: str | None = None,
                  masked: bool = False,
                  mask_nodata: bool = _MASK_NODATA_DEPRECATED_SENTINEL,  # type: ignore[assignment]
-                 mask_and_scale: bool = False,
+                 unpack: bool = False,
+                 mask_and_scale: bool = _MASK_AND_SCALE_DEPRECATED_SENTINEL,  # type: ignore[assignment]
                  parse_coordinates: bool = True,
                  lock: object | None = None,
                  cache: bool = True,
@@ -544,11 +546,12 @@ def open_geotiff(source: str | BinaryIO, *,
     ``masked`` is still only stable when combined with a
     ``[stable]`` source, codec, and options).
 
-    The read/masking parameters are named to match rioxarray's
-    ``open_rasterio`` (``masked``, ``default_name``, ``mask_and_scale``,
-    ``parse_coordinates``, ``lock``, ``cache``) so callers can move between
-    the two with minimal edits. ``masked`` defaults to ``False`` (no
-    sentinel-to-NaN promotion), matching ``open_rasterio``.
+    The read/masking parameters mostly match rioxarray's
+    ``open_rasterio`` (``masked``, ``default_name``, ``parse_coordinates``,
+    ``lock``, ``cache``) so callers can move between the two with minimal
+    edits. ``masked`` defaults to ``False`` (no sentinel-to-NaN promotion),
+    matching ``open_rasterio``. The scale/offset option is named ``unpack``
+    here; rioxarray's ``mask_and_scale`` is kept as a deprecated alias.
 
     Automatically dispatches to the best backend:
     - ``gpu=True``: GPU-accelerated read via nvCOMP (returns CuPy)
@@ -698,26 +701,32 @@ def open_geotiff(source: str | BinaryIO, *,
         ``DeprecationWarning``. Passing both ``masked`` and ``mask_nodata``
         raises ``TypeError``. Note the default also changed from
         ``mask_nodata=True`` to ``masked=False``.
-    mask_and_scale : bool, default False
+    unpack : bool, default False
         [advanced] If True, read the source's GDAL ``SCALE`` / ``OFFSET``
         metadata and return ``data * scale + offset``, masking the nodata
-        sentinel to NaN as well (matching rioxarray's ``open_rasterio``).
+        sentinel to NaN as well. This unpacks CF-packed data (integers
+        stored with a scale / offset that recover floats) and is the
+        inverse of the writer's ``pack`` option.
         The applied values are recorded on ``attrs['scale_factor']`` /
         ``attrs['add_offset']``. A source without scale / offset metadata
         is a no-op. A dataset-level scale / offset, or per-band values that
         agree across bands, applies to the whole array. A source whose
         per-band scale / offset differ raises ``MixedBandMetadataError``
         unless ``band=`` selects a single band, in which case that band's
-        scale / offset is applied. Supported on the CPU eager and dask
-        paths; combining it with ``gpu=True`` or a ``.vrt`` source raises
-        ``ValueError``.
+        scale / offset is applied. Supported on the CPU eager, dask, GPU
+        (``gpu=True``), and dask+GPU (``gpu=True, chunks=``) paths;
+        combining it with a ``.vrt`` source raises ``ValueError``.
         Round-trip caveat: the source's ``SCALE`` / ``OFFSET`` tags stay on
         ``attrs['gdal_metadata']`` / ``attrs['gdal_metadata_xml']`` after the
-        read, so writing a ``mask_and_scale=True`` result back out with
+        read, so writing an ``unpack=True`` result back out with
         ``to_geotiff`` re-embeds them, and reading that file again with
-        ``mask_and_scale=True`` applies the scale a second time. Drop those
+        ``unpack=True`` applies the scale a second time. Drop those
         tags (and ``attrs['scale_factor']`` / ``attrs['add_offset']``) before
         writing if you need a clean round-trip.
+    mask_and_scale : bool
+        [deprecated] Deprecated alias of ``unpack``; emits a
+        ``DeprecationWarning``. Named after rioxarray's ``open_rasterio``.
+        Passing both ``unpack`` and ``mask_and_scale`` raises ``TypeError``.
     parse_coordinates : bool, default True
         [stable] If True (the default), build ``x`` / ``y`` coordinate
         arrays from the transform. If False, skip them and return a
@@ -911,6 +920,23 @@ def open_geotiff(source: str | BinaryIO, *,
             "instead to match rioxarray's open_rasterio.",
             DeprecationWarning, stacklevel=2)
         default_name = name
+    if mask_and_scale is not _MASK_AND_SCALE_DEPRECATED_SENTINEL:
+        # ``unpack`` is the canonical name; ``mask_and_scale`` is the
+        # deprecated rioxarray-compatible alias. ``unpack`` carries a real
+        # default of False, so an explicit ``unpack=False`` cannot be told
+        # apart from the default; that one combination resolves to the
+        # ``mask_and_scale`` value, matching the ``masked`` / ``mask_nodata``
+        # stance above.
+        if unpack is not False:
+            raise TypeError(
+                "open_geotiff: pass either 'unpack' or the deprecated "
+                "'mask_and_scale' alias, not both.")
+        warnings.warn(
+            "open_geotiff(..., mask_and_scale=...) is deprecated; use "
+            "unpack=... instead. The behaviour is unchanged: it applies the "
+            "source's GDAL SCALE / OFFSET and masks the nodata sentinel.",
+            DeprecationWarning, stacklevel=2)
+        unpack = mask_and_scale
 
     # ``lock`` / ``cache`` are accepted for open_rasterio signature
     # compatibility. xrspatial's dask reader re-opens the source per window,
@@ -925,29 +951,32 @@ def open_geotiff(source: str | BinaryIO, *,
             "GDAL handle to lock and no caching layer to toggle.",
             GeoTIFFFallbackWarning, stacklevel=2)
 
-    # ``mask_and_scale`` and ``parse_coordinates=False`` are implemented on
-    # the CPU eager and dask paths only. The GPU and VRT-mosaic paths build
-    # their DataArrays through separate code that is not covered by the
-    # cross-backend parity suite for these options, so refuse the
-    # combination up front rather than silently ignoring the kwarg -- the
-    # same per-backend rejection contract the dispatcher already applies to
-    # on_gpu_failure / missing_sources / max_cloud_bytes.
+    # ``unpack`` and ``parse_coordinates=False`` build their DataArrays
+    # through code the cross-backend parity suite does not cover on every
+    # backend, so refuse the unsupported combinations up front rather than
+    # silently ignoring the kwarg -- the same per-backend rejection contract
+    # the dispatcher already applies to on_gpu_failure / missing_sources /
+    # max_cloud_bytes. ``unpack`` now runs on the GPU and dask+GPU paths
+    # (issue #3071), so it only rejects ``.vrt`` sources. ``parse_coordinates``
+    # is still CPU/dask-only, so it rejects both gpu=True and ``.vrt``.
     _is_vrt_source = (
         isinstance(source, str) and source.lower().endswith('.vrt'))
-    if mask_and_scale or not parse_coordinates:
-        offending = (
-            'mask_and_scale=True' if mask_and_scale
-            else 'parse_coordinates=False')
+    if not parse_coordinates:
         if gpu:
             raise ValueError(
-                f"{offending} is not supported with gpu=True; it is "
-                "implemented on the CPU eager and dask paths. Drop gpu=True "
-                "or the kwarg.")
+                "parse_coordinates=False is not supported with gpu=True; it "
+                "is implemented on the CPU eager and dask paths. Drop "
+                "gpu=True or the kwarg.")
         if _is_vrt_source:
             raise ValueError(
-                f"{offending} is not supported for .vrt sources; it is "
-                "implemented on the CPU eager and dask paths over .tif "
+                "parse_coordinates=False is not supported for .vrt sources; "
+                "it is implemented on the CPU eager and dask paths over .tif "
                 "sources. Drop the kwarg.")
+    if unpack and _is_vrt_source:
+        raise ValueError(
+            "unpack=True is not supported for .vrt sources; it is "
+            "implemented on the CPU, dask, GPU, and dask+GPU paths over .tif "
+            "sources. Drop the kwarg.")
 
     # All dispatcher-level kwarg rejection lives in
     # ``_validate_dispatch_kwargs`` so the three direct backends
@@ -972,7 +1001,7 @@ def open_geotiff(source: str | BinaryIO, *,
 
     missing_sources_passed = (
         missing_sources is not _MISSING_SOURCES_SENTINEL)
-    # ``_is_vrt_source`` was resolved above for the mask_and_scale /
+    # ``_is_vrt_source`` was resolved above for the unpack /
     # parse_coordinates gate.
 
     # Gate ``stable_only=True`` BEFORE resolving ``bbox=``. The bbox
@@ -1100,6 +1129,7 @@ def open_geotiff(source: str | BinaryIO, *,
                                  allow_internal_only_jpeg=(
                                     allow_internal_only_jpeg),
                                  mask_nodata=masked,
+                                 mask_and_scale=unpack,
                                  **gpu_kwargs)
 
     # Dask path (CPU)
@@ -1117,7 +1147,7 @@ def open_geotiff(source: str | BinaryIO, *,
                                   allow_internal_only_jpeg=(
                                      allow_internal_only_jpeg),
                                   mask_nodata=masked,
-                                  mask_and_scale=mask_and_scale,
+                                  mask_and_scale=unpack,
                                   parse_coordinates=parse_coordinates)
 
     kwargs = {}
@@ -1170,7 +1200,7 @@ def open_geotiff(source: str | BinaryIO, *,
         name=default_name,
         allow_rotated=allow_rotated,
         allow_unparseable_crs=allow_unparseable_crs,
-        mask_and_scale=mask_and_scale,
+        mask_and_scale=unpack,
         parse_coordinates=parse_coordinates,
         band=band,
     )

--- a/xrspatial/geotiff/__init__.py
+++ b/xrspatial/geotiff/__init__.py
@@ -717,6 +717,11 @@ def open_geotiff(source: str | BinaryIO, *,
         scale / offset is applied. Supported on the CPU eager, dask, GPU
         (``gpu=True``), and dask+GPU (``gpu=True, chunks=``) paths;
         combining it with a ``.vrt`` source raises ``ValueError``.
+        On the dask+GPU path, ``unpack=True`` reads through the
+        CPU-decode-then-upload route rather than the direct disk->GPU GDS
+        fast path (the GDS path has no scale step), so a local tiled COG
+        that would otherwise stream straight to the device decodes on CPU
+        first.
         Round-trip caveat: the source's ``SCALE`` / ``OFFSET`` tags stay on
         ``attrs['gdal_metadata']`` / ``attrs['gdal_metadata_xml']`` after the
         read, so writing an ``unpack=True`` result back out with

--- a/xrspatial/geotiff/_backends/gpu.py
+++ b/xrspatial/geotiff/_backends/gpu.py
@@ -73,6 +73,7 @@ def _read_geotiff_gpu(source: str, *,
                       allow_internal_only_jpeg: bool = False,
                       band_nodata: str | None = None,
                       mask_nodata: bool = False,
+                      mask_and_scale: bool = False,
                       gpu: str = _GPU_DEPRECATED_SENTINEL,
                       ) -> xr.DataArray:
     """Read a GeoTIFF with GPU-accelerated decompression via Numba CUDA.
@@ -189,6 +190,14 @@ def _read_geotiff_gpu(source: str, *,
         ``_read_geotiff_gpu(path)`` keeps the source dtype and the raw
         sentinel. Pass ``mask_nodata=True`` to restore the
         promote-to-NaN behaviour.
+    mask_and_scale : bool, default False
+        [experimental] If True, apply the source's GDAL ``SCALE`` /
+        ``OFFSET`` (``data * scale + offset``) and mask the nodata
+        sentinel to NaN, matching the CPU / dask paths. This is the
+        internal name for ``open_geotiff``'s ``unpack`` option. The
+        scale/offset arithmetic runs on the CuPy buffer via numpy
+        duck-typing in the shared eager finalizer; the dask+GPU path
+        applies it through the CPU dask graph before the device upload.
     allow_rotated : bool, default False
         [experimental] Read-side opt-in for rotated / sheared
         ``ModelTransformationTag`` files. Forwarded through both GPU
@@ -362,6 +371,7 @@ def _read_geotiff_gpu(source: str, *,
             allow_experimental_codecs=allow_experimental_codecs,
             allow_internal_only_jpeg=allow_internal_only_jpeg,
             mask_nodata=mask_nodata,
+            mask_and_scale=mask_and_scale,
         )
 
     from .._compression import COMPRESSION_LERC
@@ -414,6 +424,7 @@ def _read_geotiff_gpu(source: str, *,
             allow_experimental_codecs=allow_experimental_codecs,
             allow_internal_only_jpeg=allow_internal_only_jpeg,
             mask_nodata=mask_nodata,
+            mask_and_scale=mask_and_scale,
         )
 
     # Parse metadata on CPU (fast, <1ms)
@@ -644,6 +655,8 @@ def _read_geotiff_gpu(source: str, *,
                 name=name,
                 allow_rotated=allow_rotated,
                 allow_unparseable_crs=allow_unparseable_crs,
+                mask_and_scale=mask_and_scale,
+                band=band,
             )
             # ``chunks`` was previously honoured only on the tiled path,
             # so stripped TIFFs returned an unchunked DataArray even when
@@ -1046,6 +1059,8 @@ def _read_geotiff_gpu(source: str, *,
             name=name,
             allow_rotated=allow_rotated,
             allow_unparseable_crs=allow_unparseable_crs,
+            mask_and_scale=mask_and_scale,
+            band=band,
         )
 
         # ``chunks=`` is handled at function entry via
@@ -1073,7 +1088,8 @@ def _read_geotiff_gpu_eager_via_cpu(source, *, dtype, window, overview_level,
                                     allow_invalid_nodata: bool = False,
                                     allow_experimental_codecs: bool = False,
                                     allow_internal_only_jpeg: bool = False,
-                                    mask_nodata: bool = True):
+                                    mask_nodata: bool = True,
+                                    mask_and_scale: bool = False):
     """Eager CPU decode + GPU upload for HTTP / fsspec sources.
 
     Reached via ``open_geotiff(url, gpu=True)`` and the direct
@@ -1155,6 +1171,8 @@ def _read_geotiff_gpu_eager_via_cpu(source, *, dtype, window, overview_level,
         name=name,
         allow_rotated=allow_rotated,
         allow_unparseable_crs=allow_unparseable_crs,
+        mask_and_scale=mask_and_scale,
+        band=band,
     )
 
 
@@ -1304,7 +1322,8 @@ def _read_geotiff_gpu_chunked(source, *, dtype, chunks, overview_level,
                               allow_invalid_nodata: bool = False,
                               allow_experimental_codecs: bool = False,
                               allow_internal_only_jpeg: bool = False,
-                              mask_nodata: bool = True):
+                              mask_nodata: bool = True,
+                              mask_and_scale: bool = False):
     """Lazy Dask+CuPy backend for ``_read_geotiff_gpu(chunks=...)``.
 
     Two paths produce the same shape of dask graph:
@@ -1403,8 +1422,13 @@ def _read_geotiff_gpu_chunked(source, *, dtype, chunks, overview_level,
                 ifd.tile_byte_counts is not None
                 and any(bc == 0 for bc in ifd.tile_byte_counts)
             )
-            if _gds_chunk_path_available(
-                    src_path, ifd, has_sparse_tile, orientation):
+            # ``mask_and_scale`` disqualifies the disk->GPU GDS fast path:
+            # it decodes straight to the device and has no scale/offset
+            # step. The CPU-decode fallback below applies the scale lazily
+            # through ``_read_geotiff_dask`` (as float) before the per-block
+            # device upload, so an unpack request takes that route instead.
+            if (not mask_and_scale and _gds_chunk_path_available(
+                    src_path, ifd, has_sparse_tile, orientation)):
                 return _read_geotiff_gpu_chunked_gds(
                     src_path, ifd, geo_info, header,
                     dtype=dtype, chunks=chunks, window=window, band=band,
@@ -1430,6 +1454,7 @@ def _read_geotiff_gpu_chunked(source, *, dtype, chunks, overview_level,
         allow_experimental_codecs=allow_experimental_codecs,
         allow_internal_only_jpeg=allow_internal_only_jpeg,
         mask_nodata=mask_nodata,
+        mask_and_scale=mask_and_scale,
     )
 
     cpu_dask_arr = cpu_da.data

--- a/xrspatial/geotiff/_backends/gpu.py
+++ b/xrspatial/geotiff/_backends/gpu.py
@@ -1487,6 +1487,12 @@ def _read_geotiff_gpu_chunked_gds(source, ifd, geo_info, header, *,
     ``_gds_chunk_path_available``. Each chunk task pulls only the tile
     subset overlapping its window via KvikIO GDS (or an mmap fallback
     inside ``gpu_decode_tiles_from_file``) and crops on device.
+
+    This path is unpack-free: it decodes straight to the device with no
+    SCALE/OFFSET step, so ``_read_geotiff_gpu_chunked`` disqualifies it
+    when ``mask_and_scale=True`` and routes that read through the
+    CPU-decode fallback instead. A future direct caller that needs unpack
+    must take the same fallback rather than calling this helper.
     """
     import cupy
     import dask

--- a/xrspatial/geotiff/_runtime.py
+++ b/xrspatial/geotiff/_runtime.py
@@ -56,6 +56,10 @@ _VRT_PATH_MISSING_SENTINEL = object()
 # as ``_GPU_DEPRECATED_SENTINEL`` above.
 _MASK_NODATA_DEPRECATED_SENTINEL = object()
 _NAME_DEPRECATED_SENTINEL = object()
+# ``mask_and_scale`` was renamed to ``unpack`` (the operation unpacks
+# CF-packed integers via SCALE/OFFSET). Same sentinel deprecation as the
+# pair above: the old name still works but warns, and passing both raises.
+_MASK_AND_SCALE_DEPRECATED_SENTINEL = object()
 
 
 # Spatial dim names recognised on 3D writer inputs. ``y``/``x`` are the

--- a/xrspatial/geotiff/tests/read/test_mask_and_scale_dtype_parity_3066.py
+++ b/xrspatial/geotiff/tests/read/test_mask_and_scale_dtype_parity_3066.py
@@ -1,7 +1,7 @@
 """Eager/dask dtype parity for ``mask_and_scale`` reads (#3066).
 
 The dask reader used to promote any integer source to float64 for
-``mask_and_scale=True`` regardless of whether a scale/offset or a fittable
+``unpack=True`` regardless of whether a scale/offset or a fittable
 nodata sentinel was present, while the eager reader kept the integer dtype
 when there was nothing to transform. These tests pin the two paths to the
 same dtype (and values) across the relevant cases.
@@ -54,8 +54,8 @@ def test_eager_dask_dtype_parity(tmp_path, label, nodata, scale, offset,
         tmp_path / f"src_{label}_3066.tif", _DATA,
         nodata=nodata, scale=scale, offset=offset)
 
-    eager = open_geotiff(path, mask_and_scale=True)
-    lazy = open_geotiff(path, mask_and_scale=True, chunks=2)
+    eager = open_geotiff(path, unpack=True)
+    lazy = open_geotiff(path, unpack=True, chunks=2)
 
     assert str(eager.dtype) == expected_dtype
     assert str(lazy.dtype) == expected_dtype

--- a/xrspatial/geotiff/tests/read/test_rioxarray_compat_2961.py
+++ b/xrspatial/geotiff/tests/read/test_rioxarray_compat_2961.py
@@ -418,6 +418,26 @@ def test_unpack_dask_gpu_matches_cpu(tmp_path):
     assert dgpu.attrs.get("scale_factor") == 2.0
 
 
+@requires_gpu
+def test_unpack_gpu_no_metadata_is_noop(tmp_path):
+    """GPU ``unpack`` on a source without SCALE/OFFSET masks but does not
+    scale, matching the CPU no-op contract."""
+    path = _int_sentinel_tiff(str(tmp_path / "t3071_unpack_gpu_noop.tif"))
+    gpu = open_geotiff(path, unpack=True, gpu=True)
+    host = gpu.data.get()
+    assert host[0, 0] == 1.0
+    assert np.isnan(host[0, 2])
+    assert "scale_factor" not in gpu.attrs
+
+
+@requires_gpu
+def test_unpack_gpu_int_dtype_raises(tmp_path):
+    """A ``dtype=<integer>`` cast under GPU ``unpack`` raises, like CPU."""
+    path = _scale_offset_tiff(str(tmp_path / "t3071_unpack_gpu_int.tif"))
+    with pytest.raises(ValueError):
+        open_geotiff(path, unpack=True, gpu=True, dtype="uint8")
+
+
 def test_parse_coordinates_false_gpu_rejected(tmp_path):
     path = _int_sentinel_tiff(str(tmp_path / "t2961_gate_gpu_pc.tif"))
     with pytest.raises(ValueError, match="parse_coordinates=False.*gpu=True"):

--- a/xrspatial/geotiff/tests/read/test_rioxarray_compat_2961.py
+++ b/xrspatial/geotiff/tests/read/test_rioxarray_compat_2961.py
@@ -5,10 +5,11 @@ Covers the renamed parameters and the masking-off default flip:
 * ``masked`` (canonical) <- ``mask_nodata`` (deprecated alias), default
   flipped from True to False to match rioxarray.
 * ``default_name`` (canonical) <- ``name`` (deprecated alias).
-* ``mask_and_scale`` (new): apply GDAL SCALE/OFFSET + mask.
+* ``unpack`` (canonical) <- ``mask_and_scale`` (deprecated alias): apply
+  GDAL SCALE/OFFSET + mask. Runs on CPU, dask, GPU, and dask+GPU (#3071).
 * ``parse_coordinates`` (new): skip x/y coords.
 * ``lock`` / ``cache`` (new, accept-and-warn shims).
-* GPU / VRT gating for ``mask_and_scale`` / ``parse_coordinates=False``.
+* VRT gating for ``unpack``; GPU / VRT gating for ``parse_coordinates=False``.
 """
 import numpy as np
 import pytest
@@ -182,12 +183,36 @@ def test_default_name_and_name_both_raises(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# mask_and_scale
+# unpack (renamed from mask_and_scale)
 # ---------------------------------------------------------------------------
+
+def test_mask_and_scale_alias_warns_and_matches(tmp_path):
+    """The deprecated ``mask_and_scale`` alias warns and matches ``unpack``."""
+    path = _scale_offset_tiff(str(tmp_path / "t3071_ms_alias.tif"))
+    with pytest.warns(DeprecationWarning, match="mask_and_scale.*deprecated"):
+        legacy = open_geotiff(path, mask_and_scale=True)
+    canonical = open_geotiff(path, unpack=True)
+    np.testing.assert_array_equal(legacy.data, canonical.data)
+    assert legacy.attrs.get("scale_factor") == canonical.attrs.get(
+        "scale_factor") == 2.0
+
+
+def test_unpack_and_mask_and_scale_both_raises(tmp_path):
+    path = _scale_offset_tiff(str(tmp_path / "t3071_ms_both.tif"))
+    with pytest.raises(TypeError, match="either 'unpack' or"):
+        open_geotiff(path, unpack=True, mask_and_scale=True)
+
+
+def test_unpack_false_emits_no_warning(tmp_path, recwarn):
+    path = _scale_offset_tiff(str(tmp_path / "t3071_ms_nowarn.tif"))
+    open_geotiff(path, unpack=False)
+    assert not [w for w in recwarn.list
+                if issubclass(w.category, DeprecationWarning)]
+
 
 def test_mask_and_scale_eager(tmp_path):
     path = _scale_offset_tiff(str(tmp_path / "t2961_ms_eager.tif"))
-    out = open_geotiff(path, mask_and_scale=True)
+    out = open_geotiff(path, unpack=True)
     assert out.dtype.kind == "f"
     # data * 2 + 10, sentinel pixel -> NaN
     expected = np.array([[12.0, 14.0, 16.0], [18.0, 20.0, np.nan]])
@@ -198,8 +223,8 @@ def test_mask_and_scale_eager(tmp_path):
 
 def test_mask_and_scale_dask_matches_eager(tmp_path):
     path = _scale_offset_tiff(str(tmp_path / "t2961_ms_dask.tif"))
-    eager = open_geotiff(path, mask_and_scale=True)
-    lazy = open_geotiff(path, mask_and_scale=True, chunks=2)
+    eager = open_geotiff(path, unpack=True)
+    lazy = open_geotiff(path, unpack=True, chunks=2)
     np.testing.assert_array_equal(eager.data, lazy.compute().data)
     assert lazy.attrs.get("scale_factor") == 2.0
 
@@ -207,7 +232,7 @@ def test_mask_and_scale_dask_matches_eager(tmp_path):
 def test_mask_and_scale_no_metadata_is_noop(tmp_path):
     """A source with no SCALE/OFFSET keeps raw values (scale 1, offset 0)."""
     path = _int_sentinel_tiff(str(tmp_path / "t2961_ms_noop.tif"))
-    out = open_geotiff(path, mask_and_scale=True)
+    out = open_geotiff(path, unpack=True)
     # sentinel still masked, but values otherwise unscaled
     assert out.data[0, 0] == 1.0
     assert np.isnan(out.data[0, 2])
@@ -217,7 +242,7 @@ def test_mask_and_scale_no_metadata_is_noop(tmp_path):
 def test_mask_and_scale_int_dtype_raises(tmp_path):
     path = _scale_offset_tiff(str(tmp_path / "t2961_ms_int.tif"))
     with pytest.raises(ValueError):
-        open_geotiff(path, mask_and_scale=True, dtype="uint8")
+        open_geotiff(path, unpack=True, dtype="uint8")
 
 
 # ---------------------------------------------------------------------------
@@ -244,20 +269,20 @@ def test_mask_and_scale_malformed_scale_raises(tmp_path):
     """A present-but-unparseable SCALE fails closed under mask_and_scale."""
     path = _malformed_scale_tiff(str(tmp_path / "t2987_bad_scale.tif"))
     with pytest.raises(MalformedScaleOffsetError, match="SCALE"):
-        open_geotiff(path, mask_and_scale=True)
+        open_geotiff(path, unpack=True)
 
 
 def test_mask_and_scale_malformed_offset_raises(tmp_path):
     path = _malformed_scale_tiff(
         str(tmp_path / "t2987_bad_offset.tif"), scale="1", offset="xyz")
     with pytest.raises(MalformedScaleOffsetError, match="OFFSET"):
-        open_geotiff(path, mask_and_scale=True)
+        open_geotiff(path, unpack=True)
 
 
 def test_mask_and_scale_malformed_scale_dask_raises(tmp_path):
     path = _malformed_scale_tiff(str(tmp_path / "t2987_bad_scale_dask.tif"))
     with pytest.raises(MalformedScaleOffsetError, match="SCALE"):
-        open_geotiff(path, mask_and_scale=True, chunks=2)
+        open_geotiff(path, unpack=True, chunks=2)
 
 
 def test_malformed_scale_ignored_without_mask_and_scale(tmp_path):
@@ -300,13 +325,13 @@ def test_mask_and_scale_malformed_xml_raises(tmp_path):
     """Malformed GDAL_METADATA XML fails closed under mask_and_scale."""
     path = _malformed_xml_tiff(str(tmp_path / "t2998_bad_xml.tif"))
     with pytest.raises(MalformedScaleOffsetError, match="XML"):
-        open_geotiff(path, mask_and_scale=True)
+        open_geotiff(path, unpack=True)
 
 
 def test_mask_and_scale_malformed_xml_dask_raises(tmp_path):
     path = _malformed_xml_tiff(str(tmp_path / "t2998_bad_xml_dask.tif"))
     with pytest.raises(MalformedScaleOffsetError, match="XML"):
-        open_geotiff(path, mask_and_scale=True, chunks=2)
+        open_geotiff(path, unpack=True, chunks=2)
 
 
 def test_malformed_xml_ignored_without_mask_and_scale(tmp_path):
@@ -369,13 +394,28 @@ def test_default_lock_cache_no_warning(tmp_path, recwarn):
 
 
 # ---------------------------------------------------------------------------
-# GPU / VRT gating for the new behavioral options
+# unpack GPU / dask+GPU support (#3071) and remaining gating
 # ---------------------------------------------------------------------------
 
-def test_mask_and_scale_gpu_rejected(tmp_path):
-    path = _scale_offset_tiff(str(tmp_path / "t2961_gate_gpu.tif"))
-    with pytest.raises(ValueError, match="mask_and_scale.*gpu=True"):
-        open_geotiff(path, mask_and_scale=True, gpu=True)
+@requires_gpu
+def test_unpack_gpu_matches_cpu(tmp_path):
+    """``unpack=True`` on the GPU eager path matches the CPU eager read."""
+    path = _scale_offset_tiff(str(tmp_path / "t3071_unpack_gpu.tif"))
+    cpu = open_geotiff(path, unpack=True)
+    gpu = open_geotiff(path, unpack=True, gpu=True)
+    np.testing.assert_array_equal(cpu.data, gpu.data.get())
+    assert gpu.attrs.get("scale_factor") == 2.0
+    assert gpu.attrs.get("add_offset") == 10.0
+
+
+@requires_gpu
+def test_unpack_dask_gpu_matches_cpu(tmp_path):
+    """``unpack=True`` on the dask+GPU path matches the CPU eager read."""
+    path = _scale_offset_tiff(str(tmp_path / "t3071_unpack_dask_gpu.tif"))
+    cpu = open_geotiff(path, unpack=True)
+    dgpu = open_geotiff(path, unpack=True, gpu=True, chunks=2)
+    np.testing.assert_array_equal(cpu.data, dgpu.compute().data.get())
+    assert dgpu.attrs.get("scale_factor") == 2.0
 
 
 def test_parse_coordinates_false_gpu_rejected(tmp_path):
@@ -384,11 +424,11 @@ def test_parse_coordinates_false_gpu_rejected(tmp_path):
         open_geotiff(path, parse_coordinates=False, gpu=True)
 
 
-def test_mask_and_scale_vrt_rejected(tmp_path):
+def test_unpack_vrt_rejected(tmp_path):
     src = _int_sentinel_tiff(str(tmp_path / "t2961_gate_vrt_src.tif"))
     vrt = _build_vrt(str(tmp_path / "t2961_gate.vrt"), source_files=[src])
-    with pytest.raises(ValueError, match="mask_and_scale.*.vrt"):
-        open_geotiff(vrt, mask_and_scale=True)
+    with pytest.raises(ValueError, match="unpack.*.vrt"):
+        open_geotiff(vrt, unpack=True)
 
 
 def test_parse_coordinates_false_vrt_rejected(tmp_path):
@@ -436,7 +476,7 @@ def test_mask_and_scale_mixed_per_band_eager_raises(tmp_path):
         str(tmp_path / "t2988_mixed_eager.tif"),
         scales=[2.0, 4.0, 8.0], offsets=[0.0, 0.0, 0.0])
     with pytest.raises(MixedBandMetadataError, match="per-band SCALE"):
-        open_geotiff(path, mask_and_scale=True)
+        open_geotiff(path, unpack=True)
 
 
 def test_mask_and_scale_mixed_per_band_offset_raises(tmp_path):
@@ -445,7 +485,7 @@ def test_mask_and_scale_mixed_per_band_offset_raises(tmp_path):
         str(tmp_path / "t2988_mixed_offset.tif"),
         scales=[2.0, 2.0, 2.0], offsets=[1.0, 5.0, 9.0])
     with pytest.raises(MixedBandMetadataError, match="per-band OFFSET"):
-        open_geotiff(path, mask_and_scale=True)
+        open_geotiff(path, unpack=True)
 
 
 def test_mask_and_scale_mixed_per_band_dask_raises(tmp_path):
@@ -454,7 +494,7 @@ def test_mask_and_scale_mixed_per_band_dask_raises(tmp_path):
         str(tmp_path / "t2988_mixed_dask.tif"),
         scales=[2.0, 4.0, 8.0], offsets=[0.0, 0.0, 0.0])
     with pytest.raises(MixedBandMetadataError, match="per-band SCALE"):
-        open_geotiff(path, mask_and_scale=True, chunks=2)
+        open_geotiff(path, unpack=True, chunks=2)
 
 
 def test_mask_and_scale_band_selects_own_scale(tmp_path):
@@ -463,7 +503,7 @@ def test_mask_and_scale_band_selects_own_scale(tmp_path):
         str(tmp_path / "t2988_band_sel.tif"),
         scales=[2.0, 4.0, 8.0], offsets=[1.0, 5.0, 9.0])
     # band 1: raw value 2, scale 4, offset 5 -> 2 * 4 + 5 = 13.
-    out = open_geotiff(path, mask_and_scale=True, band=1)
+    out = open_geotiff(path, unpack=True, band=1)
     assert out.attrs.get("scale_factor") == 4.0
     assert out.attrs.get("add_offset") == 5.0
     np.testing.assert_array_equal(out.data, np.full((3, 4), 13.0))
@@ -474,8 +514,8 @@ def test_mask_and_scale_band_select_dask_matches_eager(tmp_path):
     path = _per_band_scale_tiff(
         str(tmp_path / "t2988_band_dask.tif"),
         scales=[2.0, 4.0, 8.0], offsets=[1.0, 5.0, 9.0])
-    eager = open_geotiff(path, mask_and_scale=True, band=2)
-    lazy = open_geotiff(path, mask_and_scale=True, band=2, chunks=2)
+    eager = open_geotiff(path, unpack=True, band=2)
+    lazy = open_geotiff(path, unpack=True, band=2, chunks=2)
     np.testing.assert_array_equal(eager.data, lazy.compute().data)
     assert lazy.attrs.get("scale_factor") == 8.0
 
@@ -485,7 +525,7 @@ def test_mask_and_scale_uniform_per_band_applies(tmp_path):
     path = _per_band_scale_tiff(
         str(tmp_path / "t2988_uniform.tif"),
         scales=[3.0, 3.0, 3.0], offsets=[2.0, 2.0, 2.0])
-    out = open_geotiff(path, mask_and_scale=True)
+    out = open_geotiff(path, unpack=True)
     assert out.attrs.get("scale_factor") == 3.0
     assert out.attrs.get("add_offset") == 2.0
     # band b raw value (b + 1) * 3 + 2.

--- a/xrspatial/geotiff/tests/unit/test_signatures.py
+++ b/xrspatial/geotiff/tests/unit/test_signatures.py
@@ -435,9 +435,12 @@ _CANONICAL_ORDER = (
     # immediately before its deprecated ``mask_nodata`` alias.
     "masked",
     "mask_nodata",
-    # rioxarray-compatible read options. ``mask_and_scale`` /
-    # ``parse_coordinates`` are also threaded into ``read_geotiff_dask``;
-    # ``lock`` / ``cache`` are open_geotiff-only accept-and-warn shims.
+    # rioxarray-compatible read options. ``unpack`` (canonical) and its
+    # deprecated ``mask_and_scale`` alias, plus ``parse_coordinates``, are
+    # threaded into ``read_geotiff_dask``; ``unpack`` also reaches the GPU /
+    # dask+GPU backends (#3071). ``lock`` / ``cache`` are open_geotiff-only
+    # accept-and-warn shims.
+    "unpack",
     "mask_and_scale",
     "parse_coordinates",
     "lock",

--- a/xrspatial/geotiff/tests/write/test_pack_3064.py
+++ b/xrspatial/geotiff/tests/write/test_pack_3064.py
@@ -1,6 +1,6 @@
-"""``to_geotiff(pack=True)`` -- the inverse of ``mask_and_scale=True`` (#3064).
+"""``to_geotiff(pack=True)`` -- the inverse of ``unpack=True`` (#3064).
 
-A ``mask_and_scale=True`` read promotes an integer raster to float64,
+A ``unpack=True`` read promotes an integer raster to float64,
 applies the GDAL SCALE/OFFSET, and masks the nodata sentinel to NaN.
 ``pack=True`` reverses that on write: it un-scales, fills NaN back to the
 sentinel, and restores the integer source dtype recorded on
@@ -41,8 +41,8 @@ def _write_int_tiff(path, data, *, nodata=None, scale=None, offset=None):
 
 
 def _reopen(path, chunks):
-    return (open_geotiff(path, mask_and_scale=True) if chunks is None
-            else open_geotiff(path, mask_and_scale=True, chunks=chunks))
+    return (open_geotiff(path, unpack=True) if chunks is None
+            else open_geotiff(path, unpack=True, chunks=chunks))
 
 
 # ---------------------------------------------------------------------------
@@ -107,8 +107,8 @@ def test_pack_with_scale_offset_round_trip(tmp_path, chunks):
 
     # The SCALE/OFFSET tags are kept, so a mask_and_scale read of the packed
     # file reproduces the original decoded values rather than scaling twice.
-    eager_decoded = open_geotiff(src, mask_and_scale=True)
-    repacked_decoded = open_geotiff(out, mask_and_scale=True)
+    eager_decoded = open_geotiff(src, unpack=True)
+    repacked_decoded = open_geotiff(out, unpack=True)
     np.testing.assert_allclose(
         repacked_decoded.data, eager_decoded.data, equal_nan=True)
 
@@ -122,8 +122,8 @@ def test_mask_and_scale_dtype_recorded_eager_dask_match(tmp_path):
     data = np.array([[1, 2, 255], [4, 5, 6]], dtype=np.uint8)
     src = _write_int_tiff(tmp_path / "src_attr_3064.tif", data, nodata=255)
 
-    eager = open_geotiff(src, mask_and_scale=True)
-    lazy = open_geotiff(src, mask_and_scale=True, chunks=2)
+    eager = open_geotiff(src, unpack=True)
+    lazy = open_geotiff(src, unpack=True, chunks=2)
     assert eager.attrs.get("mask_and_scale_dtype") == "uint8"
     assert (eager.attrs.get("mask_and_scale_dtype")
             == lazy.attrs.get("mask_and_scale_dtype"))

--- a/xrspatial/tests/test_open_geotiff_coregister.py
+++ b/xrspatial/tests/test_open_geotiff_coregister.py
@@ -1,5 +1,5 @@
 """Tests for ``.xrs.open_geotiff(coregister=True)`` (issue #3069 -
-mask_and_scale + reproject + resample onto the caller's exact grid)."""
+unpack + reproject + resample onto the caller's exact grid)."""
 from __future__ import annotations
 
 import numpy as np
@@ -143,12 +143,12 @@ def test_coregister_dask_template(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# mask_and_scale
+# unpack (renamed from mask_and_scale)
 # ---------------------------------------------------------------------------
 
-def test_coregister_forwards_mask_and_scale(tmp_path, monkeypatch):
-    # coregister must read with mask_and_scale=True. Spy on the real
-    # open_geotiff and confirm the kwarg, then delegate.
+def test_coregister_forwards_unpack(tmp_path, monkeypatch):
+    # coregister must read with unpack=True. Spy on the real open_geotiff
+    # and confirm the kwarg, then delegate.
     path = _file_4326(tmp_path, np.float32, 'cg_ms.tif')
     template = _template_3857(6)
 
@@ -157,12 +157,12 @@ def test_coregister_forwards_mask_and_scale(tmp_path, monkeypatch):
     seen = {}
 
     def spy(src, **kw):
-        seen['mask_and_scale'] = kw.get('mask_and_scale')
+        seen['unpack'] = kw.get('unpack')
         return real(src, **kw)
 
     monkeypatch.setattr(gt, 'open_geotiff', spy)
     template.xrs.open_geotiff(path, coregister=True)
-    assert seen['mask_and_scale'] is True
+    assert seen['unpack'] is True
 
 
 def test_coregister_masks_nodata_to_nan(tmp_path):


### PR DESCRIPTION
Closes #3071.

Renames `open_geotiff`'s `mask_and_scale` read option to `unpack` and
extends it to the GPU and dask+GPU backends.

## What changed

- New `unpack: bool = False` parameter on `open_geotiff`. The operation
  unpacks CF-packed data: integers stored with a SCALE/OFFSET that recover
  floats. It pairs with the writer's `pack` option.
- `mask_and_scale` is now a deprecated alias. Passing it warns and forwards
  to `unpack`; passing both raises `TypeError`. Same sentinel pattern used
  for `mask_nodata` -> `masked`. Behaviour is unchanged: `unpack=True`
  applies SCALE/OFFSET and masks the nodata sentinel to NaN.
- `unpack` now runs on the GPU eager, GPU-via-CPU, and dask+GPU paths. The
  scale/offset arithmetic already ran on CuPy via numpy duck-typing in the
  shared eager finalizer; the change threads the flag through the GPU eager
  sites and the dask+GPU chunked path and drops the `gpu=True` rejection.
  The dask+GPU disk->GPU GDS fast path has no scale step, so an `unpack`
  request takes the CPU-decode-then-upload route, which applies the scale
  lazily before the device upload.
- The merged `coregister` feature (#3072) read with `mask_and_scale=True`
  internally; it now passes `unpack=True` so it no longer trips its own
  deprecation warning. Its CPU-only gpu/.vrt rejection is unchanged.

## Scope

- VRT sources still raise for `unpack`. Out of scope.
- `parse_coordinates=False` GPU gating is unchanged. Out of scope.
- The `attrs['mask_and_scale_dtype']` round-trip key keeps its name; it
  pairs with the writer's pack path. Only the public parameter is renamed.

## Backends

numpy, dask+numpy, cupy, dask+cupy. Verified all four produce identical
values on a packed uint8 raster (`data*2+10`, sentinel -> NaN).

## Test plan

- [x] GPU eager and dask+GPU parity vs CPU (`@requires_gpu`)
- [x] Deprecation alias warns and matches `unpack`; both -> `TypeError`
- [x] `unpack` + `.vrt` still raises
- [x] Signature canonical-order test updated for the new param
- [x] coregister forwards `unpack`; coregister suite passes warning-strict
- [x] Existing pack / dtype-parity / rioxarray-compat suites pass
