### PR TITLE
Make merge() output-size guard backend-aware (#3048)

### DIFF
--- a/xrspatial/reproject/__init__.py
+++ b/xrspatial/reproject/__init__.py
@@ -23,6 +23,7 @@ from ._crs_utils import (
     _resolve_crs,
 )
 from ._grid import (
+    _MAX_OUTPUT_PIXELS,
     _chunk_bounds,
     _compute_chunk_layout,
     _compute_output_grid,
@@ -2346,8 +2347,8 @@ def merge(
         # output array. Re-apply the output-size guard that was skipped
         # during grid computation so a genuinely in-memory merge over the
         # pixel limit still raises (the guard skip only applies to the
-        # lazy dask path).
-        _MAX_OUTPUT_PIXELS = 1_000_000_000
+        # lazy dask path). _MAX_OUTPUT_PIXELS is imported from _grid so the
+        # limit stays in sync with _compute_output_grid's own check.
         if out_shape[0] * out_shape[1] > _MAX_OUTPUT_PIXELS:
             raise ValueError(
                 f"Computed output grid is too large ({out_shape[1]} x "

--- a/xrspatial/reproject/__init__.py
+++ b/xrspatial/reproject/__init__.py
@@ -63,6 +63,10 @@ __all__ = [
 _Y_NAMES = {'y', 'lat', 'latitude', 'Y', 'Lat', 'Latitude'}
 _X_NAMES = {'x', 'lon', 'longitude', 'X', 'Lon', 'Longitude'}
 
+# Output byte budget above which merge() auto-promotes an in-memory mosaic
+# to the lazy dask path instead of allocating the whole array.
+_MERGE_OOM_THRESHOLD = 512 * 1024 * 1024  # 512 MB
+
 # Map friendly vertical datum tokens to EPSG codes so attrs['vertical_crs']
 # from reproject output matches the convention used by xrspatial.geotiff,
 # which also writes EPSG ints to attrs['vertical_crs'].
@@ -2305,19 +2309,12 @@ def merge(
     else:
         merged_bounds = bounds
 
-    # Use first raster's info for resolution estimation if needed
-    info0 = raster_infos[0]
-    grid = _compute_output_grid(
-        info0['src_bounds'], info0['src_shape'],
-        info0['src_crs'], tgt_crs,
-        resolution=resolution, bounds=merged_bounds,
-        bounds_policy=bounds_policy,
-    )
-    out_bounds = grid['bounds']
-    out_shape = grid['shape']
-    tgt_wkt = tgt_crs.to_wkt()
-
-    # Detect if any input is dask, or if total size exceeds memory threshold
+    # Detect dask inputs up front. A dask-backed merge runs through the
+    # lazy _merge_dask path and never materializes the full output, so its
+    # output-size guard must be skipped. The auto-promote-to-dask decision
+    # below also needs the output shape, which only exists after the grid
+    # is computed -- so compute the grid with the guard disabled here and
+    # re-apply it only when the final path is the in-memory merge.
     from ..utils import has_dask_array
 
     any_dask = False
@@ -2325,12 +2322,39 @@ def merge(
         import dask.array as _da
         any_dask = any(isinstance(r.data, _da.Array) for r in rasters)
 
+    # Use first raster's info for resolution estimation if needed
+    info0 = raster_infos[0]
+    grid = _compute_output_grid(
+        info0['src_bounds'], info0['src_shape'],
+        info0['src_crs'], tgt_crs,
+        resolution=resolution, bounds=merged_bounds,
+        bounds_policy=bounds_policy,
+        lazy_output=True,
+    )
+    out_bounds = grid['bounds']
+    out_shape = grid['shape']
+    tgt_wkt = tgt_crs.to_wkt()
+
     # Auto-promote to dask path if output would be too large for in-memory merge
     if not any_dask:
         out_nbytes = out_shape[0] * out_shape[1] * 8 * len(rasters)  # float64 per tile
-        _OOM_THRESHOLD = 512 * 1024 * 1024
-        if out_nbytes > _OOM_THRESHOLD:
+        if out_nbytes > _MERGE_OOM_THRESHOLD:
             any_dask = True
+
+    if not any_dask:
+        # The final path is the in-memory merge, which allocates the whole
+        # output array. Re-apply the output-size guard that was skipped
+        # during grid computation so a genuinely in-memory merge over the
+        # pixel limit still raises (the guard skip only applies to the
+        # lazy dask path).
+        _MAX_OUTPUT_PIXELS = 1_000_000_000
+        if out_shape[0] * out_shape[1] > _MAX_OUTPUT_PIXELS:
+            raise ValueError(
+                f"Computed output grid is too large ({out_shape[1]} x "
+                f"{out_shape[0]} = {out_shape[0] * out_shape[1]:,} pixels, "
+                f"limit is {_MAX_OUTPUT_PIXELS:,}). Increase the resolution "
+                f"parameter or reduce the output extent."
+            )
 
     if any_dask:
         result_data = _merge_dask(

--- a/xrspatial/reproject/_grid.py
+++ b/xrspatial/reproject/_grid.py
@@ -7,6 +7,12 @@ import numpy as np
 
 _VALID_BOUNDS_POLICIES = ("auto", "raw", "clamp", "percentile")
 
+# Largest output grid a materializing backend may allocate. 1 billion pixels
+# is ~8 GB for a single float64 array, and the pipeline holds several such
+# arrays at once. Lazy dask outputs never materialize the full grid, so the
+# guard is skipped for them. Shared so merge()'s in-memory check matches.
+_MAX_OUTPUT_PIXELS = 1_000_000_000
+
 
 def _validate_bounds_policy(bounds_policy, func_name):
     """Reject unknown bounds_policy tokens at the API boundary."""
@@ -437,13 +443,10 @@ def _compute_output_grid(source_bounds, source_shape, source_crs, target_crs,
     if height is None:
         height = max(1, int(round((top - bottom) / res_y)))
 
-    # Guard: reject output grids that would exhaust memory.
-    # 1 billion pixels ~= 8 GB for a single float64 array, and the
-    # reprojection pipeline allocates several arrays of this size.
-    # Lazy dask outputs never materialize the full grid (peak memory is
-    # bounded by the chunk size), so the guard only applies to backends
-    # that allocate the whole output array.
-    _MAX_OUTPUT_PIXELS = 1_000_000_000
+    # Guard: reject output grids that would exhaust memory. See
+    # _MAX_OUTPUT_PIXELS above for the rationale. Lazy dask outputs never
+    # materialize the full grid (peak memory is bounded by the chunk size),
+    # so the guard only applies to backends that allocate the whole output.
     if not lazy_output and width * height > _MAX_OUTPUT_PIXELS:
         raise ValueError(
             f"Computed output grid is too large ({width} x {height} = "

--- a/xrspatial/tests/test_reproject.py
+++ b/xrspatial/tests/test_reproject.py
@@ -2534,6 +2534,76 @@ class TestSecurityGuards:
         result = reproject(raster, target_crs='EPSG:3857')
         assert result.shape[0] > 0 and result.shape[1] > 0
 
+    @pytest.mark.skipif(not HAS_DASK, reason="dask required")
+    def test_merge_dask_output_over_limit_stays_lazy(self):
+        """A dask-backed merge whose output exceeds 1e9 pixels runs through
+        the lazy path instead of tripping the in-memory guard (issue #3048)."""
+        from xrspatial.reproject import merge
+
+        a = _make_raster(
+            np.full((32, 32), 1.0), x_range=(-105, -104), y_range=(39, 40)
+        )
+        b = _make_raster(
+            np.full((32, 32), 2.0), x_range=(-104, -103), y_range=(39, 40)
+        )
+        a.data = da.from_array(a.values, chunks=(16, 16))
+        b.data = da.from_array(b.values, chunks=(16, 16))
+
+        # Tiny resolution forces > 1e9 output pixels. The merge is dask
+        # backed, so the result stays lazy and the guard must not fire.
+        out = merge([a, b], resolution=4e-5, chunk_size=1024)
+
+        assert isinstance(out.data, da.Array)
+        assert out.shape[0] * out.shape[1] > 1_000_000_000
+        # A single block computes without materializing the whole grid.
+        assert out.data.blocks[0, 0].compute().shape == (1024, 1024)
+
+    @pytest.mark.skipif(not HAS_DASK, reason="dask required")
+    def test_merge_inmemory_auto_promote_over_limit_stays_lazy(self):
+        """An in-memory merge whose output exceeds 1e9 pixels auto-promotes
+        to the dask path and must not raise the in-memory guard (issue #3048)."""
+        from xrspatial.reproject import merge
+
+        a = _make_raster(
+            np.full((32, 32), 1.0), x_range=(-105, -104), y_range=(39, 40)
+        )
+        b = _make_raster(
+            np.full((32, 32), 2.0), x_range=(-104, -103), y_range=(39, 40)
+        )
+
+        # Numpy inputs over the in-memory size threshold auto-promote to
+        # dask, so the > 1e9 pixel output must not trip the guard.
+        out = merge([a, b], resolution=4e-5, chunk_size=1024)
+
+        assert isinstance(out.data, da.Array)
+        assert out.shape[0] * out.shape[1] > 1_000_000_000
+
+    def test_merge_inmemory_over_limit_still_raises(self, monkeypatch):
+        """A genuinely in-memory merge over the pixel limit still raises the
+        'too large' guard (issue #3048 must not weaken the in-memory path).
+
+        Disabling the auto-promote-to-dask threshold keeps a > 1e9 pixel
+        output on the in-memory path, where the guard must still reject it.
+        """
+        import importlib
+
+        from xrspatial.reproject import merge
+        _reproject = importlib.import_module('xrspatial.reproject')
+
+        # Raise the auto-promote byte budget above the test output so the
+        # merge stays on the in-memory branch instead of promoting to dask.
+        monkeypatch.setattr(_reproject, '_MERGE_OOM_THRESHOLD', 1 << 60)
+
+        a = _make_raster(
+            np.full((32, 32), 1.0), x_range=(-105, -104), y_range=(39, 40)
+        )
+        b = _make_raster(
+            np.full((32, 32), 2.0), x_range=(-104, -103), y_range=(39, 40)
+        )
+
+        with pytest.raises(ValueError, match="too large"):
+            merge([a, b], resolution=4e-5)
+
 
 # =====================================================================
 # Issue #1431: _validate_raster on public API inputs


### PR DESCRIPTION
Closes #3048

`merge()` computed the output grid with the default `lazy_output=False`, so the 1-billion-pixel guard in `_compute_output_grid` fired for every merge, before `merge()` had decided whether the result would be dask-backed. That rejected merges whose output exceeds 1e9 pixels but actually run lazily through `_merge_dask`, where the full array is never materialized. It hit two cases:

- an input is already a dask array, and
- a large in-memory output that auto-promotes to the dask path.

## Fix

- Detect dask inputs up front and compute the output grid with the guard disabled (`lazy_output=True`).
- Re-apply the pixel check only when the final path is the in-memory merge, so a genuinely in-memory output over the limit still raises.
- Hoist the auto-promote byte budget to a module constant (`_MERGE_OOM_THRESHOLD`) so the in-memory guard branch is reachable in tests.

Same approach as the `reproject()` fix in #3046 / #3047.

## Backend coverage

`merge()` runs the same grid logic for all inputs; the change is in the path selection, not in any backend kernel. The added tests cover numpy inputs (in-memory and auto-promote) and dask inputs.

## Test plan

- [x] dask-input merge whose output exceeds 1e9 pixels stays lazy and does not raise
- [x] large in-memory merge that auto-promotes to dask does not raise
- [x] genuinely in-memory merge over the limit still raises the "too large" ValueError
- [x] full `test_reproject.py` suite passes (432 tests)