### PR TITLE
contour: batch dask chunk compute to bound client memory

### DIFF
--- a/xrspatial/contour.py
+++ b/xrspatial/contour.py
@@ -36,6 +36,12 @@ except ImportError:
     cuda = None
 
 
+# Maximum number of delayed chunk tasks to submit in a single dask.compute
+# call.  Batching bounds peak client memory and reduces scheduler pressure
+# when a large dask-backed raster has many chunks.
+_DASK_COMPUTE_BATCH_SIZE = 64
+
+
 def _available_memory_bytes():
     """Best-effort estimate of available memory in bytes."""
     try:
@@ -421,7 +427,20 @@ def _contours_dask(data, levels):
     Uses ``dask.array.overlap.overlap`` to give each chunk a 1-cell halo
     so that 2x2 quads at chunk boundaries are processed by both neighbors.
     Duplicate segments are removed during the merge/stitch step.
+
+    Chunk results are computed in batches so peak client memory scales
+    with a batch of chunks rather than the total number of chunks.
     """
+    return _contours_dask_generic(data, levels, _process_chunk_numpy)
+
+
+def _contours_dask_cupy(data, levels):
+    """Dask+CuPy backend: overlap chunks, transfer each to CPU."""
+    return _contours_dask_generic(data, levels, _process_chunk_cupy)
+
+
+def _contours_dask_generic(data, levels, process_chunk):
+    """Shared dask backend implementation with batched chunk execution."""
     if da is None:
         raise ImportError("Dask is required for chunked contour extraction")
 
@@ -439,50 +458,22 @@ def _contours_dask(data, levels):
             # Padded chunk has 1-cell halo on each side (NaN at edges).
             # Global coordinate of the padded chunk's (0,0) is
             # (r_off - 1, c_off - 1).
-            result = dask.delayed(_process_chunk_numpy)(
+            result = dask.delayed(process_chunk)(
                 chunk, levels, r_off - 1, c_off - 1
             )
             all_results.append(result)
             c_off += csize
         r_off += rsize
 
-    chunk_results = dask.compute(*all_results)
-
+    # Compute chunk results in batches to bound peak client memory and
+    # scheduler pressure on large rasters.
     merged = []
-    for chunk_lines in chunk_results:
-        merged.extend(chunk_lines)
-
-    return _deduplicate_by_level(merged)
-
-
-def _contours_dask_cupy(data, levels):
-    """Dask+CuPy backend: overlap chunks, transfer each to CPU."""
-    if da is None:
-        raise ImportError("Dask is required for chunked contour extraction")
-
-    padded = _overlap_for_contours(data)
-    orig_row_chunks = data.chunks[0]
-    orig_col_chunks = data.chunks[1]
-    padded_blocks = padded.to_delayed()
-
-    all_results = []
-    r_off = 0
-    for ri, rsize in enumerate(orig_row_chunks):
-        c_off = 0
-        for ci, csize in enumerate(orig_col_chunks):
-            chunk = padded_blocks[ri, ci]
-            result = dask.delayed(_process_chunk_cupy)(
-                chunk, levels, r_off - 1, c_off - 1
-            )
-            all_results.append(result)
-            c_off += csize
-        r_off += rsize
-
-    chunk_results = dask.compute(*all_results)
-
-    merged = []
-    for chunk_lines in chunk_results:
-        merged.extend(chunk_lines)
+    batch_size = _DASK_COMPUTE_BATCH_SIZE
+    for i in range(0, len(all_results), batch_size):
+        batch = all_results[i:i + batch_size]
+        batch_results = dask.compute(*batch)
+        for chunk_lines in batch_results:
+            merged.extend(chunk_lines)
 
     return _deduplicate_by_level(merged)
 

--- a/xrspatial/tests/test_contour.py
+++ b/xrspatial/tests/test_contour.py
@@ -615,6 +615,8 @@ class TestDaskBatchedCompute:
     @dask_array_available
     def test_dask_compute_called_in_batches(self, monkeypatch):
         """_contours_dask computes chunk results in batches, not all at once."""
+        import math
+
         import dask
         import xrspatial.contour as contour_mod
 
@@ -622,24 +624,36 @@ class TestDaskBatchedCompute:
         np_agg = create_test_raster(data, backend='numpy')
         dk_agg = create_test_raster(data, backend='dask+numpy', chunks=(2, 2))
 
-        # Force a small batch size so 16 chunks require multiple compute calls.
-        monkeypatch.setattr(contour_mod, '_DASK_COMPUTE_BATCH_SIZE', 3)
+        # 8x8 with 2x2 chunks -> 16 chunks.
+        num_chunks = 16
+        batch_size = 3
+        expected_batches = math.ceil(num_chunks / batch_size)
+
+        # Force a small batch size so many chunks require multiple compute calls.
+        monkeypatch.setattr(contour_mod, '_DASK_COMPUTE_BATCH_SIZE', batch_size)
 
         original_compute = dask.compute
-        compute_calls = []
 
         def counting_compute(*args, **kwargs):
             compute_calls.append(len(args))
             return original_compute(*args, **kwargs)
 
+        compute_calls = []
+
+        # Run the numpy path first (should not call dask.compute since
+        # levels are explicit, skipping the auto-level path).
+        np_result = contours(np_agg, levels=[2.5, 4.5])
+
+        # Reset the counter so only the dask path's calls are counted.
+        compute_calls.clear()
         monkeypatch.setattr(dask, 'compute', counting_compute)
 
-        np_result = contours(np_agg, levels=[2.5, 4.5])
         dk_result = contours(dk_agg, levels=[2.5, 4.5])
 
-        # 16 chunks / batch size 3 -> 6 compute calls.
-        assert len(compute_calls) == 6, (
-            f"expected 6 batched dask.compute calls, got {len(compute_calls)}"
+        assert len(compute_calls) == expected_batches, (
+            f"expected {expected_batches} batched dask.compute calls "
+            f"(16 chunks / batch {batch_size}), "
+            f"got {len(compute_calls)}"
         )
 
         np_segs = _segments_by_level(np_result)
@@ -648,6 +662,34 @@ class TestDaskBatchedCompute:
         for lvl in np_segs:
             assert np_segs[lvl] == dk_segs[lvl], (
                 f"Batched dask result diverges from numpy at level {lvl}")
+
+    @dask_array_available
+    def test_single_batch_when_chunks_fit(self, monkeypatch):
+        """All chunks fit in one batch when batch size exceeds chunk count."""
+        import dask
+        import xrspatial.contour as contour_mod
+
+        data = _make_ramp(ny=4, nx=4)
+        dk_agg = create_test_raster(data, backend='dask+numpy', chunks=(2, 2))
+
+        # 4 chunks, batch size 64 (default) -> single compute call.
+        monkeypatch.setattr(contour_mod, '_DASK_COMPUTE_BATCH_SIZE', 64)
+
+        compute_calls = []
+        original_compute = dask.compute
+
+        def counting_compute(*args, **kwargs):
+            compute_calls.append(len(args))
+            return original_compute(*args, **kwargs)
+
+        monkeypatch.setattr(dask, 'compute', counting_compute)
+
+        contours(dk_agg, levels=[1.5, 2.5])
+
+        assert len(compute_calls) == 1, (
+            f"expected 1 dask.compute call for 4 chunks with batch size 64, "
+            f"got {len(compute_calls)}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/xrspatial/tests/test_contour.py
+++ b/xrspatial/tests/test_contour.py
@@ -607,6 +607,50 @@ class TestBackendEquivalence:
 
 
 # ---------------------------------------------------------------------------
+# Batched dask compute (#3333)
+# ---------------------------------------------------------------------------
+
+class TestDaskBatchedCompute:
+
+    @dask_array_available
+    def test_dask_compute_called_in_batches(self, monkeypatch):
+        """_contours_dask computes chunk results in batches, not all at once."""
+        import dask
+        import xrspatial.contour as contour_mod
+
+        data = _make_ramp(ny=8, nx=8)
+        np_agg = create_test_raster(data, backend='numpy')
+        dk_agg = create_test_raster(data, backend='dask+numpy', chunks=(2, 2))
+
+        # Force a small batch size so 16 chunks require multiple compute calls.
+        monkeypatch.setattr(contour_mod, '_DASK_COMPUTE_BATCH_SIZE', 3)
+
+        original_compute = dask.compute
+        compute_calls = []
+
+        def counting_compute(*args, **kwargs):
+            compute_calls.append(len(args))
+            return original_compute(*args, **kwargs)
+
+        monkeypatch.setattr(dask, 'compute', counting_compute)
+
+        np_result = contours(np_agg, levels=[2.5, 4.5])
+        dk_result = contours(dk_agg, levels=[2.5, 4.5])
+
+        # 16 chunks / batch size 3 -> 6 compute calls.
+        assert len(compute_calls) == 6, (
+            f"expected 6 batched dask.compute calls, got {len(compute_calls)}"
+        )
+
+        np_segs = _segments_by_level(np_result)
+        dk_segs = _segments_by_level(dk_result)
+        assert set(np_segs.keys()) == set(dk_segs.keys())
+        for lvl in np_segs:
+            assert np_segs[lvl] == dk_segs[lvl], (
+                f"Batched dask result diverges from numpy at level {lvl}")
+
+
+# ---------------------------------------------------------------------------
 # Integer dtype: NaN halo regression (issue #3020)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Closes #3333.

The dask and dask+cupy `contours()` backends previously submitted every delayed chunk task in a single `dask.compute(*all_results)` call. For large dask-backed rasters this materializes all chunk contour results in the client process at once and creates a large single synchronization point for the scheduler. Peak memory therefore scaled with total contour complexity rather than with chunk size.

This change computes chunk results in batches of `_DASK_COMPUTE_BATCH_SIZE` (default 64). Batching bounds the amount of intermediate chunk geometry held in memory at one time and reduces scheduler pressure, while preserving the same final deduplication and stitching behavior.

## Changes
- Added a private `_DASK_COMPUTE_BATCH_SIZE` constant.
- Consolidated `_contours_dask` and `_contours_dask_cupy` into a shared `_contours_dask_generic` helper so the batching logic is not duplicated.
- Added `TestDaskBatchedCompute::test_dask_compute_called_in_batches` to verify that compute is called in multiple batches when the chunk count exceeds the batch size, and that the batched result still matches the numpy backend.

## Testing
- `python -m pytest xrspatial/tests/test_contour.py -q` passes (61 passed, 30 skipped).
- The new test specifically monkey-patches the batch size to 3 for a 16-chunk raster and confirms 6 `dask.compute` calls.

## Notes
This is a targeted fix for the HIGH-severity materialization finding from the 2026-06-15 performance sweep against `xrspatial/contour.py`. The MEDIUM Python-loop-over-chunks finding is related but left as-is to keep the change surgical; future work could vectorize the offset/graph construction if needed.