### PR TITLE
Type-check compression_level in to_geotiff

### DIFF
--- a/xrspatial/geotiff/_validation.py
+++ b/xrspatial/geotiff/_validation.py
@@ -375,6 +375,33 @@ def _validate_overview_level_arg(overview_level) -> None:
         )
 
 
+def _validate_compression_level_arg(compression_level) -> None:
+    """Validate the ``compression_level`` kwarg type.
+
+    Accepts ``None`` (default, codec picks its own level) and any
+    ``int`` / ``numpy.integer`` instance. ``bool`` is rejected
+    explicitly because Python treats it as a subclass of ``int``;
+    without the check, ``compression_level=True`` is coerced to ``1``
+    and silently used as level 1. Non-int types like ``str`` and
+    ``list`` would otherwise leak a raw ``TypeError`` from the
+    ``lo <= compression_level <= hi`` range comparison, or pass through
+    unchecked for codecs with no ``_LEVEL_RANGES`` entry.
+
+    Runs in ``to_geotiff`` before the codec-specific range check and
+    before backend dispatch, so every backend (numpy, cupy, dask) sees
+    the same rejection. The out-of-range ``ValueError`` for valid ints
+    is unchanged (#3321).
+    """
+    if compression_level is None:
+        return
+    if (not isinstance(compression_level, (int, np.integer))
+            or isinstance(compression_level, bool)):
+        raise TypeError(
+            f"compression_level must be an int or None, got "
+            f"{type(compression_level).__name__}: {compression_level!r}"
+        )
+
+
 def _validate_gpu_arg(gpu, *, allow_none: bool = False) -> None:
     """Validate the ``gpu`` dispatch flag type.
 

--- a/xrspatial/geotiff/_writers/eager.py
+++ b/xrspatial/geotiff/_writers/eager.py
@@ -34,7 +34,8 @@ from .._geotags import RASTER_PIXEL_IS_AREA, GeoTransform
 from .._nodata import NodataLifecycle as _NL
 from .._runtime import (GeoTIFFFallbackWarning, _geotiff_strict_mode, _gpu_fallback_warning_message,
                         _resolve_spatial_coords)
-from .._validation import (_validate_3d_writer_dims, _validate_gpu_arg, _validate_no_rotated_affine,
+from .._validation import (_validate_3d_writer_dims, _validate_compression_level_arg,
+                           _validate_gpu_arg, _validate_no_rotated_affine,
                            _validate_nodata_arg, _validate_tile_size_arg,
                            _validate_writer_spatial_shape, validate_write_metadata)
 from .._writer import _COG_REQUIRES_TILED_MSG, write
@@ -653,6 +654,13 @@ def to_geotiff(data: xr.DataArray | np.ndarray,
             or compression.lower() != 'lerc'):
         raise ValueError(
             "max_z_error is only valid with compression='lerc'")
+
+    # Reject non-int / bool compression_level before the range check so
+    # ``compression_level=True`` is not coerced to level 1 and non-int
+    # junk gets a clear, parameter-named TypeError instead of a raw
+    # comparison error or a silent pass for codecs without a level range
+    # (#3321). Runs for every codec, ahead of backend dispatch.
+    _validate_compression_level_arg(compression_level)
 
     # Validate compression_level against the codec-specific range before
     # any backend dispatch (GPU, VRT, streaming, eager) so every path

--- a/xrspatial/geotiff/_writers/eager.py
+++ b/xrspatial/geotiff/_writers/eager.py
@@ -1270,7 +1270,10 @@ def _write_vrt_tiled(data, vrt_path, *, crs=None, nodata=None,
         'no_georef_marker': _has_no_georef_marker(data),
     })
 
-    # Validate compression_level against codec-specific range
+    # Validate compression_level against codec-specific range. Reached
+    # only via to_geotiff, which already rejects non-int / bool
+    # compression_level upstream (#3321), so the range comparison here is
+    # safe on the type.
     if compression_level is not None:
         level_range = _LEVEL_RANGES.get(compression.lower())
         if level_range is not None:

--- a/xrspatial/geotiff/_writers/gpu.py
+++ b/xrspatial/geotiff/_writers/gpu.py
@@ -391,6 +391,9 @@ def _write_geotiff_gpu(data: xr.DataArray | cupy.ndarray | np.ndarray,
         # dispatcher applies upstream (#3167). Runs before the
         # experimental-codec opt-in warning below so a rejected call
         # raises without warning first, matching to_geotiff's order.
+        # to_geotiff also rejects non-int / bool compression_level
+        # upstream (#3321), so the range comparison here is type-safe on
+        # the normal dispatch path.
         if compression_level is not None:
             _level_range = _LEVEL_RANGES.get(_gpu_codec)
             if _level_range is not None:

--- a/xrspatial/geotiff/tests/write/test_basic.py
+++ b/xrspatial/geotiff/tests/write/test_basic.py
@@ -208,6 +208,54 @@ class TestWriteInvalidInput:
         with pytest.raises(TypeError, match="compression must be a str"):
             write(arr, path, compression=None)
 
+    # compression_level is documented as ``int | None`` but historically
+    # only got a range check, so ``True`` slipped through as level 1 (bool
+    # is an int subclass) and non-int junk raised a raw comparison
+    # TypeError or was silently ignored for codecs without a level range
+    # (#3321). The type guard runs in ``to_geotiff`` before backend
+    # dispatch, so one numpy test exercises the path every backend shares.
+    def test_to_geotiff_compression_level_bool_rejected_3321(self, tmp_path):
+        arr = np.zeros((4, 4), dtype=np.float32)
+        path = str(tmp_path / 'tmp_3321_level_bool.tif')
+        with pytest.raises(TypeError, match="compression_level must be"):
+            to_geotiff(arr, path, compression='deflate',
+                       compression_level=True)
+
+    @pytest.mark.parametrize('bad', ['9', [9], 9.0, object()])
+    def test_to_geotiff_compression_level_non_int_rejected_3321(
+            self, tmp_path, bad):
+        arr = np.zeros((4, 4), dtype=np.float32)
+        path = str(tmp_path / 'tmp_3321_level_nonint.tif')
+        with pytest.raises(TypeError, match="compression_level must be"):
+            to_geotiff(arr, path, compression='deflate',
+                       compression_level=bad)
+
+    def test_to_geotiff_compression_level_non_int_rejected_no_range_3321(
+            self, tmp_path):
+        # lzw has no ``_LEVEL_RANGES`` entry, so the old range block was
+        # skipped and junk passed through. The type guard must still fire.
+        arr = np.zeros((4, 4), dtype=np.float32)
+        path = str(tmp_path / 'tmp_3321_level_nonint_lzw.tif')
+        with pytest.raises(TypeError, match="compression_level must be"):
+            to_geotiff(arr, path, compression='lzw',
+                       compression_level=[9])
+
+    def test_to_geotiff_compression_level_valid_int_still_writes_3321(
+            self, tmp_path):
+        arr = np.arange(16, dtype=np.float32).reshape(4, 4)
+        path = str(tmp_path / 'tmp_3321_level_valid.tif')
+        to_geotiff(arr, path, compression='deflate', compression_level=6)
+        assert os.path.exists(path)
+
+    def test_to_geotiff_compression_level_out_of_range_still_valueerror_3321(
+            self, tmp_path):
+        # Valid type, bad value: the existing ValueError contract is kept.
+        arr = np.zeros((4, 4), dtype=np.float32)
+        path = str(tmp_path / 'tmp_3321_level_oor.tif')
+        with pytest.raises(ValueError, match="out of range"):
+            to_geotiff(arr, path, compression='deflate',
+                       compression_level=999)
+
 
 # -------------------------------------------------------------------------
 # Section: writer dtype x compression matrix


### PR DESCRIPTION
Closes #3321

`to_geotiff` documents `compression_level` as `int | None`, but the
validation only did a range comparison. That left three holes:

- `compression_level=True` was accepted as level 1 (`bool` is an int subclass).
- A string or list raised a raw `TypeError` from the `lo <= compression_level <= hi` comparison instead of a clear message.
- Codecs with no `_LEVEL_RANGES` entry (e.g. lzw) skipped the check, so junk passed through and was ignored.

This adds `_validate_compression_level_arg` in `_validation.py`, mirroring
the existing `_validate_overview_level_arg` guard, and calls it in
`to_geotiff` before the range check. It rejects `bool` and any non-int
with a `TypeError` that names the parameter, for every codec. Valid ints
keep the existing out-of-range `ValueError` behavior. Well-typed ints for
codecs without a level range are still silently ignored, matching how the
rest of the module treats inapplicable-but-well-typed params.

Backend coverage: the guard runs in `to_geotiff` before backend dispatch,
so it covers numpy, cupy, dask+numpy, and dask+cupy through one path.

Test plan:
- [x] `compression_level=True` raises `TypeError`
- [x] `'9'`, `[9]`, `9.0`, `object()` raise `TypeError`
- [x] non-int rejected for lzw (no level range)
- [x] valid int still writes
- [x] out-of-range int still raises `ValueError`
- [x] existing writer + codec-roundtrip suites pass (429 + streaming)