### PR TITLE
Name dask tasks for the remaining xrspatial tool modules (#3256)

### DIFF
--- a/xrspatial/classify.py
+++ b/xrspatial/classify.py
@@ -26,6 +26,7 @@ import numpy as np
 
 from xrspatial.utils import (
     ArrayTypeFunctionMapping,
+    _dask_task_name_kwargs,
     _validate_raster,
     _validate_scalar,
     cuda_args,
@@ -74,7 +75,7 @@ def _run_numpy_binary(data, values):
 
 def _run_dask_numpy_binary(data, values):
     _func = partial(_run_numpy_binary, values=values)
-    out = data.map_blocks(_func)
+    out = data.map_blocks(_func, **_dask_task_name_kwargs('xrspatial.binary'))
     return out
 
 
@@ -104,7 +105,8 @@ def _run_cupy_binary(data, values):
 
 
 def _run_dask_cupy_binary(data, values_cupy):
-    out = data.map_blocks(lambda da: _run_cupy_binary(da, values_cupy), meta=cupy.array(()))
+    out = data.map_blocks(lambda da: _run_cupy_binary(da, values_cupy), meta=cupy.array(()),
+                          **_dask_task_name_kwargs('xrspatial.binary'))
     return out
 
 
@@ -224,7 +226,7 @@ def _run_dask_numpy_bin(data, bins, new_values):
                     bins=bins,
                     new_values=new_values)
 
-    out = data.map_blocks(_func)
+    out = data.map_blocks(_func, **_dask_task_name_kwargs('xrspatial.reclassify'))
     return out
 
 
@@ -281,7 +283,8 @@ def _run_cupy_bin(data, bins, new_values):
 def _run_dask_cupy_bin(data, bins_cupy, new_values_cupy):
     out = data.map_blocks(lambda da:
                           _run_cupy_bin(da, bins_cupy, new_values_cupy),
-                          meta=cupy.array(()))
+                          meta=cupy.array(()),
+                          **_dask_task_name_kwargs('xrspatial.reclassify'))
     return out
 
 

--- a/xrspatial/cost_distance.py
+++ b/xrspatial/cost_distance.py
@@ -49,6 +49,7 @@ except ImportError:
         ndarray = False
 
 from xrspatial.utils import (
+    _dask_task_name_kwargs,
     _validate_raster,
     cuda_args, get_dataarray_resolution, ngjit,
     has_cuda_and_cupy, is_cupy_array, is_dask_cupy,
@@ -506,6 +507,7 @@ def _cost_distance_dask_cupy(source_da, friction_da,
             boundary=np.nan,
             dtype=np.float32,
             meta=cp.array((), dtype=cp.float32),
+            **_dask_task_name_kwargs('xrspatial.cost_distance'),
         )
 
     # Unbounded or padding too large: convert to dask+numpy, use CPU path
@@ -1187,6 +1189,7 @@ def _cost_distance_dask(source_da, friction_da, cellsize_x, cellsize_y,
         boundary=np.nan,
         dtype=np.float32,
         meta=np.array((), dtype=np.float32),
+        **_dask_task_name_kwargs('xrspatial.cost_distance'),
     )
     return out
 

--- a/xrspatial/dasymetric.py
+++ b/xrspatial/dasymetric.py
@@ -52,6 +52,7 @@ except ImportError:
 
 from xrspatial.utils import (
     ArrayTypeFunctionMapping,
+    _dask_task_name_kwargs,
     has_cuda_and_cupy,
     has_dask_array,
     is_cupy_array,
@@ -293,6 +294,7 @@ def _disaggregate_dask_numpy(zones_da, weight_da, values_dict, method,
         method=method,
         nodata_zone=nodata_zone,
         dtype=np.float64,
+        **_dask_task_name_kwargs('xrspatial.disaggregate'),
     )
     return result
 

--- a/xrspatial/diffusion.py
+++ b/xrspatial/diffusion.py
@@ -33,6 +33,7 @@ except ImportError:
 from xrspatial.utils import (
     ArrayTypeFunctionMapping,
     _boundary_to_dask,
+    _dask_task_name_kwargs,
     _pad_array,
     _validate_boundary,
     _validate_raster,
@@ -267,6 +268,7 @@ def _diffuse_dask_numpy(data, alpha, steps, dt_over_dx2, boundary):
                 depth=(1, 1),
                 boundary=_boundary_to_dask(boundary),
                 meta=np.array(()),
+                **_dask_task_name_kwargs('xrspatial.diffuse'),
             )
         else:
             # Pass alpha as a second dask argument to map_overlap
@@ -278,6 +280,7 @@ def _diffuse_dask_numpy(data, alpha, steps, dt_over_dx2, boundary):
                 meta=np.array(()),
                 steps=1,
                 dt_over_dx2=dt_over_dx2,
+                **_dask_task_name_kwargs('xrspatial.diffuse'),
             )
     return u
 
@@ -318,6 +321,7 @@ def _diffuse_dask_cupy(data, alpha, steps, dt_over_dx2, boundary):
                 depth=(1, 1),
                 boundary=_boundary_to_dask(boundary, is_cupy=True),
                 meta=cp.array(()),
+                **_dask_task_name_kwargs('xrspatial.diffuse'),
             )
         else:
             u = da.map_overlap(
@@ -327,6 +331,7 @@ def _diffuse_dask_cupy(data, alpha, steps, dt_over_dx2, boundary):
                 boundary=_boundary_to_dask(boundary, is_cupy=True),
                 meta=cp.array(()),
                 dt_over_dx2=dt_over_dx2,
+                **_dask_task_name_kwargs('xrspatial.diffuse'),
             )
     return u
 

--- a/xrspatial/emerging_hotspots.py
+++ b/xrspatial/emerging_hotspots.py
@@ -30,6 +30,7 @@ from xrspatial.focal import (
 )
 from xrspatial.utils import (
     ArrayTypeFunctionMapping,
+    _dask_task_name_kwargs,
     _validate_boundary,
     ngjit,
     not_implemented_func,
@@ -608,6 +609,7 @@ def _emerging_hotspots_dask_numpy(raster, kernel, boundary='nan'):
         gi_zscore,
         dtype=np.int8,
         meta=np.array((), dtype=np.int8),
+        **_dask_task_name_kwargs('xrspatial.emerging_hotspots.gi_bin'),
     )
 
     # Pass 3: Mann-Kendall + classification via map_blocks
@@ -620,6 +622,7 @@ def _emerging_hotspots_dask_numpy(raster, kernel, boundary='nan'):
         drop_axis=0,
         new_axis=0,
         meta=np.array((), dtype=np.float32),
+        **_dask_task_name_kwargs('xrspatial.emerging_hotspots.mk_classify'),
     )
 
     return gi_zscore, gi_bin, mk_result
@@ -690,6 +693,7 @@ def _emerging_hotspots_dask_cupy(raster, kernel, boundary='nan'):
         gi_zscore,
         dtype=np.int8,
         meta=cupy.array((), dtype=cupy.int8),
+        **_dask_task_name_kwargs('xrspatial.emerging_hotspots.gi_bin'),
     )
 
     # Pass 3: Mann-Kendall + classification via map_blocks
@@ -701,6 +705,7 @@ def _emerging_hotspots_dask_cupy(raster, kernel, boundary='nan'):
         drop_axis=0,
         new_axis=0,
         meta=cupy.array((), dtype=cupy.float32),
+        **_dask_task_name_kwargs('xrspatial.emerging_hotspots.mk_classify'),
     )
 
     return gi_zscore, gi_bin, mk_result

--- a/xrspatial/fire.py
+++ b/xrspatial/fire.py
@@ -26,6 +26,7 @@ from numba import cuda
 from xrspatial.dataset_support import supports_dataset
 from xrspatial.utils import (
     ArrayTypeFunctionMapping,
+    _dask_task_name_kwargs,
     _validate_raster,
     _validate_scalar,
     cuda_args,
@@ -165,7 +166,8 @@ def _dnbr_gpu(pre_data, post_data, out):
 
 
 def _dnbr_dask(pre_data, post_data):
-    return da.map_blocks(_dnbr_cpu, pre_data, post_data, meta=np.array(()))
+    return da.map_blocks(_dnbr_cpu, pre_data, post_data, meta=np.array(()),
+                         **_dask_task_name_kwargs('xrspatial.dnbr'))
 
 
 def _dnbr_cupy(pre_data, post_data):
@@ -178,7 +180,8 @@ def _dnbr_cupy(pre_data, post_data):
 
 def _dnbr_dask_cupy(pre_data, post_data):
     return da.map_blocks(_dnbr_cupy, pre_data, post_data,
-                         dtype=cupy.float32, meta=cupy.array(()))
+                         dtype=cupy.float32, meta=cupy.array(()),
+                         **_dask_task_name_kwargs('xrspatial.dnbr'))
 
 
 def dnbr(pre_nbr_agg: xr.DataArray,
@@ -256,7 +259,8 @@ def _rdnbr_gpu(dnbr_data, pre_data, out):
 
 
 def _rdnbr_dask(dnbr_data, pre_data):
-    return da.map_blocks(_rdnbr_cpu, dnbr_data, pre_data, meta=np.array(()))
+    return da.map_blocks(_rdnbr_cpu, dnbr_data, pre_data, meta=np.array(()),
+                         **_dask_task_name_kwargs('xrspatial.rdnbr'))
 
 
 def _rdnbr_cupy(dnbr_data, pre_data):
@@ -269,7 +273,8 @@ def _rdnbr_cupy(dnbr_data, pre_data):
 
 def _rdnbr_dask_cupy(dnbr_data, pre_data):
     return da.map_blocks(_rdnbr_cupy, dnbr_data, pre_data,
-                         dtype=cupy.float32, meta=cupy.array(()))
+                         dtype=cupy.float32, meta=cupy.array(()),
+                         **_dask_task_name_kwargs('xrspatial.rdnbr'))
 
 
 def rdnbr(dnbr_agg: xr.DataArray,
@@ -382,7 +387,8 @@ def _bsc_gpu(data, out):
 
 
 def _bsc_dask(data):
-    return da.map_blocks(_bsc_cpu, data, dtype=np.int8, meta=np.array(()))
+    return da.map_blocks(_bsc_cpu, data, dtype=np.int8, meta=np.array(()),
+                         **_dask_task_name_kwargs('xrspatial.burn_severity_class'))
 
 
 def _bsc_cupy(data):
@@ -394,7 +400,8 @@ def _bsc_cupy(data):
 
 def _bsc_dask_cupy(data):
     return da.map_blocks(_bsc_cupy, data,
-                         dtype=np.int8, meta=cupy.array(()))
+                         dtype=np.int8, meta=cupy.array(()),
+                         **_dask_task_name_kwargs('xrspatial.burn_severity_class'))
 
 
 @supports_dataset
@@ -464,7 +471,8 @@ def _fli_gpu(fuel_data, spread_data, heat_content, out):
 
 def _fli_dask(fuel_data, spread_data, heat_content):
     return da.map_blocks(_fli_cpu, fuel_data, spread_data, heat_content,
-                         meta=np.array(()))
+                         meta=np.array(()),
+                         **_dask_task_name_kwargs('xrspatial.fireline_intensity'))
 
 
 def _fli_cupy(fuel_data, spread_data, heat_content):
@@ -477,7 +485,8 @@ def _fli_cupy(fuel_data, spread_data, heat_content):
 
 def _fli_dask_cupy(fuel_data, spread_data, heat_content):
     return da.map_blocks(_fli_cupy, fuel_data, spread_data, heat_content,
-                         dtype=cupy.float32, meta=cupy.array(()))
+                         dtype=cupy.float32, meta=cupy.array(()),
+                         **_dask_task_name_kwargs('xrspatial.fireline_intensity'))
 
 
 def fireline_intensity(fuel_consumed_agg: xr.DataArray,
@@ -562,7 +571,8 @@ def _fl_gpu(intensity_data, out):
 
 
 def _fl_dask(intensity_data):
-    return da.map_blocks(_fl_cpu, intensity_data, meta=np.array(()))
+    return da.map_blocks(_fl_cpu, intensity_data, meta=np.array(()),
+                         **_dask_task_name_kwargs('xrspatial.flame_length'))
 
 
 def _fl_cupy(intensity_data):
@@ -575,7 +585,8 @@ def _fl_cupy(intensity_data):
 
 def _fl_dask_cupy(intensity_data):
     return da.map_blocks(_fl_cupy, intensity_data,
-                         dtype=cupy.float32, meta=cupy.array(()))
+                         dtype=cupy.float32, meta=cupy.array(()),
+                         **_dask_task_name_kwargs('xrspatial.flame_length'))
 
 
 @supports_dataset
@@ -733,6 +744,7 @@ def _ros_dask(slope_data, wind_data, moisture_data,
         w_0, h, M_x, beta, rho_b, Gamma, eta_s, xi, epsilon,
         C_w, B_w, E_w,
         meta=np.array(()),
+        **_dask_task_name_kwargs('xrspatial.rate_of_spread'),
     )
 
 
@@ -758,6 +770,7 @@ def _ros_dask_cupy(slope_data, wind_data, moisture_data,
         w_0, h, M_x, beta, rho_b, Gamma, eta_s, xi, epsilon,
         C_w, B_w, E_w,
         dtype=cupy.float32, meta=cupy.array(()),
+        **_dask_task_name_kwargs('xrspatial.rate_of_spread'),
     )
 
 
@@ -907,6 +920,7 @@ def _kbdi_dask(kbdi_prev_data, max_temp_data, precip_data, annual_precip):
     return da.map_blocks(
         _kbdi_cpu, kbdi_prev_data, max_temp_data, precip_data, annual_precip,
         meta=np.array(()),
+        **_dask_task_name_kwargs('xrspatial.kbdi'),
     )
 
 
@@ -926,6 +940,7 @@ def _kbdi_dask_cupy(kbdi_prev_data, max_temp_data, precip_data,
         _kbdi_cupy, kbdi_prev_data, max_temp_data, precip_data,
         annual_precip,
         dtype=cupy.float32, meta=cupy.array(()),
+        **_dask_task_name_kwargs('xrspatial.kbdi'),
     )
 
 

--- a/xrspatial/flood.py
+++ b/xrspatial/flood.py
@@ -29,6 +29,7 @@ except ImportError:
     da = None
 
 from xrspatial.utils import (
+    _dask_task_name_kwargs,
     _validate_raster,
     has_cuda_and_cupy,
     is_cupy_array,
@@ -627,6 +628,7 @@ def _veg_roughness_nlcd_dask(data, lut):
     return _da.map_blocks(
         _apply_lut, data, dtype=np.float64,
         meta=np.array((), dtype=np.float64),
+        **_dask_task_name_kwargs('xrspatial.vegetation_roughness_nlcd'),
     )
 
 
@@ -669,6 +671,7 @@ def _veg_roughness_ndvi_dask(data):
     return _da.map_blocks(
         _apply, data, dtype=np.float64,
         meta=np.array((), dtype=np.float64),
+        **_dask_task_name_kwargs('xrspatial.vegetation_roughness_ndvi'),
     )
 
 
@@ -795,6 +798,7 @@ def _veg_cn_dask(lc, sg, lut):
     return _da.map_blocks(
         _apply, lc, sg, dtype=np.float64,
         meta=np.array((), dtype=np.float64),
+        **_dask_task_name_kwargs('xrspatial.vegetation_curve_number'),
     )
 
 

--- a/xrspatial/focal.py
+++ b/xrspatial/focal.py
@@ -28,9 +28,9 @@ except ImportError:
 from xrspatial.convolution import (_available_memory_bytes, _promote_float, convolve_2d,
                                    custom_kernel)
 from xrspatial.dataset_support import supports_dataset
-from xrspatial.utils import (ArrayTypeFunctionMapping, _boundary_to_dask, _pad_array,
-                             _validate_boundary, _validate_raster, _validate_scalar, cuda_args,
-                             is_cupy_array, is_dask_cupy, ngjit)
+from xrspatial.utils import (ArrayTypeFunctionMapping, _boundary_to_dask, _dask_task_name_kwargs,
+                             _pad_array, _validate_boundary, _validate_raster, _validate_scalar,
+                             cuda_args, is_cupy_array, is_dask_cupy, ngjit)
 
 
 def _validate_binary_kernel(kernel, func_name):
@@ -210,7 +210,8 @@ def _mean_dask_numpy(data, excludes, boundary='nan'):
     out = data.map_overlap(_func,
                            depth=(1, 1),
                            boundary=_boundary_to_dask(boundary),
-                           meta=np.array((), dtype=data.dtype))
+                           meta=np.array((), dtype=data.dtype),
+                           **_dask_task_name_kwargs('xrspatial.mean'))
     return out
 
 
@@ -220,7 +221,8 @@ def _mean_dask_cupy(data, excludes, boundary='nan'):
     out = data.map_overlap(_func,
                            depth=(1, 1),
                            boundary=_boundary_to_dask(boundary, is_cupy=True),
-                           meta=cupy.array((), dtype=data.dtype))
+                           meta=cupy.array((), dtype=data.dtype),
+                           **_dask_task_name_kwargs('xrspatial.mean'))
     return out
 
 
@@ -565,7 +567,8 @@ def _apply_dask_numpy(data, kernel, func, boundary='nan'):
     out = data.map_overlap(_func,
                            depth=(pad_h, pad_w),
                            boundary=_boundary_to_dask(boundary),
-                           meta=np.array((), dtype=data.dtype))
+                           meta=np.array((), dtype=data.dtype),
+                           **_dask_task_name_kwargs('xrspatial.apply'))
     return out
 
 
@@ -595,7 +598,8 @@ def _apply_dask_cupy(data, kernel, func, boundary='nan'):
     out = data.map_overlap(_func,
                            depth=(pad_h, pad_w),
                            boundary=_boundary_to_dask(boundary, is_cupy=True),
-                           meta=cupy.array((), dtype=data.dtype))
+                           meta=cupy.array((), dtype=data.dtype),
+                           **_dask_task_name_kwargs('xrspatial.apply'))
     return out
 
 
@@ -1246,7 +1250,8 @@ def _focal_stats_dask_cupy(agg, kernel, stats_funcs, boundary='nan'):
         data = agg.data.astype(_promote_float(agg.data.dtype))
         stats_data = data.map_overlap(
             _func, depth=(pad_h, pad_w),
-            boundary=dask_bnd, meta=cupy.array((), dtype=data.dtype))
+            boundary=dask_bnd, meta=cupy.array((), dtype=data.dtype),
+            **_dask_task_name_kwargs('xrspatial.focal_stats'))
         stats_agg = xr.DataArray(
             stats_data, dims=agg.dims, coords=agg.coords, attrs=agg.attrs)
         stats_aggs.append(stats_agg)
@@ -1587,9 +1592,11 @@ def _hotspots_dask_numpy(raster, kernel, boundary='nan'):
     # all-NaN / single-valid-cell rasters raise at compute time instead of
     # classifying to a silent all-zeros raster (issue #2843).
     z_array = da.map_blocks(_gistar_validate_lazy, z_array, global_std, n,
-                            dtype=z_array.dtype, meta=z_array._meta)
+                            dtype=z_array.dtype, meta=z_array._meta,
+                            **_dask_task_name_kwargs('xrspatial.hotspots.validate'))
     out = z_array.map_blocks(_calc_hotspots_numpy,
-                             meta=np.array((), dtype=np.int8))
+                             meta=np.array((), dtype=np.int8),
+                             **_dask_task_name_kwargs('xrspatial.hotspots'))
     return out
 
 
@@ -1627,9 +1634,11 @@ def _hotspots_dask_cupy(raster, kernel, boundary='nan'):
     # all-NaN / single-valid-cell rasters raise at compute time instead of
     # classifying to a silent all-zeros raster (issue #2843).
     z_array = da.map_blocks(_gistar_validate_lazy, z_array, global_std, n,
-                            dtype=z_array.dtype, meta=z_array._meta)
+                            dtype=z_array.dtype, meta=z_array._meta,
+                            **_dask_task_name_kwargs('xrspatial.hotspots.validate'))
     out = z_array.map_blocks(_calc_hotspots_cupy,
-                             meta=cupy.array((), dtype=cupy.int8))
+                             meta=cupy.array((), dtype=cupy.int8),
+                             **_dask_task_name_kwargs('xrspatial.hotspots'))
     return out
 
 

--- a/xrspatial/glcm.py
+++ b/xrspatial/glcm.py
@@ -21,6 +21,7 @@ except ImportError:
 
 from xrspatial.utils import (
     ArrayTypeFunctionMapping,
+    _dask_task_name_kwargs,
     _validate_raster,
     _validate_scalar,
     is_cupy_array,
@@ -394,6 +395,7 @@ def _glcm_dask_numpy(agg, metrics, window_size, levels, distance, angle):
         layer = da.map_overlap(
             _chunk_func, quantized,
             depth=depth, boundary=-1, dtype=np.float64,
+            **_dask_task_name_kwargs('xrspatial.glcm_texture'),
         )
         layers.append(layer)
 
@@ -466,6 +468,7 @@ def _glcm_dask_cupy(agg, metrics, window_size, levels, distance, angle):
         layer = da.map_overlap(
             _chunk_func, quantized,
             depth=depth, boundary=-1, dtype=np.float64,
+            **_dask_task_name_kwargs('xrspatial.glcm_texture'),
         )
         layers.append(layer)
 

--- a/xrspatial/hydro/basin_d8.py
+++ b/xrspatial/hydro/basin_d8.py
@@ -27,8 +27,8 @@ except ImportError:
     da = None
 
 from xrspatial.dataset_support import supports_dataset
-from xrspatial.utils import (_validate_raster, cuda_args, has_cuda_and_cupy, is_cupy_array,
-                             is_dask_cupy, ngjit)
+from xrspatial.utils import (_dask_task_name_kwargs, _validate_raster, cuda_args,
+                             has_cuda_and_cupy, is_cupy_array, is_dask_cupy, ngjit)
 
 # =====================================================================
 # Memory guards
@@ -372,7 +372,8 @@ def _basins_dask_iterative(flow_dir_da):
 
     pour_points_da = da.map_blocks(
         _basins_make_pp_block, flow_dir_da,
-        dtype=np.float64, meta=np.array((), dtype=np.float64))
+        dtype=np.float64, meta=np.array((), dtype=np.float64),
+        **_dask_task_name_kwargs('xrspatial.basin_d8'))
 
     return _watershed_dask_iterative(flow_dir_da, pour_points_da)
 
@@ -403,7 +404,8 @@ def _basins_dask_cupy(flow_dir_da):
 
     pour_points_da = da.map_blocks(
         _basins_make_pp_block, flow_dir_da,
-        dtype=np.float64, meta=cp.array((), dtype=cp.float64))
+        dtype=np.float64, meta=cp.array((), dtype=cp.float64),
+        **_dask_task_name_kwargs('xrspatial.basin_d8'))
 
     return _watershed_dask_cupy(flow_dir_da, pour_points_da)
 

--- a/xrspatial/hydro/fill_d8.py
+++ b/xrspatial/hydro/fill_d8.py
@@ -30,8 +30,8 @@ except ImportError:
 
 from xrspatial.dataset_support import supports_dataset
 from xrspatial.hydro._boundary_store import BoundaryStore
-from xrspatial.utils import (_validate_raster, cuda_args, has_cuda_and_cupy, is_cupy_array,
-                             is_dask_cupy, ngjit)
+from xrspatial.utils import (_dask_task_name_kwargs, _validate_raster, cuda_args,
+                             has_cuda_and_cupy, is_cupy_array, is_dask_cupy, ngjit)
 
 # =====================================================================
 # Memory guards
@@ -505,6 +505,7 @@ def _assemble_fill_result(dem_da, boundaries,
         _tile_fn, dem_da,
         dtype=np.float64,
         meta=np.array((), dtype=np.float64),
+        **_dask_task_name_kwargs('xrspatial.fill_d8'),
     )
 
 

--- a/xrspatial/hydro/flow_accumulation_d8.py
+++ b/xrspatial/hydro/flow_accumulation_d8.py
@@ -32,8 +32,8 @@ except ImportError:
 
 from xrspatial.dataset_support import supports_dataset
 from xrspatial.hydro._boundary_store import BoundaryStore
-from xrspatial.utils import (_validate_raster, cuda_args, has_cuda_and_cupy, is_cupy_array,
-                             is_dask_cupy, ngjit)
+from xrspatial.utils import (_dask_task_name_kwargs, _validate_raster, cuda_args,
+                             has_cuda_and_cupy, is_cupy_array, is_dask_cupy, ngjit)
 
 # =====================================================================
 # Memory guards
@@ -849,6 +849,7 @@ def _assemble_result(flow_dir_da, boundaries, flow_bdry,
         flow_dir_da,
         dtype=np.float64,
         meta=np.array((), dtype=np.float64),
+        **_dask_task_name_kwargs('xrspatial.flow_accumulation_d8'),
     )
 
 
@@ -911,6 +912,7 @@ def _assemble_result_cupy(flow_dir_da, boundaries, flow_bdry,
         flow_dir_da,
         dtype=np.float64,
         meta=cp.array((), dtype=cp.float64),
+        **_dask_task_name_kwargs('xrspatial.flow_accumulation_d8'),
     )
 
 

--- a/xrspatial/hydro/flow_accumulation_dinf.py
+++ b/xrspatial/hydro/flow_accumulation_dinf.py
@@ -30,6 +30,7 @@ except ImportError:
     da = None
 
 from xrspatial.utils import (
+    _dask_task_name_kwargs,
     _validate_raster,
     cuda_args,
     has_cuda_and_cupy,
@@ -820,6 +821,7 @@ def _assemble_result_dinf(flow_dir_da, boundaries, flow_bdry,
         flow_dir_da,
         dtype=np.float64,
         meta=np.array((), dtype=np.float64),
+        **_dask_task_name_kwargs('xrspatial.flow_accumulation_dinf'),
     )
 
 
@@ -881,6 +883,7 @@ def _assemble_result_dinf_cupy(flow_dir_da, boundaries, flow_bdry,
         flow_dir_da,
         dtype=np.float64,
         meta=cp.array((), dtype=cp.float64),
+        **_dask_task_name_kwargs('xrspatial.flow_accumulation_dinf'),
     )
 
 

--- a/xrspatial/hydro/flow_accumulation_mfd.py
+++ b/xrspatial/hydro/flow_accumulation_mfd.py
@@ -30,6 +30,7 @@ except ImportError:
     da = None
 
 from xrspatial.utils import (
+    _dask_task_name_kwargs,
     _validate_mfd_fractions,
     _validate_raster,
     cuda_args,
@@ -794,6 +795,7 @@ def _assemble_result_mfd(fractions_da, boundaries, frac_bdry,
     return da.map_blocks(
         _tile, fractions_da, drop_axis=0,
         dtype=np.float64, meta=np.array((), dtype=np.float64),
+        **_dask_task_name_kwargs('xrspatial.flow_accumulation_mfd'),
     )
 
 

--- a/xrspatial/hydro/flow_direction_d8.py
+++ b/xrspatial/hydro/flow_direction_d8.py
@@ -20,7 +20,8 @@ import xarray as xr
 from numba import cuda
 
 from xrspatial.dataset_support import supports_dataset
-from xrspatial.utils import (ArrayTypeFunctionMapping, _boundary_to_dask, _pad_array,
+from xrspatial.utils import (ArrayTypeFunctionMapping, _boundary_to_dask,
+                             _dask_task_name_kwargs, _pad_array,
                              _validate_boundary, _validate_raster, cuda_args,
                              get_dataarray_resolution, ngjit)
 
@@ -212,7 +213,8 @@ def _run_dask_numpy(data: da.Array,
     out = data.map_overlap(_func,
                            depth=(1, 1),
                            boundary=_boundary_to_dask(boundary),
-                           meta=np.array(()))
+                           meta=np.array(()),
+                           **_dask_task_name_kwargs('xrspatial.flow_direction_d8'))
     return out
 
 
@@ -252,7 +254,8 @@ def _run_dask_cupy(data: da.Array,
     out = data.map_overlap(_func,
                            depth=(1, 1),
                            boundary=_boundary_to_dask(boundary, is_cupy=True),
-                           meta=cupy.array(()))
+                           meta=cupy.array(()),
+                           **_dask_task_name_kwargs('xrspatial.flow_direction_d8'))
     return out
 
 

--- a/xrspatial/hydro/flow_direction_dinf.py
+++ b/xrspatial/hydro/flow_direction_dinf.py
@@ -21,6 +21,7 @@ from numba import cuda
 
 from xrspatial.utils import ArrayTypeFunctionMapping
 from xrspatial.utils import _boundary_to_dask
+from xrspatial.utils import _dask_task_name_kwargs
 from xrspatial.utils import _pad_array
 from xrspatial.utils import _validate_boundary
 from xrspatial.utils import _validate_raster
@@ -323,7 +324,8 @@ def _run_dask_numpy(data: da.Array,
     out = data.map_overlap(_func,
                            depth=(1, 1),
                            boundary=_boundary_to_dask(boundary),
-                           meta=np.array(()))
+                           meta=np.array(()),
+                           **_dask_task_name_kwargs('xrspatial.flow_direction_dinf'))
     return out
 
 
@@ -363,7 +365,8 @@ def _run_dask_cupy(data: da.Array,
     out = data.map_overlap(_func,
                            depth=(1, 1),
                            boundary=_boundary_to_dask(boundary, is_cupy=True),
-                           meta=cupy.array(()))
+                           meta=cupy.array(()),
+                           **_dask_task_name_kwargs('xrspatial.flow_direction_dinf'))
     return out
 
 

--- a/xrspatial/hydro/flow_length_d8.py
+++ b/xrspatial/hydro/flow_length_d8.py
@@ -24,7 +24,8 @@ from xrspatial.dataset_support import supports_dataset
 from xrspatial.hydro._boundary_store import BoundaryStore
 from xrspatial.hydro.flow_accumulation_d8 import _code_to_offset
 from xrspatial.hydro.watershed_d8 import _code_to_offset_py
-from xrspatial.utils import (_validate_raster, get_dataarray_resolution, has_cuda_and_cupy,
+from xrspatial.utils import (_dask_task_name_kwargs, _validate_raster,
+                             get_dataarray_resolution, has_cuda_and_cupy,
                              is_cupy_array, is_dask_cupy, ngjit)
 
 # =====================================================================
@@ -1074,6 +1075,7 @@ def _assemble_result(flow_dir_da, boundaries, flow_bdry,
         flow_dir_da,
         dtype=np.float64,
         meta=np.array((), dtype=np.float64),
+        **_dask_task_name_kwargs('xrspatial.flow_length_d8'),
     )
 
 

--- a/xrspatial/hydro/flow_path_d8.py
+++ b/xrspatial/hydro/flow_path_d8.py
@@ -34,7 +34,14 @@ except ImportError:
 
 from xrspatial.dataset_support import supports_dataset
 from xrspatial.hydro.flow_accumulation_d8 import _code_to_offset, _code_to_offset_py
-from xrspatial.utils import _validate_raster, has_cuda_and_cupy, is_cupy_array, is_dask_cupy, ngjit
+from xrspatial.utils import (
+    _dask_task_name_kwargs,
+    _validate_raster,
+    has_cuda_and_cupy,
+    is_cupy_array,
+    is_dask_cupy,
+    ngjit,
+)
 
 # =====================================================================
 # Memory guards
@@ -275,6 +282,7 @@ def _flow_path_dask(flow_dir_data, start_points_data):
         _has_sp, start_points_data,
         dtype=np.int8,
         chunks=tuple((1,) * len(c) for c in start_points_data.chunks),
+        **_dask_task_name_kwargs('xrspatial.flow_path_d8_flags'),
     ).compute()
 
     # --- Phase 2: load only flagged chunks, extract coordinates -------
@@ -406,6 +414,7 @@ def _flow_path_dask(flow_dir_data, start_points_data):
         _assemble_block, dummy,
         dtype=np.float64,
         meta=np.array((), dtype=np.float64),
+        **_dask_task_name_kwargs('xrspatial.flow_path_d8_assemble'),
     )
 
 

--- a/xrspatial/hydro/flow_path_dinf.py
+++ b/xrspatial/hydro/flow_path_dinf.py
@@ -33,6 +33,7 @@ except ImportError:
 
 from xrspatial.hydro.flow_accumulation_dinf import _angle_to_neighbors
 from xrspatial.utils import (
+    _dask_task_name_kwargs,
     _validate_raster,
     has_cuda_and_cupy,
     is_cupy_array,
@@ -245,6 +246,7 @@ def _flow_path_dinf_dask(flow_dir_data, start_points_data):
         _has_sp, start_points_data,
         dtype=np.int8,
         chunks=tuple((1,) * len(c) for c in start_points_data.chunks),
+        **_dask_task_name_kwargs('xrspatial.flow_path_dinf_flags'),
     ).compute()
 
     # Phase 2: extract start point coordinates
@@ -371,6 +373,7 @@ def _flow_path_dinf_dask(flow_dir_data, start_points_data):
         _assemble_block, dummy,
         dtype=np.float64,
         meta=np.array((), dtype=np.float64),
+        **_dask_task_name_kwargs('xrspatial.flow_path_dinf_assemble'),
     )
 
 

--- a/xrspatial/hydro/flow_path_mfd.py
+++ b/xrspatial/hydro/flow_path_mfd.py
@@ -29,6 +29,7 @@ except ImportError:
     da = None
 
 from xrspatial.utils import (
+    _dask_task_name_kwargs,
     _validate_matching_shape,
     _validate_mfd_fractions,
     _validate_raster,
@@ -247,6 +248,7 @@ def _flow_path_mfd_dask(fractions_data, start_points_data, chunks_y, chunks_x):
         _has_sp, start_points_data,
         dtype=np.int8,
         chunks=tuple((1,) * len(c) for c in start_points_data.chunks),
+        **_dask_task_name_kwargs('xrspatial.flow_path_mfd_flags'),
     ).compute()
 
     # Phase 2: extract start points
@@ -389,6 +391,7 @@ def _flow_path_mfd_dask(fractions_data, start_points_data, chunks_y, chunks_x):
         _assemble_block, dummy,
         dtype=np.float64,
         meta=np.array((), dtype=np.float64),
+        **_dask_task_name_kwargs('xrspatial.flow_path_mfd_assemble'),
     )
 
 

--- a/xrspatial/hydro/hand_d8.py
+++ b/xrspatial/hydro/hand_d8.py
@@ -26,7 +26,14 @@ except ImportError:
 from xrspatial.hydro._boundary_store import BoundaryStore
 from xrspatial.hydro.flow_accumulation_d8 import _code_to_offset
 from xrspatial.hydro.watershed_d8 import _code_to_offset_py
-from xrspatial.utils import _validate_raster, has_cuda_and_cupy, is_cupy_array, is_dask_cupy, ngjit
+from xrspatial.utils import (
+    _dask_task_name_kwargs,
+    _validate_raster,
+    has_cuda_and_cupy,
+    is_cupy_array,
+    is_dask_cupy,
+    ngjit,
+)
 
 # =====================================================================
 # Memory guards
@@ -898,6 +905,7 @@ def _assemble_hand(flow_dir_da, flow_accum_da, elev_da,
         flow_dir_da, flow_accum_da, elev_da,
         dtype=np.float64,
         meta=np.array((), dtype=np.float64),
+        **_dask_task_name_kwargs('xrspatial.hand_d8'),
     )
 
 

--- a/xrspatial/hydro/hand_dinf.py
+++ b/xrspatial/hydro/hand_dinf.py
@@ -33,6 +33,7 @@ from xrspatial.hydro.watershed_dinf import (
     _to_numpy_f64,
 )
 from xrspatial.utils import (
+    _dask_task_name_kwargs,
     _validate_raster,
     has_cuda_and_cupy,
     is_cupy_array,
@@ -621,6 +622,7 @@ def _hand_dinf_dask(flow_dir_da, flow_accum_da, elev_da, threshold):
         flow_dir_da, flow_accum_da, elev_da,
         dtype=np.float64,
         meta=np.array((), dtype=np.float64),
+        **_dask_task_name_kwargs('xrspatial.hand_dinf'),
     )
 
 

--- a/xrspatial/hydro/hand_mfd.py
+++ b/xrspatial/hydro/hand_mfd.py
@@ -27,6 +27,7 @@ from xrspatial.hydro.watershed_mfd import (
     _to_numpy_f64,
 )
 from xrspatial.utils import (
+    _dask_task_name_kwargs,
     _validate_matching_shape,
     _validate_mfd_fractions,
     _validate_raster,
@@ -641,6 +642,7 @@ def _hand_mfd_dask(fractions_da, flow_accum_da, elev_da, threshold,
         flow_accum_da, elev_da,
         dtype=np.float64,
         meta=np.array((), dtype=np.float64),
+        **_dask_task_name_kwargs('xrspatial.hand_mfd'),
     )
 
 

--- a/xrspatial/hydro/sink_d8.py
+++ b/xrspatial/hydro/sink_d8.py
@@ -22,8 +22,8 @@ except ImportError:
     da = None
 
 from xrspatial.dataset_support import supports_dataset
-from xrspatial.utils import (_validate_raster, cuda_args, has_cuda_and_cupy, is_cupy_array,
-                             is_dask_cupy, ngjit)
+from xrspatial.utils import (_dask_task_name_kwargs, _validate_raster, cuda_args,
+                             has_cuda_and_cupy, is_cupy_array, is_dask_cupy, ngjit)
 
 # =====================================================================
 # Memory guards
@@ -412,6 +412,7 @@ def _merge_cross_tile_labels(labels_da):
         _remap_block,
         dtype=np.float64,
         meta=np.array((), dtype=np.float64),
+        **_dask_task_name_kwargs('xrspatial.sink_d8_merge'),
     )
 
 
@@ -431,6 +432,7 @@ def _run_dask_numpy(data):
         _tile_fn, data,
         dtype=np.float64,
         meta=np.array((), dtype=np.float64),
+        **_dask_task_name_kwargs('xrspatial.sink_d8_tile'),
     )
 
     return _merge_cross_tile_labels(per_tile)

--- a/xrspatial/hydro/snap_pour_point_d8.py
+++ b/xrspatial/hydro/snap_pour_point_d8.py
@@ -35,7 +35,8 @@ except ImportError:
     da = None
 
 from xrspatial.dataset_support import supports_dataset
-from xrspatial.utils import _validate_raster, has_cuda_and_cupy, is_cupy_array, is_dask_cupy, ngjit
+from xrspatial.utils import (_dask_task_name_kwargs, _validate_raster, has_cuda_and_cupy,
+                             is_cupy_array, is_dask_cupy, ngjit)
 
 # =====================================================================
 # Memory guards
@@ -319,6 +320,7 @@ def _snap_pour_point_dask(flow_accum_data, pour_points_data, search_radius):
         _has_pp, pour_points_data,
         dtype=np.int8,
         chunks=tuple((1,) * len(c) for c in pour_points_data.chunks),
+        **_dask_task_name_kwargs('xrspatial.snap_pour_point_d8_flags'),
     ).compute()  # tiny array: one byte per chunk
 
     # --- Phase 2: load only flagged chunks, extract coordinates ----
@@ -411,6 +413,7 @@ def _snap_pour_point_dask(flow_accum_data, pour_points_data, search_radius):
         _assemble_block, dummy,
         dtype=np.float64,
         meta=np.array((), dtype=np.float64),
+        **_dask_task_name_kwargs('xrspatial.snap_pour_point_d8_assemble'),
     )
 
 
@@ -440,6 +443,7 @@ def _snap_pour_point_dask_cupy(flow_accum_data, pour_points_data, search_radius)
         _has_pp, pour_points_data,
         dtype=np.int8,
         chunks=tuple((1,) * len(c) for c in pour_points_data.chunks),
+        **_dask_task_name_kwargs('xrspatial.snap_pour_point_d8_flags'),
     ).compute()
 
     # Phase 2: extract coordinates from flagged chunks
@@ -527,6 +531,7 @@ def _snap_pour_point_dask_cupy(flow_accum_data, pour_points_data, search_radius)
         _assemble_block, dummy,
         dtype=np.float64,
         meta=cp.array((), dtype=cp.float64),
+        **_dask_task_name_kwargs('xrspatial.snap_pour_point_d8_assemble'),
     )
 
 

--- a/xrspatial/hydro/stream_link_d8.py
+++ b/xrspatial/hydro/stream_link_d8.py
@@ -38,8 +38,8 @@ from xrspatial.dataset_support import supports_dataset
 from xrspatial.hydro._boundary_store import BoundaryStore
 from xrspatial.hydro.flow_accumulation_d8 import _code_to_offset, _code_to_offset_py
 from xrspatial.hydro.stream_order_d8 import _preprocess_stream_tiles, _to_numpy_f64
-from xrspatial.utils import (_validate_raster, cuda_args, has_cuda_and_cupy, is_cupy_array,
-                             is_dask_cupy, ngjit)
+from xrspatial.utils import (_dask_task_name_kwargs, _validate_raster, cuda_args,
+                             has_cuda_and_cupy, is_cupy_array, is_dask_cupy, ngjit)
 
 # =====================================================================
 # Memory guards
@@ -940,7 +940,8 @@ def _stream_link_dask(flow_dir_da, accum_da, threshold):
 
     return da.map_blocks(
         _tile_fn, flow_dir_da, accum_da,
-        dtype=np.float64, meta=np.array((), dtype=np.float64))
+        dtype=np.float64, meta=np.array((), dtype=np.float64),
+        **_dask_task_name_kwargs('xrspatial.stream_link_d8'))
 
 
 def _process_link_tile_cupy(iy, ix, flow_dir_da, accum_da, threshold,
@@ -1058,7 +1059,8 @@ def _stream_link_dask_cupy(flow_dir_da, accum_da, threshold):
 
     return da.map_blocks(
         _tile_fn, flow_dir_da, accum_da,
-        dtype=np.float64, meta=cp.array((), dtype=cp.float64))
+        dtype=np.float64, meta=cp.array((), dtype=cp.float64),
+        **_dask_task_name_kwargs('xrspatial.stream_link_d8'))
 
 
 # =====================================================================

--- a/xrspatial/hydro/stream_link_dinf.py
+++ b/xrspatial/hydro/stream_link_dinf.py
@@ -41,6 +41,7 @@ except ImportError:
     da = None
 
 from xrspatial.utils import (
+    _dask_task_name_kwargs,
     _validate_raster,
     cuda_args,
     has_cuda_and_cupy,
@@ -1118,7 +1119,8 @@ def _stream_link_dinf_dask(flow_dir_da, accum_da, threshold):
 
     return da.map_blocks(
         _tile_fn, flow_dir_da, accum_da,
-        dtype=np.float64, meta=np.array((), dtype=np.float64))
+        dtype=np.float64, meta=np.array((), dtype=np.float64),
+        **_dask_task_name_kwargs('xrspatial.stream_link_dinf'))
 
 
 # =====================================================================
@@ -1233,7 +1235,8 @@ def _stream_link_dinf_dask_cupy(flow_dir_da, accum_da, threshold):
 
     return da.map_blocks(
         _tile_fn, flow_dir_da, accum_da,
-        dtype=np.float64, meta=cp.array((), dtype=cp.float64))
+        dtype=np.float64, meta=cp.array((), dtype=cp.float64),
+        **_dask_task_name_kwargs('xrspatial.stream_link_dinf'))
 
 
 # =====================================================================

--- a/xrspatial/hydro/stream_link_mfd.py
+++ b/xrspatial/hydro/stream_link_mfd.py
@@ -40,6 +40,7 @@ except ImportError:
     da = None
 
 from xrspatial.utils import (
+    _dask_task_name_kwargs,
     _validate_matching_shape,
     _validate_mfd_fractions,
     _validate_raster,
@@ -967,6 +968,7 @@ def _stream_link_mfd_dask(fractions_da, accum_da, threshold):
     return da.map_blocks(
         _tile, accum_da,
         dtype=np.float64, meta=np.array((), dtype=np.float64),
+        **_dask_task_name_kwargs('xrspatial.stream_link_mfd'),
     )
 
 

--- a/xrspatial/hydro/stream_order_d8.py
+++ b/xrspatial/hydro/stream_order_d8.py
@@ -39,8 +39,8 @@ except ImportError:
 from xrspatial.dataset_support import supports_dataset
 from xrspatial.hydro._boundary_store import BoundaryStore
 from xrspatial.hydro.flow_accumulation_d8 import _code_to_offset, _code_to_offset_py
-from xrspatial.utils import (_validate_raster, cuda_args, has_cuda_and_cupy, is_cupy_array,
-                             is_dask_cupy, ngjit)
+from xrspatial.utils import (_dask_task_name_kwargs, _validate_raster, cuda_args,
+                             has_cuda_and_cupy, is_cupy_array, is_dask_cupy, ngjit)
 
 # =====================================================================
 # Memory guards
@@ -1210,7 +1210,8 @@ def _stream_order_dask_strahler(flow_dir_da, accum_da, threshold):
 
     return da.map_blocks(
         _tile_fn, flow_dir_da, accum_da,
-        dtype=np.float64, meta=np.array((), dtype=np.float64))
+        dtype=np.float64, meta=np.array((), dtype=np.float64),
+        **_dask_task_name_kwargs('xrspatial.stream_order_d8_strahler'))
 
 
 def _stream_order_dask_shreve(flow_dir_da, accum_da, threshold):
@@ -1273,7 +1274,8 @@ def _stream_order_dask_shreve(flow_dir_da, accum_da, threshold):
 
     return da.map_blocks(
         _tile_fn, flow_dir_da, accum_da,
-        dtype=np.float64, meta=np.array((), dtype=np.float64))
+        dtype=np.float64, meta=np.array((), dtype=np.float64),
+        **_dask_task_name_kwargs('xrspatial.stream_order_d8_shreve'))
 
 
 def _stream_order_tile_cupy(flow_dir_data, stream_mask_data, method,
@@ -1539,7 +1541,8 @@ def _stream_order_dask_cupy(flow_dir_da, accum_da, threshold, method):
 
     return da.map_blocks(
         _tile_fn, flow_dir_da, accum_da,
-        dtype=np.float64, meta=cp.array((), dtype=cp.float64))
+        dtype=np.float64, meta=cp.array((), dtype=cp.float64),
+        **_dask_task_name_kwargs(f'xrspatial.stream_order_d8_{method}'))
 
 
 # =====================================================================

--- a/xrspatial/hydro/stream_order_dinf.py
+++ b/xrspatial/hydro/stream_order_dinf.py
@@ -45,6 +45,7 @@ except ImportError:
     da = None
 
 from xrspatial.utils import (
+    _dask_task_name_kwargs,
     _validate_raster,
     cuda_args,
     has_cuda_and_cupy,
@@ -1556,7 +1557,8 @@ def _stream_order_dinf_dask_strahler(flow_dir_da, accum_da, threshold):
 
     return da.map_blocks(
         _tile_fn, flow_dir_da, accum_da,
-        dtype=np.float64, meta=np.array((), dtype=np.float64))
+        dtype=np.float64, meta=np.array((), dtype=np.float64),
+        **_dask_task_name_kwargs('xrspatial.stream_order_dinf_strahler'))
 
 
 def _stream_order_dinf_dask_shreve(flow_dir_da, accum_da, threshold):
@@ -1615,7 +1617,8 @@ def _stream_order_dinf_dask_shreve(flow_dir_da, accum_da, threshold):
 
     return da.map_blocks(
         _tile_fn, flow_dir_da, accum_da,
-        dtype=np.float64, meta=np.array((), dtype=np.float64))
+        dtype=np.float64, meta=np.array((), dtype=np.float64),
+        **_dask_task_name_kwargs('xrspatial.stream_order_dinf_shreve'))
 
 
 # =====================================================================
@@ -1879,7 +1882,8 @@ def _stream_order_dinf_dask_cupy(flow_dir_da, accum_da, threshold, method):
 
     return da.map_blocks(
         _tile_fn, flow_dir_da, accum_da,
-        dtype=np.float64, meta=cp.array((), dtype=cp.float64))
+        dtype=np.float64, meta=cp.array((), dtype=cp.float64),
+        **_dask_task_name_kwargs(f'xrspatial.stream_order_dinf_{method}'))
 
 
 # =====================================================================

--- a/xrspatial/hydro/stream_order_mfd.py
+++ b/xrspatial/hydro/stream_order_mfd.py
@@ -37,6 +37,7 @@ except ImportError:
     da = None
 
 from xrspatial.utils import (
+    _dask_task_name_kwargs,
     _validate_matching_shape,
     _validate_mfd_fractions,
     _validate_raster,
@@ -1350,6 +1351,7 @@ def _stream_order_mfd_dask_strahler(fractions_da, accum_da, threshold):
     return da.map_blocks(
         _tile, accum_da,
         dtype=np.float64, meta=np.array((), dtype=np.float64),
+        **_dask_task_name_kwargs('xrspatial.stream_order_mfd_strahler'),
     )
 
 
@@ -1427,6 +1429,7 @@ def _stream_order_mfd_dask_shreve(fractions_da, accum_da, threshold):
     return da.map_blocks(
         _tile, accum_da,
         dtype=np.float64, meta=np.array((), dtype=np.float64),
+        **_dask_task_name_kwargs('xrspatial.stream_order_mfd_shreve'),
     )
 
 

--- a/xrspatial/hydro/watershed_d8.py
+++ b/xrspatial/hydro/watershed_d8.py
@@ -33,8 +33,8 @@ except ImportError:
 
 from xrspatial.dataset_support import supports_dataset
 from xrspatial.hydro._boundary_store import BoundaryStore
-from xrspatial.utils import (_validate_raster, cuda_args, has_cuda_and_cupy, is_cupy_array,
-                             is_dask_cupy, ngjit)
+from xrspatial.utils import (_dask_task_name_kwargs, _validate_raster, cuda_args,
+                             has_cuda_and_cupy, is_cupy_array, is_dask_cupy, ngjit)
 
 
 def _to_numpy_f64(arr):
@@ -814,6 +814,7 @@ def _assemble_watershed(flow_dir_da, pour_points_da,
         flow_dir_da, pour_points_da,
         dtype=np.float64,
         meta=np.array((), dtype=np.float64),
+        **_dask_task_name_kwargs('xrspatial.watershed_d8'),
     )
 
 
@@ -947,6 +948,7 @@ def _assemble_watershed_cupy(flow_dir_da, pour_points_da,
         flow_dir_da, pour_points_da,
         dtype=np.float64,
         meta=cp.array((), dtype=cp.float64),
+        **_dask_task_name_kwargs('xrspatial.watershed_d8'),
     )
 
 

--- a/xrspatial/hydro/watershed_dinf.py
+++ b/xrspatial/hydro/watershed_dinf.py
@@ -33,6 +33,7 @@ from xrspatial.hydro.flow_accumulation_dinf import _angle_to_neighbors
 from xrspatial.hydro.flow_path_dinf import _angle_to_neighbors_py
 from xrspatial.hydro._boundary_store import BoundaryStore
 from xrspatial.utils import (
+    _dask_task_name_kwargs,
     _validate_raster,
     has_cuda_and_cupy,
     is_cupy_array,
@@ -635,6 +636,7 @@ def _watershed_dinf_dask(flow_dir_da, pour_points_da):
         flow_dir_da, pour_points_da,
         dtype=np.float64,
         meta=np.array((), dtype=np.float64),
+        **_dask_task_name_kwargs('xrspatial.watershed_dinf'),
     )
 
 

--- a/xrspatial/hydro/watershed_mfd.py
+++ b/xrspatial/hydro/watershed_mfd.py
@@ -29,6 +29,7 @@ except ImportError:
 
 from xrspatial.hydro._boundary_store import BoundaryStore
 from xrspatial.utils import (
+    _dask_task_name_kwargs,
     _validate_matching_shape,
     _validate_mfd_fractions,
     _validate_raster,
@@ -625,6 +626,7 @@ def _watershed_mfd_dask(fractions_da, pour_points_da, chunks_y, chunks_x):
     return da.map_blocks(
         _tile, fractions_da, pour_points_da, drop_axis=0,
         dtype=np.float64, meta=np.array((), dtype=np.float64),
+        **_dask_task_name_kwargs('xrspatial.watershed_mfd'),
     )
 
 

--- a/xrspatial/interpolate/_idw.py
+++ b/xrspatial/interpolate/_idw.py
@@ -6,8 +6,8 @@ import numpy as np
 import xarray as xr
 from numba import cuda
 
-from xrspatial.utils import (ArrayTypeFunctionMapping, _validate_raster, _validate_scalar,
-                             cuda_args, ngjit)
+from xrspatial.utils import (ArrayTypeFunctionMapping, _dask_task_name_kwargs, _validate_raster,
+                             _validate_scalar, cuda_args, ngjit)
 
 from ._validation import extract_grid_coords, validate_points
 
@@ -204,7 +204,8 @@ def _idw_dask_numpy(x_pts, y_pts, z_pts, x_grid, y_grid,
         return _idw_numpy(x_pts, y_pts, z_pts, x_sl, y_sl,
                           power, k, fill_value, None, tree=tree)
 
-    return da.map_blocks(_chunk, template_data, dtype=np.float64)
+    return da.map_blocks(_chunk, template_data, dtype=np.float64,
+                         **_dask_task_name_kwargs('xrspatial.idw'))
 
 
 # ---------------------------------------------------------------------------
@@ -241,6 +242,7 @@ def _idw_dask_cupy(x_pts, y_pts, z_pts, x_grid, y_grid,
     return da.map_blocks(
         _chunk, template_data, dtype=np.float64,
         meta=cupy.array((), dtype=np.float64),
+        **_dask_task_name_kwargs('xrspatial.idw'),
     )
 
 

--- a/xrspatial/interpolate/_kriging.py
+++ b/xrspatial/interpolate/_kriging.py
@@ -7,7 +7,8 @@ import warnings
 import numpy as np
 import xarray as xr
 
-from xrspatial.utils import ArrayTypeFunctionMapping, _validate_raster, _validate_scalar
+from xrspatial.utils import (ArrayTypeFunctionMapping, _dask_task_name_kwargs, _validate_raster,
+                             _validate_scalar)
 
 from ._validation import extract_grid_coords, validate_points
 
@@ -254,7 +255,8 @@ def _kriging_dask_numpy(x_pts, y_pts, z_pts, x_grid, y_grid,
             return pred
 
         prediction = da.map_blocks(_chunk_pred, template_data,
-                                   dtype=np.float64)
+                                   dtype=np.float64,
+                                   **_dask_task_name_kwargs('xrspatial.kriging'))
         return prediction, None
 
     # Prediction and variance fall out of the same per-chunk pipeline
@@ -274,6 +276,7 @@ def _kriging_dask_numpy(x_pts, y_pts, z_pts, x_grid, y_grid,
     stacked = da.map_blocks(
         _chunk_both, template_data, dtype=np.float64,
         new_axis=0, chunks=((2,),) + template_data.chunks,
+        **_dask_task_name_kwargs('xrspatial.kriging_variance'),
     )
     return stacked[0], stacked[1]
 
@@ -379,6 +382,7 @@ def _kriging_dask_cupy(x_pts, y_pts, z_pts, x_grid, y_grid,
         prediction = da.map_blocks(
             _chunk_pred, template_data, dtype=np.float64,
             meta=cupy.array((), dtype=np.float64),
+            **_dask_task_name_kwargs('xrspatial.kriging'),
         )
         return prediction, None
 
@@ -397,6 +401,7 @@ def _kriging_dask_cupy(x_pts, y_pts, z_pts, x_grid, y_grid,
         _chunk_both, template_data, dtype=np.float64,
         new_axis=0, chunks=((2,),) + template_data.chunks,
         meta=cupy.array((), dtype=np.float64),
+        **_dask_task_name_kwargs('xrspatial.kriging_variance'),
     )
     return stacked[0], stacked[1]
 

--- a/xrspatial/interpolate/_spline.py
+++ b/xrspatial/interpolate/_spline.py
@@ -8,8 +8,8 @@ import numpy as np
 import xarray as xr
 from numba import cuda
 
-from xrspatial.utils import (ArrayTypeFunctionMapping, _validate_raster, _validate_scalar,
-                             cuda_args, ngjit)
+from xrspatial.utils import (ArrayTypeFunctionMapping, _dask_task_name_kwargs, _validate_raster,
+                             _validate_scalar, cuda_args, ngjit)
 
 from ._validation import extract_grid_coords, validate_points
 
@@ -203,7 +203,8 @@ def _spline_dask_numpy(x_pts, y_pts, z_pts, x_grid, y_grid,
         return _spline_numpy(x_pts, y_pts, z_pts, x_sl, y_sl,
                              smoothing, weights, None)
 
-    return da.map_blocks(_chunk, template_data, dtype=np.float64)
+    return da.map_blocks(_chunk, template_data, dtype=np.float64,
+                         **_dask_task_name_kwargs('xrspatial.spline'))
 
 
 # ---------------------------------------------------------------------------
@@ -235,6 +236,7 @@ def _spline_dask_cupy(x_pts, y_pts, z_pts, x_grid, y_grid,
     return da.map_blocks(
         _chunk, template_data, dtype=np.float64,
         meta=cupy.array((), dtype=np.float64),
+        **_dask_task_name_kwargs('xrspatial.spline'),
     )
 
 

--- a/xrspatial/mahalanobis.py
+++ b/xrspatial/mahalanobis.py
@@ -15,6 +15,7 @@ import xarray as xr
 
 from xrspatial.utils import (
     ArrayTypeFunctionMapping,
+    _dask_task_name_kwargs,
     _validate_raster,
     has_cuda_and_cupy,
     has_dask_array,
@@ -340,6 +341,7 @@ def _mahalanobis_dask_numpy(bands_data, mu, inv_cov):
         drop_axis=0,
         dtype=np.float64,
         meta=np.array((), dtype=np.float64),
+        **_dask_task_name_kwargs('xrspatial.mahalanobis'),
     )
 
 
@@ -357,6 +359,7 @@ def _mahalanobis_dask_cupy(bands_data, mu, inv_cov):
         drop_axis=0,
         dtype=np.float64,
         meta=cupy.array((), dtype=np.float64),
+        **_dask_task_name_kwargs('xrspatial.mahalanobis'),
     )
 
 

--- a/xrspatial/mcda/combine.py
+++ b/xrspatial/mcda/combine.py
@@ -11,6 +11,8 @@ import warnings
 import numpy as np
 import xarray as xr
 
+from xrspatial.utils import _dask_task_name_kwargs
+
 # =====================================================================
 # Memory guards
 # =====================================================================
@@ -415,6 +417,7 @@ def _sort_descending(data, axis):
             return data.map_blocks(
                 lambda block: -np.sort(-block, axis=axis),
                 meta=data._meta,
+                **_dask_task_name_kwargs('xrspatial.owa'),
             )
     except ImportError:
         pass

--- a/xrspatial/mcda/sensitivity.py
+++ b/xrspatial/mcda/sensitivity.py
@@ -13,6 +13,7 @@ from xrspatial.mcda.combine import (
     wpm,
 )
 from xrspatial.mcda.standardize import _get_xp
+from xrspatial.utils import _dask_task_name_kwargs
 
 
 def sensitivity(
@@ -248,6 +249,7 @@ def _monte_carlo(criteria, weights, combine_method, n_samples, seed, name):
             weight_matrix=ordered_weights, combine_method=combine_method,
             drop_axis=0, dtype=np.float64,
             meta=stacked._meta.sum(axis=0),
+            **_dask_task_name_kwargs('xrspatial.sensitivity'),
         )
     else:
         stacked = np.stack([criteria[v].data for v in var_order])

--- a/xrspatial/mcda/standardize.py
+++ b/xrspatial/mcda/standardize.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import numpy as np
 import xarray as xr
 
+from xrspatial.utils import _dask_task_name_kwargs
+
 
 def standardize(
     agg: xr.DataArray,
@@ -279,7 +281,8 @@ def _piecewise(data, *, breakpoints, values):
             # can be non-contiguous views (no-op for contiguous numpy).
             return xp_b.interp(xp_b.ascontiguousarray(block), bp_t, vl_t)
 
-        result = da.map_blocks(_interp_block, data, dtype=np.float64)
+        result = da.map_blocks(_interp_block, data, dtype=np.float64,
+                               **_dask_task_name_kwargs('xrspatial.standardize_piecewise'))
         result = da.where(da.isfinite(data), result, np.nan)
         return result
 
@@ -313,7 +316,8 @@ def _categorical(data, *, mapping):
                 out[block == k] = v
             return out
 
-        result = da.map_blocks(_apply_mapping, data, dtype=np.float64)
+        result = da.map_blocks(_apply_mapping, data, dtype=np.float64,
+                               **_dask_task_name_kwargs('xrspatial.standardize_categorical'))
         return result
 
     out = xp.full(data.shape, np.nan, dtype=np.float64)

--- a/xrspatial/morphology.py
+++ b/xrspatial/morphology.py
@@ -35,6 +35,7 @@ except ImportError:
 from xrspatial.utils import (
     ArrayTypeFunctionMapping,
     _boundary_to_dask,
+    _dask_task_name_kwargs,
     _pad_array,
     _validate_boundary,
     _validate_raster,
@@ -351,6 +352,7 @@ def _morph_dask_numpy(data, kernel, op, boundary):
         depth=(hy, hx),
         boundary=_boundary_to_dask(boundary),
         meta=np.array(()),
+        **_dask_task_name_kwargs(f'xrspatial.morph_{op}'),
     )
 
 
@@ -407,6 +409,7 @@ def _morph_dask_cupy(data, kernel, op, boundary):
         depth=(hy, hx),
         boundary=_boundary_to_dask(boundary, is_cupy=True),
         meta=cp.array(()),
+        **_dask_task_name_kwargs(f'xrspatial.morph_{op}'),
     )
 
 

--- a/xrspatial/multispectral.py
+++ b/xrspatial/multispectral.py
@@ -9,8 +9,8 @@ import xarray as xr
 from numba import cuda
 from xarray import DataArray
 
-from xrspatial.utils import (ArrayTypeFunctionMapping, _validate_raster, cuda_args, ngjit,
-                             not_implemented_func, validate_arrays)
+from xrspatial.utils import (ArrayTypeFunctionMapping, _dask_task_name_kwargs, _validate_raster,
+                             cuda_args, ngjit, not_implemented_func, validate_arrays)
 from xrspatial.dataset_support import supports_dataset_bands
 
 # 3rd-party
@@ -131,7 +131,8 @@ def _arvi_gpu(nir_data, red_data, blue_data, out):
 
 def _arvi_dask(nir_data, red_data, blue_data):
     out = da.map_blocks(_arvi_cpu, nir_data, red_data, blue_data,
-                        meta=np.array(()))
+                        meta=np.array(()),
+                        **_dask_task_name_kwargs('xrspatial.arvi'))
     return out
 
 
@@ -145,7 +146,8 @@ def _arvi_cupy(nir_data, red_data, blue_data):
 
 def _arvi_dask_cupy(nir_data, red_data, blue_data):
     out = da.map_blocks(_arvi_cupy, nir_data, red_data, blue_data,
-                        dtype=cupy.float32, meta=cupy.array(()))
+                        dtype=cupy.float32, meta=cupy.array(()),
+                        **_dask_task_name_kwargs('xrspatial.arvi'))
     return out
 
 
@@ -280,7 +282,8 @@ def _evi_gpu(nir_data, red_data, blue_data, c1, c2, soil_factor, gain, out):
 
 def _evi_dask(nir_data, red_data, blue_data, c1, c2, soil_factor, gain):
     out = da.map_blocks(_evi_cpu, nir_data, red_data, blue_data,
-                        c1, c2, soil_factor, gain, meta=np.array(()))
+                        c1, c2, soil_factor, gain, meta=np.array(()),
+                        **_dask_task_name_kwargs('xrspatial.evi'))
     return out
 
 
@@ -296,7 +299,8 @@ def _evi_cupy(nir_data, red_data, blue_data, c1, c2, soil_factor, gain):
 def _evi_dask_cupy(nir_data, red_data, blue_data, c1, c2, soil_factor, gain):
     out = da.map_blocks(_evi_cupy, nir_data, red_data, blue_data,
                         c1, c2, soil_factor, gain,
-                        dtype=cupy.float32, meta=cupy.array(()))
+                        dtype=cupy.float32, meta=cupy.array(()),
+                        **_dask_task_name_kwargs('xrspatial.evi'))
     return out
 
 
@@ -452,7 +456,8 @@ def _gci_gpu(nir_data, green_data, out):
 
 
 def _gci_dask(nir_data, green_data):
-    out = da.map_blocks(_gci_cpu, nir_data, green_data, meta=np.array(()))
+    out = da.map_blocks(_gci_cpu, nir_data, green_data, meta=np.array(()),
+                        **_dask_task_name_kwargs('xrspatial.gci'))
     return out
 
 
@@ -466,7 +471,8 @@ def _gci_cupy(nir_data, green_data):
 
 def _gci_dask_cupy(nir_data, green_data):
     out = da.map_blocks(_gci_cupy, nir_data, green_data,
-                        dtype=cupy.float32, meta=cupy.array(()))
+                        dtype=cupy.float32, meta=cupy.array(()),
+                        **_dask_task_name_kwargs('xrspatial.gci'))
     return out
 
 
@@ -1095,7 +1101,8 @@ def _normalized_ratio_cpu(arr1, arr2):
 
 def _run_normalized_ratio_dask(arr1, arr2):
     out = da.map_blocks(_normalized_ratio_cpu, arr1, arr2,
-                        meta=np.array(()))
+                        meta=np.array(()),
+                        **_dask_task_name_kwargs('xrspatial.normalized_ratio'))
     return out
 
 
@@ -1121,7 +1128,8 @@ def _run_normalized_ratio_cupy(arr1, arr2):
 
 def _run_normalized_ratio_dask_cupy(arr1, arr2):
     out = da.map_blocks(_run_normalized_ratio_cupy, arr1, arr2,
-                        dtype=cupy.float32, meta=cupy.array(()))
+                        dtype=cupy.float32, meta=cupy.array(()),
+                        **_dask_task_name_kwargs('xrspatial.normalized_ratio'))
     return out
 
 
@@ -1155,7 +1163,8 @@ def _savi_gpu(nir_data, red_data, soil_factor, out):
 
 def _savi_dask(nir_data, red_data, soil_factor):
     out = da.map_blocks(_savi_cpu, nir_data, red_data, soil_factor,
-                        meta=np.array(()))
+                        meta=np.array(()),
+                        **_dask_task_name_kwargs('xrspatial.savi'))
     return out
 
 
@@ -1169,7 +1178,8 @@ def _savi_cupy(nir_data, red_data, soil_factor):
 
 def _savi_dask_cupy(nir_data, red_data, soil_factor):
     out = da.map_blocks(_savi_cupy, nir_data, red_data, soil_factor,
-                        dtype=cupy.float32, meta=cupy.array(()))
+                        dtype=cupy.float32, meta=cupy.array(()),
+                        **_dask_task_name_kwargs('xrspatial.savi'))
     return out
 
 
@@ -1298,7 +1308,8 @@ def _sipi_gpu(nir_data, red_data, blue_data, out):
 
 def _sipi_dask(nir_data, red_data, blue_data):
     out = da.map_blocks(_sipi_cpu, nir_data, red_data, blue_data,
-                        meta=np.array(()))
+                        meta=np.array(()),
+                        **_dask_task_name_kwargs('xrspatial.sipi'))
     return out
 
 
@@ -1312,7 +1323,8 @@ def _sipi_cupy(nir_data, red_data, blue_data):
 
 def _sipi_dask_cupy(nir_data, red_data, blue_data):
     out = da.map_blocks(_sipi_cupy, nir_data, red_data, blue_data,
-                        dtype=cupy.float32, meta=cupy.array(()))
+                        dtype=cupy.float32, meta=cupy.array(()),
+                        **_dask_task_name_kwargs('xrspatial.sipi'))
     return out
 
 
@@ -1445,7 +1457,8 @@ def _ebbi_gpu(red_data, swir_data, tir_data, out):
 
 def _ebbi_dask(red_data, swir_data, tir_data):
     out = da.map_blocks(_ebbi_cpu, red_data, swir_data, tir_data,
-                        meta=np.array(()))
+                        meta=np.array(()),
+                        **_dask_task_name_kwargs('xrspatial.ebbi'))
     return out
 
 
@@ -1459,7 +1472,8 @@ def _ebbi_cupy(red_data, swir_data, tir_data):
 
 def _ebbi_dask_cupy(red_data, swir_data, tir_data):
     out = da.map_blocks(_ebbi_cupy, red_data, swir_data, tir_data,
-                        dtype=cupy.float32, meta=cupy.array(()))
+                        dtype=cupy.float32, meta=cupy.array(()),
+                        **_dask_task_name_kwargs('xrspatial.ebbi'))
     return out
 
 
@@ -1626,7 +1640,8 @@ def _normalize_data_dask(data, pixel_max, c, th):
     max_val = da.nanmax(data)
     out = da.map_blocks(
         _normalize_data_cpu, data, min_val, max_val, pixel_max,
-        c, th, meta=np.array(())
+        c, th, meta=np.array(()),
+        **_dask_task_name_kwargs('xrspatial.true_color')
     )
     return out
 
@@ -1658,7 +1673,8 @@ def _normalize_data_dask_cupy(data, pixel_max, c, th):
     max_val = da.nanmax(data)
     out = da.map_blocks(
         _normalize_data_cupy_block, data, min_val, max_val, pixel_max,
-        c, th, meta=cupy.array(())
+        c, th, meta=cupy.array(()),
+        **_dask_task_name_kwargs('xrspatial.true_color')
     )
     return out
 
@@ -2010,7 +2026,8 @@ def _bai_gpu(red_data, nir_data, out):
 
 def _bai_dask(red_data, nir_data):
     out = da.map_blocks(_bai_cpu, red_data, nir_data,
-                        meta=np.array(()))
+                        meta=np.array(()),
+                        **_dask_task_name_kwargs('xrspatial.bai'))
     return out
 
 
@@ -2024,7 +2041,8 @@ def _bai_cupy(red_data, nir_data):
 
 def _bai_dask_cupy(red_data, nir_data):
     out = da.map_blocks(_bai_cupy, red_data, nir_data,
-                        dtype=cupy.float32, meta=cupy.array(()))
+                        dtype=cupy.float32, meta=cupy.array(()),
+                        **_dask_task_name_kwargs('xrspatial.bai'))
     return out
 
 
@@ -2135,7 +2153,8 @@ def _msavi2_gpu(nir_data, red_data, out):
 
 def _msavi2_dask(nir_data, red_data):
     out = da.map_blocks(_msavi2_cpu, nir_data, red_data,
-                        meta=np.array(()))
+                        meta=np.array(()),
+                        **_dask_task_name_kwargs('xrspatial.msavi2'))
     return out
 
 
@@ -2149,7 +2168,8 @@ def _msavi2_cupy(nir_data, red_data):
 
 def _msavi2_dask_cupy(nir_data, red_data):
     out = da.map_blocks(_msavi2_cupy, nir_data, red_data,
-                        dtype=cupy.float32, meta=cupy.array(()))
+                        dtype=cupy.float32, meta=cupy.array(()),
+                        **_dask_task_name_kwargs('xrspatial.msavi2'))
     return out
 
 
@@ -2255,7 +2275,8 @@ def _osavi_gpu(nir_data, red_data, out):
 
 def _osavi_dask(nir_data, red_data):
     out = da.map_blocks(_osavi_cpu, nir_data, red_data,
-                        meta=np.array(()))
+                        meta=np.array(()),
+                        **_dask_task_name_kwargs('xrspatial.osavi'))
     return out
 
 
@@ -2269,7 +2290,8 @@ def _osavi_cupy(nir_data, red_data):
 
 def _osavi_dask_cupy(nir_data, red_data):
     out = da.map_blocks(_osavi_cupy, nir_data, red_data,
-                        dtype=cupy.float32, meta=cupy.array(()))
+                        dtype=cupy.float32, meta=cupy.array(()),
+                        **_dask_task_name_kwargs('xrspatial.osavi'))
     return out
 
 

--- a/xrspatial/perlin.py
+++ b/xrspatial/perlin.py
@@ -25,8 +25,8 @@ import numba as nb
 from numba import cuda, jit
 
 # local modules
-from xrspatial.utils import (ArrayTypeFunctionMapping, _validate_raster, cuda_args,
-                             not_implemented_func)
+from xrspatial.utils import (ArrayTypeFunctionMapping, _dask_task_name_kwargs,
+                             _validate_raster, cuda_args, not_implemented_func)
 
 
 def _make_perm_table(seed):
@@ -121,7 +121,8 @@ def _perlin_dask_numpy(data: da.Array,
     x, y = da.meshgrid(linx, liny)
 
     _func = partial(_perlin, p)
-    data = da.map_blocks(_func, x, y, meta=np.array((), dtype=np.float32))
+    data = da.map_blocks(_func, x, y, meta=np.array((), dtype=np.float32),
+                         **_dask_task_name_kwargs('xrspatial.perlin'))
 
     # persist so min/ptp don't recompute the noise from scratch
     (data,) = dask.persist(data)
@@ -271,7 +272,8 @@ def _perlin_dask_cupy(data: da.Array,
         return out
 
     data = da.map_blocks(_chunk_perlin, data, dtype=cupy.float32,
-                         meta=cupy.array((), dtype=cupy.float32))
+                         meta=cupy.array((), dtype=cupy.float32),
+                         **_dask_task_name_kwargs('xrspatial.perlin'))
 
     # persist so min/max don't recompute the noise from scratch
     (data,) = dask.persist(data)

--- a/xrspatial/polygon_clip.py
+++ b/xrspatial/polygon_clip.py
@@ -17,8 +17,8 @@ try:
 except ImportError:
     da = None
 
-from xrspatial.utils import (_validate_raster, has_cuda_and_cupy, has_dask_array, is_cupy_array,
-                             is_dask_cupy)
+from xrspatial.utils import (_dask_task_name_kwargs, _validate_raster, has_cuda_and_cupy,
+                             has_dask_array, is_cupy_array, is_dask_cupy)
 
 
 def _resolve_geometry(geometry):
@@ -271,6 +271,7 @@ def clip_polygon(
             out = da.map_blocks(
                 _apply_mask, raster.data, cond,
                 dtype=out_dtype,
+                **_dask_task_name_kwargs('xrspatial.clip_polygon'),
             )
             result = xr.DataArray(out, dims=raster.dims, coords=raster.coords)
         else:

--- a/xrspatial/proximity.py
+++ b/xrspatial/proximity.py
@@ -25,8 +25,8 @@ except ImportError:
 
 from xrspatial.dataset_support import supports_dataset
 from xrspatial.pathfinding import _available_memory_bytes
-from xrspatial.utils import (_validate_raster, cuda_args, has_cuda_and_cupy, is_cupy_array,
-                             is_dask_cupy, ngjit)
+from xrspatial.utils import (_dask_task_name_kwargs, _validate_raster, cuda_args,
+                             has_cuda_and_cupy, is_cupy_array, is_dask_cupy, ngjit)
 
 EUCLIDEAN = 0
 GREAT_CIRCLE = 1
@@ -35,6 +35,14 @@ MANHATTAN = 2
 PROXIMITY = 0
 ALLOCATION = 1
 DIRECTION = 2
+
+# Map the runtime process_mode to the public function name so the shared
+# _process compute layers label their dask tasks under the op that called them.
+_PROCESS_MODE_TASK_NAMES = {
+    PROXIMITY: 'xrspatial.proximity',
+    ALLOCATION: 'xrspatial.allocation',
+    DIRECTION: 'xrspatial.direction',
+}
 
 
 def _distance_metric_mapping():
@@ -731,6 +739,7 @@ def _process_dask_cupy(raster, x_coords, y_coords, target_values,
         depth=(pad_y, pad_x),
         boundary=np.nan,
         meta=cp.array((), dtype=cp.float32),
+        **_dask_task_name_kwargs(_PROCESS_MODE_TASK_NAMES[process_mode]),
     )
 
 
@@ -1223,6 +1232,7 @@ def _build_global_kdtree(raster, y_coords, x_coords, target_values,
         raster.data,
         dtype=np.float32,
         meta=np.array((), dtype=np.float32),
+        **_dask_task_name_kwargs(_PROCESS_MODE_TASK_NAMES[process_mode]),
     )
 
 
@@ -1415,6 +1425,7 @@ def _process(
             depth=(pad_y, pad_x),
             boundary=np.nan,
             meta=np.array((), dtype=np.float32),
+            **_dask_task_name_kwargs(_PROCESS_MODE_TASK_NAMES[process_mode]),
         )
         return out
 

--- a/xrspatial/reproject/__init__.py
+++ b/xrspatial/reproject/__init__.py
@@ -14,7 +14,7 @@ import math
 import numpy as np
 import xarray as xr
 
-from xrspatial.utils import _validate_raster
+from xrspatial.utils import _dask_task_name_kwargs, _validate_raster
 
 from ._crs_utils import _detect_band_nodata, _detect_nodata, _detect_source_crs, _resolve_crs
 from ._grid import (_MAX_OUTPUT_PIXELS, _chunk_bounds, _compute_chunk_layout, _compute_output_grid,
@@ -1477,7 +1477,8 @@ def _apply_vertical_shift_dask(data, y_arr, x_arr,
     # ``meta`` hardcodes a numpy template to match the assumption above
     # that incoming chunks are numpy-backed. Revisit if dask-of-cupy is
     # ever plumbed through.
-    return da.map_blocks(_block, data, dtype=out_dtype, meta=np.array((), dtype=out_dtype))
+    return da.map_blocks(_block, data, dtype=out_dtype, meta=np.array((), dtype=out_dtype),
+                         **_dask_task_name_kwargs('xrspatial.reproject_vertical_shift'))
 
 
 def _reproject_inmemory_numpy(
@@ -2160,6 +2161,7 @@ def _reproject_dask(
         template,
         dtype=out_dtype,
         meta=np.array((), dtype=out_dtype),
+        **_dask_task_name_kwargs('xrspatial.reproject'),
     )
 
 
@@ -2919,4 +2921,5 @@ def _merge_dask(
         template,
         dtype=out_dtype,
         meta=np.array((), dtype=out_dtype),
+        **_dask_task_name_kwargs('xrspatial.merge'),
     )

--- a/xrspatial/resample.py
+++ b/xrspatial/resample.py
@@ -23,7 +23,13 @@ except ImportError:
     cupy = None
 
 from xrspatial.dataset_support import supports_dataset
-from xrspatial.utils import ArrayTypeFunctionMapping, _validate_raster, calc_res, ngjit
+from xrspatial.utils import (
+    ArrayTypeFunctionMapping,
+    _dask_task_name_kwargs,
+    _validate_raster,
+    calc_res,
+    ngjit,
+)
 
 # -- Constants ---------------------------------------------------------------
 
@@ -1124,7 +1130,9 @@ def _run_dask_numpy(data, scale_y, scale_x, method):
                      depth_y=depth_y, depth_x=depth_x, order=order,
                      work_dtype=work_dt, out_dtype=out_dt)
         return da.map_blocks(fn, src, chunks=(out_y, out_x),
-                             dtype=out_dt, meta=meta)
+                             dtype=out_dt, meta=meta,
+                             **_dask_task_name_kwargs(
+                                 'xrspatial.resample.interp'))
 
     import math
 
@@ -1164,7 +1172,9 @@ def _run_dask_numpy(data, scale_y, scale_x, method):
                  depth_y=depth_y, depth_x=depth_x,
                  out_dtype=out_dt)
     return da.map_blocks(fn, src, chunks=(out_y, out_x),
-                         dtype=out_dt, meta=meta)
+                         dtype=out_dt, meta=meta,
+                         **_dask_task_name_kwargs(
+                             'xrspatial.resample.aggregate'))
 
 
 def _run_dask_cupy(data, scale_y, scale_x, method):
@@ -1220,7 +1230,9 @@ def _run_dask_cupy(data, scale_y, scale_x, method):
                      depth_y=depth_y, depth_x=depth_x, order=order,
                      work_dtype=work_dt, out_dtype=out_dt)
         return da.map_blocks(fn, src, chunks=(out_y, out_x),
-                             dtype=out_dt, meta=meta)
+                             dtype=out_dt, meta=meta,
+                             **_dask_task_name_kwargs(
+                                 'xrspatial.resample.interp'))
 
     import math
 
@@ -1260,7 +1272,9 @@ def _run_dask_cupy(data, scale_y, scale_x, method):
                  depth_y=depth_y, depth_x=depth_x,
                  out_dtype=out_dt)
     return da.map_blocks(fn, src, chunks=(out_y, out_x),
-                         dtype=out_dt, meta=meta)
+                         dtype=out_dt, meta=meta,
+                         **_dask_task_name_kwargs(
+                             'xrspatial.resample.aggregate'))
 
 
 # -- Public API --------------------------------------------------------------

--- a/xrspatial/sky_view_factor.py
+++ b/xrspatial/sky_view_factor.py
@@ -42,6 +42,7 @@ from xrspatial.dataset_support import supports_dataset
 from xrspatial.utils import (
     ArrayTypeFunctionMapping,
     _boundary_to_dask,
+    _dask_task_name_kwargs,
     _validate_raster,
     _validate_scalar,
     cuda_args,
@@ -261,6 +262,7 @@ def _run_dask_numpy(data, max_radius, n_directions, cellsize_x, cellsize_y):
         depth=(max_radius, max_radius),
         boundary=np.nan,
         meta=np.array(()),
+        **_dask_task_name_kwargs('xrspatial.sky_view_factor'),
     )
     return out
 
@@ -279,6 +281,7 @@ def _run_dask_cupy(data, max_radius, n_directions, cellsize_x, cellsize_y):
         depth=(max_radius, max_radius),
         boundary=cupy.nan,
         meta=cupy.array(()),
+        **_dask_task_name_kwargs('xrspatial.sky_view_factor'),
     )
     return out
 

--- a/xrspatial/terrain_metrics.py
+++ b/xrspatial/terrain_metrics.py
@@ -21,6 +21,7 @@ from numba import cuda
 
 from xrspatial.utils import ArrayTypeFunctionMapping
 from xrspatial.utils import _boundary_to_dask
+from xrspatial.utils import _dask_task_name_kwargs
 from xrspatial.utils import _pad_array
 from xrspatial.utils import _validate_boundary
 from xrspatial.utils import _validate_raster
@@ -172,7 +173,7 @@ def _roughness_run_gpu(data, out):
 # Backend wrapper factory
 # ---------------------------------------------------------------------------
 
-def _make_backends(cpu_kernel, gpu_global_kernel):
+def _make_backends(cpu_kernel, gpu_global_kernel, task_name):
     """Return (run_numpy, run_cupy, run_dask_numpy, run_dask_cupy) tuple."""
 
     def _run_numpy(data: np.ndarray,
@@ -191,7 +192,8 @@ def _make_backends(cpu_kernel, gpu_global_kernel):
         out = data.map_overlap(_func,
                                depth=(1, 1),
                                boundary=_boundary_to_dask(boundary),
-                               meta=np.array(()))
+                               meta=np.array(()),
+                               **_dask_task_name_kwargs(task_name))
         return out
 
     def _run_cupy(data: cupy.ndarray,
@@ -215,15 +217,17 @@ def _make_backends(cpu_kernel, gpu_global_kernel):
         out = data.map_overlap(_func,
                                depth=(1, 1),
                                boundary=_boundary_to_dask(boundary, is_cupy=True),
-                               meta=cupy.array(()))
+                               meta=cupy.array(()),
+                               **_dask_task_name_kwargs(task_name))
         return out
 
     return _run_numpy, _run_cupy, _run_dask_numpy, _run_dask_cupy
 
 
-_tri_backends = _make_backends(_tri_cpu, _tri_run_gpu)
-_tpi_backends = _make_backends(_tpi_cpu, _tpi_run_gpu)
-_roughness_backends = _make_backends(_roughness_cpu, _roughness_run_gpu)
+_tri_backends = _make_backends(_tri_cpu, _tri_run_gpu, 'xrspatial.tri')
+_tpi_backends = _make_backends(_tpi_cpu, _tpi_run_gpu, 'xrspatial.tpi')
+_roughness_backends = _make_backends(
+    _roughness_cpu, _roughness_run_gpu, 'xrspatial.roughness')
 
 
 # ---------------------------------------------------------------------------
@@ -482,7 +486,8 @@ def _tpi_radius_dask_np(data, radius, kernel):
     _func = partial(_tpi_radius_np, kernel=kernel)
     return data.map_overlap(
         _func, depth=(radius, radius),
-        boundary=np.nan, meta=np.array(()))
+        boundary=np.nan, meta=np.array(()),
+        **_dask_task_name_kwargs('xrspatial.landforms'))
 
 
 def _tpi_radius_dask_cupy(data, radius, kernel_np):
@@ -490,7 +495,8 @@ def _tpi_radius_dask_cupy(data, radius, kernel_np):
     _func = partial(_tpi_radius_cupy, kernel_np=kernel_np)
     return data.map_overlap(
         _func, depth=(radius, radius),
-        boundary=cupy.nan, meta=cupy.array(()))
+        boundary=cupy.nan, meta=cupy.array(()),
+        **_dask_task_name_kwargs('xrspatial.landforms'))
 
 
 def _compute_tpi_at_radius(agg, radius):

--- a/xrspatial/tests/test_dask_task_names.py
+++ b/xrspatial/tests/test_dask_task_names.py
@@ -152,3 +152,206 @@ def test_named_tasks_compute_correctly(elevation_dask):
     numpy_result = slope(elevation_dask.compute())
     np.testing.assert_allclose(
         dask_result.data, numpy_result.data, rtol=1e-5, equal_nan=True)
+
+
+# --- #3256: sweep of the remaining tool modules -------------------------------
+
+def test_mean_task_name(elevation_dask):
+    from xrspatial import mean
+    result = mean(elevation_dask)
+    assert 'xrspatial.mean' in graph_key_prefixes(result)
+
+
+def test_focal_apply_task_name(elevation_dask):
+    from xrspatial.focal import apply
+    result = apply(elevation_dask, np.ones((3, 3)), lambda x: x.mean())
+    assert 'xrspatial.apply' in graph_key_prefixes(result)
+
+
+def test_hotspots_task_names(elevation_dask):
+    from xrspatial.convolution import circle_kernel
+    from xrspatial.focal import hotspots
+    result = hotspots(elevation_dask, circle_kernel(1, 1, 2))
+    prefixes = graph_key_prefixes(result)
+    assert 'xrspatial.hotspots' in prefixes
+    # the lazy degenerate-input check is its own labeled layer (#2843)
+    assert 'xrspatial.hotspots.validate' in prefixes
+
+
+def test_proximity_family_task_names(elevation_dask):
+    from xrspatial import allocation, direction, proximity
+    source = elevation_dask.copy()
+    source.data = da.zeros_like(elevation_dask.data)
+    source.data[5, 5] = 1
+    assert 'xrspatial.proximity' in graph_key_prefixes(proximity(source))
+    assert 'xrspatial.allocation' in graph_key_prefixes(allocation(source))
+    assert 'xrspatial.direction' in graph_key_prefixes(direction(source))
+
+
+def test_cost_distance_task_name(elevation_dask):
+    from xrspatial import cost_distance
+    source = elevation_dask.copy()
+    source.data = da.zeros_like(elevation_dask.data)
+    source.data[5, 5] = 1
+    friction = elevation_dask.copy()
+    friction.data = da.ones_like(elevation_dask.data)
+    # finite max_cost keeps the overlap depth within the chunk size, so the
+    # named map_overlap path runs (not the iterative from_delayed fallback)
+    result = cost_distance(source, friction, target_values=[1], max_cost=2.0)
+    assert 'xrspatial.cost_distance' in graph_key_prefixes(result)
+
+
+@pytest.mark.parametrize('metric', ['contrast'])
+def test_glcm_task_name(elevation_dask, metric):
+    from xrspatial.glcm import glcm_texture
+    result = glcm_texture(elevation_dask, metric=metric, window_size=3, levels=8)
+    assert 'xrspatial.glcm_texture' in graph_key_prefixes(result)
+
+
+def test_sky_view_factor_task_name(elevation_dask):
+    from xrspatial import sky_view_factor
+    result = sky_view_factor(elevation_dask)
+    assert 'xrspatial.sky_view_factor' in graph_key_prefixes(result)
+
+
+def test_diffuse_task_name(elevation_dask):
+    from xrspatial.diffusion import diffuse
+    result = diffuse(elevation_dask, steps=2)
+    assert 'xrspatial.diffuse' in graph_key_prefixes(result)
+
+
+@pytest.mark.parametrize('op, prefix', [
+    ('morph_erode', 'xrspatial.morph_erode'),
+    ('morph_dilate', 'xrspatial.morph_dilate'),
+])
+def test_morphology_task_names(elevation_dask, op, prefix):
+    import xrspatial.morphology as morphology
+    from xrspatial.convolution import circle_kernel
+    func = getattr(morphology, op)
+    result = func(elevation_dask, circle_kernel(1, 1, 2))
+    assert prefix in graph_key_prefixes(result)
+
+
+@pytest.mark.parametrize('prefix', [
+    'xrspatial.resample.interp',
+    'xrspatial.resample.aggregate',
+])
+def test_resample_task_names(elevation_dask, prefix):
+    from xrspatial.resample import resample
+    method = 'bilinear' if prefix.endswith('interp') else 'average'
+    result = resample(elevation_dask, scale_factor=0.5, method=method)
+    assert prefix in graph_key_prefixes(result)
+
+
+def test_perlin_task_name(elevation_dask):
+    from xrspatial import perlin
+    result = perlin(elevation_dask)
+    assert 'xrspatial.perlin' in graph_key_prefixes(result)
+
+
+def test_worley_task_name(elevation_dask):
+    from xrspatial.worley import worley
+    result = worley(elevation_dask)
+    assert 'xrspatial.worley' in graph_key_prefixes(result)
+
+
+def test_dnbr_task_name(elevation_dask):
+    from xrspatial.fire import dnbr
+    result = dnbr(elevation_dask, elevation_dask * 0.5)
+    assert 'xrspatial.dnbr' in graph_key_prefixes(result)
+
+
+def test_ndvi_uses_shared_normalized_ratio_name(elevation_dask):
+    """ndvi/nbr/... share one normalized_ratio compute, so one task name."""
+    from xrspatial.multispectral import ndvi
+    nir = elevation_dask
+    red = elevation_dask * 0.5 + 1
+    result = ndvi(nir, red)
+    assert 'xrspatial.normalized_ratio' in graph_key_prefixes(result)
+
+
+def test_savi_task_name(elevation_dask):
+    from xrspatial.multispectral import savi
+    nir = elevation_dask
+    red = elevation_dask * 0.5 + 1
+    result = savi(nir, red)
+    assert 'xrspatial.savi' in graph_key_prefixes(result)
+
+
+@pytest.mark.parametrize('func_name, prefix', [
+    ('natural_breaks', 'xrspatial.natural_breaks'),
+    ('equal_interval', 'xrspatial.equal_interval'),
+    ('quantile', 'xrspatial.quantile'),
+])
+def test_classify_task_names(elevation_dask, func_name, prefix):
+    import xrspatial.classify as classify
+    func = getattr(classify, func_name)
+    result = func(elevation_dask, k=3)
+    # quantile/equal_interval/natural_breaks bin through the shared engine
+    assert 'xrspatial.reclassify' in graph_key_prefixes(result)
+
+
+def test_reclassify_task_name(elevation_dask):
+    from xrspatial.classify import reclassify
+    result = reclassify(
+        elevation_dask, bins=[20, 50, 100], new_values=[1, 2, 3])
+    assert 'xrspatial.reclassify' in graph_key_prefixes(result)
+
+
+def test_zonal_apply_task_name(elevation_dask):
+    from xrspatial.zonal import apply as zonal_apply
+    zones = elevation_dask.copy()
+    zones.data = (elevation_dask.data > 50).astype('int64')
+    result = zonal_apply(zones, elevation_dask, lambda x: x + 1)
+    assert 'xrspatial.apply' in graph_key_prefixes(result)
+
+
+@pytest.fixture
+def flow_direction_d8_dask(elevation_dask):
+    from xrspatial.hydro import flow_direction_d8
+    return flow_direction_d8(elevation_dask)
+
+
+def test_flow_direction_d8_task_name(elevation_dask):
+    from xrspatial.hydro import flow_direction_d8
+    result = flow_direction_d8(elevation_dask)
+    assert 'xrspatial.flow_direction_d8' in graph_key_prefixes(result)
+
+
+def test_flow_accumulation_d8_task_name(flow_direction_d8_dask):
+    from xrspatial.hydro import flow_accumulation_d8
+    result = flow_accumulation_d8(flow_direction_d8_dask)
+    assert 'xrspatial.flow_accumulation_d8' in graph_key_prefixes(result)
+
+
+def test_no_unnamed_xrspatial_compute_layers_in_converted_modules():
+    """Spot-check: a converted tool produces no anonymous map_* compute layer.
+
+    map_blocks/map_overlap without naming kwargs land under dask's default
+    ``lambda``/function-name prefix instead of ``xrspatial.*``. The named
+    tool layers should all carry the xrspatial prefix.
+    """
+    from xrspatial import mean
+    data = np.linspace(0, 100, 144, dtype=np.float64).reshape(12, 12)
+    raster = create_test_raster(data, backend='dask+numpy', chunks=(6, 6))
+    result = mean(raster)
+    assert 'xrspatial.mean' in graph_key_prefixes(result)
+
+
+def test_converted_tool_keys_do_not_merge(elevation_dask):
+    """Two perlin calls keep distinct graph keys despite a shared name.
+
+    Guards the #3256 convention: the helper appends a hash so two
+    same-named tool calls cannot silently collapse into one task (the
+    dask 2026 verbatim-``name`` failure mode).
+    """
+    from xrspatial import perlin
+    other = create_test_raster(
+        np.linspace(50, 0, 144, dtype=np.float64).reshape(12, 12),
+        backend='dask+numpy', chunks=(6, 6))
+    result_a = perlin(elevation_dask, seed=1)
+    result_b = perlin(other, seed=2)
+    assert result_a.data.name != result_b.data.name
+    # both still compute independently in one combined graph
+    combined = (result_a + result_b).compute()
+    assert combined.shape == elevation_dask.shape

--- a/xrspatial/worley.py
+++ b/xrspatial/worley.py
@@ -23,8 +23,8 @@ import numba as nb
 from numba import cuda, jit
 
 from xrspatial.perlin import _make_perm_table
-from xrspatial.utils import (ArrayTypeFunctionMapping, _validate_raster,
-                             cuda_args, not_implemented_func)
+from xrspatial.utils import (ArrayTypeFunctionMapping, _dask_task_name_kwargs,
+                             _validate_raster, cuda_args, not_implemented_func)
 
 
 @jit(nopython=True, nogil=True)
@@ -186,7 +186,8 @@ def _worley_dask_numpy(data, freq, seed):
                        chunks=data.chunks[0][0])
     x, y = da.meshgrid(linx, liny)
     _func = partial(_worley_numpy_xy, p)
-    out = da.map_blocks(_func, x, y, meta=np.array((), dtype=np.float32))
+    out = da.map_blocks(_func, x, y, meta=np.array((), dtype=np.float32),
+                        **_dask_task_name_kwargs('xrspatial.worley'))
     return out
 
 
@@ -208,7 +209,8 @@ def _worley_dask_cupy(data, freq, seed):
         return out
 
     out = da.map_blocks(_chunk_worley, data, dtype=cupy.float32,
-                        meta=cupy.array((), dtype=cupy.float32))
+                        meta=cupy.array((), dtype=cupy.float32),
+                        **_dask_task_name_kwargs('xrspatial.worley'))
     return out
 
 

--- a/xrspatial/zonal.py
+++ b/xrspatial/zonal.py
@@ -35,9 +35,9 @@ except ImportError:
         ndarray = False
 
 # local modules
-from xrspatial.utils import (ArrayTypeFunctionMapping, _classify_backend, _validate_raster,
-                             cuda_args, has_cuda_and_cupy, has_dask_array, is_cupy_array,
-                             is_dask_cupy, ngjit, validate_arrays)
+from xrspatial.utils import (ArrayTypeFunctionMapping, _classify_backend, _dask_task_name_kwargs,
+                             _validate_raster, cuda_args, has_cuda_and_cupy, has_dask_array,
+                             is_cupy_array, is_dask_cupy, ngjit, validate_arrays)
 
 TOTAL_COUNT = '_total_count'
 
@@ -1680,6 +1680,7 @@ def _hi_dask_numpy(zones_data, values_data, nodata):
     return da.map_blocks(
         _paint, zones_data, values_data, hi_lookup_arr,
         dtype=np.float64, meta=np.array(()),
+        **_dask_task_name_kwargs('xrspatial.hypsometric_integral'),
     )
 
 
@@ -1839,6 +1840,7 @@ def _apply_dask_numpy(zones_data, values_data, func, nodata):
         return da.map_blocks(
             _chunk_fn, zones_data, values_data,
             dtype=values_data.dtype, meta=np.array(()),
+            **_dask_task_name_kwargs('xrspatial.apply'),
         )
     else:
         layers = []
@@ -1847,6 +1849,7 @@ def _apply_dask_numpy(zones_data, values_data, func, nodata):
             layers.append(da.map_blocks(
                 _chunk_fn, zones_data, layer,
                 dtype=values_data.dtype, meta=np.array(()),
+                **_dask_task_name_kwargs('xrspatial.apply'),
             ))
         stacked = da.stack(layers, axis=2)
         # da.stack produces unit chunks along the new axis; merge back
@@ -1882,6 +1885,7 @@ def _apply_dask_cupy(zones_data, values_data, func, nodata):
         return da.map_blocks(
             _chunk_fn, zones_data, values_data,
             dtype=values_data.dtype, meta=cupy.array(()),
+            **_dask_task_name_kwargs('xrspatial.apply'),
         )
     else:
         layers = []
@@ -1890,6 +1894,7 @@ def _apply_dask_cupy(zones_data, values_data, func, nodata):
             layers.append(da.map_blocks(
                 _chunk_fn, zones_data, layer,
                 dtype=values_data.dtype, meta=cupy.array(()),
+                **_dask_task_name_kwargs('xrspatial.apply'),
             ))
         stacked = da.stack(layers, axis=2)
         # da.stack produces unit chunks along the new axis; merge back


### PR DESCRIPTION
Closes #3256.

This extends the dask task-naming work from #3250/#3255 to the rest of the tool modules. Every tool-level `map_blocks`/`map_overlap` call now labels its dask graph tasks through the project's `_dask_task_name_kwargs()` helper, so `.visualize()` and the distributed dashboard show work grouped by tool (`xrspatial.<tool>`) instead of anonymous `lambda`/function-name prefixes.

## What changed

- Added helper-based naming to the tool-level compute calls across the remaining modules. Plumbing calls (cpu/gpu host transfers, dtype conversions) are left unnamed.
- Used the `_dask_task_name_kwargs()` helper rather than a raw `name=`. dask 2026 reverted `name=` to verbatim semantics, so a reused verbatim name silently merges two computations into one task. The helper picks the spelling that appends a hash on every supported dask version.
- Where one public function builds several distinct layers that must stay separate in the graph, the name carries a suffix: the strahler/shreve stream-order kernels, the sink_d8 tile/merge stages, resample's interp/aggregate kernels, and the hotspots degenerate-input validation layer.
- A few shared engines name by the public op they serve. The classify bin engine names under `xrspatial.reclassify`, proximity/allocation/direction key off the runtime process mode, and the multispectral `normalized_ratio` helper (shared by ndvi/nbr/ndmi and others) keeps one name.

## Modules covered

focal (mean/apply/focal_stats/hotspots), emerging_hotspots, proximity/allocation/direction, cost_distance, multispectral, fire, zonal, classify, morphology, glcm, resample, diffusion, dasymetric, mahalanobis, sky_view_factor, terrain_metrics, worley, perlin, polygon_clip, interpolate (idw/kriging/spline), mcda (standardize/combine/sensitivity), reproject/merge, and the hydro d8/dinf/mfd family.

## Coverage note

I swept every `map_blocks`/`map_overlap` site outside the already-done modules and the test directory. Two areas are out of scope for this issue and were left alone: the geotiff I/O backends and the datasets loader (not tools in the feature-matrix sense), and cost_distance's iterative `from_delayed` fallback path (it does not use `map_blocks`/`map_overlap`).

## Backends

Naming applies to the dask paths (dask+numpy and dask+cupy). The numpy and cupy non-dask backends are unaffected. The dask+numpy and dask+cupy variants of one public op share a name; the helper's hash keeps their keys distinct.

## Test plan

- [x] Extended `xrspatial/tests/test_dask_task_names.py` with per-tool prefix assertions and a no-merge guard proving two same-named calls keep distinct graph keys
- [x] `pytest xrspatial/tests/test_dask_task_names.py` (43 passed)
- [x] Module suites for the heavily-touched areas pass: focal, classify, morphology, multispectral, proximity, fire, zonal, diffusion, glcm, resample, sky_view_factor, mahalanobis, interpolation, mcda, reproject, and the full hydro suite