### PR TITLE
Fix to_geotiff(pack=True) crash on cupy and dask+cupy input

### DIFF
--- a/docs/source/reference/geotiff_release_contract.md
+++ b/docs/source/reference/geotiff_release_contract.md
@@ -93,7 +93,7 @@ category. The `Key` column matches the runtime key.
 | `reader.allow_rotated` | experimental | Opt-in `allow_rotated=True`; drops the axis-aligned `transform` attr in favour of `rotated_affine`. |
 | `reader.allow_unparseable_crs` | experimental | Opt-in escape hatch for CRS strings pyproj cannot parse. |
 | `reader.gpu` | experimental | GPU read path; no cross-backend numerical parity claim. |
-| `reader.unpack` | experimental | `unpack=True` scale/offset decode on `open_geotiff` (CF-packed integers to float, nodata sentinel to NaN). Experimental because the GPU path crashes (#3112) and the GPU / dask+GPU branches lack tests (#3114). |
+| `reader.unpack` | experimental | `unpack=True` scale/offset decode on `open_geotiff` (CF-packed integers to float, nodata sentinel to NaN). Experimental because the GPU / dask+GPU branches gained round-trip coverage only recently (#3112 pack crash fix, #3114); no behavioural promise yet. |
 
 ### Writers
 

--- a/docs/source/reference/release_gate_geotiff.rst
+++ b/docs/source/reference/release_gate_geotiff.rst
@@ -470,8 +470,9 @@ attrs contract
      - ``unpack=True`` applies GDAL ``SCALE`` / ``OFFSET`` and masks the
        nodata sentinel to NaN, recording ``scale_factor`` /
        ``add_offset`` / ``mask_and_scale_dtype`` on the attrs. CPU eager
-       and dask paths are tested; the GPU branches are not (#3112,
-       #3114), which is why the row sits at ``experimental``.
+       and dask paths are tested; the GPU branches gained round-trip
+       coverage only recently (#3112, #3114), which is why the row sits
+       at ``experimental``.
      - ``xrspatial/geotiff/tests/read/test_rioxarray_compat_2961.py``,
        ``xrspatial/geotiff/tests/read/test_mask_and_scale_dtype_parity_3066.py``
      - `#3163`_

--- a/xrspatial/geotiff/_attrs.py
+++ b/xrspatial/geotiff/_attrs.py
@@ -333,9 +333,9 @@ SUPPORTED_FEATURES = {
     'reader.gpu': 'experimental',
     # ``unpack=True`` scale/offset decode on ``open_geotiff`` (CF-style
     # packed integers -> float, nodata sentinel -> NaN). Sits at
-    # ``experimental`` rather than ``advanced``: the GPU path crashes
-    # (#3112) and the GPU / dask+GPU branches have no test coverage
-    # (#3114), so no behavioural promise is made yet.
+    # ``experimental`` rather than ``advanced``: the GPU / dask+GPU
+    # branches gained round-trip coverage only recently (#3112 pack
+    # crash fix, #3114 coverage), so no behavioural promise is made yet.
     'reader.unpack': 'experimental',
     # Write paths.
     'writer.local_file': 'stable',
@@ -355,7 +355,8 @@ SUPPORTED_FEATURES = {
     # (re-apply scale/offset, restore the recorded integer dtype, fill
     # NaN back to the nodata sentinel). Tracked at the same
     # ``experimental`` tier as ``reader.unpack`` -- the pair shares the
-    # scale/offset attr contract and the open GPU gaps (#3112, #3114).
+    # scale/offset attr contract and the recently-closed GPU gaps
+    # (#3112, #3114).
     'writer.pack': 'experimental',
     # BigTIFF COG writer surface.
     # Tracked separately from ``writer.bigtiff`` and ``writer.cog`` because
@@ -1699,6 +1700,27 @@ def _extract_scale_offset(gdal_metadata, band=None, *, malformed=False):
     return scale, offset
 
 
+def _pack_fill_nan(chunk, fill):
+    """NaN -> sentinel fill for ``_pack``, at the buffer level.
+
+    ``DataArray.fillna`` routes through xarray's ``duck_array_ops.where``,
+    which breaks on cupy-backed arrays (issue #3112): eager cupy hits
+    xarray calling ``cupy.astype`` (AttributeError on cupy 13.6), and a
+    dask+cupy graph feeds the host-side 0-d fill array into
+    ``cupy.where`` (TypeError). Filling through a boolean mask on the
+    raw buffer sidesteps ``where`` entirely: ``np.isnan`` dispatches to
+    cupy via ``__array_ufunc__`` and the masked assignment takes a
+    plain Python scalar on numpy and cupy alike.
+    """
+    if chunk.dtype.kind != 'f':
+        # Integer buffers cannot hold NaN; nothing to fill (matches
+        # ``fillna``'s no-op on non-float data).
+        return chunk
+    out = chunk.copy()
+    out[np.isnan(out)] = float(fill)
+    return out
+
+
 def _pack_guard_no_nan(chunk, tgt_name):
     """Per-chunk NaN guard for ``_pack``'s no-sentinel integer restore.
 
@@ -1830,7 +1852,17 @@ def _pack(data, nodata=None):
         # NaN at all; floats would otherwise write NaN pixels under a
         # GDAL_NODATA tag that still declares the sentinel, leaving an
         # inconsistent file that non-masking readers misread (#3078).
-        out = out.fillna(nodata)
+        # Not ``fillna``: that routes through xarray's where(), which
+        # crashes on cupy-backed arrays (#3112). ``_pack_fill_nan``
+        # fills at the buffer level on all four backends; dask backings
+        # keep the fill lazy via the same map_blocks shape as the
+        # no-sentinel guard below.
+        if hasattr(out.data, 'dask'):
+            out = out.copy(data=out.data.map_blocks(
+                _pack_fill_nan, nodata,
+                dtype=out.dtype, meta=out.data._meta))
+        else:
+            out = out.copy(data=_pack_fill_nan(out.data, nodata))
     elif tgt.kind in ('i', 'u'):
         # No sentinel exists to fill an integer's holes, so a NaN pixel
         # must abort the pack: the ``astype`` below would silently wrap

--- a/xrspatial/geotiff/tests/write/test_pack_3064.py
+++ b/xrspatial/geotiff/tests/write/test_pack_3064.py
@@ -18,6 +18,7 @@ import pytest
 import xarray as xr
 
 from xrspatial.geotiff import open_geotiff, to_geotiff
+from xrspatial.geotiff._attrs import _pack, _pack_fill_nan
 
 from .._helpers.markers import requires_gpu
 
@@ -44,9 +45,22 @@ def _write_int_tiff(path, data, *, nodata=None, scale=None, offset=None):
     return path
 
 
-def _reopen(path, chunks):
-    return (open_geotiff(path, unpack=True) if chunks is None
-            else open_geotiff(path, unpack=True, chunks=chunks))
+def _reopen(path, chunks, gpu=False):
+    kwargs = {"unpack": True}
+    if gpu:
+        kwargs["gpu"] = True
+    if chunks is not None:
+        kwargs["chunks"] = chunks
+    return open_geotiff(path, **kwargs)
+
+
+def _to_host(data):
+    """Materialise a possibly dask- and/or cupy-backed buffer as numpy."""
+    if hasattr(data, "compute"):
+        data = data.compute()
+    if hasattr(data, "get"):
+        data = data.get()
+    return np.asarray(data)
 
 
 # ---------------------------------------------------------------------------
@@ -91,8 +105,15 @@ def test_pack_restores_uint16_no_scale(tmp_path, chunks):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("chunks", [None, 2], ids=["numpy", "dask"])
-def test_pack_restores_float_nodata_sentinel(tmp_path, chunks):
+@pytest.mark.parametrize("chunks,gpu", [
+    pytest.param(None, False, id="numpy"),
+    pytest.param(2, False, id="dask"),
+    # The gpu legs pin the float branch of the #3112 fill fix: a float
+    # sentinel restored on a cupy-backed buffer.
+    pytest.param(None, True, marks=requires_gpu, id="gpu"),
+    pytest.param(2, True, marks=requires_gpu, id="dask-gpu"),
+])
+def test_pack_restores_float_nodata_sentinel(tmp_path, chunks, gpu):
     """A float raster masks its sentinel to NaN on an ``unpack=True`` read.
     ``pack=True`` must put the declared sentinel back so the pixels on disk
     match the GDAL_NODATA tag -- otherwise the file declares nodata=-9999 but
@@ -101,8 +122,8 @@ def test_pack_restores_float_nodata_sentinel(tmp_path, chunks):
     data = np.array([[1.5, 2.5, -9999.0], [4.5, 5.5, 6.5]], dtype=np.float32)
     src = _write_int_tiff(tmp_path / "src_f32_3078.tif", data, nodata=-9999.0)
 
-    decoded = _reopen(src, chunks)
-    assert np.isnan(np.asarray(decoded.data)).any()  # sentinel was masked
+    decoded = _reopen(src, chunks, gpu=gpu)
+    assert np.isnan(_to_host(decoded.data)).any()  # sentinel was masked
 
     out = str(tmp_path / "out_f32_3078.tif")
     decoded.xrs.to_geotiff(out, pack=True)
@@ -116,7 +137,7 @@ def test_pack_restores_float_nodata_sentinel(tmp_path, chunks):
     # An unpack read still round-trips the masked value to NaN.
     repacked = open_geotiff(out, unpack=True)
     np.testing.assert_array_equal(
-        np.asarray(repacked.data), np.asarray(decoded.data))
+        np.asarray(repacked.data), _to_host(decoded.data))
 
 
 # ---------------------------------------------------------------------------
@@ -195,8 +216,6 @@ def test_pack_round_trip_gpu(tmp_path, chunks):
 
 
 def test_pack_fill_nan_fills_sentinel_numpy():
-    from xrspatial.geotiff._attrs import _pack_fill_nan
-
     chunk = np.array([[1.0, np.nan], [np.nan, 4.0]])
     out = _pack_fill_nan(chunk, np.uint8(255))
     np.testing.assert_array_equal(out, [[1.0, 255.0], [255.0, 4.0]])
@@ -205,8 +224,6 @@ def test_pack_fill_nan_fills_sentinel_numpy():
 
 
 def test_pack_fill_nan_skips_integer_chunk():
-    from xrspatial.geotiff._attrs import _pack_fill_nan
-
     chunk = np.array([[1, 2]], dtype=np.int32)
     assert _pack_fill_nan(chunk, 255) is chunk
 
@@ -215,12 +232,46 @@ def test_pack_fill_nan_skips_integer_chunk():
 def test_pack_fill_nan_handles_cupy_chunks():
     import cupy
 
-    from xrspatial.geotiff._attrs import _pack_fill_nan
-
     chunk = cupy.asarray(np.array([[1.0, np.nan]]))
     out = _pack_fill_nan(chunk, 255)
     assert isinstance(out, cupy.ndarray)
     np.testing.assert_array_equal(out.get(), [[1.0, 255.0]])
+
+
+def test_pack_sentinel_fill_stays_lazy():
+    """The NaN -> sentinel fill must not compute dask input at ``_pack`` time.
+
+    Pins the lazy shape of the #3112 fill the same way
+    ``test_pack_lazy_nan_guard_3235.py`` pins the no-sentinel guard: a
+    counting identity block threaded through the graph stays at zero
+    until something computes.
+    """
+    import dask.array as dask_array
+
+    counts = {"n": 0}
+
+    def _count(block):
+        counts["n"] += 1
+        return block
+
+    values = np.array([[1.0, np.nan], [3.0, 4.0]])
+    src = dask_array.from_array(values, chunks=2)
+    # meta= keeps dask from probing _count with an empty block at graph
+    # build time, which would increment the counter without a compute.
+    arr = src.map_blocks(_count, dtype=values.dtype, meta=src._meta)
+    da = xr.DataArray(
+        arr, dims=("y", "x"),
+        attrs={"crs": 4326, "nodata": 255, "masked_nodata": True,
+               "scale_factor": 1.0, "add_offset": 0.0,
+               "mask_and_scale_dtype": "uint8"},
+    )
+
+    packed = _pack(da)
+    assert hasattr(packed.data, "dask")
+    assert counts["n"] == 0  # nothing computed at _pack time
+
+    np.testing.assert_array_equal(
+        np.asarray(packed.compute().data), [[1, 255], [3, 4]])
 
 
 # ---------------------------------------------------------------------------

--- a/xrspatial/geotiff/tests/write/test_pack_3064.py
+++ b/xrspatial/geotiff/tests/write/test_pack_3064.py
@@ -9,9 +9,9 @@ re-packed file unpacks to the same values on the next ``mask_and_scale``
 read rather than double-scaling.
 
 ``unpack`` reads run on numpy, dask, gpu, and dask+gpu since #3075 (VRT
-still rejects it). The round-trip passes on numpy and dask; the gpu and
-dask+gpu legs are pinned as strict xfail on #3112 until the cupy
-``fillna`` crash in ``_pack`` is fixed.
+still rejects it). The round-trip passes on all four backends; the gpu
+and dask+gpu legs crashed in ``_pack``'s ``fillna`` until #3112 replaced
+it with a buffer-level fill.
 """
 import numpy as np
 import pytest
@@ -152,21 +152,13 @@ def test_pack_with_scale_offset_round_trip(tmp_path, chunks):
 
 # ---------------------------------------------------------------------------
 # GPU-backed input: ``unpack=True`` works with ``gpu=True`` since #3075, so
-# the ``pack=True`` inverse must round-trip there too. Both legs crash today
-# (#3112): ``_pack``'s ``fillna`` breaks on cupy-backed arrays. Strict xfail
-# so the marker flips loudly once the crash is fixed.
+# the ``pack=True`` inverse must round-trip there too. Both legs crashed in
+# ``_pack``'s ``fillna`` (xarray's where() breaks on cupy) until #3112
+# switched the sentinel restore to a buffer-level fill.
 # ---------------------------------------------------------------------------
 
 
 @requires_gpu
-@pytest.mark.xfail(
-    strict=True,
-    # eager gpu: xarray's where() calls cupy.astype (AttributeError);
-    # dask+gpu: numpy fill value inside cupy.where (TypeError). Pinning
-    # raises= keeps an unrelated assertion failure from hiding under the
-    # known crash.
-    raises=(AttributeError, TypeError),
-    reason="to_geotiff(pack=True) crashes on cupy-backed input (#3112)")
 @pytest.mark.parametrize("chunks", [None, 2], ids=["gpu", "dask-gpu"])
 def test_pack_round_trip_gpu(tmp_path, chunks):
     """A ``gpu=True`` unpack read packs back to the integer source dtype."""
@@ -193,6 +185,42 @@ def test_pack_round_trip_gpu(tmp_path, chunks):
     np.testing.assert_allclose(
         np.asarray(repacked_decoded.data), np.asarray(cpu_decoded.data),
         equal_nan=True)
+
+
+# ---------------------------------------------------------------------------
+# ``_pack_fill_nan``: the buffer-level NaN -> sentinel fill that replaced
+# ``fillna`` (#3112). Unit-pinned on numpy and cupy so a regression back to
+# an xarray ``where``-based fill shows up without a full round trip.
+# ---------------------------------------------------------------------------
+
+
+def test_pack_fill_nan_fills_sentinel_numpy():
+    from xrspatial.geotiff._attrs import _pack_fill_nan
+
+    chunk = np.array([[1.0, np.nan], [np.nan, 4.0]])
+    out = _pack_fill_nan(chunk, np.uint8(255))
+    np.testing.assert_array_equal(out, [[1.0, 255.0], [255.0, 4.0]])
+    # The input buffer is left untouched (fillna semantics).
+    assert np.isnan(chunk[0, 1])
+
+
+def test_pack_fill_nan_skips_integer_chunk():
+    from xrspatial.geotiff._attrs import _pack_fill_nan
+
+    chunk = np.array([[1, 2]], dtype=np.int32)
+    assert _pack_fill_nan(chunk, 255) is chunk
+
+
+@requires_gpu
+def test_pack_fill_nan_handles_cupy_chunks():
+    import cupy
+
+    from xrspatial.geotiff._attrs import _pack_fill_nan
+
+    chunk = cupy.asarray(np.array([[1.0, np.nan]]))
+    out = _pack_fill_nan(chunk, 255)
+    assert isinstance(out, cupy.ndarray)
+    np.testing.assert_array_equal(out.get(), [[1.0, 255.0]])
 
 
 # ---------------------------------------------------------------------------

--- a/xrspatial/geotiff/tests/write/test_pack_float_width_3080.py
+++ b/xrspatial/geotiff/tests/write/test_pack_float_width_3080.py
@@ -7,8 +7,8 @@ Python float, i.e. float64 -- and widened the packed file. The fix records
 the source dtype on ``unpack=True`` reads of float sources too, and stops
 the fallback from keying off float-typed sentinels.
 
-GPU / dask+GPU pack round-trips are pinned on #3112 / covered by #3114;
-this file exercises the numpy and dask+numpy legs.
+GPU / dask+GPU pack round-trips are covered by ``test_pack_3064.py``
+(crash fixed in #3112); this file exercises the numpy and dask+numpy legs.
 """
 import numpy as np
 import pytest

--- a/xrspatial/geotiff/tests/write/test_pack_lazy_nan_guard_3235.py
+++ b/xrspatial/geotiff/tests/write/test_pack_lazy_nan_guard_3235.py
@@ -196,8 +196,9 @@ def test_pack_guard_skips_integer_chunk():
 def test_pack_guard_handles_cupy_chunks():
     """The guard is backend-agnostic: cupy chunks pass and raise alike.
 
-    Full dask+cupy pack round trips still crash upstream of this guard
-    (#3112), so the cupy leg is pinned at the unit level.
+    Pinned at the unit level from when full dask+cupy pack round trips
+    crashed upstream of this guard (fixed in #3112); kept as direct
+    coverage of the cupy leg.
     """
     import cupy
 


### PR DESCRIPTION
Closes #3112

- `_pack` used `DataArray.fillna` to put the nodata sentinel back, and that routes through xarray's `duck_array_ops.where`, which breaks on cupy-backed arrays. Eager GPU reads hit `AttributeError: module 'cupy' has no attribute 'astype'` (xarray 2025.12 + cupy 13.6); dask+GPU graphs raise `TypeError` at compute time when the host-side 0-d fill array reaches `cupy.where`.
- The fill is now a buffer-level helper, `_pack_fill_nan`: `np.isnan` dispatches to cupy via `__array_ufunc__` and the masked assignment takes a plain Python scalar. Dask backings map it per chunk with the same `map_blocks` shape as the existing no-sentinel guard, so the fill stays lazy.
- Removed the strict xfail from `test_pack_round_trip_gpu` (both legs pass now), added unit tests for the helper on numpy and cupy chunks, and fixed the stale "GPU pack crashes" notes in the release-contract docs and the `SUPPORTED_FEATURES` comments.

Backend coverage: numpy and dask+numpy keep the same fill semantics (full write suite passes); cupy and dask+cupy round-trip instead of crashing.

Test plan:
- [x] `pytest xrspatial/geotiff/tests/write/test_pack_3064.py`: 40 passed on a CUDA host with cupy 13.6, GPU legs un-xfailed
- [x] `pytest xrspatial/geotiff/tests/write/`: 1127 passed
- [x] `pytest xrspatial/geotiff/tests/test_round_trip.py xrspatial/geotiff/tests/read/`: 1308 passed
- [x] Issue repro script: eager GPU and dask+GPU writes both succeed