### PR TITLE
Remove obsolete strict xfail for streaming 3-D reproject (#3100)

### DIFF
--- a/xrspatial/tests/test_reproject_streaming_3101.py
+++ b/xrspatial/tests/test_reproject_streaming_3101.py
@@ -166,20 +166,16 @@ class TestStreamingMatchesInMemory:
 
 
 class TestStreaming3D:
-    """3-D sources crash in the streaming assembly (issue #3100)."""
+    """3-D sources stream correctly (issue #3100, fixed in #3111)."""
 
-    @pytest.mark.xfail(strict=True, raises=ValueError,
-                       reason="2-D output buffer vs 3-D tiles, see #3100")
     def test_3d_source_streams(self):
         from xrspatial.reproject import reproject
         data = np.random.RandomState(5).rand(32, 32, 3)
         raster = _make_raster(data)
-        # max_memory=1 -> serial loop, so the expected failure is the
-        # deterministic assembly ValueError, never the concurrent
+        # max_memory=1 -> serial loop, avoiding the concurrent
         # parallel-kernel abort from #3141.
         out = _run_streaming(raster, tile_size=16, max_memory=1)
-        # Once #3100 is fixed the xfail comes off and the streaming
-        # result must match the in-memory 3-D path:
+        # The streaming result must match the in-memory 3-D path:
         ref = reproject(raster, 'EPSG:32633')
         assert out.shape == ref.shape
         np.testing.assert_allclose(out, ref.values, equal_nan=True)


### PR DESCRIPTION
#3118 added `TestStreaming3D::test_3d_source_streams` as a strict xfail for #3100, but #3111 (which fixes the 2-D output buffer crash by carrying the band axis through both assembly branches) landed after #3118's CI ran. The test now XPASSes, which strict mode reports as a failure, so every pytest run on main is red, along with any PR branched from it (e.g. #3119).

This removes the xfail marker and updates the comments. The test runs as a plain regression test now; the file passes 15/15 locally.

Closes #3100.