### PR TITLE
Warn when coregister=True covers only a small fraction of the caller grid

### DIFF
--- a/xrspatial/accessor.py
+++ b/xrspatial/accessor.py
@@ -11,6 +11,8 @@ directly via tab-completion::
     nir.xrs.ndvi(red)
 """
 
+import warnings
+
 import xarray as xr
 
 
@@ -147,6 +149,12 @@ def _bbox_edge_samples(x_min, y_min, x_max, y_max, n_per_side=20):
 
 
 _RESAMPLING_CHOICES = ('auto', 'nearest', 'bilinear', 'cubic')
+
+# coregister=True paints the file onto the caller's full grid, NaN-filling
+# everything outside the file footprint. Below this coverage fraction the
+# result is mostly NaN, so warn and point at the crop-the-caller-first
+# pattern instead.
+_COREGISTER_COVERAGE_WARN_FRACTION = 0.10
 
 
 def _resolve_resampling(resampling, result):
@@ -318,6 +326,26 @@ def _open_geotiff_windowed(obj, source, *, auto_reproject=False,
     window = _extent_to_window(t, file_h, file_w,
                                y_min, y_max, x_min, x_max)
     kwargs.pop('window', None)
+
+    if coregister:
+        # Both extents are in file pixel units here: the caller bbox was
+        # transformed into the file CRS above when the two differ, and
+        # ``window`` is that bbox clamped to the file bounds, so the area
+        # ratio is the fraction of the caller grid the file can fill.
+        row_start, col_start, row_stop, col_stop = window
+        window_area = (max(0, row_stop - row_start)
+                       * max(0, col_stop - col_start))
+        req_rows = (y_max - y_min) / abs(t.pixel_height)
+        req_cols = (x_max - x_min) / abs(t.pixel_width)
+        coverage = window_area / (req_rows * req_cols)
+        if 0 < coverage < _COREGISTER_COVERAGE_WARN_FRACTION:
+            warnings.warn(
+                f"{source!r} covers only {coverage:.1%} of the caller "
+                "grid; the coregistered result will be mostly NaN. "
+                "Consider opening the small raster first and cropping "
+                "the caller to its bounds before coregistering.",
+                UserWarning, stacklevel=3,
+            )
 
     # Infer backend kwargs. Caller-supplied values always win.
     backend = _classify_backend(obj)
@@ -956,6 +984,9 @@ class XrsSpatialDataArrayAccessor:
             unpack-and-reproject read runs on CPU only, so
             ``coregister=True`` raises ``ValueError`` with ``gpu=True`` or
             ``.vrt`` sources, and it overrides an explicit ``unpack=False``.
+            Cells outside the file footprint come back NaN; if the file
+            covers less than 10% of ``self``'s grid a ``UserWarning``
+            suggests cropping ``self`` to the file bounds first.
             The resample mode follows ``resampling``. This is the heavier
             counterpart of ``auto_reproject``, which keeps the file's native
             resolution.
@@ -1489,6 +1520,9 @@ class XrsSpatialDatasetAccessor:
             unpack-and-reproject read runs on CPU only, so
             ``coregister=True`` raises ``ValueError`` with ``gpu=True`` or
             ``.vrt`` sources, and it overrides an explicit ``unpack=False``.
+            Cells outside the file footprint come back NaN; if the file
+            covers less than 10% of the Dataset's grid a ``UserWarning``
+            suggests cropping the Dataset to the file bounds first.
             The resample mode follows ``resampling``.
         resampling : {'auto', 'nearest', 'bilinear', 'cubic'}
             Resampling mode for the ``auto_reproject`` / ``coregister``

--- a/xrspatial/tests/test_open_geotiff_coregister.py
+++ b/xrspatial/tests/test_open_geotiff_coregister.py
@@ -302,6 +302,23 @@ def test_coregister_warns_when_file_covers_small_fraction(tmp_path):
     assert np.allclose(out.coords['y'].values, template.coords['y'].values)
 
 
+def test_coregister_warns_dask_template(tmp_path):
+    # The motivating case for #3246: a large dask-backed template. The
+    # check runs on metadata before the read, so the warning fires
+    # without computing, and the result stays lazy with caller chunks.
+    path = _file_4326(tmp_path, np.float32, 'cg3246_dask.tif')
+    template = xr.DataArray(
+        np.zeros((100, 100), dtype=np.float32),
+        dims=['y', 'x'],
+        coords={'y': np.linspace(50.0, 40.0, 100),
+                'x': np.linspace(-125.0, -115.0, 100)},
+        attrs={'crs': 4326},
+    ).chunk({'y': 50, 'x': 50})
+    with pytest.warns(UserWarning, match="covers only"):
+        out = template.xrs.open_geotiff(path, coregister=True)
+    assert out.data.chunksize == (50, 50)
+
+
 def test_coregister_full_coverage_no_warning(tmp_path):
     # Template sits entirely inside the file footprint: no warning.
     path = _file_4326(tmp_path, np.float32, 'cg3246_full.tif')

--- a/xrspatial/tests/test_open_geotiff_coregister.py
+++ b/xrspatial/tests/test_open_geotiff_coregister.py
@@ -2,6 +2,8 @@
 unpack + reproject + resample onto the caller's exact grid)."""
 from __future__ import annotations
 
+import warnings
+
 import numpy as np
 import pytest
 import xarray as xr
@@ -276,3 +278,54 @@ def test_coregister_vrt_guard(tmp_path):
     template = _template_3857(6)
     with pytest.raises(ValueError, match="not supported with gpu"):
         template.xrs.open_geotiff('nonexistent.vrt', coregister=True)
+
+
+# ---------------------------------------------------------------------------
+# sparse-coverage warning (issue #3246)
+# ---------------------------------------------------------------------------
+
+def test_coregister_warns_when_file_covers_small_fraction(tmp_path):
+    # 1x1 degree file against a 10x10 degree template: ~1% coverage.
+    path = _file_4326(tmp_path, np.float32, 'cg3246_small.tif')
+    template = xr.DataArray(
+        np.zeros((100, 100), dtype=np.float32),
+        dims=['y', 'x'],
+        coords={'y': np.linspace(50.0, 40.0, 100),
+                'x': np.linspace(-125.0, -115.0, 100)},
+        attrs={'crs': 4326},
+    )
+    with pytest.warns(UserWarning, match="covers only"):
+        out = template.xrs.open_geotiff(path, coregister=True)
+    # The warning changes nothing about the result itself.
+    assert out.shape == template.shape
+    assert np.allclose(out.coords['x'].values, template.coords['x'].values)
+    assert np.allclose(out.coords['y'].values, template.coords['y'].values)
+
+
+def test_coregister_full_coverage_no_warning(tmp_path):
+    # Template sits entirely inside the file footprint: no warning.
+    path = _file_4326(tmp_path, np.float32, 'cg3246_full.tif')
+    template = _template_3857(6)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        template.xrs.open_geotiff(path, coregister=True)
+    assert not [w for w in caught if "covers only" in str(w.message)]
+
+
+def test_coregister_warns_small_fraction_crs_mismatch(tmp_path):
+    # Coverage is computed after the caller bbox is transformed into the
+    # file CRS, so the warning also fires across a CRS mismatch.
+    from pyproj import Transformer
+    path = _file_4326(tmp_path, np.float32, 'cg3246_mismatch.tif')
+    tr = Transformer.from_crs(4326, 3857, always_xy=True)
+    x0, y0 = tr.transform(-125.0, 50.0)
+    x1, y1 = tr.transform(-115.0, 40.0)
+    template = xr.DataArray(
+        np.zeros((100, 100), dtype=np.float32),
+        dims=['y', 'x'],
+        coords={'y': np.linspace(max(y0, y1), min(y0, y1), 100),
+                'x': np.linspace(min(x0, x1), max(x0, x1), 100)},
+        attrs={'crs': 3857},
+    )
+    with pytest.warns(UserWarning, match="covers only"):
+        template.xrs.open_geotiff(path, coregister=True)


### PR DESCRIPTION
Closes #3246

- `.xrs.open_geotiff(..., coregister=True)` now emits a `UserWarning` when the file footprint covers less than 10% of the caller grid, since the result will be mostly NaN. The message points at the better pattern: open the small raster first and crop the caller to its bounds.
- Coverage comes from metadata already computed in `_open_geotiff_windowed` (caller bbox in file CRS vs. the clamped read window), so there is no extra I/O. `auto_reproject` is untouched; its output follows the file extent and is never sparse.
- Docstrings for both accessor variants (DataArray and Dataset) mention the warning.

Backend coverage: the check runs before the read, on metadata only, so it applies identically to numpy, cupy, dask+numpy, and dask+cupy callers (coregister itself remains CPU-only, as before).

Test plan:
- [x] New: small file vs. large template warns (`covers only`), result still matches the template grid
- [x] New: full-coverage file does not warn
- [x] New: warning fires across a CRS mismatch (coverage computed after bbox transform)
- [x] `test_open_geotiff_coregister.py` 18 passed
- [x] `test_accessor.py` 64 passed