### PR TITLE
Drop strict xfail on test_3d_source_streams now that #3111 fixed #3100

### DIFF
--- a/xrspatial/tests/test_reproject_streaming_3101.py
+++ b/xrspatial/tests/test_reproject_streaming_3101.py
@@ -166,20 +166,16 @@ class TestStreamingMatchesInMemory:
 
 
 class TestStreaming3D:
-    """3-D sources crash in the streaming assembly (issue #3100)."""
+    """3-D (y, x, band) sources stream correctly since #3111 fixed #3100."""
 
-    @pytest.mark.xfail(strict=True, raises=ValueError,
-                       reason="2-D output buffer vs 3-D tiles, see #3100")
     def test_3d_source_streams(self):
         from xrspatial.reproject import reproject
         data = np.random.RandomState(5).rand(32, 32, 3)
         raster = _make_raster(data)
-        # max_memory=1 -> serial loop, so the expected failure is the
-        # deterministic assembly ValueError, never the concurrent
-        # parallel-kernel abort from #3141.
+        # max_memory=1 -> serial loop, keeping the concurrent
+        # parallel-kernel abort from #3141 out of play.
         out = _run_streaming(raster, tile_size=16, max_memory=1)
-        # Once #3100 is fixed the xfail comes off and the streaming
-        # result must match the in-memory 3-D path:
+        # The streaming result must match the in-memory 3-D path:
         ref = reproject(raster, 'EPSG:32633')
         assert out.shape == ref.shape
         np.testing.assert_allclose(out, ref.values, equal_nan=True)


### PR DESCRIPTION
Closes #3177.

#3111 fixed the 2-D output buffer crash on 3-D streaming sources, and #3118 added a strict xfail expecting that crash. Each was green against the main it branched from; together they turn the XPASS into a failure, so main and every PR that syncs it are red.

The #3100 behavior is fixed, so this removes the xfail marker and the stale "once #3100 is fixed" comment, and lets the assertions run for real. All 15 tests in the file pass locally.
