### PR TITLE
Restore nodata sentinel for float rasters in to_geotiff(pack=True)

### DIFF
--- a/xrspatial/geotiff/_attrs.py
+++ b/xrspatial/geotiff/_attrs.py
@@ -1699,17 +1699,22 @@ def _pack(data):
         target = np.asarray(nodata).dtype.name
     tgt = np.dtype(target) if target is not None else np.dtype(str(out.dtype))
 
+    if nodata is not None:
+        # Restore the masked sentinel for every dtype. Integers can't hold
+        # NaN at all; floats would otherwise write NaN pixels under a
+        # GDAL_NODATA tag that still declares the sentinel, leaving an
+        # inconsistent file that non-masking readers misread (#3078).
+        out = out.fillna(nodata)
+    elif tgt.kind in ('i', 'u'):
+        # ``isnull().any()`` forces a compute on dask; only reached on the
+        # error path where no sentinel exists to fill an integer's holes.
+        if bool(out.isnull().any()):
+            raise ValueError(
+                f"pack=True: cannot restore integer dtype {tgt.name}: "
+                "NaN pixels are present but no nodata sentinel is "
+                "declared to fill them.")
+
     if tgt.kind in ('i', 'u'):
-        if nodata is None:
-            # ``isnull().any()`` forces a compute on dask; only reached on
-            # the error path where no sentinel exists to fill the holes.
-            if bool(out.isnull().any()):
-                raise ValueError(
-                    f"pack=True: cannot restore integer dtype {tgt.name}: "
-                    "NaN pixels are present but no nodata sentinel is "
-                    "declared to fill them.")
-        else:
-            out = out.fillna(nodata)
         out = out.round()
 
     out = out.astype(tgt)

--- a/xrspatial/geotiff/tests/write/test_pack_3064.py
+++ b/xrspatial/geotiff/tests/write/test_pack_3064.py
@@ -83,6 +83,39 @@ def test_pack_restores_uint16_no_scale(tmp_path, chunks):
 
 
 # ---------------------------------------------------------------------------
+# Float source: the masked sentinel must be restored, not left as NaN (#3078)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("chunks", [None, 2], ids=["numpy", "dask"])
+def test_pack_restores_float_nodata_sentinel(tmp_path, chunks):
+    """A float raster masks its sentinel to NaN on an ``unpack=True`` read.
+    ``pack=True`` must put the declared sentinel back so the pixels on disk
+    match the GDAL_NODATA tag -- otherwise the file declares nodata=-9999 but
+    stores NaN, which a non-masking reader silently treats as a valid value.
+    """
+    data = np.array([[1.5, 2.5, -9999.0], [4.5, 5.5, 6.5]], dtype=np.float32)
+    src = _write_int_tiff(tmp_path / "src_f32_3078.tif", data, nodata=-9999.0)
+
+    decoded = _reopen(src, chunks)
+    assert np.isnan(np.asarray(decoded.data)).any()  # sentinel was masked
+
+    out = str(tmp_path / "out_f32_3078.tif")
+    decoded.xrs.to_geotiff(out, pack=True)
+
+    # Plain (non-masking) read: the sentinel is back and no NaN survives.
+    back = np.asarray(open_geotiff(out).data)
+    assert not np.isnan(back).any()
+    assert back[0, 2] == -9999.0
+    assert open_geotiff(out).attrs.get("nodata") == -9999.0
+
+    # An unpack read still round-trips the masked value to NaN.
+    repacked = open_geotiff(out, unpack=True)
+    np.testing.assert_array_equal(
+        np.asarray(repacked.data), np.asarray(decoded.data))
+
+
+# ---------------------------------------------------------------------------
 # Round trip: with SCALE/OFFSET -- the file must unpack, not double-scale
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #3078

`to_geotiff(pack=True)` is the inverse of an `open_geotiff(unpack=True)` read. For integer rasters it un-scales, fills the masked NaN pixels back to the nodata sentinel, and restores the integer source dtype. For float rasters it did everything except the fill: the NaN pixels stayed NaN while the file still wrote a GDAL_NODATA tag for the sentinel. That leaves an inconsistent file (header says nodata=-9999, pixels are NaN), and a non-masking reader like plain GDAL or QGIS treats those NaN pixels as valid data.

The `fillna(nodata)` call lived inside an `if tgt.kind in ('i', 'u')` branch, so float targets skipped it. The fill now runs for every dtype when a sentinel is declared, which is what the docstring already promised. Integer behavior is unchanged: the no-sentinel-but-NaN error path and the int-only `round()` both still apply.

`_pack` is plain xarray (`fillna` / `round` / `astype`) and runs before the writer dispatches, so the fix is backend-agnostic. Exercised here on numpy and dask.

Test plan:
- Added `test_pack_restores_float_nodata_sentinel` (numpy + dask): a float32 raster with a -9999 sentinel, read with `unpack=True` (masks it to NaN), packed back. Asserts no NaN survives, the pixel equals the sentinel, the GDAL_NODATA tag matches, and an `unpack=True` read of the packed file round-trips back to NaN.
- Confirmed the new test fails without the fix and passes with it.
- Full geotiff write + attrs suites pass (1116 passed, 1 skipped).