### PR TITLE
Promote large-output in-memory cupy reproject inputs to dask (#3281)

### DIFF
--- a/xrspatial/reproject/__init__.py
+++ b/xrspatial/reproject/__init__.py
@@ -1008,7 +1008,7 @@ def reproject(
     # blockwise layer) so graph metadata is no longer a concern -- the
     # streaming fallback is only needed when dask itself is unavailable.
     _use_streaming = False
-    if not is_dask and not is_cupy:
+    if not is_dask:
         nbytes = src_shape[0] * src_shape[1] * data.dtype.itemsize
         out_nbytes = out_shape[0] * out_shape[1] * 8  # float64 working set
         if data.ndim == 3:
@@ -1025,6 +1025,13 @@ def reproject(
                 cs = (cs[0], cs[1], data.shape[2])
             try:
                 import dask.array as _da
+                # Wrapping an in-memory cupy array keeps the blocks
+                # cupy-backed, so is_cupy stays True and the promoted
+                # raster routes through _reproject_dask_cupy -- which has
+                # its own GPU VRAM check and chunked map_blocks fallback.
+                # Above the threshold an in-memory cupy input therefore
+                # yields a dask-of-cupy output, matching merge()'s
+                # promotion contract (#3281).
                 data = _da.from_array(data, chunks=cs)
                 raster = xr.DataArray(
                     data, dims=raster.dims, coords=raster.coords,
@@ -1032,8 +1039,12 @@ def reproject(
                 )
                 is_dask = True
             except ImportError:
-                # dask not available -- fall back to streaming
-                _use_streaming = True
+                # dask not available. The streaming fallback is a numpy
+                # CPU path, so it only applies to numpy inputs; a cupy
+                # input keeps the eager GPU path rather than silently
+                # moving its data off the device (#3281).
+                if not is_cupy:
+                    _use_streaming = True
 
     # Re-apply the output-size guard for paths that materialize the whole
     # output (in-memory numpy/cupy and streaming). A lazy dask output

--- a/xrspatial/reproject/__init__.py
+++ b/xrspatial/reproject/__init__.py
@@ -48,13 +48,14 @@ _X_NAMES = {'x', 'lon', 'longitude', 'X', 'Lon', 'Longitude'}
 _MERGE_OOM_THRESHOLD = 512 * 1024 * 1024  # 512 MB
 
 # Byte budget above which reproject() auto-promotes an in-memory raster
-# to the lazy dask path. Compared against the input array size and one
-# float64 output array independently, not against total memory: the
-# eager numpy path holds ~7 output-sized float64 temporaries (coordinate
-# grids, pixel-index grids, result), so eager-path peak RSS can reach
-# ~7x this budget. That multiplier is why a small input upsampled to a
-# large output exhausted memory long before the _MAX_OUTPUT_PIXELS
-# guard tripped (#3267).
+# (numpy or cupy) to the chunked dask path. Compared against the input
+# array size and one float64 output array independently, not against
+# total memory: the eager numpy path holds ~7 output-sized float64
+# temporaries (coordinate grids, pixel-index grids, result), so
+# eager-path peak RSS can reach ~7x this budget. That multiplier is why a
+# small input upsampled to a large output exhausted memory long before
+# the _MAX_OUTPUT_PIXELS guard tripped (#3267). The same budget gates the
+# cupy promotion added in #3281.
 _REPROJECT_OOM_THRESHOLD = 512 * 1024 * 1024  # 512 MB
 
 # Map friendly vertical datum tokens to EPSG codes so attrs['vertical_crs']

--- a/xrspatial/tests/test_reproject_cupy_promotion_3281.py
+++ b/xrspatial/tests/test_reproject_cupy_promotion_3281.py
@@ -1,0 +1,144 @@
+"""Regression tests for #3281.
+
+The output-size dask promotion added in #3278 only applied to numpy
+inputs (``if not is_dask and not is_cupy`` in ``reproject()``). An
+in-memory cupy raster with a very large output still allocated the full
+working set on the GPU and could fail with a device OOM.
+
+The fix drops the ``not is_cupy`` exclusion so a large-output cupy input
+is wrapped in a cupy-backed dask array and routed through
+``_reproject_dask_cupy``, which has its own GPU VRAM check and a chunked
+``map_blocks`` fallback. The result-type contract mirrors ``merge()``:
+an output that still fits in VRAM stays eager cupy, while one that
+exceeds VRAM becomes a chunked dask result.
+"""
+from __future__ import annotations
+
+import importlib
+import warnings
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from xrspatial.utils import has_cuda_and_cupy
+
+try:
+    import pyproj  # noqa: F401
+    HAS_PYPROJ = True
+except ImportError:
+    HAS_PYPROJ = False
+
+HAS_CUPY = has_cuda_and_cupy()
+
+pytestmark = pytest.mark.skipif(
+    not (HAS_PYPROJ and HAS_CUPY),
+    reason="cupy + CUDA device and pyproj required for GPU promotion tests",
+)
+
+# ``from xrspatial import reproject`` resolves to the function, not the
+# package, so load the package module explicitly to reach the helpers.
+_reproject_mod = importlib.import_module('xrspatial.reproject')
+
+
+def _make_cupy_raster():
+    import cupy as cp
+
+    h, w = 60, 60
+    arr = np.random.RandomState(0).rand(h, w).astype('float64')
+    y = np.linspace(55, 45, h)  # north-up (descending)
+    x = np.linspace(-5, 5, w)
+    return xr.DataArray(
+        cp.asarray(arr),
+        dims=['y', 'x'],
+        coords={'y': y, 'x': x},
+        attrs={'crs': 'EPSG:4326', 'nodata': np.nan},
+    )
+
+
+def test_inmemory_cupy_below_threshold_stays_eager(monkeypatch):
+    """A small cupy output keeps the eager in-memory cupy path."""
+    import cupy as cp
+
+    import dask.array as _da
+
+    r = _make_cupy_raster()
+    out = _reproject_mod.reproject(r, target_crs='EPSG:32633')
+
+    assert not isinstance(out.data, _da.Array)
+    assert isinstance(out.data, cp.ndarray)
+
+
+def test_inmemory_cupy_promotion_routes_through_dask_cupy(monkeypatch):
+    """Above the threshold a cupy input promotes to the dask+cupy path.
+
+    Before #3281 the ``not is_cupy`` guard sent a large-output cupy raster
+    straight to ``_reproject_inmemory_cupy`` (full GPU allocation). The
+    fix routes it through ``_reproject_dask_cupy`` instead.
+    """
+    r = _make_cupy_raster()
+
+    routed = {'dask_cupy': False, 'inmemory_cupy': False}
+    orig_dask_cupy = _reproject_mod._reproject_dask_cupy
+    orig_inmem_cupy = _reproject_mod._reproject_inmemory_cupy
+
+    def spy_dask_cupy(*args, **kwargs):
+        routed['dask_cupy'] = True
+        return orig_dask_cupy(*args, **kwargs)
+
+    def spy_inmem_cupy(*args, **kwargs):
+        routed['inmemory_cupy'] = True
+        return orig_inmem_cupy(*args, **kwargs)
+
+    monkeypatch.setattr(_reproject_mod, '_reproject_dask_cupy', spy_dask_cupy)
+    monkeypatch.setattr(
+        _reproject_mod, '_reproject_inmemory_cupy', spy_inmem_cupy
+    )
+    # Force promotion without building a genuinely huge GPU array.
+    monkeypatch.setattr(_reproject_mod, '_REPROJECT_OOM_THRESHOLD', 1)
+
+    _reproject_mod.reproject(r, target_crs='EPSG:32633')
+
+    assert routed['dask_cupy'], "promoted cupy input should hit the dask+cupy path"
+    assert not routed['inmemory_cupy'], (
+        "promoted cupy input must not fall back to the eager in-memory path"
+    )
+
+
+def test_inmemory_cupy_vram_fallback_yields_dask_with_parity(monkeypatch):
+    """When the output exceeds VRAM the result is a chunked dask array.
+
+    The chunked ``map_blocks`` fallback must match the eager cupy path
+    numerically while keeping peak memory bounded by the chunk size.
+    """
+    import cupy as cp
+
+    import dask.array as _da
+
+    r = _make_cupy_raster()
+    eager = _reproject_mod.reproject(r, target_crs='EPSG:32633')
+
+    # Force promotion, then force the VRAM check to report "does not fit".
+    monkeypatch.setattr(_reproject_mod, '_REPROJECT_OOM_THRESHOLD', 1)
+
+    class _FakeDevice:
+        @property
+        def mem_info(self):
+            return (1, 1)  # 1 byte free -> estimated output never fits
+
+    monkeypatch.setattr(cp.cuda, 'Device', lambda *a, **k: _FakeDevice())
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        chunked = _reproject_mod.reproject(
+            r, target_crs='EPSG:32633', chunk_size=16
+        )
+
+    assert isinstance(chunked.data, _da.Array)
+    # Blocks compute to cupy even though dask advertises a numpy meta.
+    assert type(chunked.data.blocks[0, 0].compute()).__module__ == 'cupy'
+
+    eager_np = eager.data.get()
+    chunked_np = chunked.data.compute().get()
+    assert eager_np.shape == chunked_np.shape
+    np.testing.assert_allclose(eager_np, chunked_np, equal_nan=True)


### PR DESCRIPTION
Closes #3281

The output-size dask promotion from #3278 only covered numpy inputs. The promotion branch in `reproject()` was gated on `not is_dask and not is_cupy`, so an in-memory cupy raster with a very large output still allocated the full working set on the GPU and could hit a device OOM, same as before #3278.

This drops the `not is_cupy` part of the guard. A large-output cupy input now gets wrapped in a cupy-backed dask array, which keeps `is_cupy` True and routes it through `_reproject_dask_cupy`. That helper already has a GPU VRAM check and a chunked `map_blocks` fallback.

On the result-type contract (the design question the issue flagged), this matches what `merge()` already does for promoted cupy mosaics:
- Output still fits in VRAM: stays eager cupy (no change from today).
- Output exceeds VRAM: becomes a chunked dask result, computed block-by-block on the GPU.

The streaming fallback stays numpy-only, so a cupy input with dask unavailable keeps its eager GPU path instead of moving data off the device.

Scope is limited to the cupy output-size promotion path. It does not touch the numba-concurrency path under separate review in #3141/#3142.

Backends: cupy (in-memory promotion); numpy / dask+numpy / dask+cupy paths unchanged.

Test plan:
- [x] New regression tests in `test_reproject_cupy_promotion_3281.py` (skipped without cupy + CUDA): below-threshold stays eager cupy; above-threshold routes through `_reproject_dask_cupy`; VRAM-exceeds fallback yields a chunked dask result with numerical parity to the eager path.
- [x] Existing reproject suite green (508 passed).