### PR TITLE
Add a docs-build CI job

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,42 @@
+name: docs
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'README.md'
+      - 'setup.cfg'
+      - '.readthedocs.yml'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+jobs:
+  # Job id/name kept distinct from the pytest workflow's `run` job:
+  # duplicate check names across workflows get deduplicated in the PR
+  # checks UI and can hide failures.
+  docs-build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        # Match the Read the Docs build (.readthedocs.yml).
+        python-version: '3.12'
+    - name: Install pandoc
+      # nbsphinx needs the pandoc binary; the `pandoc` pip package in
+      # the doc extra does not ship it.
+      run: sudo apt-get update && sudo apt-get install -y pandoc
+    - name: Install dependencies
+      # Same extras as the Read the Docs pre_build step, so this job
+      # and RTD cannot drift apart.
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e '.[doc,tests]'
+    - name: Build HTML
+      # No -W: the build carries a handful of pre-existing warnings in
+      # notebooks and reference pages. Gate on errors only.
+      run: sphinx-build -b html docs/source docs/build/html
+    - name: Link check
+      # External links flake; report but never fail the job.
+      continue-on-error: true
+      run: sphinx-build -b linkcheck docs/source docs/build/linkcheck

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,6 +15,10 @@ jobs:
   # checks UI and can hide failures.
   docs-build:
     runs-on: ubuntu-latest
+    # Bound a hung linkcheck: continue-on-error keeps it from gating,
+    # but without a cap a stalled external link holds the runner for
+    # the default 6-hour job timeout.
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v4
     - name: Setup Python

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,8 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     # Bound a hung linkcheck: continue-on-error keeps it from gating,
     # but without a cap a stalled external link holds the runner for
-    # the default 6-hour job timeout.
-    timeout-minutes: 30
+    # the default 6-hour job timeout. Normal runs take ~26 minutes
+    # (HTML build ~11, linkcheck ~14), so 45 leaves headroom without
+    # letting a wedged run camp on a runner.
+    timeout-minutes: 45
     steps:
     - uses: actions/checkout@v4
     - name: Setup Python

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,19 +8,24 @@ on:
       - '.readthedocs.yml'
       - '.github/workflows/docs.yml'
   workflow_dispatch:
+  schedule:
+    # Weekly linkcheck (Monday 06:00 UTC). External links rot on their
+    # own schedule, not the PR schedule; checking them per-PR cost ~10
+    # minutes of runner time and its failures were masked by
+    # continue-on-error anyway.
+    - cron: '0 6 * * 1'
 
 jobs:
   # Job id/name kept distinct from the pytest workflow's `run` job:
   # duplicate check names across workflows get deduplicated in the PR
   # checks UI and can hide failures.
   docs-build:
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
-    # Bound a hung linkcheck: continue-on-error keeps it from gating,
-    # but without a cap a stalled external link holds the runner for
-    # the default 6-hour job timeout. Normal runs take ~26 minutes
-    # (HTML build ~11, linkcheck ~14), so 45 leaves headroom without
-    # letting a wedged run camp on a runner.
-    timeout-minutes: 45
+    # Normal runs take ~4 minutes (install ~1, HTML build ~3 with
+    # parallel read), so 15 leaves headroom without letting a wedged
+    # run camp on a runner.
+    timeout-minutes: 15
     steps:
     - uses: actions/checkout@v4
     - name: Setup Python
@@ -41,8 +46,32 @@ jobs:
     - name: Build HTML
       # No -W: the build carries a handful of pre-existing warnings in
       # notebooks and reference pages. Gate on errors only.
-      run: sphinx-build -b html docs/source docs/build/html
+      #
+      # -j auto: the read phase is dominated by plot-directive examples
+      # in the reference docstrings (sample data load + numba compile
+      # per page, 30-60s each); all extensions in conf.py declare
+      # parallel_read_safe, so this fans them out across the runner's
+      # cores.
+      run: sphinx-build -b html -j auto docs/source docs/build/html
+
+  # Linkcheck runs on the weekly schedule (or manual dispatch), not on
+  # PRs: it took ~10 minutes per PR and never gated anything. Here it
+  # is allowed to fail loudly so broken links actually surface.
+  linkcheck:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - name: Install pandoc
+      run: sudo apt-get update && sudo apt-get install -y pandoc
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e '.[doc,tests]'
     - name: Link check
-      # External links flake; report but never fail the job.
-      continue-on-error: true
       run: sphinx-build -b linkcheck docs/source docs/build/linkcheck


### PR DESCRIPTION
Refs #3249 (part 2 of 6).

Sphinx currently only runs on Read the Docs, so a PR that breaks the docs build isn't caught until after merge. This adds a `docs` workflow that runs on PRs touching `docs/**`, `README.md`, `setup.cfg`, or `.readthedocs.yml`:

- installs `.[doc,tests]` on Python 3.12, mirroring the RTD pre_build step so the two can't drift
- installs the pandoc binary via apt (nbsphinx needs it; the `pandoc` pip package doesn't ship it)
- `sphinx-build -b html -j auto`, gating on errors only (no `-W`; the tree has a handful of pre-existing notebook/reference warnings). The read phase is dominated by plot-directive examples in the reference docstrings (sample data load + numba compile per page); every extension in conf.py declares parallel_read_safe, so -j auto cuts the build from ~8 minutes to ~3.5.
- linkcheck runs on a weekly cron (Mondays 06:00 UTC) and workflow_dispatch instead of per PR. It cost ~10 minutes per PR, never gated (continue-on-error), and was in fact already exiting 1 with nobody noticing. The cron job drops continue-on-error so a broken link actually fails the run. Expect the first scheduled run to be red: there are real broken links to fix.

The job id is `docs-build`, distinct from the pytest workflow's `run` job, to avoid the check-name dedup problem that hides failures.

Test plan:
- [x] YAML parses
- [x] `docs-build` passes on this PR in 4m51s (was 18m48s)
- [x] `linkcheck` is skipped on pull_request events
