### PR TITLE
geotiff: don't flip masked_nodata True on a caller dtype= cast of an unmasked buffer (#3323)

### DIFF
--- a/xrspatial/geotiff/_attrs.py
+++ b/xrspatial/geotiff/_attrs.py
@@ -2211,6 +2211,11 @@ def _finalize_eager_read(
     # ``_validation``; local import keeps ``_attrs`` free of a top-level
     # validation dependency for parity with ``_validate_read_geo_info``.
     dtype_cast_attr: str | None = None
+    # Capture float-ness BEFORE the caller's ``dtype=`` cast so ``masked``
+    # below reflects masking-promotion, not the cast (issue #3323). A
+    # caller casting an unmasked int buffer to float must not flip
+    # ``masked_nodata`` to True.
+    pre_cast_is_float = np.dtype(str(arr.dtype)).kind == 'f'
     if dtype is not None:
         from ._validation import _validate_dtype_cast
         target = np.dtype(dtype)
@@ -2219,16 +2224,18 @@ def _finalize_eager_read(
         dtype_cast_attr = target.name
 
     # Stamp the nodata lifecycle attrs. ``masked`` is True iff
-    # the caller opted into masking AND the final buffer dtype is float.
+    # the caller opted into masking AND the pre-cast buffer dtype is float.
     # ``_apply_eager_nodata_mask`` promotes a maskable integer source to
     # float64 whenever masking is on (issue #2990), so an ``int`` buffer +
     # ``mask_nodata=True`` here means the sentinel was unmaskable
     # (out-of-range / non-finite / fractional) and could never match, not
     # that masking was disabled. Either way ``masked`` is correctly False
-    # because the literal sentinel still occupies its integer slot.
+    # because the literal sentinel still occupies its integer slot. Using
+    # the pre-cast dtype keeps a caller ``dtype=<float>`` cast from
+    # flipping ``masked`` True on that unmasked int buffer (issue #3323).
     _set_nodata_attrs(
         attrs, nodata,
-        masked=(effective_mask and np.dtype(str(arr.dtype)).kind == 'f'),
+        masked=(effective_mask and pre_cast_is_float),
         pixels_present=nodata_pixels_present,
         dtype_cast=dtype_cast_attr,
     )

--- a/xrspatial/geotiff/_backends/dask.py
+++ b/xrspatial/geotiff/_backends/dask.py
@@ -521,10 +521,15 @@ def _read_geotiff_dask(source: str, *,
     # Share the validate-then-populate-then-stamp
     # block with the dask+GPU backend via ``_finalize_lazy_read_attrs``.
     #
-    # ``graph_dtype`` is the resolved dask graph dtype so
-    # ``masked_nodata`` reflects whether the per-chunk mask actually
-    # ran (masking on an int source auto-promotes to float64; an
-    # un-promoted int graph means masking didn't run).
+    # ``graph_dtype`` is ``effective_dtype`` -- the pre-cast graph dtype
+    # after the masking-induced int->float64 auto-promotion but BEFORE
+    # the caller's ``dtype=`` cast -- so ``masked_nodata`` reflects
+    # whether the per-chunk mask actually ran (masking on a maskable int
+    # source auto-promotes to float64; an un-promoted int graph means the
+    # sentinel was unmaskable and masking didn't run). Passing the
+    # post-cast ``target_dtype`` would let a caller ``dtype=<float>`` cast
+    # flip ``masked_nodata`` True on an unmasked int graph (issue #3323);
+    # the VRT path already threads its pre-cast dtype for the same reason.
     # ``caller_dtype`` is the caller's ``dtype=`` kwarg verbatim so
     # ``nodata_dtype_cast`` records caller intent rather than the
     # masking-induced auto-promotion.
@@ -538,7 +543,7 @@ def _read_geotiff_dask(source: str, *,
         geo_info=geo_info,
         nodata=nodata_attr,
         mask_nodata=(mask_nodata or mask_and_scale),
-        graph_dtype=target_dtype,
+        graph_dtype=effective_dtype,
         caller_dtype=dtype,
         window=window,
         allow_rotated=allow_rotated,

--- a/xrspatial/geotiff/_backends/gpu.py
+++ b/xrspatial/geotiff/_backends/gpu.py
@@ -1631,6 +1631,11 @@ def _read_geotiff_gpu_chunked_gds(source, ifd, geo_info, header, *,
             info = np.iinfo(file_dtype)
             if info.min <= int(nodata) <= info.max:
                 declared_dtype = np.dtype('float64')
+    # Pre-cast dtype: the masking-promotion result before the caller's
+    # ``dtype=`` cast. Drives ``masked_nodata`` so a caller ``dtype=<float>``
+    # cast does not flip the attr True on an unmasked int graph (issue
+    # #3323), matching the eager, dask+numpy, and VRT paths.
+    pre_cast_dtype = declared_dtype
     if dtype is not None:
         declared_dtype = np.dtype(dtype)
 
@@ -1705,9 +1710,11 @@ def _read_geotiff_gpu_chunked_gds(source, ifd, geo_info, header, *,
     # Share the validate-then-populate-then-stamp block with the
     # dask+numpy backend via ``_finalize_lazy_read_attrs``.
     #
-    # ``graph_dtype`` is the resolved graph dtype so ``masked_nodata``
-    # reflects whether per-chunk masking actually runs in the lazy
-    # graph. ``caller_dtype`` is the user's ``dtype=`` kwarg so
+    # ``graph_dtype`` is ``pre_cast_dtype`` -- the masking-promotion
+    # result before the caller's ``dtype=`` cast -- so ``masked_nodata``
+    # reflects whether per-chunk masking actually runs in the lazy graph,
+    # not whether the caller cast to float (issue #3323).
+    # ``caller_dtype`` is the user's ``dtype=`` kwarg so
     # ``nodata_dtype_cast`` surfaces caller intent, not the
     # masking-induced int->float64 auto-promotion.
     # ``nodata_pixels_present`` stays unset on this path for the same
@@ -1717,7 +1724,7 @@ def _read_geotiff_gpu_chunked_gds(source, ifd, geo_info, header, *,
         geo_info=geo_info,
         nodata=nodata,
         mask_nodata=mask_nodata,
-        graph_dtype=declared_dtype,
+        graph_dtype=pre_cast_dtype,
         caller_dtype=dtype,
         window=window,
         allow_rotated=allow_rotated,

--- a/xrspatial/geotiff/tests/read/test_nodata.py
+++ b/xrspatial/geotiff/tests/read/test_nodata.py
@@ -1272,6 +1272,9 @@ def test_dask_gpu_unmaskable_sentinel_plus_dtype_cast_masked_false(tmp_path):
         path, chunks=2, mask_nodata=True,
         allow_invalid_nodata=True, dtype='float32',
     )
+    computed = da.compute().data.get()
+    assert not np.isnan(computed).any()
+    np.testing.assert_array_equal(computed, [[10, 20], [30, 40]])
     assert da.attrs['masked_nodata'] is False
     assert da.attrs['nodata_dtype_cast'] == 'float32'
 

--- a/xrspatial/geotiff/tests/read/test_nodata.py
+++ b/xrspatial/geotiff/tests/read/test_nodata.py
@@ -1170,6 +1170,113 @@ def test_apply_nodata_mask_gpu_int_fractional_noop():
 
 
 # ===========================================================================
+# masked_nodata reflects masking-promotion, not a caller dtype= cast (#3323)
+# ===========================================================================
+
+
+def test_eager_unmaskable_sentinel_plus_dtype_cast_masked_false(tmp_path):
+    """Eager numpy path: an unmaskable fractional sentinel masks nothing,
+    so an explicit ``dtype='float32'`` cast must not flip
+    ``masked_nodata`` to True (#3323).
+    """
+    path = _build_uint16_tiff_1774('30.5', tmp_path)
+    da = open_geotiff(
+        path, masked=True, allow_invalid_nodata=True, dtype='float32',
+    )
+    # The caller cast lands, but no pixel was converted to NaN.
+    assert da.dtype == np.float32
+    assert not np.isnan(da.values).any()
+    np.testing.assert_array_equal(da.values, [[10, 20], [30, 40]])
+    assert da.attrs['masked_nodata'] is False
+    # The cast itself is still recorded as caller intent.
+    assert da.attrs['nodata_dtype_cast'] == 'float32'
+
+
+def test_eager_maskable_sentinel_plus_dtype_cast_masked_true(tmp_path):
+    """Eager numpy path positive case: an in-range integer sentinel
+    promotes to float and masks a pixel, so ``masked_nodata`` stays True
+    even though the caller also casts to float32 (#3323).
+    """
+    path = _build_uint16_tiff_1774('30', tmp_path)
+    da = open_geotiff(
+        path, masked=True, allow_invalid_nodata=True, dtype='float32',
+    )
+    assert da.dtype == np.float32
+    assert np.isnan(da.values[1, 0])
+    assert da.attrs['masked_nodata'] is True
+    assert da.attrs['nodata_dtype_cast'] == 'float32'
+
+
+def test_dask_unmaskable_sentinel_plus_dtype_cast_masked_false(tmp_path):
+    """Dask path: the unmaskable-sentinel + dtype-cast scenario must
+    mirror the eager path and keep ``masked_nodata=False`` (#3323).
+    """
+    path = _build_uint16_tiff_1774('30.5', tmp_path)
+    da = _read_geotiff_dask(
+        path, chunks=2, mask_nodata=True,
+        allow_invalid_nodata=True, dtype='float32',
+    )
+    assert da.dtype == np.float32
+    computed = da.compute().values
+    assert not np.isnan(computed).any()
+    np.testing.assert_array_equal(computed, [[10, 20], [30, 40]])
+    assert da.attrs['masked_nodata'] is False
+    assert da.attrs['nodata_dtype_cast'] == 'float32'
+
+
+def test_dask_maskable_sentinel_plus_dtype_cast_masked_true(tmp_path):
+    """Dask path positive case: a maskable sentinel keeps
+    ``masked_nodata=True`` through a caller dtype cast (#3323)."""
+    path = _build_uint16_tiff_1774('30', tmp_path)
+    da = _read_geotiff_dask(
+        path, chunks=2, mask_nodata=True,
+        allow_invalid_nodata=True, dtype='float32',
+    )
+    assert da.dtype == np.float32
+    assert np.isnan(da.compute().values[1, 0])
+    assert da.attrs['masked_nodata'] is True
+    assert da.attrs['nodata_dtype_cast'] == 'float32'
+
+
+def test_eager_float_source_masked_then_dtype_cast_masked_true(tmp_path):
+    """Eager numpy path: a genuinely-masked float source stays
+    ``masked_nodata=True`` when the caller casts to a wider float (#3323).
+    The cast is not the reason the buffer is float; masking is.
+    """
+    arr = np.array([[1.0, 2.0, -9999.0], [4.0, -9999.0, 6.0]],
+                   dtype=np.float32)
+    path = str(tmp_path / 'tmp_3323_float_src.tif')
+    da_in = xr.DataArray(
+        arr,
+        coords={'y': np.array([0.5, 1.5]),
+                'x': np.array([0.5, 1.5, 2.5])},
+        dims=('y', 'x'),
+        attrs={'nodata': -9999.0},
+    )
+    to_geotiff(da_in, path, nodata=-9999.0)
+    da = open_geotiff(path, masked=True, dtype='float64')
+    assert da.dtype == np.float64
+    assert np.isnan(da.values[0, 2])
+    assert da.attrs['masked_nodata'] is True
+    assert da.attrs['nodata_dtype_cast'] == 'float64'
+
+
+@_gpu_only
+def test_dask_gpu_unmaskable_sentinel_plus_dtype_cast_masked_false(tmp_path):
+    """Dask+GPU path: the unmaskable-sentinel + dtype-cast scenario keeps
+    ``masked_nodata=False`` like the eager and dask+numpy paths (#3323)."""
+    from xrspatial.geotiff import _read_geotiff_gpu
+
+    path = _build_uint16_tiff_1774('30.5', tmp_path)
+    da = _read_geotiff_gpu(
+        path, chunks=2, mask_nodata=True,
+        allow_invalid_nodata=True, dtype='float32',
+    )
+    assert da.attrs['masked_nodata'] is False
+    assert da.attrs['nodata_dtype_cast'] == 'float32'
+
+
+# ===========================================================================
 # Dropped defensive copies on the read path do not alias buffers
 # ===========================================================================
 


### PR DESCRIPTION
Closes #3323

`masked_nodata` is meant to say the reader actually converted sentinel pixels to NaN. It was being computed from the final buffer dtype, taken after the caller's explicit `dtype=` cast, so a cast to a float dtype flipped `masked_nodata` to True even when masking ran on nothing.

The trigger: a uint16 file with an unmaskable sentinel (fractional, out-of-range, or non-finite) read with `masked=True, allow_invalid_nodata=True, dtype='float32'`. No pixel can match the sentinel, the buffer stays integer and unmasked, and then the caller cast makes it float. Downstream writers that consult `masked_nodata` to decide whether NaNs should be restored to the sentinel could rewrite NaN pixels in derived arrays back to the sentinel.

## What changed

The flag now reads the buffer's float-ness from before the caller cast, so it reflects masking-promotion only:

- Eager (`_finalize_eager_read` in `_attrs.py`): capture the pre-cast dtype kind and use it for `masked`.
- dask+numpy backend (`_backends/dask.py`): pass `effective_dtype` (pre-cast) as `graph_dtype`.
- dask+GPU backend (`_backends/gpu.py`): pass the pre-cast dtype as `graph_dtype`.

The VRT path already threaded its pre-cast dtype, so it was correct and is unchanged. `nodata_dtype_cast` still records the caller's cast as before.

## Backend coverage

numpy, dask+numpy, and dask+GPU all had the bug and are fixed. cupy eager runs through the same eager finalizer. VRT was already correct.

## Test plan

- [x] New tests assert `masked_nodata is False` for the unmaskable-sentinel + dtype-cast case on eager, dask+numpy, and dask+GPU.
- [x] Positive guards: maskable integer sentinel stays True through a cast; a genuinely-masked float source stays True through a widening cast.
- [x] Full geotiff suite passes locally (6453 passed, 68 skipped, 1 xfailed), GPU included.
