### PR TITLE
Follow-up to #3243: dask warning regression test, lock note on _crs_to_dict (#3242)

### DIFF
--- a/xrspatial/reproject/_projections.py
+++ b/xrspatial/reproject/_projections.py
@@ -139,6 +139,10 @@ def _crs_to_dict(crs):
     PROJ string drops detail. The param extractors here only read short
     names and numeric projection parameters, never the lossy string, so
     silence that one warning.
+
+    ``catch_warnings`` swaps process-global filter state and is not
+    thread-safe; callers are expected to hold ``_PARALLEL_KERNEL_LOCK``
+    (all current callers run inside the ``*_locked`` entry points).
     """
     with warnings.catch_warnings():
         warnings.filterwarnings(

--- a/xrspatial/tests/test_reproject_pyproj_warning_3242.py
+++ b/xrspatial/tests/test_reproject_pyproj_warning_3242.py
@@ -92,6 +92,29 @@ def test_reproject_pyproj_crs_no_lossy_proj_warning():
     assert np.isfinite(out.data).any()
 
 
+def test_reproject_dask_pyproj_crs_no_lossy_proj_warning():
+    # Same as above but dask-backed: the param extractors also run per
+    # chunk inside worker tasks, so a leak there would not show up in
+    # the numpy-path test.
+    pytest.importorskip('dask.array')
+    ny, nx = 32, 32
+    raster = xr.DataArray(
+        np.random.RandomState(42).rand(ny, nx).astype(np.float32),
+        dims=('y', 'x'),
+        coords={
+            'y': np.linspace(1_500_000, 1_400_000, ny),
+            'x': np.linspace(-1_200_000, -1_100_000, nx),
+        },
+    ).chunk({'y': 16, 'x': 16})
+    src = pyproj.CRS.from_epsg(5070)
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter('always')
+        out = reproject(raster, pyproj.CRS.from_epsg(4326), source_crs=src)
+        result = out.compute()
+    assert not _lossy_warnings(record)
+    assert np.isfinite(result.data).any()
+
+
 def test_crs_to_dict_matches_raw_to_dict():
     crs = pyproj.CRS.from_epsg(5070)
     with warnings.catch_warnings():


### PR DESCRIPTION
Follow-up to #3243, which was merged while its review fixes were still in flight; the squash took the first commit only. This lands the two review items:

- A dask-backed variant of the end-to-end regression test. The param extractors also run per chunk inside worker tasks, so a warning leak there would not show up in the numpy-path test. Guarded with `pytest.importorskip('dask.array')`.
- A note on `_crs_to_dict` that `catch_warnings` swaps process-global filter state and callers are expected to hold `_PARALLEL_KERNEL_LOCK`.

Refs #3242.

Test plan:
- [x] `test_reproject_pyproj_warning_3242.py`: 14 passed locally on top of current main.