### PR TITLE
hotspots() returned all zeros instead of raising when the raster contains Inf

### DIFF
--- a/xrspatial/focal.py
+++ b/xrspatial/focal.py
@@ -1466,8 +1466,9 @@ def _gistar_global_stats(global_mean, global_std, n):
     if not np.isfinite(global_std):
         raise ValueError(
             "Standard deviation of the input raster values is not finite. "
-            "The raster contains Inf values; mask them (e.g. replace with "
-            "NaN) before calling hotspots()."
+            "The raster likely contains Inf values, or values too large "
+            "for float32; mask them (e.g. replace with NaN) or rescale "
+            "before calling hotspots()."
         )
     if global_std == 0:
         raise ZeroDivisionError(

--- a/xrspatial/focal.py
+++ b/xrspatial/focal.py
@@ -1456,12 +1456,18 @@ def _gistar_global_stats(global_mean, global_std, n):
     ``global_mean`` is the mean of the valid (non-NaN) raster cells,
     ``global_std`` their population standard deviation, and ``n`` the
     count of valid cells. Gi* needs ``n > 1`` (the variance term divides
-    by ``n - 1``) and a non-zero spread.
+    by ``n - 1``) and a non-zero, finite spread.
     """
     if n < 2:
         raise ValueError(
             "hotspots() needs at least 2 valid (non-NaN) cells to "
             "compute the Getis-Ord Gi* statistic."
+        )
+    if not np.isfinite(global_std):
+        raise ValueError(
+            "Standard deviation of the input raster values is not finite. "
+            "The raster contains Inf values; mask them (e.g. replace with "
+            "NaN) before calling hotspots()."
         )
     if global_std == 0:
         raise ZeroDivisionError(
@@ -1476,9 +1482,10 @@ def _gistar_validate_lazy(z_block, global_std, n):
     The dask backends keep ``global_std`` and ``n`` as lazy 0-d arrays, so
     the eager ``_gistar_global_stats`` check never runs on them. This block
     function re-applies that check at compute time and returns ``z_block``
-    unchanged, so degenerate inputs (constant raster, all-NaN raster, or a
-    single valid cell) raise the same errors as the numpy and cupy paths
-    instead of silently classifying to all zeros.
+    unchanged, so degenerate inputs (constant raster, all-NaN raster, a
+    single valid cell, or a raster containing Inf) raise the same errors
+    as the numpy and cupy paths instead of silently classifying to all
+    zeros.
     """
     _gistar_global_stats(0.0, float(global_std), int(n))
     return z_block

--- a/xrspatial/tests/test_focal.py
+++ b/xrspatial/tests/test_focal.py
@@ -1343,7 +1343,8 @@ def test_hotspots_zero_global_std():
 
 
 # Degenerate inputs: constant raster (std == 0), all-NaN raster (n == 0),
-# and a single valid cell (n == 1). The numpy/cupy paths raise eagerly via
+# a single valid cell (n == 1), and a raster containing Inf, which makes
+# the global std NaN (issue #3219). The numpy/cupy paths raise eagerly via
 # _gistar_global_stats; the dask paths must raise the same error at compute
 # time instead of silently classifying to all zeros (issue #2843).
 def _hotspots_degenerate_cases():
@@ -1354,12 +1355,21 @@ def _hotspots_degenerate_cases():
     single_valid = np.full((10, 10), np.nan, dtype=np.float32)
     single_valid[0, 0] = 5.0
 
+    pos_inf = np.arange(100, dtype=np.float32).reshape(10, 10)
+    pos_inf[4, 4] = np.inf
+
+    neg_inf = np.arange(100, dtype=np.float32).reshape(10, 10)
+    neg_inf[4, 4] = -np.inf
+
     std_msg = "Standard deviation of the input raster values is 0."
     n_msg = "needs at least 2 valid"
+    finite_msg = "Standard deviation of the input raster values is not finite"
     return [
         ('constant', constant, ZeroDivisionError, std_msg),
         ('all_nan', all_nan, ValueError, n_msg),
         ('single_valid', single_valid, ValueError, n_msg),
+        ('pos_inf', pos_inf, ValueError, finite_msg),
+        ('neg_inf', neg_inf, ValueError, finite_msg),
     ]
 
 

--- a/xrspatial/tests/test_focal.py
+++ b/xrspatial/tests/test_focal.py
@@ -1355,6 +1355,8 @@ def _hotspots_degenerate_cases():
     single_valid = np.full((10, 10), np.nan, dtype=np.float32)
     single_valid[0, 0] = 5.0
 
+    # A single Inf of either sign poisons nanstd the same way (std == NaN);
+    # both signs are pinned so neither regresses independently.
     pos_inf = np.arange(100, dtype=np.float32).reshape(10, 10)
     pos_inf[4, 4] = np.inf
 


### PR DESCRIPTION
Closes #3219

With an Inf cell in the raster, `np.nanstd` / `cupy.nanstd` comes out NaN. `_gistar_global_stats` only guarded `global_std == 0`, and `NaN == 0` is False, so validation passed. Every Gi* z-score was then NaN, and `_gistar_zscore` maps non-finite z-scores to 0, so every cell got classified as "no significance".

- `_gistar_global_stats` now raises `ValueError` when `global_std` is not finite, with a message pointing at Inf values
- numpy and cupy raise eagerly; dask+numpy and dask+cupy pick the check up through `_gistar_validate_lazy` and raise at compute time, same as the degenerate inputs from #2843
- new `pos_inf` / `neg_inf` cases in the degenerate-input test matrix, which runs on all four backends

Test plan:
- [x] `pytest xrspatial/tests/test_focal.py -k "degenerate or hotspots"`: 64 passed, 0 skipped (GPU cases ran)
- [x] the repro from the issue raises `ValueError` instead of returning all zeros