### PR TITLE
Forward caller chunking to the coregister/auto_reproject output

### DIFF
--- a/xrspatial/accessor.py
+++ b/xrspatial/accessor.py
@@ -237,7 +237,8 @@ def _open_geotiff_windowed(obj, source, *, auto_reproject=False,
     covers the full footprint even when the transform has curvature
     across the bbox.
     """
-    from .geotiff import open_geotiff, _read_geo_info, _extent_to_window
+    from .geotiff import (open_geotiff, _read_geo_info, _extent_to_window,
+                          _validate_chunks_arg)
     from .utils import _classify_backend
 
     if resampling not in _RESAMPLING_CHOICES:
@@ -320,7 +321,11 @@ def _open_geotiff_windowed(obj, source, *, auto_reproject=False,
 
     # Infer backend kwargs. Caller-supplied values always win.
     backend = _classify_backend(obj)
-    explicit_chunks = kwargs.get('chunks')
+    # Coerce here because reproject's chunk layout only unpacks builtin
+    # ints, while the read path accepts np.integer scalars.
+    explicit_chunks = _validate_chunks_arg(
+        kwargs.get('chunks'), allow_none=True
+    )
     if backend in ("cupy", "dask+cupy"):
         kwargs.setdefault('gpu', True)
     if backend in ("dask+numpy", "dask+cupy"):
@@ -977,10 +982,11 @@ class XrsSpatialDataArrayAccessor:
             The windowed portion of the GeoTIFF. In ``self``'s CRS when
             ``auto_reproject`` reprojection occurred, on ``self``'s exact
             grid when ``coregister`` is set, and otherwise in the file's
-            native CRS. A dask result chunks like an explicit ``chunks=``
-            kwarg when given, and otherwise like ``self``, including
-            through the ``auto_reproject`` / ``coregister`` reproject
-            step.
+            native CRS. The ``auto_reproject`` / ``coregister``
+            reproject step chunks its dask output like the explicit
+            ``chunks=`` kwarg when given, and otherwise like ``self``,
+            rather than reverting to
+            :func:`~xrspatial.reproject.reproject`'s own default.
         """
         return _open_geotiff_windowed(
             self._obj, source, auto_reproject=auto_reproject,

--- a/xrspatial/accessor.py
+++ b/xrspatial/accessor.py
@@ -86,22 +86,22 @@ def _pick_representative_dataarray(ds, *, var=None):
     )
 
 
-def _infer_caller_y_chunk(obj):
-    """First y-axis chunk size of a dask-backed DataArray, or None."""
+def _infer_caller_chunk(obj, axis):
+    """First chunk size along *axis* of a dask-backed DataArray, or None."""
     try:
-        y_axis = obj.get_axis_num('y')
+        axis_num = obj.get_axis_num(axis)
     except (ValueError, KeyError):
         return None
     chunks_tuple = getattr(obj, 'chunks', None)
     if not chunks_tuple:
         return None
     try:
-        y_chunks = chunks_tuple[y_axis]
+        axis_chunks = chunks_tuple[axis_num]
     except (IndexError, TypeError):
         return None
-    if not y_chunks:
+    if not axis_chunks:
         return None
-    return int(y_chunks[0])
+    return int(axis_chunks[0])
 
 
 def _to_pyproj_crs(crs):
@@ -320,14 +320,28 @@ def _open_geotiff_windowed(obj, source, *, auto_reproject=False,
 
     # Infer backend kwargs. Caller-supplied values always win.
     backend = _classify_backend(obj)
+    explicit_chunks = kwargs.get('chunks')
     if backend in ("cupy", "dask+cupy"):
         kwargs.setdefault('gpu', True)
     if backend in ("dask+numpy", "dask+cupy"):
-        inferred_chunk = _infer_caller_y_chunk(obj)
+        inferred_chunk = _infer_caller_chunk(obj, 'y')
         if inferred_chunk is not None:
             kwargs.setdefault('chunks', inferred_chunk)
 
     result = open_geotiff(source, window=window, **kwargs)
+
+    # reproject defaults its dask output chunks to 512x512; forward the
+    # explicit ``chunks=`` kwarg, or failing that the caller's chunk
+    # layout, so a coregistered / auto-reprojected result keeps the
+    # chunking of the array it is meant to align with (#3234).
+    caller_y_chunk = _infer_caller_chunk(obj, 'y')
+    caller_x_chunk = _infer_caller_chunk(obj, 'x')
+    if explicit_chunks is not None:
+        reproject_chunk_size = explicit_chunks
+    elif caller_y_chunk is not None and caller_x_chunk is not None:
+        reproject_chunk_size = (caller_y_chunk, caller_x_chunk)
+    else:
+        reproject_chunk_size = None
 
     # A masked read replaces the nodata sentinel with NaN but leaves
     # attrs['nodata'] as the raw sentinel; tell reproject the holes are
@@ -356,6 +370,7 @@ def _open_geotiff_windowed(obj, source, *, auto_reproject=False,
             height=height_out,
             resampling=_resolve_resampling(resampling, result),
             nodata=nodata_arg,
+            chunk_size=reproject_chunk_size,
         )
     elif crs_mismatch:
         from .reproject import reproject
@@ -365,6 +380,7 @@ def _open_geotiff_windowed(obj, source, *, auto_reproject=False,
             source_crs=file_crs,
             resampling=_resolve_resampling(resampling, result),
             nodata=nodata_arg,
+            chunk_size=reproject_chunk_size,
         )
 
     return result
@@ -961,7 +977,10 @@ class XrsSpatialDataArrayAccessor:
             The windowed portion of the GeoTIFF. In ``self``'s CRS when
             ``auto_reproject`` reprojection occurred, on ``self``'s exact
             grid when ``coregister`` is set, and otherwise in the file's
-            native CRS.
+            native CRS. A dask result chunks like an explicit ``chunks=``
+            kwarg when given, and otherwise like ``self``, including
+            through the ``auto_reproject`` / ``coregister`` reproject
+            step.
         """
         return _open_geotiff_windowed(
             self._obj, source, auto_reproject=auto_reproject,

--- a/xrspatial/tests/test_open_geotiff_coregister.py
+++ b/xrspatial/tests/test_open_geotiff_coregister.py
@@ -167,6 +167,19 @@ def test_coregister_explicit_chunks_kwarg(tmp_path):
     assert out.data.chunksize == (2, 2)
 
 
+def test_coregister_chunks_kwarg_tuple_and_np_integer(tmp_path):
+    # the (row, col) tuple form is what _compute_chunk_layout unpacks
+    # directly, and np.integer scalars are valid for the read so they
+    # must be coerced before reaching reproject.
+    path = _file_4326(tmp_path, np.float32, 'cg_chunks_forms_3234.tif')
+    template = _template_3857(6)
+    out = template.xrs.open_geotiff(path, coregister=True, chunks=(3, 2))
+    assert out.data.chunksize == (3, 2)
+    out = template.xrs.open_geotiff(path, coregister=True,
+                                    chunks=np.int64(2))
+    assert out.data.chunksize == (2, 2)
+
+
 def test_auto_reproject_dask_template_keeps_caller_chunks(tmp_path):
     # the auto_reproject branch reprojects onto an auto-computed grid,
     # but the output chunk layout should still follow the caller.

--- a/xrspatial/tests/test_open_geotiff_coregister.py
+++ b/xrspatial/tests/test_open_geotiff_coregister.py
@@ -143,6 +143,40 @@ def test_coregister_dask_template(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# output chunking follows the caller (#3234)
+# ---------------------------------------------------------------------------
+
+def test_coregister_dask_template_keeps_caller_chunks(tmp_path):
+    # reproject defaults its dask output chunks to 512 (one whole-array
+    # chunk for a small template); the coregistered result must instead
+    # carry the caller's chunk layout. Asymmetric chunks prove the
+    # (y, x) ordering.
+    path = _file_4326(tmp_path, np.float32, 'cg_chunks_3234.tif')
+    template = _template_3857(6).chunk({'y': 3, 'x': 2})
+    out = template.xrs.open_geotiff(path, coregister=True)
+    assert out.data.chunksize == (3, 2)
+
+
+def test_coregister_explicit_chunks_kwarg(tmp_path):
+    # numpy template + explicit chunks=: the windowed read is dask, and
+    # the coregistered output keeps the requested chunking instead of
+    # reverting to reproject's default.
+    path = _file_4326(tmp_path, np.float32, 'cg_chunks_kw_3234.tif')
+    template = _template_3857(6)
+    out = template.xrs.open_geotiff(path, coregister=True, chunks=2)
+    assert out.data.chunksize == (2, 2)
+
+
+def test_auto_reproject_dask_template_keeps_caller_chunks(tmp_path):
+    # the auto_reproject branch reprojects onto an auto-computed grid,
+    # but the output chunk layout should still follow the caller.
+    path = _file_4326(tmp_path, np.float32, 'ar_chunks_3234.tif')
+    template = _template_3857(6).chunk({'y': 3, 'x': 3})
+    out = template.xrs.open_geotiff(path, auto_reproject=True)
+    assert out.data.chunksize == (3, 3)
+
+
+# ---------------------------------------------------------------------------
 # unpack (renamed from mask_and_scale)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #3234

- `.xrs.open_geotiff` now passes `chunk_size` to the `reproject()` call used by `coregister=True` and `auto_reproject=True`, so a dask result keeps the caller's chunk layout (or the explicit `chunks=` kwarg when one is given) instead of reverting to reproject's 512x512 default.
- Renamed the internal `_infer_caller_y_chunk` to `_infer_caller_chunk(obj, axis)` so the x-axis chunk can be inferred too. Single call site, no public API change.
- Documented the chunking behavior in the DataArray accessor docstring.

Backend coverage: the fix sits in the shared windowed-read path. `coregister` is CPU-only by design (numpy / dask+numpy); the `auto_reproject` chunk forwarding also covers dask+cupy callers.

Test plan:
- [x] `test_coregister_dask_template_keeps_caller_chunks`: dask template chunked (3, 2) gives output chunksize (3, 2), asymmetric to prove (y, x) ordering
- [x] `test_coregister_explicit_chunks_kwarg`: numpy template + `chunks=2` gives output chunksize (2, 2)
- [x] `test_auto_reproject_dask_template_keeps_caller_chunks`: auto_reproject output follows caller chunks
- [x] `test_open_geotiff_coregister.py`, `test_open_geotiff_resampling.py`, `test_accessor.py` all pass (90 tests)