### PR TITLE
Keep float32 sources float32 through to_geotiff(pack=True) (#3080)

### DIFF
--- a/xrspatial/geotiff/_attrs.py
+++ b/xrspatial/geotiff/_attrs.py
@@ -571,7 +571,10 @@ _TIFF_SHORT = 3
 # Version 5 adds ``attrs['mask_and_scale_dtype']``: the integer source
 # dtype recorded when ``mask_nodata`` / ``mask_and_scale`` promoted the
 # array to float on read. ``to_geotiff(pack=True)`` reads it to restore
-# the on-disk dtype. Existing keys keep their pre-v5 shape.
+# the on-disk dtype. Existing keys keep their pre-v5 shape. #3080 later
+# extended emission (same key, same shape, still v5) to float sources on
+# ``mask_and_scale`` reads that carry a sentinel or a non-identity
+# scale / offset, so ``pack`` keeps float32 sources float32.
 _ATTRS_CONTRACT_VERSION = 5
 
 

--- a/xrspatial/geotiff/_attrs.py
+++ b/xrspatial/geotiff/_attrs.py
@@ -77,10 +77,13 @@ Canonical (xrspatial owns these; round-trip stable):
   happened so consumers can tell float-because-masked from
   float-because-promoted.
 - ``mask_and_scale_dtype`` (#3064, contract v5): string dtype name of
-  the integer source (e.g. ``"int8"``), only emitted when masking
-  and / or ``mask_and_scale`` promoted an integer array to float on
-  read. ``to_geotiff(pack=True)`` reads it to reverse the promotion and
-  restore the on-disk dtype.
+  the source (e.g. ``"int8"``). Emitted when masking and / or
+  ``mask_and_scale`` promoted an integer array to float on read, and
+  on ``mask_and_scale`` reads of float sources that carry a declared
+  sentinel or a non-identity scale / offset (#3080) -- float sources
+  are never promoted, but recording their width keeps
+  ``to_geotiff(pack=True)`` from widening float32 to float64.
+  ``pack`` reads it to restore the on-disk dtype.
 - ``raster_type``: ``'area'`` (implicit / RasterPixelIsArea) or ``'point'``
   (explicit / RasterPixelIsPoint).
 - ``georef_status``: one of ``'full'``, ``'transform_only'``, ``'crs_only'``,
@@ -1718,10 +1721,11 @@ def _pack(data, nodata=None):
 
     Reverses the scale / offset applied on read (``(data - add_offset) /
     scale_factor``), fills NaN back to the nodata sentinel, and
-    casts to the integer source dtype recorded in
-    ``attrs['mask_and_scale_dtype']`` (falling back to the dtype of
-    ``attrs['nodata']`` for arrays read by an xrspatial release predating
-    contract v5). Returns a new DataArray; ``data`` is left untouched.
+    casts to the source dtype recorded in
+    ``attrs['mask_and_scale_dtype']`` (falling back to the dtype of an
+    integer ``attrs['nodata']`` for arrays read by an xrspatial release
+    predating contract v5, and to the buffer's own dtype otherwise).
+    Returns a new DataArray; ``data`` is left untouched.
 
     ``nodata`` is the writer's explicit ``nodata=`` kwarg. When given, it
     overrides the attrs sentinel as the NaN fill value, matching the
@@ -1789,11 +1793,16 @@ def _pack(data, nodata=None):
 
     out = (data - offset) / scale
 
-    if target is None and attrs_nodata is not None:
-        # Best-effort recovery for pre-v5 reads: the attrs sentinel is
-        # stored in the source dtype, so its width is the source width.
-        # (The ``nodata`` kwarg carries no width information, so it never
-        # feeds this fallback.)
+    if (target is None and attrs_nodata is not None
+            and np.asarray(attrs_nodata).dtype.kind in ('i', 'u')):
+        # Best-effort recovery for pre-v5 reads of integer sources: the
+        # attrs sentinel is stored in the source dtype, so its width is
+        # the source width. Float sentinels are excluded -- a reader
+        # stores them as plain Python floats, so their width says
+        # float64 regardless of the source's width (issue #3080); the
+        # buffer below is the better signal because float sources are
+        # never promoted on read. (The ``nodata`` kwarg carries no width
+        # information, so it never feeds this fallback.)
         target = np.asarray(attrs_nodata).dtype.name
     tgt = np.dtype(target) if target is not None else np.dtype(str(out.dtype))
 
@@ -2007,15 +2016,21 @@ def _finalize_eager_read(
             attrs['scale_factor'] = scale
             attrs['add_offset'] = offset
 
-    # Record the integer source dtype when ``mask_and_scale`` promoted it to
-    # float, so ``to_geotiff(pack=True)`` can re-pack the decoded array
-    # (issue #3064). Scoped to ``mask_and_scale`` reads (not a plain
-    # ``masked`` read) since ``pack`` is the inverse of ``mask_and_scale``;
-    # the attr name says as much. Checked before the caller ``dtype=`` cast
-    # so it captures the on-disk dtype, not the caller's requested cast.
-    if (mask_and_scale and pre_promote_dtype.kind != 'f'
-            and np.dtype(str(arr.dtype)).kind == 'f'):
-        attrs['mask_and_scale_dtype'] = pre_promote_dtype.name
+    # Record the source dtype so ``to_geotiff(pack=True)`` can re-pack the
+    # decoded array (issue #3064). Scoped to ``mask_and_scale`` reads (not a
+    # plain ``masked`` read) since ``pack`` is the inverse of
+    # ``mask_and_scale``; the attr name says as much. Checked before the
+    # caller ``dtype=`` cast so it captures the on-disk dtype, not the
+    # caller's requested cast. Integer sources record it when the read
+    # promoted them to float. Float sources are never promoted, but record
+    # it too whenever the read carries unpack state to reverse (a declared
+    # sentinel or a non-identity scale / offset): without the attr,
+    # ``_pack`` falls back to the nodata scalar's dtype and widens a
+    # float32 source to float64 (issue #3080).
+    if mask_and_scale and np.dtype(str(arr.dtype)).kind == 'f':
+        if (pre_promote_dtype.kind != 'f'
+                or nodata is not None or 'scale_factor' in attrs):
+            attrs['mask_and_scale_dtype'] = pre_promote_dtype.name
 
     # Caller-requested dtype cast (post-mask so the integer
     # promotion above runs first). ``_validate_dtype_cast`` lives in

--- a/xrspatial/geotiff/_backends/dask.py
+++ b/xrspatial/geotiff/_backends/dask.py
@@ -545,16 +545,18 @@ def _read_geotiff_dask(source: str, *,
         allow_unparseable_crs=allow_unparseable_crs,
     )
 
-    # Record the integer source dtype when a *real* ``mask_and_scale``
-    # transform -- masking a fittable sentinel, here, or a non-identity
-    # scale / offset, in the block below -- promotes the array to float, so
-    # ``to_geotiff(pack=True)`` can re-pack (issue #3064). Scoped to
-    # ``mask_and_scale`` (not a plain ``masked`` read) to mirror the eager
-    # path. ``effective_dtype`` now agrees with this gate (issue #3066), so a
-    # bare ``mask_and_scale`` read of an int source with no scale / offset and
-    # no sentinel stays integer and records nothing.
+    # Record the source dtype when a *real* ``mask_and_scale`` transform --
+    # masking a fittable sentinel, here, or a non-identity scale / offset,
+    # in the block below -- runs, so ``to_geotiff(pack=True)`` can re-pack
+    # (issue #3064). Scoped to ``mask_and_scale`` (not a plain ``masked``
+    # read) to mirror the eager path. ``effective_dtype`` now agrees with
+    # this gate (issue #3066), so a bare ``mask_and_scale`` read of an int
+    # source with no scale / offset and no sentinel stays integer and
+    # records nothing. Float sources record it too (issue #3080): they are
+    # never promoted, but without the attr ``_pack`` infers the target
+    # dtype from the nodata scalar and widens float32 to float64.
     if (mask_and_scale
-            and file_dtype.kind in ('u', 'i')
+            and file_dtype.kind in ('u', 'i', 'f')
             and nodata is not None
             and lifecycle.sentinel_fits_buffer):
         attrs['mask_and_scale_dtype'] = file_dtype.name
@@ -668,9 +670,9 @@ def _read_geotiff_dask(source: str, *,
         attrs['scale_factor'] = ms_scale
         attrs['add_offset'] = ms_offset
         # A non-identity scale / offset is the other real transform that
-        # promotes an int source to float (issue #3064).
-        if file_dtype.kind != 'f':
-            attrs.setdefault('mask_and_scale_dtype', file_dtype.name)
+        # promotes an int source to float (issue #3064). Float sources
+        # record their dtype too so ``pack`` keeps their width (#3080).
+        attrs.setdefault('mask_and_scale_dtype', file_dtype.name)
 
     # ``parse_coordinates=False`` drops the x / y coordinate arrays (the
     # transform / crs attrs still carry georeferencing); the band coord is

--- a/xrspatial/geotiff/_writers/eager.py
+++ b/xrspatial/geotiff/_writers/eager.py
@@ -365,15 +365,21 @@ def to_geotiff(data: xr.DataArray | np.ndarray,
         [experimental] Inverse of ``open_geotiff(unpack=True)``. Re-pack
         a decoded float array before writing: reverse the scale / offset
         recorded on ``attrs['scale_factor']`` / ``attrs['add_offset']``,
-        fill NaN back to the nodata sentinel, and cast to the integer source
+        fill NaN back to the nodata sentinel, and cast to the source
         dtype recorded on ``attrs['mask_and_scale_dtype']`` (contract v5;
-        the attr keeps its historical name). The output stores the raw
-        packed integers and keeps the SCALE / OFFSET GDAL_METADATA, so
-        reopening it with ``unpack=True`` unpacks to the original values
-        instead of scaling a second time. Raises ``ValueError`` for a bare
-        array (no attrs) or one that never went through an ``unpack``
-        read. The dtype falls back to the ``attrs['nodata']`` width for
-        arrays read before contract v5. An explicit ``nodata=`` kwarg
+        the attr keeps its historical name). The recorded dtype is the
+        on-disk one, so an integer source gets its integer dtype back and
+        a float32 source stays float32 rather than widening to float64
+        (#3080). The output stores the raw packed values and keeps the
+        SCALE / OFFSET GDAL_METADATA, so reopening it with
+        ``unpack=True`` unpacks to the original values instead of scaling
+        a second time. Raises ``ValueError`` for a bare array (no attrs)
+        or one that never went through an ``unpack`` read. When the attr
+        is absent (arrays read before contract v5), the dtype falls back
+        to the width of an integer-typed ``attrs['nodata']``, or to the
+        buffer's own dtype when the sentinel is a float (a float sentinel
+        is stored as a plain Python float and carries no width
+        information). An explicit ``nodata=`` kwarg
         overrides the attrs sentinel as the NaN fill value, so the filled
         pixels always agree with the GDAL_NODATA tag the writer emits.
         When NaN pixels exist with no sentinel to fill them and an

--- a/xrspatial/geotiff/tests/write/test_pack_float_width_3080.py
+++ b/xrspatial/geotiff/tests/write/test_pack_float_width_3080.py
@@ -1,0 +1,141 @@
+"""``to_geotiff(pack=True)`` must keep a float32 source float32 (#3080).
+
+``_pack`` casts to the dtype recorded on ``attrs['mask_and_scale_dtype']``.
+Float sources never used to record that attr (they are not promoted on
+read), so ``_pack`` fell back to the dtype of the nodata scalar -- a plain
+Python float, i.e. float64 -- and widened the packed file. The fix records
+the source dtype on ``unpack=True`` reads of float sources too, and stops
+the fallback from keying off float-typed sentinels.
+
+GPU / dask+GPU pack round-trips are pinned on #3112 / covered by #3114;
+this file exercises the numpy and dask+numpy legs.
+"""
+import numpy as np
+import pytest
+import xarray as xr
+
+from xrspatial.geotiff import open_geotiff, to_geotiff
+
+
+def _write_f32_tiff(path, data, *, nodata=None, scale=None, offset=None):
+    """Write float32 ``data`` as a GeoTIFF, optionally carrying a nodata
+    sentinel and GDAL SCALE/OFFSET packing metadata."""
+    h, w = data.shape
+    attrs = {"crs": 4326}
+    if nodata is not None:
+        attrs["nodata"] = nodata
+    if scale is not None or offset is not None:
+        attrs["gdal_metadata"] = {
+            "SCALE": str(scale if scale is not None else 1.0),
+            "OFFSET": str(offset if offset is not None else 0.0),
+        }
+    da = xr.DataArray(
+        data,
+        dims=("y", "x"),
+        coords={"y": np.arange(h, 0, -1) - 0.5, "x": np.arange(w) + 0.5},
+        attrs=attrs,
+    )
+    to_geotiff(da, path)
+    return path
+
+
+def _reopen(path, chunks, **kwargs):
+    return (open_geotiff(path, **kwargs) if chunks is None
+            else open_geotiff(path, chunks=chunks, **kwargs))
+
+
+@pytest.mark.parametrize("chunks", [None, 2], ids=["numpy", "dask"])
+def test_pack_preserves_float32_width(tmp_path, chunks):
+    """float32 + nodata, read with unpack=True, packs back to float32."""
+    data = np.array([[1.5, 2.5, -9999.0], [4.5, 5.5, 6.5]], dtype=np.float32)
+    src = _write_f32_tiff(tmp_path / "src_f32_3080.tif", data, nodata=-9999.0)
+
+    decoded = _reopen(src, chunks, unpack=True)
+    assert decoded.dtype == np.float32  # read never promotes float sources
+    assert decoded.attrs.get("mask_and_scale_dtype") == "float32"
+
+    out = str(tmp_path / "out_f32_3080.tif")
+    decoded.xrs.to_geotiff(out, pack=True)
+
+    back = open_geotiff(out)
+    assert str(back.dtype) == "float32"
+    np.testing.assert_array_equal(np.asarray(back.data), data)
+
+
+@pytest.mark.parametrize("chunks", [None, 2], ids=["numpy", "dask"])
+def test_pack_preserves_float32_width_with_scale_offset(tmp_path, chunks):
+    data = np.array([[1.5, 2.5, -9999.0], [4.5, 5.5, 6.5]], dtype=np.float32)
+    src = _write_f32_tiff(
+        tmp_path / "src_f32_so_3080.tif", data,
+        nodata=-9999.0, scale=2.0, offset=10.0)
+
+    decoded = _reopen(src, chunks, unpack=True)
+    assert decoded.dtype == np.float32
+    assert decoded.attrs.get("mask_and_scale_dtype") == "float32"
+
+    out = str(tmp_path / "out_f32_so_3080.tif")
+    decoded.xrs.to_geotiff(out, pack=True)
+
+    # Raw read: float32 width and the stored values round-trip exactly
+    # (1.5 / 2.0 / 10.0 are all binary-exact in float32).
+    raw = open_geotiff(out)
+    assert str(raw.dtype) == "float32"
+    np.testing.assert_array_equal(np.asarray(raw.data), data)
+
+    # The kept SCALE/OFFSET tags unpack the packed file to the same
+    # values as the source, not scaled twice.
+    src_decoded = open_geotiff(src, unpack=True)
+    repacked_decoded = open_geotiff(out, unpack=True)
+    np.testing.assert_array_equal(
+        np.asarray(repacked_decoded.data), np.asarray(src_decoded.data))
+
+
+def test_float32_attr_recorded_eager_dask_match(tmp_path):
+    data = np.array([[1.5, 2.5, -9999.0], [4.5, 5.5, 6.5]], dtype=np.float32)
+    src = _write_f32_tiff(
+        tmp_path / "src_f32_attr_3080.tif", data, nodata=-9999.0)
+
+    eager = open_geotiff(src, unpack=True)
+    lazy = open_geotiff(src, unpack=True, chunks=2)
+    assert eager.attrs.get("mask_and_scale_dtype") == "float32"
+    assert (eager.attrs.get("mask_and_scale_dtype")
+            == lazy.attrs.get("mask_and_scale_dtype"))
+
+
+@pytest.mark.parametrize("chunks", [None, 2], ids=["numpy", "dask"])
+def test_pack_masked_read_keeps_float32_width(tmp_path, chunks):
+    """A plain ``masked=True`` read records no ``mask_and_scale_dtype``
+    (pack is the inverse of unpack specifically), so ``_pack`` used to
+    fall back to the float64 width of the nodata scalar. The buffer's own
+    width is the right target: float sources are never promoted on read.
+    """
+    data = np.array([[1.5, 2.5, -9999.0], [4.5, 5.5, 6.5]], dtype=np.float32)
+    src = _write_f32_tiff(
+        tmp_path / "src_f32_masked_3080.tif", data, nodata=-9999.0)
+
+    decoded = _reopen(src, chunks, masked=True)
+    assert "mask_and_scale_dtype" not in decoded.attrs
+
+    out = str(tmp_path / "out_f32_masked_3080.tif")
+    decoded.xrs.to_geotiff(out, pack=True)
+
+    back = open_geotiff(out)
+    assert str(back.dtype) == "float32"
+    np.testing.assert_array_equal(np.asarray(back.data), data)
+
+
+@pytest.mark.parametrize("chunks", [None, 2], ids=["numpy", "dask"])
+def test_pack_still_rejects_no_op_float_unpack_read(tmp_path, chunks):
+    """A float source with no sentinel and no scale / offset carries no
+    unpack state to reverse. Recording the float dtype is gated on real
+    unpack state so this read still gets the loud error rather than a
+    silent pass-through write."""
+    data = np.array([[1.5, 2.5], [4.5, 5.5]], dtype=np.float32)
+    src = _write_f32_tiff(tmp_path / "src_f32_noop_3080.tif", data)
+
+    decoded = _reopen(src, chunks, unpack=True)
+    assert "mask_and_scale_dtype" not in decoded.attrs
+
+    with pytest.raises(ValueError, match="no unpack state"):
+        decoded.xrs.to_geotiff(
+            str(tmp_path / "out_f32_noop_3080.tif"), pack=True)

--- a/xrspatial/geotiff/tests/write/test_pack_float_width_3080.py
+++ b/xrspatial/geotiff/tests/write/test_pack_float_width_3080.py
@@ -103,6 +103,58 @@ def test_float32_attr_recorded_eager_dask_match(tmp_path):
 
 
 @pytest.mark.parametrize("chunks", [None, 2], ids=["numpy", "dask"])
+def test_pack_keeps_float64_width(tmp_path, chunks):
+    """float64 sources now record ``mask_and_scale_dtype='float64'`` too.
+    The recorded cast is a no-op there; pin it so the widest-float case
+    cannot regress."""
+    data = np.array([[1.5, 2.5, -9999.0], [4.5, 5.5, 6.5]], dtype=np.float64)
+    src = _write_f32_tiff(tmp_path / "src_f64_3080.tif", data, nodata=-9999.0)
+
+    decoded = _reopen(src, chunks, unpack=True)
+    assert decoded.dtype == np.float64
+    assert decoded.attrs.get("mask_and_scale_dtype") == "float64"
+
+    out = str(tmp_path / "out_f64_3080.tif")
+    decoded.xrs.to_geotiff(out, pack=True)
+
+    back = open_geotiff(out)
+    assert str(back.dtype) == "float64"
+    np.testing.assert_array_equal(np.asarray(back.data), data)
+
+
+def test_pack_pre_v5_integer_sentinel_fallback(tmp_path):
+    """``_pack``'s pre-v5 fallback still keys off an integer-typed
+    sentinel. #3080 narrowed that fallback to integer sentinels only, so
+    pin the surviving branch: with ``mask_and_scale_dtype`` absent and an
+    integer-dtype ``attrs['nodata']``, pack restores the sentinel's
+    dtype."""
+    data = np.array([[1, 2, -128], [4, 5, 6]], dtype=np.int8)
+    h, w = data.shape
+    src_da = xr.DataArray(
+        data,
+        dims=("y", "x"),
+        coords={"y": np.arange(h, 0, -1) - 0.5, "x": np.arange(w) + 0.5},
+        attrs={"crs": 4326, "nodata": -128},
+    )
+    src = tmp_path / "src_i8_prev5_3080.tif"
+    to_geotiff(src_da, src)
+
+    decoded = open_geotiff(src, unpack=True)
+    assert decoded.attrs.get("mask_and_scale_dtype") == "int8"
+    # Simulate a pre-v5 read: no recorded dtype, sentinel stored in the
+    # source dtype.
+    decoded.attrs.pop("mask_and_scale_dtype")
+    decoded.attrs["nodata"] = np.int8(-128)
+
+    out = str(tmp_path / "out_i8_prev5_3080.tif")
+    decoded.xrs.to_geotiff(out, pack=True)
+
+    back = open_geotiff(out)
+    assert str(back.dtype) == "int8"
+    np.testing.assert_array_equal(np.asarray(back.data), data)
+
+
+@pytest.mark.parametrize("chunks", [None, 2], ids=["numpy", "dask"])
 def test_pack_masked_read_keeps_float32_width(tmp_path, chunks):
     """A plain ``masked=True`` read records no ``mask_and_scale_dtype``
     (pack is the inverse of unpack specifically), so ``_pack`` used to


### PR DESCRIPTION
Closes #3080.

- `unpack=True` reads of float sources now record `attrs['mask_and_scale_dtype']` when there is real unpack state to reverse (a declared nodata sentinel or a non-identity scale/offset). Both the eager and dask read paths record it; the cupy and dask+cupy backends share those code paths (`_finalize_eager_read` / `_read_geotiff_dask`), so the attr lands on all four backends.
- `_pack` no longer infers the target dtype from a float-typed nodata scalar. That fallback was written for pre-v5 integer reads, where the sentinel is stored in the source dtype; it now only applies to integer sentinels. Float buffers keep their own width, which also fixes the same widening when a plain `masked=True` read is packed back.
- No new attrs key and no shape change, so the attrs contract stays at v5. The contract docs in `_attrs.py` are updated.

Backend coverage: numpy and dask+numpy are tested directly. cupy and dask+cupy get the read-side attr through the shared paths, but their pack round-trips are still pinned on #3112; #3114 is adding that coverage separately.

Test plan:
- [x] New tests in `xrspatial/geotiff/tests/write/test_pack_float_width_3080.py`: float32 round-trip with and without scale/offset (numpy + dask), eager/dask attr parity, masked-read pack width, and a guard that a no-op unpack read still raises "no unpack state". 7 of the 9 fail without the fix.
- [x] Full `xrspatial/geotiff/tests` suite: 6385 passed, 68 skipped, 3 xfailed.

Heads up: #3114 (GPU/dask+GPU pack round-trip test coverage) is in flight on a separate branch from main. Both PRs touch the pack area, so whichever merges second may need a small reconcile. The new tests here live in their own file to keep the overlap small.