### PR TITLE
Export VRTUnsupportedError, CloudSizeLimitError, PixelSafetyLimitError publicly (#3265)

### DIFF
--- a/docs/source/reference/geotiff.rst
+++ b/docs/source/reference/geotiff.rst
@@ -414,7 +414,9 @@ turn the process into a port scanner. The knobs are:
 * ``max_cloud_bytes`` (kwarg) / ``XRSPATIAL_GEOTIFF_MAX_CLOUD_BYTES``
   (env). Per-call total byte budget for a remote read. The kwarg wins
   over the env var; the env var wins over the built-in default. Pass
-  ``max_cloud_bytes=None`` to disable the cap on a single call. Locked
+  ``max_cloud_bytes=None`` to disable the cap on a single call. A
+  breach raises :class:`xrspatial.geotiff.CloudSizeLimitError` (a
+  ``ValueError`` subclass). Locked
   by ``xrspatial/geotiff/tests/integration/test_http_sources.py``
   (max_cloud_bytes_dispatcher and max_cloud_bytes_annot sections, plus
   the http_read_all_bounded section).

--- a/docs/source/user_guide/geotiff_safe_io.rst
+++ b/docs/source/user_guide/geotiff_safe_io.rst
@@ -41,10 +41,10 @@ the read and write paths:
        eager numpy reader; dask, GPU, VRT, and remote-URL paths require
        a string. A ``.vrt`` source reads a GDAL mosaic (tier:
        ``advanced``) over a documented subset of the GDAL VRT schema;
-       unsupported features raise ``VRTUnsupportedError`` or
+       unsupported features raise
+       :class:`xrspatial.geotiff.VRTUnsupportedError` or
        :class:`xrspatial.geotiff.UnsupportedGeoTIFFFeatureError` at
-       graph-build time rather than producing wrong pixels. Both error
-       classes live in :mod:`xrspatial.geotiff._errors`.
+       graph-build time rather than producing wrong pixels.
    * - :func:`xrspatial.geotiff.to_geotiff`
      - Write a DataArray to a local path. Pass ``cog=True`` for a
        Cloud-optimized GeoTIFF layout. Pass ``allow_experimental_codecs=True``
@@ -229,7 +229,7 @@ the ambiguous-metadata family at once.
      - ``attrs['nodata']`` and ``attrs['nodatavals']`` disagree on
        write.
      - Resolve in caller code; the writer will not pick one silently.
-   * - ``VRTUnsupportedError``
+   * - :class:`~xrspatial.geotiff.VRTUnsupportedError`
      - The parsed VRT declares a feature the read pipeline does not
        honour (CRS / dtype / band / nodata / transform / pixel-size /
        window / resampling mismatch).

--- a/xrspatial/geotiff/__init__.py
+++ b/xrspatial/geotiff/__init__.py
@@ -71,9 +71,13 @@ from ._errors import (ConflictingCRSError, ConflictingNodataError, DuplicateIFDT
                       NonRepresentableEPSGCRSError, NonUniformCoordsError,
                       RemoteStableSourcesOnlyError, RotatedTransformError, UnknownCRSModelTypeError,
                       UnparseableCRSError, UnsupportedGeoTIFFFeatureError,
-                      VRTStableSourcesOnlyError)
+                      VRTStableSourcesOnlyError, VRTUnsupportedError)
 from ._geotags import RASTER_PIXEL_IS_AREA, RASTER_PIXEL_IS_POINT, GeoTransform  # noqa: F401
-from ._reader import _MAX_CLOUD_BYTES_SENTINEL, CloudSizeLimitError, UnsafeURLError
+# ``PixelSafetyLimitError`` is defined in ``_layout`` and re-exported by
+# ``_reader`` (the historical import surface); bind it here so callers can
+# catch the ``max_pixels`` rejection without a private-module import.
+from ._reader import (_MAX_CLOUD_BYTES_SENTINEL, CloudSizeLimitError, PixelSafetyLimitError,
+                      UnsafeURLError)
 from ._reader import read_to_array as _read_to_array
 from ._runtime import (_CRS_WKT_DEPRECATED_SENTINEL, _GPU_DEPRECATED_SENTINEL,  # noqa: F401
                        _MASK_AND_SCALE_DEPRECATED_SENTINEL, _MASK_NODATA_DEPRECATED_SENTINEL,
@@ -103,6 +107,7 @@ from ._writers.vrt import _build_vrt  # noqa: F401
 # is intentionally omitted: it is deprecated in favour of ``da.xrs.plot()``
 # and emits a ``DeprecationWarning`` when called.
 __all__ = [
+    'CloudSizeLimitError',
     'ConflictingCRSError',
     'ConflictingNodataError',
     'DuplicateIFDTagError',
@@ -121,6 +126,7 @@ __all__ = [
     'MixedBandMetadataError',
     'NonRepresentableEPSGCRSError',
     'NonUniformCoordsError',
+    'PixelSafetyLimitError',
     'RemoteStableSourcesOnlyError',
     'RotatedTransformError',
     'SUPPORTED_FEATURES',
@@ -129,6 +135,7 @@ __all__ = [
     'UnsafeURLError',
     'UnsupportedGeoTIFFFeatureError',
     'VRTStableSourcesOnlyError',
+    'VRTUnsupportedError',
     'open_geotiff',
     'to_geotiff',
 ]

--- a/xrspatial/geotiff/__init__.py
+++ b/xrspatial/geotiff/__init__.py
@@ -642,7 +642,9 @@ def open_geotiff(source: str | BinaryIO, *,
         each chunk's decode buffer instead, so a small ``max_pixels``
         no longer rejects a large lazy raster up front. None uses the
         default (~1 billion). Raise it to read legitimately large
-        files.
+        files. Exceeding the cap raises
+        :class:`~xrspatial.geotiff.PixelSafetyLimitError` (a
+        ``ValueError`` subclass).
     max_cloud_bytes : int or None, optional
         [advanced] fsspec cloud reads can run up cost on large objects;
         the budget defends against accidental large downloads but the
@@ -650,7 +652,9 @@ def open_geotiff(source: str | BinaryIO, *,
         Byte ceiling for eager reads from fsspec sources (``s3://``,
         ``gs://``, ``az://``, ``abfs://``, ``memory://``, ...). The
         compressed object size is checked against this budget before
-        any bytes are downloaded. Default is 256 MiB, overridable via
+        any bytes are downloaded; a breach raises
+        :class:`~xrspatial.geotiff.CloudSizeLimitError` (a
+        ``ValueError`` subclass). Default is 256 MiB, overridable via
         the ``XRSPATIAL_GEOTIFF_MAX_CLOUD_BYTES`` env var. Pass
         ``None`` to skip the check entirely. The HTTP path already
         reads only what it needs via range requests and is not subject

--- a/xrspatial/geotiff/tests/release_gates/test_features.py
+++ b/xrspatial/geotiff/tests/release_gates/test_features.py
@@ -2860,8 +2860,20 @@ class TestPublicAPI:
             # ``stable_only=True`` is rejected because those readers are
             # advanced-tier.
             'RemoteStableSourcesOnlyError',
+            # Typed rejection when the parsed VRT declares a feature the
+            # read pipeline does not honour (CRS / dtype / band / nodata /
+            # transform / pixel-size / window / resampling mismatch).
+            # Exported in issue #3265 so callers can catch it without
+            # importing from the private ``_errors`` module.
+            'VRTUnsupportedError',
             'GeoTIFFFallbackWarning',
             'UnsafeURLError',
+            # Safety-cap rejections on public read paths (issue #3265):
+            # ``max_cloud_bytes`` breaches and ``max_pixels`` breaches.
+            # Both are ``ValueError`` subclasses, exported so callers can
+            # catch the specific cap without private-module imports.
+            'CloudSizeLimitError',
+            'PixelSafetyLimitError',
             # Canonical georef_status constants. Exposed so downstream
             # code can branch on the five reader states via constants
             # rather than string literals.

--- a/xrspatial/geotiff/tests/unit/test_exception_exports_3265.py
+++ b/xrspatial/geotiff/tests/unit/test_exception_exports_3265.py
@@ -1,0 +1,61 @@
+"""Public export of read-path exceptions (#3265).
+
+``VRTUnsupportedError``, ``CloudSizeLimitError``, and
+``PixelSafetyLimitError`` are raised on public ``open_geotiff`` paths
+(VRT capability validation, the ``max_cloud_bytes`` budget, and the
+``max_pixels`` cap) but used to require private-module imports to catch
+specifically, while the other 17 error classes were exported. These
+tests pin the additive export: the names resolve on the package, sit in
+``__all__``, and are the same objects the private modules define, so
+existing private import paths keep working.
+"""
+import numpy as np
+import pytest
+import xarray as xr
+
+import xrspatial.geotiff as g
+from xrspatial.geotiff import open_geotiff, to_geotiff
+
+
+@pytest.mark.parametrize("name", [
+    "VRTUnsupportedError",
+    "CloudSizeLimitError",
+    "PixelSafetyLimitError",
+])
+def test_exception_is_public_3265(name):
+    assert hasattr(g, name), f"{name} not exposed on xrspatial.geotiff"
+    assert name in g.__all__, f"{name} not listed in xrspatial.geotiff.__all__"
+    assert issubclass(getattr(g, name), ValueError)
+
+
+def test_public_names_are_the_private_definitions_3265():
+    """Same objects as the defining modules: private imports keep working."""
+    from xrspatial.geotiff._errors import VRTUnsupportedError
+    from xrspatial.geotiff._layout import PixelSafetyLimitError
+    from xrspatial.geotiff._sources import CloudSizeLimitError
+
+    assert g.VRTUnsupportedError is VRTUnsupportedError
+    assert g.PixelSafetyLimitError is PixelSafetyLimitError
+    assert g.CloudSizeLimitError is CloudSizeLimitError
+    # The historical _reader re-export surface is unchanged too.
+    from xrspatial.geotiff._reader import \
+        PixelSafetyLimitError as reader_pixel_err
+    assert g.PixelSafetyLimitError is reader_pixel_err
+
+
+def test_vrt_unsupported_subclasses_exported_base_3265():
+    """Broad catches via the exported base class still work."""
+    assert issubclass(g.VRTUnsupportedError, g.GeoTIFFAmbiguousMetadataError)
+
+
+def test_max_pixels_raises_publicly_catchable_error_3265(tmp_path):
+    """The [stable] max_pixels cap raises the now-public class."""
+    path = str(tmp_path / "t3265_cap.tif")
+    da = xr.DataArray(
+        np.arange(64, dtype=np.uint8).reshape(8, 8), dims=("y", "x"),
+        coords={"y": np.arange(8, 0, -1) - 0.5, "x": np.arange(8) + 0.5},
+        attrs={"crs": 4326})
+    to_geotiff(da, path)
+
+    with pytest.raises(g.PixelSafetyLimitError):
+        open_geotiff(path, max_pixels=4)


### PR DESCRIPTION
Closes #3265

- Imports `VRTUnsupportedError` (from `_errors`) and `PixelSafetyLimitError` (via `_reader`'s historical re-export of `_layout`) into `xrspatial/geotiff/__init__.py` and adds both, plus the already-bound `CloudSizeLimitError`, to `__all__`. All three are raised on public `open_geotiff` paths (VRT capability validation, `max_cloud_bytes`, `max_pixels`) and were the only such exceptions missing from the public surface; the other 17 error classes were already exported.
- Updates `docs/source/user_guide/geotiff_safe_io.rst`: the VRT error-table row and the `open_geotiff` overview now use the `:class:~xrspatial.geotiff.` role instead of steering readers to the private `_errors` module.
- Purely additive: no renames, no behavior change, private import paths (`_errors`, `_layout`, `_reader`) keep working and the new test pins object identity with them.

Backends: not applicable, no runtime dispatch touched. The change is namespace plus docs.

Test plan:
- [x] `pytest xrspatial/geotiff/tests/unit/test_exception_exports_3265.py` (export, `__all__`, identity, base-class catch, functional `max_pixels` raise)
- [x] `pytest xrspatial/geotiff/tests/parity/test_api_consolidation.py xrspatial/geotiff/tests/unit/test_metadata.py` (existing surface-pinning tests still pass)
- [x] isort / flake8 clean on the touched files