### PR TITLE
Document coregister=True and register it as an experimental feature

### DIFF
--- a/docs/source/reference/geotiff.rst
+++ b/docs/source/reference/geotiff.rst
@@ -226,6 +226,80 @@ the top level, so ``from xrspatial import open_geotiff`` and
 
     xrspatial.geotiff.open_geotiff
 
+Coregistered reads (experimental)
+=================================
+
+``myarr.xrs.open_geotiff(source, coregister=True)`` reads a file
+windowed to ``myarr``'s extent, unpacks it (``unpack=True``: scale and
+offset applied, nodata masked to NaN), reprojects it into ``myarr``'s
+CRS, and resamples it onto ``myarr``'s exact grid, so the result shares
+``myarr``'s ``y``/``x`` coordinates and shape. The feature is tagged
+``experimental`` in :data:`xrspatial.geotiff.SUPPORTED_FEATURES`
+(``reader.coregister``): it works and is tested
+(``xrspatial/tests/test_open_geotiff_coregister.py``), but the surface
+can shift without a deprecation window.
+
+These combinations raise ``ValueError``:
+
+* GPU input. ``coregister=True`` with ``gpu=True``, or with a CuPy or
+  dask+CuPy caller, raises -- the unpack-and-reproject pipeline runs on
+  CPU only. NumPy and dask+NumPy callers work.
+* ``.vrt`` sources. GeoTIFF files only.
+* No CRS anywhere. A CRS must exist on the caller (``attrs['crs']``)
+  or in the file. When only the file lacks one, the file is assumed to
+  share the caller's CRS and the read degrades to a pure resample; if
+  that assumption is wrong, the data lands in the wrong place with no
+  error.
+* A single-cell caller without ``attrs['res']`` or
+  ``attrs['transform']`` -- resolution cannot be inferred from one
+  coordinate. The caller must carry ``y``/``x`` coordinates either way.
+
+What you should know about the output:
+
+* The caller's grid always wins. The output shape and coords exactly
+  match the caller, and the grid snap (a resample) happens even when
+  the CRS already matches. The file's native resolution is not
+  recoverable from the result; use ``auto_reproject=True`` instead if
+  you want to keep it.
+* Cells outside the file footprint come back NaN. When the file
+  covers less than 10% of the caller's grid, a ``UserWarning`` flags
+  that the result will be mostly NaN (#3247); above that threshold the
+  NaN fill is silent. To avoid a mostly-NaN result, open the small
+  file first, crop the caller to its bounds, then coregister.
+* ``unpack=True`` is forced, overriding an explicit ``unpack=False``.
+  Integer rasters carrying a nodata sentinel are promoted to float;
+  ``attrs['nodata']`` keeps the raw sentinel. The unpack round-trip
+  caveat applies: the source's SCALE / OFFSET tags survive on
+  ``attrs['gdal_metadata']`` / ``attrs['gdal_metadata_xml']``, so
+  writing the result with ``to_geotiff`` and reading that file back
+  with ``unpack=True`` applies the scale twice unless those attrs are
+  dropped before the write.
+* ``resampling='auto'`` picks ``'nearest'`` for integer dtypes or
+  paletted rasters and ``'bilinear'`` otherwise, and can guess wrong
+  in both directions. An int16 continuous DEM is treated as
+  categorical and gets blocky ``'nearest'`` output (pass
+  ``resampling='bilinear'``). An integer class raster carrying nodata
+  is promoted to float by the forced unpack and gets ``'bilinear'``,
+  which smears class IDs (pass ``resampling='nearest'``). Only
+  ``'nearest'``, ``'bilinear'``, and ``'cubic'`` are available.
+* Dask output follows an explicit ``chunks=`` kwarg when given, and
+  otherwise the caller's chunk layout, rather than
+  :func:`~xrspatial.reproject.reproject`'s 512x512 default (#3236).
+
+Untested under coregister:
+
+* Multi-band reads. Extra kwargs (``band=``, ``overview_level=``, the
+  per-source opt-ins) forward to ``open_geotiff``, but the coregister
+  test suite covers single-band, axis-aligned sources with a parseable
+  CRS only.
+* Rotated sources. The underlying read rejects them by default
+  (``allow_rotated=False``), and the coregister windowing math assumes
+  an axis-aligned file transform, so the opt-in is not expected to
+  work here.
+* Extreme reprojections. The CRS-mismatch bbox transform samples 20
+  points per edge to handle curvature, but polar and antimeridian
+  cases are not covered by tests.
+
 Writing
 =======
 ``to_geotiff`` is the single write entry point (``gpu=True`` or CuPy data

--- a/docs/source/reference/geotiff_release_contract.md
+++ b/docs/source/reference/geotiff_release_contract.md
@@ -94,6 +94,7 @@ category. The `Key` column matches the runtime key.
 | `reader.allow_unparseable_crs` | experimental | Opt-in escape hatch for CRS strings pyproj cannot parse. |
 | `reader.gpu` | experimental | GPU read path; no cross-backend numerical parity claim. |
 | `reader.unpack` | experimental | `unpack=True` scale/offset decode on `open_geotiff` (CF-packed integers to float, nodata sentinel to NaN). Experimental because the GPU / dask+GPU branches gained round-trip coverage only recently (#3112 pack crash fix, #3114); no behavioural promise yet. |
+| `reader.coregister` | experimental | `coregister=True` on the `.xrs.open_geotiff` accessor: unpack-and-reproject read resampled onto the caller's exact grid. CPU only (numpy and dask+numpy); raises with `gpu=True` or `.vrt` sources. Forces `unpack=True`. Cells outside the file footprint come back NaN; a `UserWarning` fires when the file covers less than 10% of the caller grid (#3247). See the "Coregistered reads" section in the {ref}`GeoTIFF reference <reference.geotiff>` for the full caveat list. |
 
 ### Writers
 

--- a/xrspatial/geotiff/_attrs.py
+++ b/xrspatial/geotiff/_attrs.py
@@ -337,6 +337,15 @@ SUPPORTED_FEATURES = {
     # branches gained round-trip coverage only recently (#3112 pack
     # crash fix, #3114 coverage), so no behavioural promise is made yet.
     'reader.unpack': 'experimental',
+    # ``coregister=True`` on the ``.xrs.open_geotiff`` accessor: an
+    # unpack-and-reproject read that resamples the file onto the
+    # caller's exact grid. Sits at ``experimental``: CPU-only (raises
+    # with ``gpu=True`` / ``.vrt`` sources), forces ``unpack=True``,
+    # and the surface (resampling heuristic, NaN fill outside the file
+    # footprint) can shift without a deprecation window. See the
+    # "Coregistered reads" section in
+    # ``docs/source/reference/geotiff.rst``.
+    'reader.coregister': 'experimental',
     # Write paths.
     'writer.local_file': 'stable',
     # ``writer.cog`` is ``stable``: the CPU writer emits a


### PR DESCRIPTION
## Summary

`coregister=True` on the `.xrs.open_geotiff` accessor existed in code and tests but never made it into the feature registry or the reference docs. This registers it as `experimental` and writes it up:

- `xrspatial/geotiff/_attrs.py`: add `reader.coregister: experimental` to `SUPPORTED_FEATURES`
- `docs/source/reference/geotiff_release_contract.md`: matching row in the contract feature table
- `docs/source/reference/geotiff.rst`: new "Coregistered reads (experimental)" section

The new reference section lists the `ValueError` cases (GPU input, `.vrt` sources, missing CRS, single-cell caller without resolution), then the caveats a user actually hits: the caller's grid always wins, out-of-footprint cells come back NaN (with the #3247 low-coverage warning), `unpack=True` is forced and can double-apply scale on a write/read round trip, `resampling='auto'` can pick wrong in both directions, and dask chunk layout follows #3236. It also says plainly what is untested: multi-band reads, rotated sources, and polar/antimeridian reprojections.

Docs plus one registry constant; no behavior change. The accessor docstrings already describe the NaN/warning behavior since #3247.