### PR TITLE
Silence pyproj's lossy-PROJ-string warning in reproject param extractors (#3242)

### DIFF
--- a/xrspatial/reproject/_projections.py
+++ b/xrspatial/reproject/_projections.py
@@ -132,22 +132,30 @@ _DATUM_PARAMS = {
 }
 
 
+def _crs_to_dict(crs):
+    """``crs.to_dict()`` without pyproj's lossy-PROJ-string UserWarning.
+
+    crs.to_dict() goes through pyproj's to_proj4(), which warns that a
+    PROJ string drops detail. The param extractors here only read short
+    names and numeric projection parameters, never the lossy string, so
+    silence that one warning.
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            'ignore',
+            message='.*lose important projection information.*',
+            category=UserWarning,
+        )
+        return crs.to_dict()
+
+
 def _get_datum_params(crs):
     """Return (dx, dy, dz, rx, ry, rz, ds, a_src, f_src) for a non-WGS84 datum.
 
     Returns None for WGS84/NAD83/GRS80 (no shift needed).
     """
     try:
-        # crs.to_dict() goes through pyproj's to_proj4(), which warns that a
-        # PROJ string drops detail. We only read the datum/ellps short names
-        # here, never the lossy string, so silence that one warning.
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                'ignore',
-                message='.*lose important projection information.*',
-                category=UserWarning,
-            )
-            d = crs.to_dict()
+        d = _crs_to_dict(crs)
     except Exception:
         return None
     datum = d.get('datum', '')
@@ -305,7 +313,7 @@ def _lcc_params(crs):
     Returns (lon0, lat0, n, c, rho0, k0) or None.
     """
     try:
-        d = crs.to_dict()
+        d = _crs_to_dict(crs)
     except Exception:
         return None
     if d.get('proj') != 'lcc':
@@ -450,7 +458,7 @@ def _aea_params(crs):
     Returns (lon0, n, c, dd, rho0, fe, fn) or None.
     """
     try:
-        d = crs.to_dict()
+        d = _crs_to_dict(crs)
     except Exception:
         return None
     if d.get('proj') != 'aea':
@@ -554,7 +562,7 @@ def _cea_params(crs):
     Returns (lon0, k0, fe, fn) or None.
     """
     try:
-        d = crs.to_dict()
+        d = _crs_to_dict(crs)
     except Exception:
         return None
     if d.get('proj') != 'cea':
@@ -673,7 +681,7 @@ def _sinu_params(crs):
     Returns (lon0, fe, fn) or None.
     """
     try:
-        d = crs.to_dict()
+        d = _crs_to_dict(crs)
     except Exception:
         return None
     if d.get('proj') != 'sinu':
@@ -739,7 +747,7 @@ def _laea_params(crs):
     Or None if not LAEA.
     """
     try:
-        d = crs.to_dict()
+        d = _crs_to_dict(crs)
     except Exception:
         return None
     if d.get('proj') != 'laea':
@@ -922,7 +930,7 @@ def _stere_params(crs):
     and generic stere/ups proj definitions with polar lat_0.
     """
     try:
-        d = crs.to_dict()
+        d = _crs_to_dict(crs)
     except Exception:
         return None
     proj = d.get('proj', '')
@@ -1063,7 +1071,7 @@ def _sterea_params(crs):
     Returns (lon0, sinc0, cosc0, R2, C_gauss, K_gauss, ratexp, fe, fn, e) or None.
     """
     try:
-        d = crs.to_dict()
+        d = _crs_to_dict(crs)
     except Exception:
         return None
     if d.get('proj') != 'sterea':
@@ -1199,7 +1207,7 @@ def _omerc_params(crs):
              singam, cosgam, sinaz, cosaz, BH, AH, e) or None.
     """
     try:
-        d = crs.to_dict()
+        d = _crs_to_dict(crs)
     except Exception:
         return None
     if d.get('proj') != 'omerc':
@@ -1668,7 +1676,7 @@ def _tmerc_params(crs):
     Zb is the Krueger northing offset for non-zero lat_0.
     """
     try:
-        d = crs.to_dict()
+        d = _crs_to_dict(crs)
     except Exception:
         return None
     if d.get('proj') != 'tmerc':
@@ -1747,7 +1755,7 @@ def _is_wgs84_compatible_ellipsoid(crs):
     will wrap the projection with a datum shift.
     """
     try:
-        d = crs.to_dict()
+        d = _crs_to_dict(crs)
     except Exception:
         return False
     ellps = d.get('ellps', '')

--- a/xrspatial/tests/test_reproject_pyproj_warning_3242.py
+++ b/xrspatial/tests/test_reproject_pyproj_warning_3242.py
@@ -1,0 +1,100 @@
+"""Regression tests for issue #3242.
+
+The projection parameter extractors in ``xrspatial.reproject._projections``
+read parameters via ``pyproj.CRS.to_dict()``, which pyproj implements on
+top of ``to_proj4()`` and therefore emits a "You will likely lose important
+projection information" UserWarning. The extractors only read short names
+and numeric parameters, never the lossy PROJ string, so the warning is
+noise. All ``to_dict()`` calls must go through ``_crs_to_dict``, which
+silences exactly that warning.
+"""
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pytest
+import xarray as xr
+
+try:
+    import pyproj
+    HAS_PYPROJ = True
+except ImportError:
+    HAS_PYPROJ = False
+
+pytestmark = pytest.mark.skipif(
+    not HAS_PYPROJ, reason="pyproj required for reproject tests"
+)
+
+from xrspatial.reproject import reproject  # noqa: E402
+from xrspatial.reproject import _projections  # noqa: E402
+
+LOSSY_MSG = 'lose important projection information'
+
+# One representative EPSG code per param extractor's projection family.
+EXTRACTOR_CASES = [
+    ('_lcc_params', 2154),     # Lambert Conformal Conic (RGF93 / Lambert-93)
+    ('_aea_params', 5070),     # Albers Equal Area (NAD83 / CONUS Albers)
+    ('_cea_params', 6933),     # Cylindrical Equal Area (EASE-Grid 2.0)
+    ('_laea_params', 3035),    # Lambert Azimuthal Equal Area (ETRS89-LAEA)
+    ('_stere_params', 3413),   # Polar Stereographic (NSIDC Sea Ice North)
+    ('_sterea_params', 28992),  # Oblique Stereographic (RD New)
+    ('_omerc_params', 3375),   # Oblique Mercator Hotine (RSO Peninsular)
+    ('_tmerc_params', 32633),  # Transverse Mercator (UTM 33N)
+    ('_is_wgs84_compatible_ellipsoid', 5070),
+    ('_get_datum_params', 27700),  # OSGB36, non-WGS84 datum
+]
+
+
+def _lossy_warnings(record):
+    return [w for w in record if LOSSY_MSG in str(w.message)]
+
+
+@pytest.mark.parametrize('func_name,epsg', EXTRACTOR_CASES)
+def test_param_extractors_no_lossy_proj_warning(func_name, epsg):
+    func = getattr(_projections, func_name)
+    crs = pyproj.CRS.from_epsg(epsg)
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter('always')
+        func(crs)
+    assert not _lossy_warnings(record)
+
+
+def test_sinu_params_no_lossy_proj_warning():
+    # Sinusoidal (MODIS) has no EPSG code; build from a PROJ string.
+    crs = pyproj.CRS.from_proj4(
+        '+proj=sinu +lon_0=0 +x_0=0 +y_0=0 +R=6371007.181 +units=m'
+    )
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter('always')
+        _projections._sinu_params(crs)
+    assert not _lossy_warnings(record)
+
+
+def test_reproject_pyproj_crs_no_lossy_proj_warning():
+    # End-to-end repro of #3242: a projected raster whose CRS arrives as a
+    # pyproj.CRS object (as it does when read from a GeoTIFF) reprojected
+    # to geographic coordinates.
+    ny, nx = 32, 32
+    raster = xr.DataArray(
+        np.random.RandomState(42).rand(ny, nx).astype(np.float32),
+        dims=('y', 'x'),
+        coords={
+            'y': np.linspace(1_500_000, 1_400_000, ny),
+            'x': np.linspace(-1_200_000, -1_100_000, nx),
+        },
+    )
+    src = pyproj.CRS.from_epsg(5070)
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter('always')
+        out = reproject(raster, pyproj.CRS.from_epsg(4326), source_crs=src)
+    assert not _lossy_warnings(record)
+    assert np.isfinite(out.data).any()
+
+
+def test_crs_to_dict_matches_raw_to_dict():
+    crs = pyproj.CRS.from_epsg(5070)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        expected = crs.to_dict()
+    assert _projections._crs_to_dict(crs) == expected


### PR DESCRIPTION
Closes #3242

- pyproj implements `CRS.to_dict()` on top of `to_proj4()` and warns that the conversion drops projection metadata. Ten parameter extractors in `xrspatial/reproject/_projections.py` called `to_dict()` raw, so reprojecting (or coregistering) any raster in one of those projections printed the warning.
- `_get_datum_params` already suppressed the warning with a comment on why that's safe (only short names and numeric parameters are read, never the lossy string). This PR moves that suppression into a `_crs_to_dict()` helper and uses it at all eleven call sites.
- No behavior change other than the silenced warning.

Backend coverage: the fix is in CRS parsing, which runs before backend dispatch, so it applies equally to numpy / cupy / dask+numpy / dask+cupy.

Test plan:
- [x] New `test_reproject_pyproj_warning_3242.py`: per-extractor no-warning checks across the 10 projection families, an end-to-end `reproject()` call with a `pyproj.CRS` source (the #3242 repro shape), and a check that `_crs_to_dict()` returns the same dict as raw `to_dict()`.
- [x] 12 of 13 new tests fail without the fix (the 13th covers `_get_datum_params`, which was already wrapped).
- [x] Full reproject suite: 500 passed, no lossy-PROJ warnings left.