### PR TITLE
Validate raster inputs in hypsometric_integral()

### DIFF
--- a/xrspatial/tests/test_hypsometric_integral.py
+++ b/xrspatial/tests/test_hypsometric_integral.py
@@ -405,3 +405,41 @@ def test_hi_preserves_backend_2525(backend):
         # confirm chunks are cupy
         sample = result.data.blocks[0, 0].compute()
         assert is_cupy_array(sample)
+
+
+def test_hypsometric_integral_rejects_complex_values():
+    """Regression #3200: complex/non-numeric inputs must raise, not silently
+    drop the imaginary part.
+
+    hypsometric_integral() used to skip _validate_raster(), so a complex
+    `values` array slipped through and numpy discarded its imaginary part
+    (only a ComplexWarning), returning finite wrong numbers. Every other
+    zonal function rejects complex input with a clear ValueError; this one
+    must too.
+    """
+    from xrspatial.zonal import hypsometric_integral
+
+    zones = xr.DataArray(
+        np.array([[1, 1], [2, 2]], dtype=np.int32), dims=['y', 'x']
+    )
+    values = xr.DataArray(
+        np.array([[1 + 2j, 3 + 1j], [5j, 2 + 0j]], dtype=np.complex128),
+        dims=['y', 'x'],
+    )
+    with pytest.raises(ValueError, match='real numeric dtype'):
+        hypsometric_integral(zones, values, nodata=None)
+
+
+def test_hypsometric_integral_rejects_non_dataarray_values():
+    """Regression #3200: a non-DataArray `values` must raise a clear
+    TypeError from _validate_raster, not an opaque AttributeError from
+    validate_arrays.
+    """
+    from xrspatial.zonal import hypsometric_integral
+
+    zones = xr.DataArray(
+        np.array([[1, 1], [2, 2]], dtype=np.int32), dims=['y', 'x']
+    )
+    raw_values = np.array([[1.0, 2.0], [3.0, 4.0]])
+    with pytest.raises(TypeError, match='must be an xarray.DataArray'):
+        hypsometric_integral(zones, raw_values, nodata=None)

--- a/xrspatial/tests/test_hypsometric_integral.py
+++ b/xrspatial/tests/test_hypsometric_integral.py
@@ -407,7 +407,8 @@ def test_hi_preserves_backend_2525(backend):
         assert is_cupy_array(sample)
 
 
-def test_hypsometric_integral_rejects_complex_values():
+@pytest.mark.parametrize("backend", ['numpy', 'dask+numpy', 'cupy', 'dask+cupy'])
+def test_hypsometric_integral_rejects_complex_values(backend):
     """Regression #3200: complex/non-numeric inputs must raise, not silently
     drop the imaginary part.
 
@@ -415,19 +416,45 @@ def test_hypsometric_integral_rejects_complex_values():
     `values` array slipped through and numpy discarded its imaginary part
     (only a ComplexWarning), returning finite wrong numbers. Every other
     zonal function rejects complex input with a clear ValueError; this one
-    must too.
+    must too. The guard runs before backend dispatch, so it must fire the
+    same way on numpy, cupy, dask+numpy, and dask+cupy.
+    """
+    from xrspatial.utils import has_cuda_and_cupy, has_dask_array
+    from xrspatial.zonal import hypsometric_integral
+
+    if 'cupy' in backend and not has_cuda_and_cupy():
+        pytest.skip("Requires CUDA and CuPy")
+    if 'dask' in backend and not has_dask_array():
+        pytest.skip("Requires Dask")
+
+    zones = create_test_raster(
+        np.array([[1, 1], [2, 2]], dtype=np.int32), backend,
+        dims=['y', 'x'], chunks=(2, 2),
+    )
+    values = create_test_raster(
+        np.array([[1 + 2j, 3 + 1j], [5j, 2 + 0j]], dtype=np.complex128),
+        backend, dims=['y', 'x'], chunks=(2, 2),
+    )
+    with pytest.raises(ValueError, match='real numeric dtype'):
+        hypsometric_integral(zones, values, nodata=None)
+
+
+def test_hypsometric_integral_rejects_3d_values():
+    """Regression #3200: hypsometric_integral is documented 2D-only.
+
+    The added _validate_raster(ndim=2) guard rejects a 3D `values`
+    DataArray with a clear ValueError instead of mangling it downstream.
     """
     from xrspatial.zonal import hypsometric_integral
 
     zones = xr.DataArray(
         np.array([[1, 1], [2, 2]], dtype=np.int32), dims=['y', 'x']
     )
-    values = xr.DataArray(
-        np.array([[1 + 2j, 3 + 1j], [5j, 2 + 0j]], dtype=np.complex128),
-        dims=['y', 'x'],
+    values_3d = xr.DataArray(
+        np.zeros((2, 2, 2), dtype=np.float64), dims=['y', 'x', 'z']
     )
-    with pytest.raises(ValueError, match='real numeric dtype'):
-        hypsometric_integral(zones, values, nodata=None)
+    with pytest.raises(ValueError, match='must be 2D'):
+        hypsometric_integral(zones, values_3d, nodata=None)
 
 
 def test_hypsometric_integral_rejects_non_dataarray_values():

--- a/xrspatial/zonal.py
+++ b/xrspatial/zonal.py
@@ -1743,6 +1743,10 @@ def hypsometric_integral(
     """
     zones = _maybe_rasterize_zones(zones, values, column=column,
                                    rasterize_kw=rasterize_kw)
+
+    _validate_raster(zones, func_name='hypsometric_integral', name='zones', ndim=2)
+    _validate_raster(values, func_name='hypsometric_integral', name='values', ndim=2)
+
     validate_arrays(zones, values)
 
     _nodata = nodata  # capture for closures


### PR DESCRIPTION
Closes #3200

`hypsometric_integral()` was the only public function in `zonal.py` that did not call `_validate_raster()` on its inputs. It went straight from `_maybe_rasterize_zones()` to `validate_arrays()`, which only checks shape and backend parity, not dtype. A complex-dtype `values` array slipped through and numpy silently discarded the imaginary part, returning finite wrong numbers with just a `ComplexWarning`.

- Add `_validate_raster()` for both `zones` and `values` (2D, real numeric) before `validate_arrays()`, matching the pattern in `crop()`.
- Complex / non-numeric `values` now raise a clear `ValueError` (same as `stats()`); a non-DataArray `values` raises a clear `TypeError` instead of an opaque `AttributeError`.

Found during a security sweep of the zonal module (dtype-confusion category).

Backend coverage: the validation runs before backend dispatch, so it applies to numpy, cupy, dask+numpy, and dask+cupy. No backend-specific code changed.

Test plan:
- [x] `test_hypsometric_integral_rejects_complex_values` (complex -> ValueError)
- [x] `test_hypsometric_integral_rejects_non_dataarray_values` (raw ndarray -> TypeError)
- [x] Full `test_hypsometric_integral.py` suite passes (38 passed), confirming valid float/int inputs across all backends are unaffected.