### PR TITLE
Make monte_carlo sensitivity chunk-bounded on dask and drop constrain() deep copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,7 +514,7 @@ For a broader catalog of spectral indices and sensor-specific band combinations,
 | [Fuzzy Overlay](xrspatial/mcda/combine.py) | Combines criteria using fuzzy set operators (AND, OR, sum, product, gamma) | Eastman 1999 | ✅ | 🔼 | 🧪 | 🧪 |
 | [Boolean Overlay](xrspatial/mcda/combine.py) | Combines binary criterion masks using AND/OR logic | Standard | ✅ | 🔼 | 🧪 | 🧪 |
 | [Constrain](xrspatial/mcda/constrain.py) | Masks exclusion zones from a suitability surface | Standard | ✅ | 🔼 | 🧪 | 🧪 |
-| [Sensitivity](xrspatial/mcda/sensitivity.py) | Assesses weight stability via one-at-a-time or Monte Carlo perturbation | Standard | ✅ | 🔼 | 🚫 | 🚫 |
+| [Sensitivity](xrspatial/mcda/sensitivity.py) | Assesses weight stability via one-at-a-time or Monte Carlo perturbation | Standard | ✅ | 🔼 | 🧪 | 🧪 |
 
 -------
 

--- a/xrspatial/mcda/constrain.py
+++ b/xrspatial/mcda/constrain.py
@@ -35,7 +35,11 @@ def constrain(
     if name is None:
         name = suitability.name
 
-    result = suitability.copy()
+    # Shallow copy: xr.where returns new objects and nothing below
+    # mutates the data, so a deep copy would only duplicate the full
+    # raster. The copy still keeps the .name assignment from leaking
+    # into the caller's object when exclude is empty.
+    result = suitability.copy(deep=False)
     for mask in exclude:
         result = xr.where(mask, fill, result)
 

--- a/xrspatial/mcda/sensitivity.py
+++ b/xrspatial/mcda/sensitivity.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 import numpy as np
 import xarray as xr
 
-from xrspatial.mcda.combine import wlc, wpm
+from xrspatial.mcda.combine import (
+    _check_wpm_positive,
+    _validate_criteria,
+    _validate_weights,
+    wlc,
+    wpm,
+)
+from xrspatial.mcda.standardize import _get_xp
 
 
 def sensitivity(
@@ -46,7 +53,9 @@ def sensitivity(
         For ``"one_at_a_time"``: Dataset with per-criterion DataArrays
         showing the absolute score difference under perturbation.
         For ``"monte_carlo"``: DataArray of per-pixel coefficient of
-        variation across random weight samples.
+        variation across random weight samples. Dask-backed criteria
+        produce a lazy dask-backed result; the sample loop runs inside
+        each chunk, so memory stays bounded by chunk size.
     """
     combine_fn = {"wlc": wlc, "wpm": wpm}.get(combine_method)
     if combine_fn is None:
@@ -63,7 +72,7 @@ def sensitivity(
                 f"n_samples must be a positive integer >= 1, got {n_samples!r}"
             )
         return _monte_carlo(
-            criteria, weights, combine_fn, int(n_samples), seed, name
+            criteria, weights, combine_method, int(n_samples), seed, name
         )
     else:
         raise ValueError(
@@ -135,7 +144,48 @@ def _is_dask_dataset(criteria):
         return False
 
 
-def _monte_carlo(criteria, weights, combine_fn, n_samples, seed, name):
+def _mc_block(block, weight_matrix, combine_method):
+    """Run the Monte Carlo sample loop on one in-memory block.
+
+    ``block`` has shape ``(n_criteria,) + grid`` with weight columns in
+    the same criterion order. Welford's online algorithm keeps only the
+    running mean and M2 buffers alive, so peak memory per block is a
+    few times the block size regardless of ``n_samples``. Works on
+    numpy and cupy blocks alike.
+    """
+    xp = _get_xp(block)
+    n_samples = weight_matrix.shape[0]
+    n_criteria = block.shape[0]
+    shape = block.shape[1:]
+    running_mean = xp.zeros(shape, dtype=np.float64)
+    running_m2 = xp.zeros(shape, dtype=np.float64)
+
+    for i in range(n_samples):
+        w = weight_matrix[i]
+        if combine_method == "wpm":
+            score = block[0] ** float(w[0])
+            for j in range(1, n_criteria):
+                score = score * block[j] ** float(w[j])
+        else:
+            score = block[0] * float(w[0])
+            for j in range(1, n_criteria):
+                score = score + block[j] * float(w[j])
+
+        delta_val = score - running_mean
+        running_mean = running_mean + delta_val / (i + 1)
+        delta2 = score - running_mean
+        running_m2 = running_m2 + delta_val * delta2
+
+    variance = running_m2 / n_samples
+    std_dev = xp.sqrt(variance)
+    # Coefficient of variation
+    with np.errstate(divide="ignore", invalid="ignore"):
+        return xp.where(
+            running_mean != 0, std_dev / xp.abs(running_mean), 0.0
+        )
+
+
+def _monte_carlo(criteria, weights, combine_method, n_samples, seed, name):
     """Monte Carlo sensitivity: random weight vectors, measure CV."""
     rng = np.random.default_rng(seed)
     n_criteria = len(weights)
@@ -146,44 +196,59 @@ def _monte_carlo(criteria, weights, combine_fn, n_samples, seed, name):
     alpha = np.array([weights[k] for k in criteria_names]) * n_criteria * 5
     alpha = np.maximum(alpha, 0.5)  # floor to avoid zero concentrations
 
+    # Draw sequentially so a given seed reproduces the sample stream of
+    # the previous per-iteration implementation.
+    weight_matrix = np.stack(
+        [rng.dirichlet(alpha) for _ in range(n_samples)]
+    )
+
+    # Validate once up front with the first sampled vector (it is
+    # finite and sums to 1, so only key-set mismatches can fire) the
+    # way the first combine call used to.
+    _validate_criteria(criteria)
+    probe = {k: float(weight_matrix[0][j])
+             for j, k in enumerate(criteria_names)}
+    _validate_weights(probe, criteria)
+    if combine_method == "wpm":
+        _check_wpm_positive(criteria)
+
     first_var = list(criteria.data_vars)[0]
     template = criteria[first_var]
 
-    use_dask = _is_dask_dataset(criteria)
+    # Stack criterion layers in data_vars order (the order wlc/wpm
+    # combine in) and permute the weight columns to match.
+    var_order = list(criteria.data_vars)
+    col = {k: j for j, k in enumerate(criteria_names)}
+    ordered_weights = weight_matrix[:, [col[v] for v in var_order]]
 
-    # Accumulate running mean and M2 for Welford's online algorithm
-    # to avoid storing all n_samples surfaces in memory
-    running_mean = template.values * 0.0 if not use_dask else np.zeros(template.shape)
-    running_m2 = running_mean.copy()
+    if _is_dask_dataset(criteria):
+        import dask.array as da
 
-    # For dask inputs: compute each score eagerly to avoid graph
-    # explosion (each lazy iteration would chain ~35 graph nodes;
-    # 1000 iterations = 35000 chained tasks with no parallelism).
-    # The criterion layers are small enough per-pixel that the
-    # bottleneck is the combination, not I/O.
-    if use_dask:
-        criteria_np = criteria.compute()
+        base_chunks = next(
+            criteria[v].data.chunks for v in var_order
+            if isinstance(criteria[v].data, da.Array)
+        )
+        layers = []
+        for v in var_order:
+            arr = criteria[v].data
+            if isinstance(arr, da.Array):
+                arr = arr.rechunk(base_chunks)
+            else:
+                arr = da.from_array(arr, chunks=base_chunks)
+            layers.append(arr)
+        # The sample loop runs inside one chunk function, so the graph
+        # stays at one task per chunk and nothing materializes the full
+        # criteria stack.
+        stacked = da.stack(layers).rechunk({0: -1})
+        cv_vals = da.map_blocks(
+            _mc_block, stacked,
+            weight_matrix=ordered_weights, combine_method=combine_method,
+            drop_axis=0, dtype=np.float64,
+            meta=stacked._meta.sum(axis=0),
+        )
     else:
-        criteria_np = criteria
-
-    for i in range(n_samples):
-        raw = rng.dirichlet(alpha)
-        sample_weights = {
-            k: float(raw[j]) for j, k in enumerate(criteria_names)
-        }
-        score = combine_fn(criteria_np, sample_weights)
-        score_vals = score.values
-
-        delta_val = score_vals - running_mean
-        running_mean = running_mean + delta_val / (i + 1)
-        delta2 = score_vals - running_mean
-        running_m2 = running_m2 + delta_val * delta2
-
-    variance = running_m2 / n_samples
-    std_dev = np.sqrt(variance)
-    # Coefficient of variation
-    with np.errstate(divide="ignore", invalid="ignore"):
-        cv_vals = np.where(running_mean != 0, std_dev / np.abs(running_mean), 0.0)
+        stacked = np.stack([criteria[v].data for v in var_order])
+        cv_vals = _mc_block(stacked, ordered_weights, combine_method)
 
     result = xr.DataArray(
         cv_vals, name=name, dims=template.dims,

--- a/xrspatial/mcda/sensitivity.py
+++ b/xrspatial/mcda/sensitivity.py
@@ -162,6 +162,9 @@ def _mc_block(block, weight_matrix, combine_method):
 
     for i in range(n_samples):
         w = weight_matrix[i]
+        # Same per-pixel arithmetic as combine.wlc / combine.wpm (the
+        # canonical definitions), inlined on raw arrays so the loop
+        # runs inside a single dask chunk. Keep in sync with those.
         if combine_method == "wpm":
             score = block[0] ** float(w[0])
             for j in range(1, n_criteria):

--- a/xrspatial/tests/test_mcda.py
+++ b/xrspatial/tests/test_mcda.py
@@ -6,6 +6,8 @@ import numpy as np
 import pytest
 import xarray as xr
 
+from xrspatial.tests.general_checks import cuda_and_cupy_available
+
 from xrspatial.mcda import (
     ahp_weights,
     boolean_overlay,
@@ -836,24 +838,94 @@ class TestSensitivityMonteCarlo:
 
 @pytest.mark.skipif(not HAS_DASK, reason="Requires dask")
 class TestSensitivityDask:
-    def test_monte_carlo_dask_returns_numpy(self):
-        """MC with dask input should compute eagerly, not build huge graph."""
-        ds = xr.Dataset({
-            "a": xr.DataArray(
-                np.random.rand(20, 20), dims=["y", "x"],
-            ).chunk({"y": 10, "x": 10}),
-            "b": xr.DataArray(
-                np.random.rand(20, 20), dims=["y", "x"],
-            ).chunk({"y": 10, "x": 10}),
+    """Monte Carlo on dask input stays lazy and chunk-bounded (#3152).
+
+    The previous implementation called criteria.compute() up front,
+    materializing the full dataset; the sample loop now runs inside a
+    single map_blocks chunk function instead.
+    """
+
+    @pytest.fixture
+    def numpy_ds(self):
+        np.random.seed(3152)
+        return xr.Dataset({
+            "a": xr.DataArray(np.random.rand(20, 20), dims=["y", "x"]),
+            "b": xr.DataArray(np.random.rand(20, 20), dims=["y", "x"]),
         })
+
+    def test_monte_carlo_dask_stays_lazy(self, numpy_ds):
+        ds = numpy_ds.chunk({"y": 10, "x": 10})
         result = sensitivity(
             ds, {"a": 0.6, "b": 0.4},
             method="monte_carlo", n_samples=30,
         )
-        # Result should be eagerly computed numpy, not dask
-        assert isinstance(result.data, np.ndarray)
-        assert result.shape == (20, 20)
-        assert np.all(result.values >= 0)
+        assert isinstance(result.data, da.Array)
+        # One MC task per chunk: the graph must not scale with n_samples.
+        assert len(result.data.__dask_graph__()) < 30
+        computed = result.compute()
+        assert computed.shape == (20, 20)
+        assert np.all(computed.values >= 0)
+
+    @pytest.mark.parametrize("combine_method", ["wlc", "wpm"])
+    def test_monte_carlo_dask_matches_numpy(self, numpy_ds, combine_method):
+        """Same seed gives the same values on both backends."""
+        ds = numpy_ds.chunk({"y": 10, "x": 10})
+        kwargs = dict(
+            method="monte_carlo", combine_method=combine_method,
+            n_samples=30, seed=7,
+        )
+        numpy_result = sensitivity(numpy_ds, {"a": 0.6, "b": 0.4}, **kwargs)
+        dask_result = sensitivity(ds, {"a": 0.6, "b": 0.4}, **kwargs)
+        np.testing.assert_allclose(
+            dask_result.compute().values, numpy_result.values,
+            atol=1e-14,
+        )
+
+    def test_monte_carlo_dask_nan_propagates(self, numpy_ds):
+        with_nan = numpy_ds.copy(deep=True)
+        with_nan["a"].values[3, 4] = np.nan
+        ds = with_nan.chunk({"y": 10, "x": 10})
+        result = sensitivity(
+            ds, {"a": 0.6, "b": 0.4},
+            method="monte_carlo", n_samples=10,
+        ).compute()
+        assert np.isnan(result.values[3, 4])
+        assert np.isfinite(result.values[0, 0])
+
+    def test_monte_carlo_dask_missing_weight_raises(self, numpy_ds):
+        ds = numpy_ds.chunk({"y": 10, "x": 10})
+        with pytest.raises(ValueError, match="Missing weights"):
+            sensitivity(
+                ds, {"a": 1.0}, method="monte_carlo", n_samples=5,
+            )
+
+
+class TestSensitivityCupy:
+    """Monte Carlo on cupy input (#3151): no .values round trips."""
+
+    @cuda_and_cupy_available
+    def test_monte_carlo_cupy_matches_numpy(self):
+        import cupy
+        np.random.seed(3151)
+        arrays = {
+            "a": np.random.rand(10, 10),
+            "b": np.random.rand(10, 10),
+        }
+        numpy_ds = xr.Dataset({
+            k: xr.DataArray(v, dims=["y", "x"]) for k, v in arrays.items()
+        })
+        cupy_ds = xr.Dataset({
+            k: xr.DataArray(cupy.asarray(v), dims=["y", "x"])
+            for k, v in arrays.items()
+        })
+        kwargs = dict(method="monte_carlo", n_samples=20, seed=11)
+        numpy_result = sensitivity(numpy_ds, {"a": 0.6, "b": 0.4}, **kwargs)
+        cupy_result = sensitivity(cupy_ds, {"a": 0.6, "b": 0.4}, **kwargs)
+        # Accumulation runs on the device; result is still cupy
+        assert isinstance(cupy_result.data, cupy.ndarray)
+        np.testing.assert_allclose(
+            cupy_result.data.get(), numpy_result.values, atol=1e-12,
+        )
 
 
 # ===========================================================================
@@ -1224,6 +1296,16 @@ class TestConstrainEdgeCases:
         )
         result = constrain(suit, exclude=[mask])
         assert np.all(np.isnan(result.values))
+
+    def test_input_name_unchanged(self):
+        """Renaming the output must not leak into the caller's object."""
+        suit = xr.DataArray(
+            np.array([[0.8]], dtype=np.float64), dims=["y", "x"],
+            name="orig",
+        )
+        result = constrain(suit, exclude=[], name="new")
+        assert result.name == "new"
+        assert suit.name == "orig"
 
 
 # ===========================================================================

--- a/xrspatial/tests/test_mcda.py
+++ b/xrspatial/tests/test_mcda.py
@@ -867,9 +867,19 @@ class TestSensitivityDask:
         assert np.all(computed.values >= 0)
 
     @pytest.mark.parametrize("combine_method", ["wlc", "wpm"])
-    def test_monte_carlo_dask_matches_numpy(self, numpy_ds, combine_method):
+    @pytest.mark.parametrize(
+        "chunks",
+        [
+            {"y": 10, "x": 10},
+            # Ragged chunks: 20 does not divide evenly by 7 or 9
+            {"y": 7, "x": 9},
+        ],
+    )
+    def test_monte_carlo_dask_matches_numpy(
+        self, numpy_ds, combine_method, chunks,
+    ):
         """Same seed gives the same values on both backends."""
-        ds = numpy_ds.chunk({"y": 10, "x": 10})
+        ds = numpy_ds.chunk(chunks)
         kwargs = dict(
             method="monte_carlo", combine_method=combine_method,
             n_samples=30, seed=7,
@@ -878,6 +888,21 @@ class TestSensitivityDask:
         dask_result = sensitivity(ds, {"a": 0.6, "b": 0.4}, **kwargs)
         np.testing.assert_allclose(
             dask_result.compute().values, numpy_result.values,
+            atol=1e-14,
+        )
+
+    def test_monte_carlo_mixed_numpy_and_dask_vars(self, numpy_ds):
+        """A numpy variable inside an otherwise dask Dataset works."""
+        mixed = xr.Dataset({
+            "a": numpy_ds["a"].chunk({"y": 10, "x": 10}),
+            "b": numpy_ds["b"],  # stays numpy-backed
+        })
+        kwargs = dict(method="monte_carlo", n_samples=30, seed=7)
+        numpy_result = sensitivity(numpy_ds, {"a": 0.6, "b": 0.4}, **kwargs)
+        mixed_result = sensitivity(mixed, {"a": 0.6, "b": 0.4}, **kwargs)
+        assert isinstance(mixed_result.data, da.Array)
+        np.testing.assert_allclose(
+            mixed_result.compute().values, numpy_result.values,
             atol=1e-14,
         )
 


### PR DESCRIPTION
Closes #3152
Closes #3151 (the `monte_carlo` item; the `standardize` items are fixed in #3159)

- `_monte_carlo` called `criteria.compute()` on dask input, materializing the whole dataset before sampling. The sample loop now runs inside a single `map_blocks` chunk function: weight vectors are drawn up front (sequentially, so a given seed reproduces the old sample stream), criterion layers are stacked per chunk, and Welford accumulation happens per block. The graph is ~8 tasks per chunk regardless of `n_samples` (measured with n_samples=1000 on a 2560x2560 / 256-chunk dataset) and peak memory is bounded by chunk size.
- The dask result is now lazy instead of eagerly-computed numpy. `test_monte_carlo_dask_returns_numpy` codified the old behavior and is replaced by lazy/parity/NaN/validation tests. Numpy results for a given seed are unchanged (same draws, same per-pixel arithmetic).
- The same kernel also fixes the cupy crash from #3151: the old loop read `score.values` every iteration, which cupy rejects. Accumulation now runs on the device and the result stays a cupy array.
- `constrain()` deep-copied the suitability raster even though nothing mutates it (`xr.where` returns new objects). It now takes a shallow copy, which still keeps the `.name` assignment from leaking into the caller's object.

Backend coverage: numpy values unchanged for a given seed; dask+numpy goes from materialize-everything to chunk-bounded and lazy; cupy and dask+cupy go from crashing to working, verified on a CUDA host with parity against numpy.

Test plan:
- [x] `pytest xrspatial/tests/test_mcda.py` (181 passed)
- [x] New dask tests: lazy result with small graph, wlc/wpm parity vs numpy with same seed, NaN propagation, missing-weight validation
- [x] New cupy test (gated on `cuda_and_cupy_available`): MC parity vs numpy, result stays on device
- [x] dask+cupy MC verified manually for wlc and wpm (parity vs numpy)
- [x] Graph probe: 800 tasks for 100 chunks at n_samples=1000 (no scaling with sample count)
- [x] New constrain test: output rename does not leak into the input