### PR TITLE
coregister=True reads COG overviews and fails fast on bad templates

### DIFF
--- a/docs/source/reference/geotiff.rst
+++ b/docs/source/reference/geotiff.rst
@@ -253,9 +253,29 @@ These combinations raise ``ValueError``:
 * A single-cell caller without ``attrs['res']`` or
   ``attrs['transform']`` -- resolution cannot be inferred from one
   coordinate. The caller must carry ``y``/``x`` coordinates either way.
+* ``allow_rotated=True``. A rotated file reads as an ungeoreferenced
+  pixel grid, which reproject would mis-place wholesale, so the
+  combination is refused up front (#3253).
+* A file that does not overlap the caller's grid at all -- the result
+  would be entirely NaN, so the read raises instead (#3253).
+* An irregular caller grid, or one with ``x`` descending or ``y``
+  ascending. The grid snap assumes a regular x-ascending /
+  y-descending template (reproject's output convention); anything else
+  would misalign silently, so it raises with a ``sortby`` hint
+  (#3253).
 
 What you should know about the output:
 
+* COG overviews are used automatically (#3253). When the caller's grid
+  is coarser than the file's full-resolution pixels and the file
+  carries overviews, the read probes the pyramid with header-only
+  reads and decodes the coarsest overview that still meets the
+  caller's resolution on both axes. Overview pixels are resampled at
+  write time, so values can differ slightly from a full-resolution
+  read; pass ``overview_level=0`` to force full resolution, or
+  ``overview_level=N`` to pick a level yourself (the window is
+  computed in that level's pixel space). Plain TIFFs without
+  overviews read at full resolution as before.
 * The caller's grid always wins. The output shape and coords exactly
   match the caller, and the grid snap (a resample) happens even when
   the CRS already matches. The file's native resolution is not
@@ -277,28 +297,27 @@ What you should know about the output:
 * ``resampling='auto'`` picks ``'nearest'`` for integer dtypes or
   paletted rasters and ``'bilinear'`` otherwise, and can guess wrong
   in both directions. An int16 continuous DEM is treated as
-  categorical and gets blocky ``'nearest'`` output (pass
-  ``resampling='bilinear'``). An integer class raster carrying nodata
-  is promoted to float by the forced unpack and gets ``'bilinear'``,
-  which smears class IDs (pass ``resampling='nearest'``). Only
-  ``'nearest'``, ``'bilinear'``, and ``'cubic'`` are available.
+  categorical and gets blocky ``'nearest'`` output; since #3253 a
+  ``UserWarning`` flags this case (integer dtype, no colormap) with
+  the override spelled out (pass ``resampling='bilinear'``). An
+  integer class raster carrying nodata is promoted to float by the
+  forced unpack and gets ``'bilinear'``, which smears class IDs (pass
+  ``resampling='nearest'``). Only ``'nearest'``, ``'bilinear'``, and
+  ``'cubic'`` are available.
 * Dask output follows an explicit ``chunks=`` kwarg when given, and
   otherwise the caller's chunk layout, rather than
   :func:`~xrspatial.reproject.reproject`'s 512x512 default (#3236).
 
 Untested under coregister:
 
-* Multi-band reads. Extra kwargs (``band=``, ``overview_level=``, the
-  per-source opt-ins) forward to ``open_geotiff``, but the coregister
-  test suite covers single-band, axis-aligned sources with a parseable
-  CRS only.
-* Rotated sources. The underlying read rejects them by default
-  (``allow_rotated=False``), and the coregister windowing math assumes
-  an axis-aligned file transform, so the opt-in is not expected to
-  work here.
-* Extreme reprojections. The CRS-mismatch bbox transform samples 20
-  points per edge to handle curvature, but polar and antimeridian
-  cases are not covered by tests.
+* Multi-band reads. Extra kwargs (``band=``, the per-source opt-ins)
+  forward to ``open_geotiff``, but the coregister test suite covers
+  single-band, axis-aligned sources with a parseable CRS only.
+* Polar reprojections. The CRS-mismatch bbox transform samples 20
+  points per edge to handle curvature, but polar cases are not
+  covered by tests. A caller grid crossing the antimeridian is
+  detected and handled (#3253): the read warns and falls back to the
+  full file width, which is a correct superset, just slower.
 
 Writing
 =======

--- a/docs/source/reference/geotiff_release_contract.md
+++ b/docs/source/reference/geotiff_release_contract.md
@@ -94,7 +94,7 @@ category. The `Key` column matches the runtime key.
 | `reader.allow_unparseable_crs` | experimental | Opt-in escape hatch for CRS strings pyproj cannot parse. |
 | `reader.gpu` | experimental | GPU read path; no cross-backend numerical parity claim. |
 | `reader.unpack` | experimental | `unpack=True` scale/offset decode on `open_geotiff` (CF-packed integers to float, nodata sentinel to NaN). Experimental because the GPU / dask+GPU branches gained round-trip coverage only recently (#3112 pack crash fix, #3114); no behavioural promise yet. |
-| `reader.coregister` | experimental | `coregister=True` on the `.xrs.open_geotiff` accessor: unpack-and-reproject read resampled onto the caller's exact grid. CPU only (numpy and dask+numpy); raises with `gpu=True` or `.vrt` sources. Forces `unpack=True`. Cells outside the file footprint come back NaN; a `UserWarning` fires when the file covers less than 10% of the caller grid (#3247). See the "Coregistered reads" section in the {ref}`GeoTIFF reference <reference.geotiff>` for the full caveat list. |
+| `reader.coregister` | experimental | `coregister=True` on the `.xrs.open_geotiff` accessor: unpack-and-reproject read resampled onto the caller's exact grid. CPU only (numpy and dask+numpy); raises with `gpu=True` or `.vrt` sources. Forces `unpack=True`. Cells outside the file footprint come back NaN; a `UserWarning` fires when the file covers less than 10% of the caller grid (#3247) and a disjoint file raises (#3253). Reads COG overviews automatically when the caller grid is coarser than the file's full resolution; `overview_level=0` opts out (#3253). See the "Coregistered reads" section in the {ref}`GeoTIFF reference <reference.geotiff>` for the full caveat list. |
 
 ### Writers
 

--- a/xrspatial/accessor.py
+++ b/xrspatial/accessor.py
@@ -168,11 +168,23 @@ def _resolve_resampling(resampling, result):
     if resampling != 'auto':
         return resampling
     import numpy as np
-    categorical = (
-        result.attrs.get('colormap') is not None
-        or np.issubdtype(result.dtype, np.integer)
-    )
-    return 'nearest' if categorical else 'bilinear'
+    has_colormap = result.attrs.get('colormap') is not None
+    if has_colormap:
+        return 'nearest'
+    if np.issubdtype(result.dtype, np.integer):
+        # An integer dtype alone does not prove categorical data: an
+        # int16 DEM is continuous, and 'nearest' silently costs it the
+        # interpolation quality. Say what was picked and how to choose.
+        warnings.warn(
+            "resampling='auto' chose 'nearest' because the data has an "
+            f"integer dtype ({result.dtype}) and no colormap. If this "
+            "raster is continuous (e.g. a DEM), pass "
+            "resampling='bilinear'; pass resampling='nearest' to keep "
+            "this choice and silence the warning.",
+            UserWarning, stacklevel=4,
+        )
+        return 'nearest'
+    return 'bilinear'
 
 
 def _axis_res(coord, n, obj, axis):
@@ -195,6 +207,82 @@ def _axis_res(coord, n, obj, axis):
         f"template; use a template with 2+ cells along {axis}, or set "
         f"attrs['res'] / attrs['transform']"
     )
+
+
+def _validate_template_grid(obj):
+    """Reject caller templates ``_caller_grid`` cannot reproduce.
+
+    The coregister output grid is derived from the template's first /
+    last coords and a uniform spacing, in reproject's output convention
+    (``x`` ascending, ``y`` descending). An irregular or differently
+    oriented template would come back silently misaligned, so refuse it
+    and name the offending axis.
+    """
+    import numpy as np
+    for axis, direction in (('x', 'ascending'), ('y', 'descending')):
+        coord = np.asarray(obj.coords[axis].values, dtype='float64')
+        if coord.size < 2:
+            continue
+        diffs = np.diff(coord)
+        sign_ok = (
+            (diffs > 0).all() if direction == 'ascending'
+            else (diffs < 0).all()
+        )
+        if not sign_ok:
+            raise ValueError(
+                f"coregister=True needs the caller's {axis} coords in "
+                f"{direction} order to line up cell-for-cell with "
+                f"reproject's output; sort the caller along {axis} "
+                f"first (e.g. .sortby('{axis}'"
+                + (", ascending=False)" if direction == 'descending'
+                   else ")")
+                + ")."
+            )
+        if coord.size >= 3:
+            steps = np.abs(diffs)
+            mean = steps.mean()
+            if (np.abs(steps - mean) > 1e-6 * mean).any():
+                raise ValueError(
+                    f"coregister=True needs a regular caller grid, but "
+                    f"the {axis} coords are not evenly spaced (max "
+                    f"spacing {steps.max():g}, min {steps.min():g}). "
+                    "Resample the caller onto a regular grid first."
+                )
+
+
+def _select_overview_level(source, base_transform, res_x, res_y):
+    """Pick the coarsest overview still finer than the caller's grid.
+
+    ``res_x`` / ``res_y`` are the caller's cell sizes in file-CRS units.
+    Probes overview levels with header-only reads and returns the
+    highest level whose pixel size stays <= the caller's on both axes,
+    or ``None`` when the full-resolution read is the right choice (no
+    overviews, or the caller grid is too fine to benefit). Levels are
+    probed in order, so a missing level ends the search.
+    """
+    from .geotiff import _read_geo_info
+
+    # A level-1 overview is conventionally ~2x the base pixel size; skip
+    # the probing reads entirely when even that could not stay finer
+    # than the caller's grid.
+    if (abs(base_transform.pixel_width) * 2 > res_x
+            or abs(base_transform.pixel_height) * 2 > res_y):
+        return None
+    selected = None
+    level = 1
+    while True:
+        try:
+            geo_info, _h, _w, _dtype, _nbands = _read_geo_info(
+                source, overview_level=level)
+        except ValueError:
+            # out of range: no more pyramid levels
+            break
+        t = geo_info.transform
+        if (abs(t.pixel_width) > res_x or abs(t.pixel_height) > res_y):
+            break
+        selected = level
+        level += 1
+    return selected
 
 
 def _caller_grid(obj):
@@ -267,6 +355,14 @@ def _open_geotiff_windowed(obj, source, *, auto_reproject=False,
                 "runs on CPU only and is not supported with gpu=True or "
                 ".vrt sources. Read on CPU, or pass coregister=False."
             )
+        if kwargs.get('allow_rotated'):
+            raise ValueError(
+                "coregister=True is not supported with allow_rotated="
+                "True: a rotated file reads as an ungeoreferenced pixel "
+                "grid, so reproject would treat its row/col indices as "
+                "map coordinates and mis-place every pixel. Read the "
+                "file without coregister and resample it explicitly."
+            )
         # coregister implies an unpacked (scaled + masked) read; this
         # overrides an explicit unpack=False.
         kwargs['unpack'] = True
@@ -276,6 +372,8 @@ def _open_geotiff_windowed(obj, source, *, auto_reproject=False,
             "Caller must have 'y' and 'x' coordinates to compute a "
             "spatial window"
         )
+    if coregister:
+        _validate_template_grid(obj)
     y = obj.coords['y'].values
     x = obj.coords['x'].values
     y_min, y_max = float(y.min()), float(y.max())
@@ -302,7 +400,9 @@ def _open_geotiff_windowed(obj, source, *, auto_reproject=False,
             f"and reproject the result back to the caller CRS."
         )
 
+    crosses_antimeridian = False
     if crs_mismatch:
+        import numpy as np
         from pyproj import Transformer
         transformer = Transformer.from_crs(
             caller_crs, file_crs, always_xy=True
@@ -316,6 +416,52 @@ def _open_geotiff_windowed(obj, source, *, auto_reproject=False,
         x_max = float(px.max())
         y_min = float(py.min())
         y_max = float(py.max())
+        # A caller grid straddling the antimeridian lands as two
+        # longitude clusters near +180 and -180: a gap wider than 180
+        # degrees between consecutive sorted samples is the signature
+        # (a genuinely global caller fills the range without such a
+        # gap). min/max windowing then covers the full file width --
+        # still correct, but a much larger read than the footprint.
+        if file_crs.is_geographic:
+            gaps = np.diff(np.sort(np.asarray(px, dtype='float64')))
+            if gaps.size and float(gaps.max()) > 180.0:
+                crosses_antimeridian = True
+                warnings.warn(
+                    "the caller grid appears to cross the antimeridian "
+                    f"in {source!r}'s geographic CRS; the windowed read "
+                    "falls back to the full file width, which is "
+                    "correct but may be slow. Consider splitting the "
+                    "analysis at the dateline or reprojecting the file "
+                    "into the caller's CRS.",
+                    UserWarning, stacklevel=3,
+                )
+
+    # open_geotiff interprets window= in the pixel space of the selected
+    # overview level, so an explicit overview_level= means the window
+    # must be computed against that level's transform and dimensions,
+    # not the full-resolution ones read above.
+    overview_arg = kwargs.get('overview_level')
+    if overview_arg not in (None, 0):
+        geo_info, file_h, file_w, _dtype, _nbands = _read_geo_info(
+            source, overview_level=overview_arg)
+        t = geo_info.transform
+    elif (coregister and overview_arg is None and isinstance(source, str)
+          and not crosses_antimeridian):
+        # The caller's grid fixes the output resolution, so decoding
+        # file pixels finer than that grid is wasted work: read the
+        # coarsest overview that still meets the caller's resolution.
+        # Pass overview_level=0 to force the full-resolution read.
+        # (Skipped across the antimeridian: the wrapped bbox span would
+        # grossly overstate the caller's cell size.)
+        res_x_caller = (x_max - x_min) / len(x)
+        res_y_caller = (y_max - y_min) / len(y)
+        level = _select_overview_level(source, t, res_x_caller,
+                                       res_y_caller)
+        if level is not None:
+            kwargs['overview_level'] = level
+            geo_info, file_h, file_w, _dtype, _nbands = _read_geo_info(
+                source, overview_level=level)
+            t = geo_info.transform
 
     # Expand extent by half a pixel so we capture edge pixels
     y_min -= abs(t.pixel_height) * 0.5
@@ -338,6 +484,13 @@ def _open_geotiff_windowed(obj, source, *, auto_reproject=False,
         req_rows = (y_max - y_min) / abs(t.pixel_height)
         req_cols = (x_max - x_min) / abs(t.pixel_width)
         coverage = window_area / (req_rows * req_cols)
+        if coverage == 0:
+            raise ValueError(
+                f"{source!r} does not overlap the caller grid; the "
+                "coregistered result would be entirely NaN. Check the "
+                "caller's coords / attrs['crs'] against the file's "
+                "georeferencing."
+            )
         if 0 < coverage < _COREGISTER_COVERAGE_WARN_FRACTION:
             warnings.warn(
                 f"{source!r} covers only {coverage:.1%} of the caller "
@@ -986,7 +1139,19 @@ class XrsSpatialDataArrayAccessor:
             ``.vrt`` sources, and it overrides an explicit ``unpack=False``.
             Cells outside the file footprint come back NaN; if the file
             covers less than 10% of ``self``'s grid a ``UserWarning``
-            suggests cropping ``self`` to the file bounds first.
+            suggests cropping ``self`` to the file bounds first, and a
+            file that does not overlap ``self`` at all raises
+            ``ValueError``. ``self``'s grid must be regularly spaced
+            with ``x`` ascending and ``y`` descending (reproject's
+            output convention); other templates raise ``ValueError``,
+            as does combining ``coregister=True`` with
+            ``allow_rotated=True``.
+            When the file carries overviews (a COG) and ``self``'s grid
+            is coarser than the full-resolution pixels, the read
+            automatically uses the coarsest overview that still meets
+            ``self``'s resolution; pass ``overview_level=0`` to force
+            the full-resolution read or ``overview_level=N`` to pick a
+            level yourself.
             The resample mode follows ``resampling``. This is the heavier
             counterpart of ``auto_reproject``, which keeps the file's native
             resolution.
@@ -997,15 +1162,17 @@ class XrsSpatialDataArrayAccessor:
             rasters (a paletted colormap is present, or the data has an
             integer dtype) and ``'bilinear'`` otherwise. Note an
             integer-typed continuous DEM (e.g. int16 elevation) is
-            treated as categorical under ``'auto'``; pass
-            ``resampling='bilinear'`` for those. Conversely, an integer
-            raster read with a nodata sentinel is promoted to float on
-            read, so a categorical raster that carries nodata and no
-            colormap resolves to ``'bilinear'``; pass
-            ``resampling='nearest'`` for those.
+            treated as categorical under ``'auto'`` (a ``UserWarning``
+            points this out); pass ``resampling='bilinear'`` for those.
+            Conversely, an integer raster read with a nodata sentinel is
+            promoted to float on read, so a categorical raster that
+            carries nodata and no colormap resolves to ``'bilinear'``;
+            pass ``resampling='nearest'`` for those.
         **kwargs
             Forwarded to :func:`xrspatial.geotiff.open_geotiff` (except
-            ``window=``, which is computed automatically).
+            ``window=``, which is computed automatically; an explicit
+            ``overview_level=`` is honoured and the window is computed
+            in that overview's pixel space).
 
         Returns
         -------
@@ -1522,7 +1689,17 @@ class XrsSpatialDatasetAccessor:
             ``.vrt`` sources, and it overrides an explicit ``unpack=False``.
             Cells outside the file footprint come back NaN; if the file
             covers less than 10% of the Dataset's grid a ``UserWarning``
-            suggests cropping the Dataset to the file bounds first.
+            suggests cropping the Dataset to the file bounds first, and
+            a file that does not overlap the Dataset at all raises
+            ``ValueError``. The Dataset's grid must be regularly spaced
+            with ``x`` ascending and ``y`` descending; other grids raise
+            ``ValueError``, as does combining ``coregister=True`` with
+            ``allow_rotated=True``.
+            When the file carries overviews (a COG) and the Dataset's
+            grid is coarser than the full-resolution pixels, the read
+            automatically uses the coarsest overview that still meets
+            the Dataset's resolution; pass ``overview_level=0`` to force
+            the full-resolution read.
             The resample mode follows ``resampling``.
         resampling : {'auto', 'nearest', 'bilinear', 'cubic'}
             Resampling mode for the ``auto_reproject`` / ``coregister``

--- a/xrspatial/accessor.py
+++ b/xrspatial/accessor.py
@@ -229,14 +229,15 @@ def _validate_template_grid(obj):
             else (diffs < 0).all()
         )
         if not sign_ok:
+            if direction == 'descending':
+                hint = f".sortby('{axis}', ascending=False)"
+            else:
+                hint = f".sortby('{axis}')"
             raise ValueError(
                 f"coregister=True needs the caller's {axis} coords in "
                 f"{direction} order to line up cell-for-cell with "
                 f"reproject's output; sort the caller along {axis} "
-                f"first (e.g. .sortby('{axis}'"
-                + (", ascending=False)" if direction == 'descending'
-                   else ")")
-                + ")."
+                f"first (e.g. {hint})."
             )
         if coord.size >= 3:
             steps = np.abs(diffs)
@@ -259,6 +260,12 @@ def _select_overview_level(source, base_transform, res_x, res_y):
     or ``None`` when the full-resolution read is the right choice (no
     overviews, or the caller grid is too fine to benefit). Levels are
     probed in order, so a missing level ends the search.
+
+    Each probe re-parses the header: sub-millisecond mmap work for
+    local paths, one bounded range fetch per level for fsspec / HTTP
+    sources. Real pyramids top out around 8 levels, and the probes
+    replace full-resolution tile fetches that can run to gigabytes on
+    remote COGs, so the trade holds on both source types.
     """
     from .geotiff import _read_geo_info
 

--- a/xrspatial/tests/test_open_geotiff_coregister.py
+++ b/xrspatial/tests/test_open_geotiff_coregister.py
@@ -255,7 +255,10 @@ def test_coregister_categorical_preserves_class_ids(tmp_path):
     path = str(tmp_path / 'cg_classes.tif')
     to_geotiff(da, path, compression='none')
 
-    out = _template_3857(6).xrs.open_geotiff(path, coregister=True)
+    # integer dtype + no colormap also triggers the is-this-really-
+    # categorical advisory; the class IDs are the point of this test.
+    with pytest.warns(UserWarning, match="nearest"):
+        out = _template_3857(6).xrs.open_geotiff(path, coregister=True)
     vals = np.asarray(out.data)
     finite = vals[np.isfinite(vals)]
     assert finite.size > 0
@@ -346,3 +349,234 @@ def test_coregister_warns_small_fraction_crs_mismatch(tmp_path):
     )
     with pytest.warns(UserWarning, match="covers only"):
         template.xrs.open_geotiff(path, coregister=True)
+
+
+# ---------------------------------------------------------------------------
+# overview-aware windowing + auto overview selection
+# ---------------------------------------------------------------------------
+
+def _cog_4326(tmp_path, name):
+    # 256x256 smooth gradient COG over ~44..46N / -121..-119E with
+    # internal overviews (tile_size=64 -> levels at 128 and 64).
+    height = width = 256
+    arr = np.add.outer(np.arange(height, dtype=np.float32),
+                       np.arange(width, dtype=np.float32))
+    y = np.linspace(45.999, 44.001, height)
+    x = np.linspace(-120.999, -119.001, width)
+    da = xr.DataArray(arr, dims=['y', 'x'],
+                      coords={'y': y, 'x': x}, attrs={'crs': 4326})
+    path = str(tmp_path / name)
+    to_geotiff(da, path, cog=True, tile_size=64)
+    return path
+
+
+def _interior_template_4326(n=8):
+    return xr.DataArray(
+        np.zeros((n, n), dtype=np.float32),
+        dims=['y', 'x'],
+        coords={'y': np.linspace(45.4, 44.6, n),
+                'x': np.linspace(-120.4, -119.6, n)},
+        attrs={'crs': 4326},
+    )
+
+
+def test_coregister_explicit_overview_level(tmp_path):
+    # An explicit overview_level= must window in that overview's pixel
+    # space; computing the window against the full-resolution transform
+    # reads the wrong region of the overview (or falls outside it).
+    path = _cog_4326(tmp_path, 'cg_ov_explicit.tif')
+    template = _interior_template_4326(8)
+    full = template.xrs.open_geotiff(path, coregister=True,
+                                     overview_level=0)
+    out = template.xrs.open_geotiff(path, coregister=True,
+                                    overview_level=1)
+    assert np.allclose(out.coords['x'].values, template.coords['x'].values)
+    assert np.allclose(out.coords['y'].values, template.coords['y'].values)
+    vals = np.asarray(out.data)
+    assert not np.isnan(vals).any()
+    # The template sits inside the file, the source is a smooth gradient:
+    # the overview read must land within resampling tolerance of the
+    # full-resolution read.
+    assert np.allclose(vals, np.asarray(full.data), atol=2.0)
+
+
+def _spy_read_overview_level(monkeypatch):
+    # Capture the overview_level the windowed read ends up using.
+    import xrspatial.geotiff as gt
+    real = gt.open_geotiff
+    seen = {}
+
+    def spy(src, **kw):
+        seen['overview_level'] = kw.get('overview_level')
+        return real(src, **kw)
+
+    monkeypatch.setattr(gt, 'open_geotiff', spy)
+    return seen
+
+
+def test_coregister_auto_selects_overview(tmp_path, monkeypatch):
+    # A caller grid much coarser than the file: coregister should read
+    # the coarsest overview that is still finer than the caller grid
+    # (256px file, 8px template -> 32x decimation -> level 2 = 64px)
+    # instead of decoding the full-resolution pixels.
+    path = _cog_4326(tmp_path, 'cg_ov_auto.tif')
+    template = _interior_template_4326(8)
+    seen = _spy_read_overview_level(monkeypatch)
+    full = template.xrs.open_geotiff(path, coregister=True,
+                                     overview_level=0)
+    out = template.xrs.open_geotiff(path, coregister=True)
+    assert seen['overview_level'] == 2
+    vals = np.asarray(out.data)
+    assert not np.isnan(vals).any()
+    assert np.allclose(vals, np.asarray(full.data), atol=8.0)
+
+
+def test_coregister_explicit_overview_level_wins_over_auto(tmp_path,
+                                                           monkeypatch):
+    path = _cog_4326(tmp_path, 'cg_ov_explicit_wins.tif')
+    template = _interior_template_4326(8)
+    seen = _spy_read_overview_level(monkeypatch)
+    template.xrs.open_geotiff(path, coregister=True, overview_level=1)
+    assert seen['overview_level'] == 1
+    # overview_level=0 is an explicit full-resolution opt-out.
+    template.xrs.open_geotiff(path, coregister=True, overview_level=0)
+    assert seen['overview_level'] == 0
+
+
+def test_coregister_no_overviews_falls_back_to_full_res(tmp_path,
+                                                        monkeypatch):
+    # A plain (non-COG) TIFF has no overviews: a coarse caller grid must
+    # fall back to the full-resolution read, not raise.
+    path = _file_4326(tmp_path, np.float32, 'cg_ov_plain.tif')
+    template = _template_3857(3)  # 30px file onto 3px template: 10x
+    seen = _spy_read_overview_level(monkeypatch)
+    out = template.xrs.open_geotiff(path, coregister=True)
+    assert seen['overview_level'] is None
+    assert out.shape == template.shape
+
+
+def test_coregister_no_overview_when_res_similar(tmp_path, monkeypatch):
+    # Template resolution close to the file's: stay at full resolution.
+    path = _cog_4326(tmp_path, 'cg_ov_similar.tif')
+    template = _interior_template_4326(200)
+    seen = _spy_read_overview_level(monkeypatch)
+    template.xrs.open_geotiff(path, coregister=True)
+    assert seen['overview_level'] is None
+
+
+# ---------------------------------------------------------------------------
+# fail-fast guards
+# ---------------------------------------------------------------------------
+
+def test_coregister_zero_overlap_raises_clear_error(tmp_path):
+    # A file fully disjoint from the caller grid would come back all
+    # NaN; raise up front with a message that names the problem instead
+    # of the low-level "window is outside the source extent" error.
+    path = _file_4326(tmp_path, np.float32, 'cg_disjoint.tif')
+    template = xr.DataArray(
+        np.zeros((6, 6), dtype=np.float32),
+        dims=['y', 'x'],
+        coords={'y': np.linspace(10.0, 9.0, 6),
+                'x': np.linspace(30.0, 31.0, 6)},
+        attrs={'crs': 4326},
+    )
+    with pytest.raises(ValueError, match="does not overlap"):
+        template.xrs.open_geotiff(path, coregister=True)
+
+
+def test_coregister_allow_rotated_guard(tmp_path):
+    # allow_rotated=True reads a rotated file as an ungeoreferenced
+    # pixel grid; reproject would then treat its y/x coords as
+    # axis-aligned map coordinates and produce silently wrong
+    # georeferencing. Refuse the combination up front (so the guard
+    # fires before any read).
+    template = _template_3857(6)
+    with pytest.raises(ValueError, match="allow_rotated"):
+        template.xrs.open_geotiff('unused.tif', coregister=True,
+                                  allow_rotated=True)
+
+
+def test_coregister_irregular_template_raises(tmp_path):
+    # _caller_grid derives the output grid from first/last coords and a
+    # uniform spacing; an irregular template would silently misalign.
+    path = _file_4326(tmp_path, np.float32, 'cg_irregular.tif')
+    x = np.linspace(-120.3, -119.7, 8)
+    x[3] += 0.05  # well past any float tolerance
+    template = xr.DataArray(
+        np.zeros((8, 8), dtype=np.float32),
+        dims=['y', 'x'],
+        coords={'y': np.linspace(45.3, 44.7, 8), 'x': x},
+        attrs={'crs': 4326},
+    )
+    with pytest.raises(ValueError, match="regular"):
+        template.xrs.open_geotiff(path, coregister=True)
+
+
+def test_coregister_template_orientation_raises(tmp_path):
+    # reproject emits x-ascending / y-descending output; a template in
+    # any other orientation cannot line up cell-for-cell, so refuse it
+    # rather than returning coords in a different order than the caller.
+    path = _file_4326(tmp_path, np.float32, 'cg_orient.tif')
+    base = _interior_template_4326(8)
+    flipped_x = base.assign_coords(x=base.coords['x'].values[::-1])
+    with pytest.raises(ValueError, match="ascending"):
+        flipped_x.xrs.open_geotiff(path, coregister=True)
+    flipped_y = base.assign_coords(y=base.coords['y'].values[::-1])
+    with pytest.raises(ValueError, match="descending"):
+        flipped_y.xrs.open_geotiff(path, coregister=True)
+
+
+def test_coregister_antimeridian_template_warns(tmp_path, monkeypatch):
+    # A caller grid straddling the dateline transforms into file-CRS
+    # longitudes near +180 and -180; min/max windowing then covers the
+    # full file width. That stays correct (a superset read) but is easy
+    # to hit by accident and reads far more than the caller footprint,
+    # so warn -- and skip auto overview selection, because the inflated
+    # bbox span would otherwise pick an overview far coarser than the
+    # caller's real resolution.
+    from pyproj import Transformer
+    height = width = 256
+    arr = np.add.outer(np.arange(height, dtype=np.float32),
+                       np.arange(width, dtype=np.float32))
+    da = xr.DataArray(
+        arr, dims=['y', 'x'],
+        coords={'y': np.linspace(59.99, 50.01, height),
+                'x': np.linspace(-179.99, 179.99, width)},
+        attrs={'crs': 4326},
+    )
+    path = str(tmp_path / 'cg_antimeridian.tif')
+    to_geotiff(da, path, cog=True, tile_size=64)
+
+    # UTM zone 60N caller crossing 180E (lon 179..181).
+    tr = Transformer.from_crs(4326, 32660, always_xy=True)
+    x0, y0 = tr.transform(179.0, 54.0)
+    x1, y1 = tr.transform(181.0, 56.0)
+    template = xr.DataArray(
+        np.zeros((8, 8), dtype=np.float32),
+        dims=['y', 'x'],
+        coords={'y': np.linspace(max(y0, y1), min(y0, y1), 8),
+                'x': np.linspace(min(x0, x1), max(x0, x1), 8)},
+        attrs={'crs': 32660},
+    )
+    seen = _spy_read_overview_level(monkeypatch)
+    with pytest.warns(UserWarning, match="antimeridian"):
+        out = template.xrs.open_geotiff(path, coregister=True)
+    assert seen['overview_level'] is None
+    assert out.shape == template.shape
+    assert np.isfinite(np.asarray(out.data)).any()
+
+
+def test_coregister_auto_nearest_integer_warns(tmp_path):
+    # 'auto' picks 'nearest' for integer rasters on the assumption they
+    # are categorical. For an integer DEM that silently throws away
+    # interpolation quality, so say what was chosen and how to override.
+    path = _file_4326(tmp_path, np.int16, 'cg_intwarn.tif')
+    template = _template_3857(6)
+    with pytest.warns(UserWarning, match="nearest"):
+        template.xrs.open_geotiff(path, coregister=True)
+    # An explicit choice is not second-guessed.
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        template.xrs.open_geotiff(path, coregister=True,
+                                  resampling='nearest')
+    assert not [w for w in caught if "resampling" in str(w.message)]

--- a/xrspatial/tests/test_open_geotiff_coregister.py
+++ b/xrspatial/tests/test_open_geotiff_coregister.py
@@ -431,6 +431,32 @@ def test_coregister_auto_selects_overview(tmp_path, monkeypatch):
     assert np.allclose(vals, np.asarray(full.data), atol=8.0)
 
 
+def test_coregister_auto_overview_crs_mismatch(tmp_path, monkeypatch):
+    # The caller resolution that drives level selection is estimated in
+    # file-CRS units from the transformed bbox; a 3857 template over a
+    # 4326 file exercises that conversion (the same-CRS tests run it
+    # with an identity transform only).
+    from pyproj import Transformer
+    path = _cog_4326(tmp_path, 'cg_ov_auto_3857.tif')
+    tr = Transformer.from_crs(4326, 3857, always_xy=True)
+    x0, y0 = tr.transform(-120.4, 45.4)
+    x1, y1 = tr.transform(-119.6, 44.6)
+    template = xr.DataArray(
+        np.zeros((8, 8), dtype=np.float32),
+        dims=['y', 'x'],
+        coords={'y': np.linspace(max(y0, y1), min(y0, y1), 8),
+                'x': np.linspace(min(x0, x1), max(x0, x1), 8)},
+        attrs={'crs': 3857},
+    )
+    seen = _spy_read_overview_level(monkeypatch)
+    out = template.xrs.open_geotiff(path, coregister=True)
+    # ~0.1 deg per template cell vs 0.0078 deg file pixels: level 2
+    # (0.031 deg) is the coarsest that still meets the template.
+    assert seen['overview_level'] == 2
+    vals = np.asarray(out.data)
+    assert not np.isnan(vals).any()
+
+
 def test_coregister_explicit_overview_level_wins_over_auto(tmp_path,
                                                            monkeypatch):
     path = _cog_4326(tmp_path, 'cg_ov_explicit_wins.tif')

--- a/xrspatial/tests/test_open_geotiff_resampling.py
+++ b/xrspatial/tests/test_open_geotiff_resampling.py
@@ -26,8 +26,12 @@ def test_auto_float_no_colormap_picks_bilinear():
 
 
 def test_auto_integer_picks_nearest():
-    assert _resolve_resampling('auto', _da('int16')) == 'nearest'
-    assert _resolve_resampling('auto', _da('uint8')) == 'nearest'
+    # integer-without-colormap also fires the is-this-really-categorical
+    # advisory alongside the 'nearest' choice
+    with pytest.warns(UserWarning, match="nearest"):
+        assert _resolve_resampling('auto', _da('int16')) == 'nearest'
+    with pytest.warns(UserWarning, match="nearest"):
+        assert _resolve_resampling('auto', _da('uint8')) == 'nearest'
 
 
 def test_auto_float_with_colormap_picks_nearest():
@@ -102,7 +106,8 @@ def test_auto_float_forwards_bilinear(tmp_path, reproject_spy):
 def test_auto_integer_forwards_nearest(tmp_path, reproject_spy):
     template, path = _mismatch_template_and_file(
         tmp_path, np.int16, 'rs3067_int.tif')
-    template.xrs.open_geotiff(path, auto_reproject=True)
+    with pytest.warns(UserWarning, match="nearest"):
+        template.xrs.open_geotiff(path, auto_reproject=True)
     assert reproject_spy['resampling'] == 'nearest'
 
 
@@ -131,7 +136,8 @@ def test_categorical_real_reproject_preserves_class_ids(tmp_path):
     )
     to_geotiff(file_da, path, compression='none')
 
-    result = template.xrs.open_geotiff(path, auto_reproject=True)
+    with pytest.warns(UserWarning, match="nearest"):
+        result = template.xrs.open_geotiff(path, auto_reproject=True)
     vals = np.asarray(result.data)
     finite = vals[np.isfinite(vals)]
     assert finite.size > 0


### PR DESCRIPTION
Closes #3253

- `coregister=True` now reads the coarsest overview that still meets the caller grid's resolution instead of always decoding full-resolution pixels. A 4096px COG onto a 64px grid went from 109ms to 5ms locally; remote COGs gain more because fewer bytes are fetched. `overview_level=0` forces full resolution, an explicit level wins over the auto pick, and plain TIFFs without overviews behave as before. Windows are now computed in the selected overview's pixel space, which also fixes explicit `overview_level=` on every accessor windowed read (previously it raised "window is outside the source extent" or read the wrong region).
- New fail-fast guards: a disjoint file raises "does not overlap" instead of the low-level window error; `allow_rotated=True` is refused (a rotated file reads as an ungeoreferenced grid that reproject would mis-place); irregular or flipped template grids raise with a `sortby` hint; an antimeridian-crossing template warns and falls back to the full-width window (correct superset, just slower) while skipping overview auto-selection.
- `resampling='auto'` warns when it picks `nearest` for integer data with no colormap (the int16 DEM case), with the override named.

Backend coverage: numpy and dask+numpy, same as coregister today (GPU paths still raise by design). The reader and reproject are untouched; everything lives in `xrspatial/accessor.py`.

Test plan:
- [x] `test_open_geotiff_coregister.py` grew 19 -> 30 tests: explicit overview windowing, auto selection, explicit-wins/opt-out, plain-TIFF fallback, similar-resolution no-op, zero overlap, allow_rotated, irregular/flipped templates, antimeridian, integer auto-nearest warning
- [x] `test_open_geotiff_resampling.py` updated for the new advisory warning
- [x] Full geotiff + reproject suites: 6906 passed, 64 skipped, 1 xfailed, no new warnings
- [x] flake8 clean on changed files