### PR TITLE
Widen rasterize() dtype annotation to the accepted forms (#3291)

### DIFF
--- a/xrspatial/rasterize.py
+++ b/xrspatial/rasterize.py
@@ -3226,8 +3226,9 @@ def rasterize(
         Data type of the output array.  Accepts anything ``np.dtype()``
         can parse: an ``np.dtype`` instance, a dtype name string
         (``'int32'``), or a numpy scalar type (``np.int32``).  Defaults
-        to np.float64, or to the dtype of ``like`` if provided.  When this resolves to an
-        integer type, burn values are validated against the float64 safe
+        to np.float64, or to the dtype of ``like`` if provided.  When
+        this resolves to an integer type, burn values are validated
+        against the float64 safe
         integer range: the rasterizer computes in float64, so a value
         with magnitude above ``2**53 - 1`` cannot be cast back to an
         exact integer (e.g. ``2**53 + 1`` would land on ``2**53``).  Such

--- a/xrspatial/rasterize.py
+++ b/xrspatial/rasterize.py
@@ -3152,7 +3152,7 @@ def rasterize(
     column: Optional[str] = None,
     columns: Optional[Sequence[str]] = None,
     fill: float = np.nan,
-    dtype: Optional[np.dtype] = None,
+    dtype: Optional[Union[str, np.dtype, type]] = None,
     all_touched: bool = False,
     gpu: bool = False,
     name: str = 'rasterize',
@@ -3222,9 +3222,11 @@ def rasterize(
         ``nodata`` / ``_FillValue`` attrs would disagree.  Pass a fill the
         dtype can hold (e.g. ``fill=0`` or ``fill=-9999`` for integers,
         ``fill=False`` for bool) or use a floating dtype.
-    dtype : numpy dtype, optional
-        Data type of the output array.  Defaults to np.float64, or
-        to the dtype of ``like`` if provided.  When this resolves to an
+    dtype : numpy dtype, dtype name, or scalar type, optional
+        Data type of the output array.  Accepts anything ``np.dtype()``
+        can parse: an ``np.dtype`` instance, a dtype name string
+        (``'int32'``), or a numpy scalar type (``np.int32``).  Defaults
+        to np.float64, or to the dtype of ``like`` if provided.  When this resolves to an
         integer type, burn values are validated against the float64 safe
         integer range: the rasterizer computes in float64, so a value
         with magnitude above ``2**53 - 1`` cannot be cast back to an

--- a/xrspatial/tests/test_rasterize_dtype_annot_3291.py
+++ b/xrspatial/tests/test_rasterize_dtype_annot_3291.py
@@ -1,0 +1,43 @@
+"""Regression: rasterize() dtype annotation covers the accepted forms.
+
+Pins the fix for issue #3291 (api-consistency sweep, Cat 3). The
+implementation accepts anything ``np.dtype()`` can parse -- a dtype name
+string, a numpy scalar type, or an ``np.dtype`` instance -- and the
+module's own tests call it with scalar types (``dtype=np.int32``). The
+old ``Optional[np.dtype]`` hint rejected two of the three working forms
+under mypy/pyright.
+"""
+from __future__ import annotations
+
+import typing
+
+import numpy as np
+import pytest
+
+from xrspatial.rasterize import rasterize
+
+shapely = pytest.importorskip("shapely")
+from shapely.geometry import box  # noqa: E402
+
+
+def test_dtype_annotation_accepts_str_dtype_and_type():
+    hints = typing.get_type_hints(rasterize)
+    args = set(typing.get_args(hints["dtype"]))
+    assert str in args, "dtype hint must accept dtype name strings"
+    assert np.dtype in args, "dtype hint must accept np.dtype instances"
+    assert type in args, "dtype hint must accept numpy scalar types"
+    assert type(None) in args, "dtype hint must stay optional"
+
+
+@pytest.mark.parametrize(
+    "dtype_arg",
+    ["int32", np.int32, np.dtype("int32")],
+    ids=["str-name", "scalar-type", "dtype-instance"],
+)
+def test_dtype_forms_accepted_at_runtime(dtype_arg):
+    result = rasterize(
+        [(box(0, 0, 5, 5), 1.0)],
+        width=4, height=4, bounds=(0, 0, 10, 10),
+        fill=0, dtype=dtype_arg,
+    )
+    assert result.dtype == np.int32

--- a/xrspatial/tests/test_rasterize_dtype_annot_3291.py
+++ b/xrspatial/tests/test_rasterize_dtype_annot_3291.py
@@ -16,9 +16,6 @@ import pytest
 
 from xrspatial.rasterize import rasterize
 
-shapely = pytest.importorskip("shapely")
-from shapely.geometry import box  # noqa: E402
-
 
 def test_dtype_annotation_accepts_str_dtype_and_type():
     hints = typing.get_type_hints(rasterize)
@@ -35,6 +32,9 @@ def test_dtype_annotation_accepts_str_dtype_and_type():
     ids=["str-name", "scalar-type", "dtype-instance"],
 )
 def test_dtype_forms_accepted_at_runtime(dtype_arg):
+    pytest.importorskip("shapely")
+    from shapely.geometry import box
+
     result = rasterize(
         [(box(0, 0, 5, 5), 1.0)],
         width=4, height=4, bounds=(0, 0, 10, 10),


### PR DESCRIPTION
Closes #3291.

- `dtype` was annotated `Optional[np.dtype]` but the implementation accepts anything `np.dtype()` parses: string names (`'int32'`), numpy scalar types (`np.int32`), and `np.dtype` instances. Widened to `Optional[Union[str, np.dtype, type]]`, matching how the function is actually called (`dtype=np.int32` is the dominant form in the existing tests) and lining up with `open_geotiff`'s `str | np.dtype | None`.
- Docstring now names the accepted forms.
- Annotation and docs only, no runtime change, so no deprecation shim.

Backends: the signature is shared across numpy / cupy / dask+numpy / dask+cupy; all four were smoke-tested with identical kwargs during the sweep and values matched.

Test plan:
- [x] `test_rasterize_dtype_annot_3291.py`: pins the hint args (str / np.dtype / type / None) and runtime acceptance of all three forms
- [x] `test_rasterize_signature_annot_2250.py` still passes (every param annotated)
- [x] `test_rasterize.py`: 215 passed, 2 skipped