### PR TITLE
Rewrite the installation page: environments, all extras, GPU and cloud notes

### DIFF
--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -4,21 +4,139 @@
 Installation
 ************
 
+Requirements
+============
+
+``xarray-spatial`` requires Python 3.12 or newer and runs on Linux, macOS,
+and Windows. The required core is small: ``numpy``, ``numba``, ``scipy``,
+``xarray``, ``urllib3``, and ``zstandard``. There is no GDAL or GEOS
+anywhere in the stack, so nothing needs to be compiled and there are no
+system libraries to hunt down.
+
+Setting up an environment
+=========================
+
+Install into a fresh environment rather than your system Python. Any of
+the following works.
+
+With ``venv`` (standard library):
+
 .. code-block:: bash
 
-   # via pip
+   python -m venv .venv
+   source .venv/bin/activate      # Windows: .venv\Scripts\activate
    pip install xarray-spatial
 
-   # with plotting helpers (matplotlib)
-   pip install xarray-spatial[plot]
+With conda or mamba:
 
-   # with vector rasterization (shapely): rasterize, polygonize
-   pip install xarray-spatial[vector]
+.. code-block:: bash
 
-   # via conda
+   conda create -n xrspatial python=3.12
+   conda activate xrspatial
    conda install -c conda-forge xarray-spatial
 
-matplotlib and shapely are optional dependencies. The compute functions work
-without either; install the ``plot`` extra for the ``.xrs.plot`` accessor
-helpers, and the ``vector`` extra for the ``rasterize`` and ``polygonize``
-vector-to-raster paths.
+With `uv <https://docs.astral.sh/uv/>`_:
+
+.. code-block:: bash
+
+   uv venv
+   source .venv/bin/activate
+   uv pip install xarray-spatial
+
+Optional dependencies
+=====================
+
+The base install covers every compute function plus GeoTIFF / COG read
+and write. The extras below add features on top. Combine them as needed:
+
+.. code-block:: bash
+
+   pip install 'xarray-spatial[plot,vector,geotiff,reproject,dask]'
+
+.. list-table::
+   :header-rows: 1
+   :widths: 14 26 60
+
+   * - Extra
+     - Installs
+     - Enables
+   * - ``plot``
+     - matplotlib
+     - The ``.xrs.plot`` accessor helpers.
+   * - ``vector``
+     - shapely
+     - The vector-to-raster paths, ``rasterize`` and ``polygonize``.
+   * - ``geotiff``
+     - deflate, pyproj
+     - Faster DEFLATE compression (libdeflate) and full CRS support in
+       the GeoTIFF writer. Without pyproj the writer only recognizes a
+       small allowlist of EPSG codes.
+   * - ``reproject``
+     - pyproj
+     - WKT / PROJ CRS resolution for reprojection.
+   * - ``dask``
+     - dask[array], dask-geopandas
+     - Chunked, lazy, out-of-core processing on a single machine or a
+       cluster. See :doc:`/reference/dask_laziness`.
+   * - ``gpu``
+     - cupy, cuspatial
+     - The CuPy GPU backend. Needs an NVIDIA GPU and a CUDA toolkit
+       matching your cupy build.
+   * - ``optional``
+     - awkward, geopandas, spatialpandas, rtxpy
+     - Additional ``polygonize`` return types and the ray-traced
+       ``gpu_rtx`` functions (rtxpy also needs cupy).
+   * - ``examples``
+     - datashader
+     - Used by some of the example notebooks.
+   * - ``doc``, ``tests``
+     - sphinx, pytest, ...
+     - Building this documentation and running the test suite.
+
+GPU notes
+=========
+
+``pip install 'xarray-spatial[gpu]'`` pulls in cupy and cuspatial. You
+also need an NVIDIA driver and a CUDA toolkit compatible with your cupy
+build; see the `CuPy install guide
+<https://docs.cupy.dev/en/stable/install.html>`_ if you are unsure which
+cupy package to pick.
+
+Two GPU features have runtime dependencies that are *not* part of the
+``gpu`` extra because they ship as system libraries:
+
+* ``libnvcomp`` -- GPU batch decompression (DEFLATE, ZSTD) for the
+  GeoTIFF GPU read path
+* ``kvikio`` -- GPUDirect Storage, reading straight from SSD into GPU
+  memory
+
+Install both via conda from the ``rapidsai`` / ``nvidia`` channels. The
+rest of the GPU path works without them.
+
+Cloud storage
+=============
+
+``open_geotiff`` reads ``s3://``, ``gs://``, and ``az://`` URLs through
+``fsspec``. Install ``fsspec`` plus the filesystem package you need:
+``s3fs`` for S3, ``gcsfs`` for Google Cloud Storage, or ``adlfs`` for
+Azure. Plain ``http(s)://`` URLs work with no extra packages. See
+:doc:`/reference/geotiff` for the details of remote reads.
+
+Verifying the install
+=====================
+
+.. code-block:: bash
+
+   python -c "import xrspatial; print(xrspatial.__version__)"
+
+A quick functional check that exercises the compute path, with no data
+download:
+
+.. code-block:: python
+
+   import numpy as np
+   import xarray as xr
+   from xrspatial import generate_terrain, hillshade
+
+   terrain = generate_terrain(xr.DataArray(np.zeros((300, 400)), dims=['y', 'x']))
+   print(hillshade(terrain).shape)

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -46,8 +46,9 @@ With `uv <https://docs.astral.sh/uv/>`_:
 Optional dependencies
 =====================
 
-The base install covers every compute function plus GeoTIFF / COG read
-and write. The extras below add features on top. Combine them as needed:
+The base install covers the raster compute functions plus GeoTIFF / COG
+read and write. The extras below add features on top. Combine them as
+needed:
 
 .. code-block:: bash
 
@@ -119,8 +120,10 @@ Cloud storage
 ``open_geotiff`` reads ``s3://``, ``gs://``, and ``az://`` URLs through
 ``fsspec``. Install ``fsspec`` plus the filesystem package you need:
 ``s3fs`` for S3, ``gcsfs`` for Google Cloud Storage, or ``adlfs`` for
-Azure. Plain ``http(s)://`` URLs work with no extra packages. See
-:doc:`/reference/geotiff` for the details of remote reads.
+Azure. Plain ``http(s)://`` URLs work with no extra packages. Remote
+reads are an advanced-tier feature (see the feature matrix in the README
+and :doc:`/user_guide/stability_policy`); :doc:`/reference/geotiff` has
+the details.
 
 Verifying the install
 =====================


### PR DESCRIPTION
Refs #3249 (part 3 of 6).

The installation page covered two of the ten extras and nothing about environments. New structure:

- Requirements: Python >= 3.12, the six core deps, and the fact that nothing needs compiling (no GDAL/GEOS).
- Environment setup: venv, conda/mamba, and uv, a few lines each.
- Optional dependencies: a table covering every extra in setup.cfg and what it enables, plus a combined-extras install line. Descriptions come from the setup.cfg comments and the code (e.g. the pyproj note matches the writer's EPSG allowlist behavior from issue #2277, and `deflate` is the libdeflate binding used by `xrspatial/geotiff/_compression.py`).
- GPU notes: cupy/CUDA matching, and the libnvcomp + kvikio caveat from the README (system libraries, not in the `gpu` extra, conda rapidsai/nvidia channels).
- Cloud storage: fsspec + s3fs/gcsfs/adlfs for `open_geotiff` remote reads.
- Verifying the install: a version check plus a generate_terrain/hillshade snippet that needs no data download.

Test plan:
- [x] `sphinx-build -b html` succeeds, same 9 pre-existing warnings, none in getting_started
- [x] the verification snippet runs as written (printed `(300, 400)`)
- [x] `pip install --dry-run 'xarray-spatial[plot,vector,geotiff,reproject,dask]'` resolves with no unknown-extra warnings
- [x] `:doc:` targets (/reference/dask_laziness, /reference/geotiff) resolve in the built HTML

Note: trivially conflicts with #3251 on installation.rst (this is a full rewrite that includes #3251's Python-version line); whichever merges second gets a one-line resolution.