### PR TITLE
Fix stale Datashader claim and dead links in getting-started docs

### DIFF
--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -4,6 +4,8 @@
 Installation
 ************
 
+``xarray-spatial`` requires Python 3.12 or newer.
+
 .. code-block:: bash
 
    # via pip

--- a/docs/source/getting_started/usage.rst
+++ b/docs/source/getting_started/usage.rst
@@ -36,13 +36,16 @@ arguments.
    ndvi_result = ndvi(my_dataset, nir='band_5', red='band_4')
 
 
-Check out the user guide `here <https://github.com/xarray-contrib/xarray-spatial/blob/main/examples/user_guide>`_.
+Check out the :doc:`user guide </user_guide/index>` for worked examples of every module.
 
 
 Dependencies
 ============
 
-``xarray-spatial`` currently depends on Datashader, but will soon be updated to depend only on ``xarray`` and ``numba``\ , while still being able to make use of Datashader output when available. 
+``xarray-spatial`` has a small required core: ``numpy``, ``numba``, ``scipy``,
+``xarray``, ``urllib3``, and ``zstandard``. Everything else (plotting, vector
+rasterization, dask, GPU support, CRS handling) is an optional extra; see
+:doc:`installation`.
 
 
 .. image:: ../_static/img/dependencies.svg


### PR DESCRIPTION
Refs #3249 (part 1 of 6).

- usage.rst claimed xarray-spatial "currently depends on Datashader, but will soon be updated". That text predates the current packaging: core deps per setup.cfg are numpy, numba, scipy, xarray, urllib3, zstandard, and datashader only appears in the `examples` extra. Replaced with the actual list and a pointer to the installation page. The dependencies.svg diagram is already accurate, so it stays.
- Replaced the hardcoded GitHub link to examples/user_guide with a `:doc:` link to the rendered user guide.
- installation.rst now states the Python >= 3.12 requirement (matches `python_requires` in setup.cfg).

Test plan:
- [x] `sphinx-build -b html docs/source` succeeds; 9 warnings, all pre-existing in notebooks/reference pages, none in getting_started
- [x] the new `:doc:` link resolves to `../user_guide/index.html` in the built output