### PR TITLE
Silence pyproj PROJ-string warning in _get_datum_params (#3076)

### DIFF
--- a/xrspatial/reproject/_projections.py
+++ b/xrspatial/reproject/_projections.py
@@ -22,6 +22,7 @@ All other CRS pairs fall back to pyproj.
 from __future__ import annotations
 
 import math
+import warnings
 
 import numpy as np
 from numba import njit, prange
@@ -127,7 +128,16 @@ def _get_datum_params(crs):
     Returns None for WGS84/NAD83/GRS80 (no shift needed).
     """
     try:
-        d = crs.to_dict()
+        # crs.to_dict() goes through pyproj's to_proj4(), which warns that a
+        # PROJ string drops detail. We only read the datum/ellps short names
+        # here, never the lossy string, so silence that one warning.
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                'ignore',
+                message='.*lose important projection information.*',
+                category=UserWarning,
+            )
+            d = crs.to_dict()
     except Exception:
         return None
     datum = d.get('datum', '')

--- a/xrspatial/tests/test_reproject.py
+++ b/xrspatial/tests/test_reproject.py
@@ -1,6 +1,8 @@
 """Tests for xrspatial.reproject module."""
 from __future__ import annotations
 
+import warnings
+
 import numpy as np
 import pytest
 import xarray as xr
@@ -589,6 +591,32 @@ class TestDatumShiftBounds:
         ).transform(cx, cy)
         assert abs(left - rx.min()) < abs(left - unshifted_x.min())
         assert abs(right - rx.max()) < abs(right - unshifted_x.max())
+
+
+@pytest.mark.skipif(not HAS_PYPROJ, reason="pyproj required")
+class TestDatumProbeNoProjWarning:
+    """_get_datum_params probes the datum via crs.to_dict(), which routes
+    through pyproj's to_proj4() and warns that a PROJ string drops detail.
+    The probe never uses that lossy string, so the warning must not leak to
+    callers of reproject(). See GH #3076.
+    """
+
+    def test_get_datum_params_silences_proj_warning(self):
+        from xrspatial.reproject._projections import _get_datum_params
+        # EPSG:3857 round-trips through to_proj4() inside to_dict() and is
+        # the CRS that surfaced the warning in the original report.
+        with warnings.catch_warnings(record=True) as rec:
+            warnings.simplefilter('always')
+            _get_datum_params(pyproj.CRS.from_epsg(3857))
+        leaked = [w for w in rec
+                  if 'lose important projection information' in str(w.message)]
+        assert leaked == []
+
+    def test_get_datum_params_still_resolves_known_datum(self):
+        # Silencing the warning must not break the datum lookup: NAD27
+        # (EPSG:4267) is in the shift table and must still return params.
+        from xrspatial.reproject._projections import _get_datum_params
+        assert _get_datum_params(pyproj.CRS.from_epsg(4267)) is not None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #3076

## What

`reproject` (and `open_geotiff` with `auto_reproject=True` / `coregister=True`) printed a pyproj `UserWarning` on every call:

> You will likely lose important projection information when converting to a PROJ string from another format.

The warning came from `_get_datum_params`, which calls `crs.to_dict()` to read the datum/ellipsoid short names for a custom 7-parameter shift lookup. pyproj's `to_dict()` runs `to_proj4()` under the hood and warns about the lossy conversion. The probe never uses that string, so the warning was noise leaking to callers.

- Wrap the `to_dict()` probe in `warnings.catch_warnings()` and filter out that one pyproj message. The datum lookup still uses the proj4 short names, so behaviour is unchanged.

## Backend coverage

CRS-metadata helper shared by all backends (numpy / cupy / dask+numpy / dask+cupy); no backend-specific code touched.

## Test plan

- [x] `TestDatumProbeNoProjWarning::test_get_datum_params_silences_proj_warning` — no PROJ-string warning leaks for EPSG:3857 (fails without the fix, passes with it).
- [x] `TestDatumProbeNoProjWarning::test_get_datum_params_still_resolves_known_datum` — NAD27 (EPSG:4267) still resolves to shift params.
- [x] Full `test_reproject.py` suite passes (429 passed).