### PR TITLE
Remove obsolete strict xfail on the streaming 3-D reproject test (#3100)

### DIFF
--- a/xrspatial/tests/test_reproject_streaming_3101.py
+++ b/xrspatial/tests/test_reproject_streaming_3101.py
@@ -166,20 +166,16 @@ class TestStreamingMatchesInMemory:
 
 
 class TestStreaming3D:
-    """3-D sources crash in the streaming assembly (issue #3100)."""
+    """3-D sources stream with the band axis intact (#3100, fixed in #3111)."""
 
-    @pytest.mark.xfail(strict=True, raises=ValueError,
-                       reason="2-D output buffer vs 3-D tiles, see #3100")
     def test_3d_source_streams(self):
         from xrspatial.reproject import reproject
         data = np.random.RandomState(5).rand(32, 32, 3)
         raster = _make_raster(data)
-        # max_memory=1 -> serial loop, so the expected failure is the
-        # deterministic assembly ValueError, never the concurrent
+        # max_memory=1 -> serial loop, keeping clear of the concurrent
         # parallel-kernel abort from #3141.
         out = _run_streaming(raster, tile_size=16, max_memory=1)
-        # Once #3100 is fixed the xfail comes off and the streaming
-        # result must match the in-memory 3-D path:
+        # The streaming result must match the in-memory 3-D path:
         ref = reproject(raster, 'EPSG:32633')
         assert out.shape == ref.shape
         np.testing.assert_allclose(out, ref.values, equal_nan=True)


### PR DESCRIPTION
## Summary

CI on main fails with `[XPASS(strict)]` on `test_reproject_streaming_3101.py::TestStreaming3D::test_3d_source_streams`.

This was a merge race: #3111 (merged 13:11 UTC) fixed the 2-D output buffer crash in `_reproject_streaming` as part of the dtype work, and #3118 (merged 13:13 UTC) added a strict xfail test pinning that same crash, written against pre-#3111 main. With both merged, the test body passes and the strict xfail marker fails the run.

The test already says what to do when this happens: "Once #3100 is fixed the xfail comes off and the streaming result must match the in-memory 3-D path." This PR removes the xfail marker and updates the stale docstring, so the parity assertions now run.

Closes #3100 (the fix itself landed in #3111; this PR turns on the regression test).

## Test plan

- `pytest xrspatial/tests/test_reproject_streaming_3101.py`: 15 passed (was 1 failed via XPASS(strict))
- `pytest xrspatial/tests/test_reproject.py`: 439 passed