### PR TITLE
Burn all_touched lines with the supercover walk (#3102)

### DIFF
--- a/xrspatial/rasterize.py
+++ b/xrspatial/rasterize.py
@@ -764,6 +764,98 @@ def _extract_lines_vectorized(geometries, bounds, height, width):
     return (r0[v], c0[v], r1[v], c1[v], seg_geom_idx[v])
 
 
+def _extract_line_segments_float(geometries, bounds, height, width):
+    """LineString/MultiLineString segments in float pixel space.
+
+    Variant of :func:`_extract_line_segments` that keeps sub-pixel
+    precision so the supercover grid walker can pick up every cell a
+    segment crosses (issue #3102, the line counterpart to the polygon
+    boundary path).  World-space clipping uses the same Liang-Barsky
+    pass; the result is converted to pixel coordinates
+    (``cx`` = x in pixels, ``cy`` = y in pixels, increasing downward)
+    without rounding.
+
+    Returns ``(cx0, cy0, cx1, cy1, geom_idx)`` as float64 arrays (and
+    int32 ids into the per-type props table).
+    """
+    if not geometries:
+        return _EMPTY_LINES_FLOAT
+
+    shapely = _require_shapely()
+    xmin, ymin, xmax, ymax = bounds
+    px = (xmax - xmin) / width
+    py = (ymax - ymin) / height
+
+    geom_arr = np.array(geometries, dtype=object)
+    idx_arr = np.arange(len(geometries), dtype=np.int32)
+
+    # Explode MultiLineStrings to individual LineStrings
+    parts, part_idx = shapely.get_parts(geom_arr, return_index=True)
+    part_geom_idx = idx_arr[part_idx]
+
+    if len(parts) == 0:
+        return _EMPTY_LINES_FLOAT
+
+    coords, coord_line_idx = shapely.get_coordinates(
+        parts, return_index=True)
+    n_coords = len(coords)
+    if n_coords < 2:
+        return _EMPTY_LINES_FLOAT
+
+    # Mark last coordinate of each line (don't form cross-line segments)
+    is_last = np.zeros(n_coords, dtype=bool)
+    changes = np.nonzero(np.diff(coord_line_idx))[0]
+    is_last[changes] = True
+    is_last[-1] = True
+
+    start_idx = np.nonzero(~is_last)[0]
+    end_idx = start_idx + 1
+    seg_geom_idx = part_geom_idx[coord_line_idx[start_idx]].astype(np.int32)
+
+    x0 = coords[start_idx, 0].astype(np.float64)
+    y0 = coords[start_idx, 1].astype(np.float64)
+    x1 = coords[end_idx, 0].astype(np.float64)
+    y1 = coords[end_idx, 1].astype(np.float64)
+
+    # Vectorized Liang-Barsky clip to raster world-space bounds.
+    dx = x1 - x0
+    dy = y1 - y0
+    p = np.array([-dx, dx, -dy, dy])
+    q = np.array([x0 - xmin, xmax - x0, y0 - ymin, ymax - y0])
+
+    t0 = np.zeros(len(x0))
+    t1 = np.ones(len(x0))
+    valid = np.ones(len(x0), dtype=bool)
+
+    for i in range(4):
+        parallel = p[i] == 0.0
+        valid &= ~(parallel & (q[i] < 0.0))
+        neg = (~parallel) & (p[i] < 0.0)
+        pos = (~parallel) & (p[i] > 0.0)
+        with np.errstate(divide='ignore', invalid='ignore'):
+            t_neg = np.where(neg, q[i] / p[i], 0.0)
+            t_pos = np.where(pos, q[i] / p[i], 1.0)
+        t0 = np.where(neg, np.maximum(t0, t_neg), t0)
+        t1 = np.where(pos, np.minimum(t1, t_pos), t1)
+
+    valid &= (t0 <= t1)
+
+    cx0_w = x0 + t0 * dx
+    cy0_w = y0 + t0 * dy
+    cx1_w = x0 + t1 * dx
+    cy1_w = y0 + t1 * dy
+
+    # World -> float pixel coordinates. ymax is the top of the raster,
+    # row 0 is at the top, so y increases downward in pixel space.
+    cx0 = (cx0_w - xmin) / px
+    cy0 = (ymax - cy0_w) / py
+    cx1 = (cx1_w - xmin) / px
+    cy1 = (ymax - cy1_w) / py
+
+    v = valid
+    return (cx0[v], cy0[v], cx1[v], cy1[v], seg_geom_idx[v])
+
+
 # ---------------------------------------------------------------------------
 # Polygon boundary segments (for all_touched mode)
 # ---------------------------------------------------------------------------
@@ -1636,24 +1728,46 @@ def _run_numpy(geometries, props_array, bounds, height, width, fill, dtype,
                     poly_props, height, width, poly_global,
                     merge_fn, should_write, order)
 
-    # 2. Lines.  sum/count: enumerate + dedup cells so the connecting
-    #    vertex of consecutive segments is burned once (issue #3304).
-    r0, c0, r1, c1, line_idx = _extract_line_segments(
-        line_geoms, bounds, height, width)
-    if len(r0) > 0:
-        if dedup:
-            lrows, lcols, lgids = _bresenham_cells(
-                r0, c0, r1, c1, line_idx, height, width)
-            lrows, lcols, lgids = _dedup_cells(
-                lrows, lcols, lgids, height, width)
-            if len(lrows) > 0:
-                _burn_points_cpu(out, written, lrows, lcols, lgids,
-                                 line_props, line_global,
-                                 merge_fn, should_write, order)
-        else:
-            _burn_lines_cpu(out, written, r0, c0, r1, c1, line_idx,
-                            line_props, height, width, line_global,
-                            merge_fn, should_write, order)
+    # 2. Lines.  all_touched burns every cell a segment crosses via the
+    #    supercover walk (issue #3102), matching the polygon-boundary
+    #    path and rasterio; otherwise the Bresenham burner runs.
+    #    sum/count: enumerate + dedup cells so the connecting vertex of
+    #    consecutive segments is burned once (issue #3304).
+    if all_touched and line_geoms:
+        lx0, ly0, lx1, ly1, line_idx = _extract_line_segments_float(
+            line_geoms, bounds, height, width)
+        if len(lx0) > 0:
+            if dedup:
+                lrows, lcols, lgids = _supercover_cells(
+                    lx0, ly0, lx1, ly1, line_idx, height, width)
+                lrows, lcols, lgids = _dedup_cells(
+                    lrows, lcols, lgids, height, width)
+                if len(lrows) > 0:
+                    _burn_points_cpu(out, written, lrows, lcols, lgids,
+                                     line_props, line_global,
+                                     merge_fn, should_write, order)
+            else:
+                _burn_lines_supercover_cpu(
+                    out, written, lx0, ly0, lx1, ly1, line_idx,
+                    line_props, height, width, line_global,
+                    merge_fn, should_write, order)
+    else:
+        r0, c0, r1, c1, line_idx = _extract_line_segments(
+            line_geoms, bounds, height, width)
+        if len(r0) > 0:
+            if dedup:
+                lrows, lcols, lgids = _bresenham_cells(
+                    r0, c0, r1, c1, line_idx, height, width)
+                lrows, lcols, lgids = _dedup_cells(
+                    lrows, lcols, lgids, height, width)
+                if len(lrows) > 0:
+                    _burn_points_cpu(out, written, lrows, lcols, lgids,
+                                     line_props, line_global,
+                                     merge_fn, should_write, order)
+            else:
+                _burn_lines_cpu(out, written, r0, c0, r1, c1, line_idx,
+                                line_props, height, width, line_global,
+                                merge_fn, should_write, order)
 
     # 3. Points
     prows, pcols, pt_idx = _extract_points(
@@ -2588,26 +2702,50 @@ def _run_cupy(geometries, props_array, bounds, height, width, fill, dtype,
                     cupy.asarray(bidx), poly_props_gpu,
                     poly_global_gpu, len(bx0))
 
-    r0, c0, r1, c1, line_idx = _extract_line_segments(
-        line_geoms, bounds, height, width)
+    # all_touched routes lines through the supercover walk (issue #3102),
+    # the same float-segment kernel the polygon boundaries use.
     line_launch = None
-    if len(r0) > 0:
-        if dedup:
-            lrows, lcols, lgids = _bresenham_cells(
-                r0, c0, r1, c1, line_idx, height, width)
-            lrows, lcols, lgids = _dedup_cells(
-                lrows, lcols, lgids, height, width)
-            if len(lrows) > 0:
-                extra_point_launches.append((
-                    cupy.asarray(lrows), cupy.asarray(lcols),
-                    cupy.asarray(lgids), cupy.asarray(line_props),
-                    cupy.asarray(line_global), len(lrows)))
-        else:
-            line_launch = (
-                cupy.asarray(r0), cupy.asarray(c0),
-                cupy.asarray(r1), cupy.asarray(c1),
-                cupy.asarray(line_idx), cupy.asarray(line_props),
-                cupy.asarray(line_global), len(r0))
+    line_supercover_launch = None
+    if all_touched and line_geoms:
+        lx0, ly0, lx1, ly1, line_idx = _extract_line_segments_float(
+            line_geoms, bounds, height, width)
+        if len(lx0) > 0:
+            if dedup:
+                lrows, lcols, lgids = _supercover_cells(
+                    lx0, ly0, lx1, ly1, line_idx, height, width)
+                lrows, lcols, lgids = _dedup_cells(
+                    lrows, lcols, lgids, height, width)
+                if len(lrows) > 0:
+                    extra_point_launches.append((
+                        cupy.asarray(lrows), cupy.asarray(lcols),
+                        cupy.asarray(lgids), cupy.asarray(line_props),
+                        cupy.asarray(line_global), len(lrows)))
+            else:
+                line_supercover_launch = (
+                    cupy.asarray(lx0), cupy.asarray(ly0),
+                    cupy.asarray(lx1), cupy.asarray(ly1),
+                    cupy.asarray(line_idx), cupy.asarray(line_props),
+                    cupy.asarray(line_global), len(lx0))
+    else:
+        r0, c0, r1, c1, line_idx = _extract_line_segments(
+            line_geoms, bounds, height, width)
+        if len(r0) > 0:
+            if dedup:
+                lrows, lcols, lgids = _bresenham_cells(
+                    r0, c0, r1, c1, line_idx, height, width)
+                lrows, lcols, lgids = _dedup_cells(
+                    lrows, lcols, lgids, height, width)
+                if len(lrows) > 0:
+                    extra_point_launches.append((
+                        cupy.asarray(lrows), cupy.asarray(lcols),
+                        cupy.asarray(lgids), cupy.asarray(line_props),
+                        cupy.asarray(line_global), len(lrows)))
+            else:
+                line_launch = (
+                    cupy.asarray(r0), cupy.asarray(c0),
+                    cupy.asarray(r1), cupy.asarray(c1),
+                    cupy.asarray(line_idx), cupy.asarray(line_props),
+                    cupy.asarray(line_global), len(r0))
 
     prows, pcols, pt_idx = _extract_points(
         point_geoms, bounds, height, width)
@@ -2643,6 +2781,18 @@ def _run_cupy(geometries, props_array, bounds, height, width, fill, dtype,
                               line_launch[2], line_launch[3],
                               line_launch[4], line_launch[5],
                               line_launch[6], n_segs, height, width)
+        if line_supercover_launch is not None:
+            n_lsegs = line_supercover_launch[7]
+            bpg = (n_lsegs + tpb - 1) // tpb
+            k_boundary[bpg, tpb](out, written, order,
+                                 line_supercover_launch[0],
+                                 line_supercover_launch[1],
+                                 line_supercover_launch[2],
+                                 line_supercover_launch[3],
+                                 line_supercover_launch[4],
+                                 line_supercover_launch[5],
+                                 line_supercover_launch[6],
+                                 n_lsegs, height, width)
         if point_launch is not None:
             n_pts = point_launch[5]
             bpg = (n_pts + tpb - 1) // tpb
@@ -2798,6 +2948,27 @@ def _segments_for_tile(r0, c0, r1, c1, geom_idx, seg_bboxes,
             geom_idx[mask])
 
 
+def _float_segments_for_tile(x0, y0, x1, y1, seg_bboxes,
+                             r_start, r_end, c_start, c_end):
+    """Filter float line segments with the same mask as integer segments.
+
+    Uses the integer ``seg_bboxes`` (computed from the Bresenham
+    endpoints) so the selection matches :func:`_segments_for_tile`
+    exactly, keeping the float supercover segments aligned with the
+    integer ``seg_geom_idx`` for the same tile (issue #3102).  Float
+    endpoints are offset to tile-local pixel space; the supercover walk's
+    bounds check handles endpoints landing outside the tile.
+    """
+    if len(x0) == 0:
+        empty = np.empty(0, dtype=np.float64)
+        return empty, empty, empty, empty
+    seg_rmin, seg_rmax, seg_cmin, seg_cmax = seg_bboxes
+    mask = ((seg_rmax >= r_start) & (seg_rmin < r_end) &
+            (seg_cmax >= c_start) & (seg_cmin < c_end))
+    return (x0[mask] - c_start, y0[mask] - r_start,
+            x1[mask] - c_start, y1[mask] - r_start)
+
+
 def _points_for_tile(rows, cols, geom_idx, r_start, r_end, c_start, c_end):
     """Filter points within the tile, offset to tile-local coordinates.
 
@@ -2875,7 +3046,8 @@ def _rasterize_tile_numpy(poly_wkb, poly_props_2d, poly_global_2d, tile_bounds,
                           seg_r0, seg_c0, seg_r1, seg_c1, seg_geom_idx,
                           line_props, line_global,
                           pt_rows, pt_cols, pt_geom_idx,
-                          point_props, point_global):
+                          point_props, point_global,
+                          lseg_x0, lseg_y0, lseg_x1, lseg_y1):
     """Rasterize a single tile.
 
     Polygons are passed as WKB bytes (cheap to pickle) and deserialized
@@ -2883,6 +3055,12 @@ def _rasterize_tile_numpy(poly_wkb, poly_props_2d, poly_global_2d, tile_bounds,
     pixel coordinates with geometry indices into their respective props
     tables.  Each per-type global-input-index array carries the original
     input position so order-sensitive merges work across types.
+
+    Under ``all_touched`` the line segments arrive as float tile-local
+    pixel coordinates (``lseg_*``) so the supercover walk can pick up
+    every cell crossed, matching the eager path (issue #3102); the
+    integer ``seg_*`` arrays carry the Bresenham endpoints used
+    otherwise.  ``seg_geom_idx`` indexes ``line_props`` for both.
     """
     out = np.full((tile_h, tile_w), fill, dtype=np.float64)
     written = np.zeros((tile_h, tile_w), dtype=np.int8)
@@ -2931,10 +3109,29 @@ def _rasterize_tile_numpy(poly_wkb, poly_props_2d, poly_global_2d, tile_bounds,
                         poly_props_2d, tile_h, tile_w,
                         poly_global_2d, merge_fn, should_write, order)
 
-    # 2. Lines (tile-local segments, Bresenham with bounds check).
-    #    sum/count dedup the visited cells first (issue #3304); cells
-    #    partition across tiles, so per-tile dedup equals global dedup.
-    if len(seg_r0) > 0:
+    # 2. Lines (tile-local segments).  all_touched walks float segments
+    #    with the supercover traversal (issue #3102); otherwise Bresenham
+    #    runs on the integer endpoints.  sum/count dedup the visited cells
+    #    first (issue #3304); cells partition across tiles, so per-tile
+    #    dedup equals global dedup.
+    if all_touched:
+        if len(lseg_x0) > 0:
+            if dedup:
+                lrows, lcols, lgids = _supercover_cells(
+                    lseg_x0, lseg_y0, lseg_x1, lseg_y1, seg_geom_idx,
+                    tile_h, tile_w)
+                lrows, lcols, lgids = _dedup_cells(
+                    lrows, lcols, lgids, tile_h, tile_w)
+                if len(lrows) > 0:
+                    _burn_points_cpu(out, written, lrows, lcols, lgids,
+                                     line_props, line_global,
+                                     merge_fn, should_write, order)
+            else:
+                _burn_lines_supercover_cpu(
+                    out, written, lseg_x0, lseg_y0, lseg_x1, lseg_y1,
+                    seg_geom_idx, line_props, tile_h, tile_w,
+                    line_global, merge_fn, should_write, order)
+    elif len(seg_r0) > 0:
         if dedup:
             lrows, lcols, lgids = _bresenham_cells(
                 seg_r0, seg_c0, seg_r1, seg_c1, seg_geom_idx,
@@ -2979,6 +3176,16 @@ def _run_dask_numpy(geometries, props_array, bounds, height, width, fill,
     pt_rows, pt_cols, pt_geom_idx = _extract_points(
         point_geoms, bounds, height, width)
 
+    # Float line segments for the supercover walk under all_touched
+    # (issue #3102).  Shares the clipping logic of _extract_line_segments
+    # so it produces the same number of segments in the same order, which
+    # keeps it aligned with seg_geom_idx and the per-tile filter mask.
+    if all_touched:
+        lseg_x0, lseg_y0, lseg_x1, lseg_y1, _ = _extract_line_segments_float(
+            line_geoms, bounds, height, width)
+    else:
+        lseg_x0 = lseg_y0 = lseg_x1 = lseg_y1 = None
+
     # Pre-serialize polygons to WKB (20x cheaper to pickle than shapely).
     # Store as object array for single-pass boolean indexing per tile.
     if poly_geoms:
@@ -3021,6 +3228,16 @@ def _run_dask_numpy(geometries, props_array, bounds, height, width, fill,
             tp = _points_for_tile(pt_rows, pt_cols, pt_geom_idx,
                                   r_start, r_end, c_start, c_end)
 
+            # all_touched: float supercover segments, filtered by the
+            # identical mask so they stay aligned with ts geom indices.
+            if all_touched:
+                lts = _float_segments_for_tile(
+                    lseg_x0, lseg_y0, lseg_x1, lseg_y1, seg_bboxes,
+                    r_start, r_end, c_start, c_end)
+            else:
+                _empty_f = np.empty(0, dtype=np.float64)
+                lts = (_empty_f, _empty_f, _empty_f, _empty_f)
+
             # Slice line_props / point_props (and their global-idx
             # companions) to only the geometries this tile actually
             # references, remapping the geom_idx arrays to local indices.
@@ -3036,7 +3253,8 @@ def _run_dask_numpy(geometries, props_array, bounds, height, width, fill,
                 tile_h, tile_w, fill, dtype, all_touched,
                 merge_fn, should_write,
                 *ts, tile_line_props, tile_line_global,
-                *tp, tile_point_props, tile_point_global)
+                *tp, tile_point_props, tile_point_global,
+                *lts)
             blocks[i][j] = da.from_delayed(
                 delayed_tile, shape=(tile_h, tile_w), dtype=dtype)
             ri += 1
@@ -3057,7 +3275,9 @@ def _rasterize_tile_cupy(poly_wkb, poly_props_2d, poly_global_2d, tile_bounds,
                          seg_r0, seg_c0, seg_r1, seg_c1, seg_geom_idx,
                          line_props, line_global,
                          pt_rows, pt_cols, pt_geom_idx,
-                         point_props, point_global, merge_name=None):
+                         point_props, point_global,
+                         lseg_x0, lseg_y0, lseg_x1, lseg_y1,
+                         merge_name=None):
     """GPU tile rasterization: polygons as WKB, lines/points as segments.
 
     When ``merge_name`` selects an atomic built-in merge, the per-tile
@@ -3140,8 +3360,31 @@ def _rasterize_tile_cupy(poly_wkb, poly_props_2d, poly_global_2d, tile_bounds,
                         cupy.asarray(bidx), poly_props_2d_gpu,
                         poly_global_2d_gpu, len(bx0))
 
+    # all_touched routes lines through the supercover walk on float
+    # segments (issue #3102); otherwise Bresenham runs on the integer
+    # endpoints.
     line_launch = None
-    if len(seg_r0) > 0:
+    line_supercover_launch = None
+    if all_touched:
+        if len(lseg_x0) > 0:
+            if dedup:
+                lrows, lcols, lgids = _supercover_cells(
+                    lseg_x0, lseg_y0, lseg_x1, lseg_y1, seg_geom_idx,
+                    tile_h, tile_w)
+                lrows, lcols, lgids = _dedup_cells(
+                    lrows, lcols, lgids, tile_h, tile_w)
+                if len(lrows) > 0:
+                    extra_point_launches.append((
+                        cupy.asarray(lrows), cupy.asarray(lcols),
+                        cupy.asarray(lgids), _ensure_cupy(line_props),
+                        _ensure_cupy(line_global), len(lrows)))
+            else:
+                line_supercover_launch = (
+                    cupy.asarray(lseg_x0), cupy.asarray(lseg_y0),
+                    cupy.asarray(lseg_x1), cupy.asarray(lseg_y1),
+                    cupy.asarray(seg_geom_idx), _ensure_cupy(line_props),
+                    _ensure_cupy(line_global), len(lseg_x0))
+    elif len(seg_r0) > 0:
         if dedup:
             lrows, lcols, lgids = _bresenham_cells(
                 seg_r0, seg_c0, seg_r1, seg_c1, seg_geom_idx,
@@ -3193,6 +3436,18 @@ def _rasterize_tile_cupy(poly_wkb, poly_props_2d, poly_global_2d, tile_bounds,
                               line_launch[2], line_launch[3],
                               line_launch[4], line_launch[5],
                               line_launch[6], n_segs, tile_h, tile_w)
+        if line_supercover_launch is not None:
+            n_lsegs = line_supercover_launch[7]
+            bpg = (n_lsegs + tpb - 1) // tpb
+            k_boundary[bpg, tpb](out, written, order,
+                                 line_supercover_launch[0],
+                                 line_supercover_launch[1],
+                                 line_supercover_launch[2],
+                                 line_supercover_launch[3],
+                                 line_supercover_launch[4],
+                                 line_supercover_launch[5],
+                                 line_supercover_launch[6],
+                                 n_lsegs, tile_h, tile_w)
         if point_launch is not None:
             n_pts = point_launch[5]
             bpg = (n_pts + tpb - 1) // tpb
@@ -3242,6 +3497,14 @@ def _run_dask_cupy(geometries, props_array, bounds, height, width, fill,
         line_geoms, bounds, height, width)
     pt_rows, pt_cols, pt_geom_idx = _extract_points(
         point_geoms, bounds, height, width)
+
+    # Float line segments for the supercover walk under all_touched
+    # (issue #3102); aligned with seg_geom_idx via the shared clip logic.
+    if all_touched:
+        lseg_x0, lseg_y0, lseg_x1, lseg_y1, _ = _extract_line_segments_float(
+            line_geoms, bounds, height, width)
+    else:
+        lseg_x0 = lseg_y0 = lseg_x1 = lseg_y1 = None
 
     # Pre-serialize polygons to WKB (20x cheaper to pickle than shapely).
     if poly_geoms:
@@ -3293,6 +3556,15 @@ def _run_dask_cupy(geometries, props_array, bounds, height, width, fill,
             tp = _points_for_tile(pt_rows, pt_cols, pt_geom_idx,
                                   r_start, r_end, c_start, c_end)
 
+            # all_touched: float supercover segments, same mask as ts.
+            if all_touched:
+                lts = _float_segments_for_tile(
+                    lseg_x0, lseg_y0, lseg_x1, lseg_y1, seg_bboxes,
+                    r_start, r_end, c_start, c_end)
+            else:
+                _empty_f = np.empty(0, dtype=np.float64)
+                lts = (_empty_f, _empty_f, _empty_f, _empty_f)
+
             ts_local_idx, tile_line_props, tile_line_global = \
                 _slice_per_tile(ts[4], line_props, line_global)
             ts = (*ts[:4], ts_local_idx)
@@ -3306,7 +3578,7 @@ def _run_dask_cupy(geometries, props_array, bounds, height, width, fill,
                 merge_fn, should_write,
                 *ts, tile_line_props, tile_line_global,
                 *tp, tile_point_props, tile_point_global,
-                merge_name)
+                *lts, merge_name)
             blocks[i][j] = da.from_delayed(
                 delayed_tile, shape=(tile_h, tile_w), dtype=dtype,
                 meta=cupy.empty(()))
@@ -3745,13 +4017,15 @@ def rasterize(
         for int32, ``True`` for bool).  ``merge='count'`` is exempt
         because it burns overlap counts, never the property values.
     all_touched : bool, default False
-        If True, every pixel a polygon boundary passes through is
-        burned in addition to the normal center-fill, using a
-        supercover (Amanatides & Woo) grid traversal. Output matches
-        ``rasterio.features.rasterize(..., all_touched=True)``
+        If True, every pixel a geometry passes through is burned, using
+        a supercover (Amanatides & Woo) grid traversal: polygon
+        boundaries in addition to the normal center-fill, and every
+        cell a line crosses rather than only the Bresenham path. Output
+        matches ``rasterio.features.rasterize(..., all_touched=True)``
         pixel-for-pixel up to rasterization tie-breaking on shared
-        edges. If False, only pixels whose centers fall inside a
-        polygon are burned.
+        edges and exact cell-corner crossings. If False, only pixels
+        whose centers fall inside a polygon (or on the Bresenham line)
+        are burned.
     gpu : bool, default False
         If True, use the CuPy/CUDA backend.  Same convention as
         ``open_geotiff(gpu=True)``; combine with ``chunks`` for the

--- a/xrspatial/tests/test_rasterize_coverage_2026_06_09.py
+++ b/xrspatial/tests/test_rasterize_coverage_2026_06_09.py
@@ -5,13 +5,11 @@ pass-2 (2026-05-21), pass-3 (2026-05-27), and pass-4 (2026-05-29) audits.
 Issue #3105.
 
 - ``all_touched=True`` with LineString input had no coverage on any
-  backend.  The flag currently changes polygon handling only: lines burn
-  through Bresenham whether the flag is set or not, so the output matches
-  rasterio's *default* mode rather than its all_touched mode.  Issue
-  #3102 tracks that divergence.  The tests here pin the current contract
-  (all_touched is a no-op for lines) on numpy / cupy / dask+numpy /
-  dask+cupy, plus a strict xfail for rasterio all_touched parity that
-  flips visibly when #3102 lands.
+  backend.  Issue #3102 fixed the flag to route lines through the same
+  supercover (Amanatides & Woo) traversal that polygon boundaries use,
+  so every cell a line crosses is burned.  The tests here pin that
+  behavior on numpy / cupy / dask+numpy / dask+cupy and check rasterio
+  all_touched parity for an off-corner line.
 
 - the non-iterable ``geometries`` TypeError in ``_parse_input``
   (``"geometries must be a GeoDataFrame or iterable of (geometry, value)
@@ -105,55 +103,60 @@ def _line():
 
 
 # ---------------------------------------------------------------------------
-# Cat 4 MEDIUM -- all_touched with line input (issue #3102 pins)
+# Cat 4 MEDIUM -- all_touched with line input (issue #3102)
 # ---------------------------------------------------------------------------
 
-class TestAllTouchedLineNoOp:
-    """Pin the current contract: ``all_touched`` does not affect lines.
+# Off-corner line: every endpoint and crossing lands inside a cell, so
+# the supercover walk and rasterio agree pixel-for-pixel (no exact
+# corner-crossing tie-break to disagree on).
+_OFF_CORNER = [(0.5, 0.7), (4.5, 3.3)]
 
-    ``_run_numpy`` applies the supercover burn to polygon boundary
-    segments only; lines always go through ``_burn_lines_cpu`` (and the
-    GPU / dask tile paths mirror that layout).  Issue #3102 tracks
-    whether lines should join the supercover path.  Until that is
-    decided, pin the no-op on every backend so any behavior change is
-    visible in CI rather than shipping silently.
+
+class TestAllTouchedLineSupercover:
+    """``all_touched`` routes lines through the supercover walk (#3102).
+
+    Before the fix lines always went through ``_burn_lines_cpu`` (and the
+    GPU / dask tile paths mirrored that layout), so ``all_touched=True``
+    returned the same pixels as ``all_touched=False``.  These pin the
+    fixed behavior on every backend.
     """
 
-    @pytest.mark.parametrize('coords', [_DIAG, _INTERIOR],
-                             ids=['corner_crossing', 'interior_crossing'])
     @pytest.mark.parametrize('backend_name,kw', _BACKENDS)
-    def test_line_all_touched_equals_default(self, backend_name, kw, coords):
-        line = LineString(coords)
-        flagged = rasterize([(line, 1.0)], **_GRID,
-                            all_touched=True, **kw)
-        default = rasterize([(line, 1.0)], **_GRID,
-                            all_touched=False, **kw)
-        np.testing.assert_array_equal(
-            _materialise(flagged), _materialise(default))
+    def test_line_all_touched_burns_more_than_default(self, backend_name, kw):
+        line = LineString(_OFF_CORNER)
+        flagged = _materialise(
+            rasterize([(line, 1.0)], **_GRID, all_touched=True, **kw))
+        default = _materialise(
+            rasterize([(line, 1.0)], **_GRID, all_touched=False, **kw))
+        assert int((flagged > 0).sum()) > int((default > 0).sum())
 
-    def test_line_all_touched_burns_bresenham_diagonal(self):
-        """The numpy result is the 5-pixel Bresenham anti-diagonal."""
-        r = rasterize([(_line(), 1.0)], **_GRID, all_touched=True)
-        expected = np.eye(5)[:, ::-1]
-        np.testing.assert_array_equal(r.data, expected)
+    @pytest.mark.parametrize('backend_name,kw', _BACKENDS[1:])
+    def test_line_all_touched_matches_numpy(self, backend_name, kw):
+        """Every backend agrees with the eager numpy supercover burn."""
+        line = LineString(_OFF_CORNER)
+        cpu = _materialise(
+            rasterize([(line, 1.0)], **_GRID, all_touched=True))
+        other = _materialise(
+            rasterize([(line, 1.0)], **_GRID, all_touched=True, **kw))
+        np.testing.assert_array_equal(other, cpu)
 
-    def test_multilinestring_all_touched_equals_default(self):
-        """The MultiLineString explode path is also unaffected."""
-        mls = MultiLineString([_DIAG, [(0.5, 4.5), (4.5, 4.5)]])
+    def test_multilinestring_all_touched_burns_more(self):
+        """The MultiLineString explode path also joins the supercover."""
+        mls = MultiLineString([_OFF_CORNER, [(0.5, 4.5), (4.5, 4.5)]])
         flagged = rasterize([(mls, 1.0)], **_GRID, all_touched=True)
         default = rasterize([(mls, 1.0)], **_GRID, all_touched=False)
-        np.testing.assert_array_equal(flagged.data, default.data)
+        assert int((flagged.data > 0).sum()) > int((default.data > 0).sum())
 
 
 @pytest.mark.skipif(not has_rasterio, reason="rasterio not installed")
 class TestAllTouchedLineRasterioParity:
-    """Where lines + all_touched stand relative to rasterio."""
+    """Lines + all_touched now match rasterio's all_touched burn."""
 
-    def _rio(self, all_touched):
+    def _rio(self, coords, all_touched):
         transform = from_bounds(*_GRID['bounds'],
                                 _GRID['width'], _GRID['height'])
         return rasterio.features.rasterize(
-            [(_line(), 1)],
+            [(LineString(coords), 1)],
             out_shape=(_GRID['height'], _GRID['width']),
             transform=transform,
             fill=0,
@@ -161,23 +164,19 @@ class TestAllTouchedLineRasterioParity:
             dtype='uint8',
         )
 
-    def test_line_all_touched_matches_rasterio_default_mode(self):
-        """Today's output equals rasterio's *default* (Bresenham-style)
-        burn, not its all_touched burn."""
-        r = rasterize([(_line(), 1.0)], **_GRID, all_touched=True)
+    def test_default_line_matches_rasterio_default_mode(self):
+        """all_touched=False still equals rasterio's default burn."""
+        r = rasterize([(_line(), 1.0)], **_GRID, all_touched=False)
         np.testing.assert_array_equal(
-            r.data.astype(np.uint8), self._rio(all_touched=False))
+            r.data.astype(np.uint8), self._rio(_DIAG, all_touched=False))
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="all_touched=True is a no-op for lines; supercover burn "
-               "is applied to polygon boundaries only (issue #3102)")
     def test_line_all_touched_matches_rasterio_all_touched(self):
-        """Flips when #3102 plumbs line segments through the supercover
-        burn.  Strict, so the fix must update the no-op pins above."""
-        r = rasterize([(_line(), 1.0)], **_GRID, all_touched=True)
+        """Off-corner line: supercover matches rasterio's all_touched
+        burn pixel-for-pixel."""
+        r = rasterize([(LineString(_OFF_CORNER), 1.0)], **_GRID,
+                      all_touched=True)
         np.testing.assert_array_equal(
-            r.data.astype(np.uint8), self._rio(all_touched=True))
+            r.data.astype(np.uint8), self._rio(_OFF_CORNER, all_touched=True))
 
 
 # ---------------------------------------------------------------------------

--- a/xrspatial/tests/test_rasterize_lines_all_touched_3102.py
+++ b/xrspatial/tests/test_rasterize_lines_all_touched_3102.py
@@ -1,0 +1,251 @@
+"""rasterize ``all_touched`` with line input, plus the non-iterable input
+error path (issues #3102 and #3105).
+
+#3102: ``all_touched=True`` used to be a no-op for LineString /
+MultiLineString -- lines always went through the Bresenham burner, so the
+output matched ``all_touched=False``.  The fix routes lines through the
+same supercover (Amanatides & Woo) grid traversal that polygon boundaries
+use, so every cell a line crosses is burned.  These tests pin that across
+numpy, cupy, dask+numpy, and dask+cupy.
+
+#3105: the two coverage gaps the test-coverage sweep flagged -- lines with
+``all_touched`` on every backend, and the ``_parse_input`` TypeError for
+non-iterable input.
+
+Single-segment lines are nudged off integer cell boundaries so the
+supercover walk and rasterio agree pixel-for-pixel.  Multi-segment lines
+can disagree with rasterio by a cell or two at shared vertices / exact
+corner crossings (the same tie-breaking wiggle the polygon parity tests
+in ``test_rasterize_all_touched_supercover_2169.py`` allow), so those are
+checked for cross-backend equality and for covering at least as many
+cells as the Bresenham path rather than for exact rasterio parity.
+"""
+import numpy as np
+import pytest
+
+try:
+    from shapely.geometry import LineString, MultiLineString
+    has_shapely = True
+except ImportError:
+    has_shapely = False
+
+try:
+    import rasterio  # noqa: F401
+    import rasterio.features  # noqa: F401
+    from rasterio.transform import from_bounds
+    has_rasterio = True
+except ImportError:
+    has_rasterio = False
+
+try:
+    import cupy  # noqa: F401
+    has_cupy = True
+except ImportError:
+    has_cupy = False
+
+try:
+    import dask.array as da  # noqa: F401
+    has_dask = True
+except ImportError:
+    has_dask = False
+
+try:
+    from numba import cuda
+    has_cuda = has_cupy and cuda.is_available()
+except Exception:
+    has_cuda = False
+
+if has_shapely:
+    from xrspatial.rasterize import rasterize
+
+pytestmark = pytest.mark.skipif(not has_shapely, reason="shapely not installed")
+
+
+_H, _W = 20, 20
+_BOUNDS = (0.0, 0.0, 20.0, 20.0)
+
+
+def _to_host(arr):
+    values = arr.data
+    if hasattr(values, 'compute'):
+        values = values.compute()
+    if hasattr(values, 'get'):
+        values = values.get()
+    return np.asarray(values)
+
+
+def _xs_mask(line, *, all_touched, chunks=None, gpu=False):
+    kwargs = dict(width=_W, height=_H, bounds=_BOUNDS,
+                  all_touched=all_touched, fill=0)
+    if chunks is not None:
+        kwargs['chunks'] = chunks
+    if gpu:
+        kwargs['gpu'] = True
+    arr = rasterize([(line, 1.0)], **kwargs)
+    return (_to_host(arr) > 0).astype('uint8')
+
+
+def _rio_mask(line):
+    transform = from_bounds(*_BOUNDS, _W, _H)
+    return rasterio.features.rasterize(
+        [(line, 1)], out_shape=(_H, _W), transform=transform,
+        fill=0, all_touched=True, dtype='uint8')
+
+
+# Single-segment lines with sub-pixel endpoints -- supercover and
+# rasterio agree exactly here (no shared vertex, no exact corner cross).
+def _exact_cases():
+    return {
+        'shallow': LineString([(0.7, 1.3), (19.3, 7.6)]),
+        'steep': LineString([(2.4, 0.5), (6.1, 19.4)]),
+        'descending': LineString([(0.6, 18.7), (19.4, 2.2)]),
+        'multi_disjoint': MultiLineString([
+            [(0.7, 1.3), (19.3, 7.6)],
+            [(2.4, 0.5), (6.1, 19.4)],
+        ]),
+    }
+
+
+# Multi-segment line: cross-backend equality + supercover-covers-Bresenham,
+# but not pinned to rasterio (corner tie-break wiggle at shared vertices).
+def _coverage_case():
+    return LineString([(1.2, 1.4), (9.6, 7.3), (3.1, 14.8), (18.4, 18.2)])
+
+
+# ---------------------------------------------------------------------------
+# numpy backend
+# ---------------------------------------------------------------------------
+
+class TestNumpyLinesAllTouched:
+    @pytest.mark.skipif(not has_rasterio, reason="rasterio not installed")
+    @pytest.mark.parametrize("name,line", list(_exact_cases().items()))
+    def test_matches_rasterio(self, name, line):
+        rio = _rio_mask(line)
+        xs = _xs_mask(line, all_touched=True)
+        assert np.array_equal(rio, xs), (
+            f"{name}: rio={int(rio.sum())} xs={int(xs.sum())} "
+            f"diff={int(np.abs(rio.astype(int) - xs.astype(int)).sum())}"
+        )
+
+    def test_all_touched_burns_more_than_bresenham(self):
+        """The bug: all_touched=True returned the same pixels as
+        all_touched=False for lines.  After the fix the supercover walk
+        must add the off-axis cells a diagonal segment crosses."""
+        line = _exact_cases()['shallow']
+        at = _xs_mask(line, all_touched=True)
+        no = _xs_mask(line, all_touched=False)
+        assert int(at.sum()) > int(no.sum())
+
+    @pytest.mark.skipif(not has_rasterio, reason="rasterio not installed")
+    def test_coverage_at_least_bresenham(self):
+        line = _coverage_case()
+        at = _xs_mask(line, all_touched=True)
+        no = _xs_mask(line, all_touched=False)
+        rio = _rio_mask(line)
+        assert int(at.sum()) >= int(no.sum())
+        # Within a couple of cells of rasterio (corner tie-break wiggle).
+        assert abs(int(at.sum()) - int(rio.sum())) <= 2
+
+
+# ---------------------------------------------------------------------------
+# dask + numpy backend
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not has_dask, reason="dask not installed")
+class TestDaskNumpyLinesAllTouched:
+    @pytest.mark.skipif(not has_rasterio, reason="rasterio not installed")
+    @pytest.mark.parametrize("name,line", list(_exact_cases().items()))
+    def test_matches_rasterio(self, name, line):
+        rio = _rio_mask(line)
+        xs = _xs_mask(line, all_touched=True, chunks=(_H // 2, _W // 2))
+        assert np.array_equal(rio, xs), (
+            f"{name}: rio={int(rio.sum())} xs={int(xs.sum())}"
+        )
+
+    @pytest.mark.parametrize("name,line",
+                             list(_exact_cases().items()) +
+                             [('coverage', _coverage_case())])
+    def test_dask_matches_numpy(self, name, line):
+        eager = _xs_mask(line, all_touched=True)
+        chunked = _xs_mask(line, all_touched=True, chunks=(_H // 2, _W // 2))
+        assert np.array_equal(eager, chunked), (
+            f"{name}: eager={int(eager.sum())} chunked={int(chunked.sum())}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# cupy backend (skipped without a GPU)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not has_cuda, reason="CUDA / CuPy not available")
+class TestCupyLinesAllTouched:
+    @pytest.mark.skipif(not has_rasterio, reason="rasterio not installed")
+    @pytest.mark.parametrize("name,line", list(_exact_cases().items()))
+    def test_matches_rasterio(self, name, line):
+        rio = _rio_mask(line)
+        xs = _xs_mask(line, all_touched=True, gpu=True)
+        assert np.array_equal(rio, xs), (
+            f"{name}: rio={int(rio.sum())} xs={int(xs.sum())}"
+        )
+
+    def test_cupy_matches_numpy(self):
+        line = _coverage_case()
+        cpu = _xs_mask(line, all_touched=True)
+        gpu = _xs_mask(line, all_touched=True, gpu=True)
+        assert np.array_equal(cpu, gpu)
+
+
+# ---------------------------------------------------------------------------
+# dask + cupy backend (skipped without a GPU)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(not (has_cuda and has_dask),
+                    reason="dask + CUDA / CuPy not available")
+class TestDaskCupyLinesAllTouched:
+    @pytest.mark.skipif(not has_rasterio, reason="rasterio not installed")
+    @pytest.mark.parametrize("name,line", list(_exact_cases().items()))
+    def test_matches_rasterio(self, name, line):
+        rio = _rio_mask(line)
+        xs = _xs_mask(line, all_touched=True, chunks=(_H // 2, _W // 2),
+                      gpu=True)
+        assert np.array_equal(rio, xs), (
+            f"{name}: rio={int(rio.sum())} xs={int(xs.sum())}"
+        )
+
+    def test_dask_cupy_matches_numpy(self):
+        line = _coverage_case()
+        cpu = _xs_mask(line, all_touched=True)
+        gpu = _xs_mask(line, all_touched=True, chunks=(_H // 2, _W // 2),
+                       gpu=True)
+        assert np.array_equal(cpu, gpu)
+
+
+# ---------------------------------------------------------------------------
+# merge='sum' / 'count' dedup with all_touched lines (issue #3304 path)
+# ---------------------------------------------------------------------------
+
+class TestLinesAllTouchedDedup:
+    def test_self_crossing_sum_counts_once(self):
+        """A self-crossing line under merge='sum' must contribute its
+        value at most once per pixel (per-geometry dedup), even though
+        the supercover walk visits the crossing cell from two segments."""
+        line = LineString([(0.5, 0.5), (8.5, 8.5), (0.5, 8.5), (8.5, 0.5)])
+        arr = rasterize([(line, 2.0)], width=10, height=10,
+                        bounds=(0.0, 0.0, 10.0, 10.0), fill=0,
+                        all_touched=True, merge='sum')
+        host = _to_host(arr)
+        assert np.nanmax(host) == 2.0
+
+    @pytest.mark.skipif(not has_dask, reason="dask not installed")
+    def test_sum_dask_matches_numpy(self):
+        line = LineString([(0.5, 0.5), (8.5, 8.5), (0.5, 8.5), (8.5, 0.5)])
+        common = dict(width=10, height=10, bounds=(0.0, 0.0, 10.0, 10.0),
+                      fill=0, all_touched=True, merge='sum')
+        eager = _to_host(rasterize([(line, 2.0)], **common))
+        chunked = _to_host(rasterize([(line, 2.0)], chunks=(5, 5), **common))
+        assert np.array_equal(np.nan_to_num(eager), np.nan_to_num(chunked))
+
+
+# The non-iterable ``geometries`` TypeError path (issue #3105, item 2) is
+# pinned by ``TestNonIterableGeometries`` in
+# ``test_rasterize_coverage_2026_06_09.py``; not duplicated here.


### PR DESCRIPTION
## Summary

`rasterize(all_touched=True)` had no effect on LineString / MultiLineString input. Lines went through the Bresenham burner regardless of the flag, so `all_touched=True` returned the same pixels as `all_touched=False` on all four backends. The supercover machinery already existed for polygon boundaries, so this routes lines through it when `all_touched` is set.

- Added `_extract_line_segments_float`: float pixel-space line segments that feed the supercover (Amanatides & Woo) grid walk, the line counterpart to the polygon boundary extractor.
- Routed lines through the supercover walk under `all_touched=True` in the numpy, cupy, dask+numpy, and dask+cupy paths, including the `merge='sum'`/`'count'` per-geometry cell dedup.
- Updated the `all_touched` docstring to cover lines.

Closes #3102
Closes #3105

## Backend coverage

numpy, cupy, dask+numpy, dask+cupy.

## Test plan

- [x] Off-corner single-segment lines match `rasterio.features.rasterize(all_touched=True)` pixel-for-pixel.
- [x] dask+numpy and cupy results equal eager numpy.
- [x] `merge='sum'` on a self-crossing line counts each pixel once per geometry.
- [x] The non-iterable input TypeError path stays covered (it lives in the sweep file).
- [x] Updated the test-coverage sweep file that pinned the old no-op behavior and its strict xfail.
- [x] Full rasterize suite passes (855 passed, 2 skipped).

Exact cell-corner crossings can still differ from rasterio by a cell or two. That is the same tie-breaking wiggle the polygon supercover parity tests already allow.