### PR TITLE
focal: handle empty rasters consistently across backends (#3225)

### DIFF
--- a/xrspatial/focal.py
+++ b/xrspatial/focal.py
@@ -33,6 +33,19 @@ from xrspatial.utils import (ArrayTypeFunctionMapping, _boundary_to_dask, _pad_a
                              is_cupy_array, is_dask_cupy, ngjit)
 
 
+def _is_empty_raster(agg):
+    """True if *agg* has a degenerate spatial axis (0 rows or 0 cols).
+
+    An empty raster has no cells to filter, but the GPU and dask paths
+    crash on it rather than no-op: ``cuda_args`` hands ``cuLaunchKernel``
+    a zero-sized grid, and ``map_overlap`` rejects a depth that exceeds
+    the (zero-length) axis. The numpy path already returns an empty
+    result with the input shape preserved, so the focal APIs short
+    circuit empty input to match it on every backend (issue #3225).
+    """
+    return agg.shape[-2] == 0 or agg.shape[-1] == 0
+
+
 def _validate_binary_kernel(kernel, func_name):
     """Reject non-binary kernels for the mask-based focal APIs.
 
@@ -441,6 +454,16 @@ def mean(agg, passes=1, excludes=None, name='mean', boundary='nan'):
         return _apply_per_band(mean, agg, passes=passes, excludes=excludes,
                                name=name, boundary=boundary)
 
+    if _is_empty_raster(agg):
+        # No cells to filter; return an empty result of the input shape
+        # and dtype contract, matching the numpy path on every backend
+        # (issue #3225).
+        return DataArray(agg.data.astype(_promote_float(agg.dtype)),
+                         name=name,
+                         dims=agg.dims,
+                         coords=agg.coords,
+                         attrs=agg.attrs)
+
     # Preserve the input float dtype, promoting ints to float32 -- the same
     # contract as apply() / focal_stats() (#2769) and convolve_2d() (#1096).
     # Cast excludes to the working dtype so value matching behaves the same
@@ -758,6 +781,15 @@ def apply(agg=None, kernel=None, func=None, name='focal_apply',
     _check_kernel_vs_raster_memory(kernel, rows, cols, func_name='apply',
                                    chunks=getattr(agg.data, 'chunks', None),
                                    itemsize=itemsize)
+
+    if _is_empty_raster(agg):
+        # No cells to filter; return an empty result of the input shape,
+        # matching the numpy path on every backend (issue #3225).
+        return DataArray(agg.data.astype(_promote_float(agg.dtype)),
+                         name=name,
+                         coords=agg.coords,
+                         dims=agg.dims,
+                         attrs=agg.attrs)
 
     # apply kernel to raster values
     # if agg is a numpy or dask with numpy backed data array,
@@ -1402,6 +1434,16 @@ def focal_stats(agg,
                                    chunks=getattr(agg.data, 'chunks', None),
                                    itemsize=itemsize)
 
+    if _is_empty_raster(agg):
+        # No cells to filter; build the empty stacked result the same way
+        # the real paths do, reusing apply()'s empty short circuit so the
+        # output matches the numpy path on every backend (issue #3225).
+        stats_aggs = [apply(agg, kernel, boundary=boundary) for _ in stats_funcs]
+        result = xr.concat(stats_aggs,
+                           pd.Index(stats_funcs, name='stats', dtype=object))
+        result.name = name
+        return result
+
     mapper = ArrayTypeFunctionMapping(
         numpy_func=partial(_focal_stats_cpu, boundary=boundary),
         cupy_func=partial(_focal_stats_cupy_boundary, boundary=boundary),
@@ -1804,6 +1846,15 @@ def hotspots(agg=None, kernel=None, name='hotspots', boundary='nan', *,
     # 4 bytes/cell budget is correct here (issue #3223).
     _check_kernel_vs_raster_memory(kernel, rows, cols, func_name='hotspots',
                                    chunks=getattr(agg.data, 'chunks', None))
+
+    if _is_empty_raster(agg):
+        # An empty raster has no valid cells, so Gi* is undefined. Raise the
+        # same clear error the numpy path already raises, before the cupy and
+        # dask backends crash on a zero-sized reduction or overlap (#3225).
+        raise ValueError(
+            "hotspots() needs at least 2 valid (non-NaN) cells to "
+            "compute the Getis-Ord Gi* statistic."
+        )
 
     mapper = ArrayTypeFunctionMapping(
         numpy_func=partial(_hotspots_numpy, boundary=boundary),

--- a/xrspatial/tests/test_focal.py
+++ b/xrspatial/tests/test_focal.py
@@ -2573,17 +2573,45 @@ def test_focal_strip_raster_3220(backend, shape, chunks):
         _materialize(fs.data).reshape(shape), expected, rtol=1e-6)
 
 
-def test_focal_empty_raster_numpy_3220():
-    # A 0-row raster passes through the numpy backend with its shape
-    # preserved. The cupy and dask backends currently crash on empty
-    # input (issue #3225), so only the numpy behavior is pinned here.
-    data = np.empty((0, 5))
-    agg = create_test_raster(data, backend='numpy')
-    assert mean(agg).shape == (0, 5)
-    assert apply(agg, _sweep_cross_kernel).shape == (0, 5)
+@pytest.mark.parametrize("backend", ALL_BACKENDS)
+@pytest.mark.parametrize("shape", [(0, 5), (5, 0), (0, 0)])
+def test_focal_empty_raster_3220(backend, shape):
+    # A raster with a 0-length spatial axis has no cells to filter. numpy
+    # returns an empty result with the input shape preserved; the cupy and
+    # dask backends used to crash on it (a zero-sized kernel grid or an
+    # overlap depth larger than the axis). After issue #3225 every backend
+    # matches numpy: an empty result of the input shape and backend type.
+    _skip_unavailable_backend(backend)
+    data = np.empty(shape, dtype=np.float64)
+    agg = create_test_raster(data, backend=backend, chunks=(3, 3))
+
+    mean_result = mean(agg)
+    assert mean_result.shape == shape
+    assert isinstance(mean_result.data, type(agg.data))
+    assert _materialize(mean_result.data).shape == shape
+
+    apply_result = apply(agg, _sweep_cross_kernel, _apply_func_for(backend))
+    assert apply_result.shape == shape
+    assert isinstance(apply_result.data, type(agg.data))
+
     fs = focal_stats(agg, custom_kernel(_sweep_cross_kernel),
                      stats_funcs=['mean'])
-    assert fs.shape == (1, 0, 5)
+    assert fs.shape == (1, *shape)
+    assert isinstance(fs.data, type(agg.data))
+
+
+@pytest.mark.parametrize("backend", ALL_BACKENDS)
+@pytest.mark.parametrize("shape", [(0, 5), (5, 0), (0, 0)])
+def test_hotspots_empty_raster_3225(backend, shape):
+    # An empty raster has no valid cells, so Gi* is undefined. numpy already
+    # raises a clear "needs at least 2 valid cells" error; the cupy and dask
+    # backends used to crash on a zero-sized reduction or overlap. Every
+    # backend now raises the same error up front (issue #3225).
+    _skip_unavailable_backend(backend)
+    data = np.empty(shape, dtype=np.float64)
+    agg = create_test_raster(data, backend=backend, chunks=(3, 3))
+    with pytest.raises(ValueError, match="needs at least 2 valid"):
+        hotspots(agg, np.ones((3, 3)))
 
 
 @dask_array_available


### PR DESCRIPTION
Closes #3225

## Problem

A raster with a 0-length spatial axis (e.g. shape `(0, 5)`) behaved differently per backend. numpy returned an empty result with the input shape preserved, but cupy crashed with a raw `CudaAPIError` from a zero-sized kernel grid, and the dask backends raised `ValueError: The overlapping depth 1 is larger than your array 0` from `map_overlap`.

## Change

- `mean()`, `apply()`, and `focal_stats()` short circuit an empty raster and return an empty result of the input shape on every backend, matching the numpy path. The result keeps the input backend type (numpy stays numpy, dask stays lazy).
- `hotspots()` raises the same "needs at least 2 valid (non-NaN) cells" error numpy already raised, up front on every backend, instead of crashing in a zero-sized cupy reduction or a dask overlap.

## Backend coverage

numpy, cupy, dask+numpy, dask+cupy.

## Test plan

- [x] New `test_focal_empty_raster_3220` covers mean/apply/focal_stats across all four backends and shapes `(0,5)`, `(5,0)`, `(0,0)`; checks shape and backend type are preserved.
- [x] New `test_hotspots_empty_raster_3225` covers hotspots raising the clear error across all four backends and the same shapes.
- [x] Full `test_focal.py` suite passes (351 passed). GPU tests run here and skip when cupy is unavailable.