### PR TITLE
cost_distance: route bounded large-radius dask path to iterative Dijkstra (#3342)

### DIFF
--- a/.claude/sweep-performance-state.csv
+++ b/.claude/sweep-performance-state.csv
@@ -7,7 +7,7 @@ classify,2026-04-16T18:00:00Z,SAFE,compute-bound,0,fixed-in-tree,"Fixed-in-tree 
 contour,2026-03-31T18:00:00Z,SAFE,compute-bound,0,,
 convolution,2026-03-31T18:00:00Z,SAFE,compute-bound,0,,
 corridor,2026-03-31T18:00:00Z,SAFE,compute-bound,0,,
-cost_distance,2026-04-16T12:00:00Z,WILL OOM,memory-bound,4,1118,"Re-audit 2026-04-16 after PR 1192 Bellman-Ford fix. 4 HIGH re-surface in iterative tile_cache path (L645 full-dataset materialization, L1015 da.from_delayed wrapping computed tiles). Finite max_cost path remains SAFE. Unbounded path is fundamentally O(dataset) driver memory — covered by #1118."
+cost_distance,2026-06-15,RISKY,memory-bound,1,3342,"Perf sweep 2026-06-15. HIGH: bounded map_overlap branch in _cost_distance_dask gated on full dims (pad>=height/width) not chunk size; pad>chunk collapses to single chunk (#880-class OOM, verified npartitions=1 at chunks=10/pad=96). Fixed: compare pad vs max chunk dim, route to iterative when pad>=chunk (matches GPU path L484). dask+cupy path already correct. Register count 37 (no pressure). nanmin().compute() L478/L1149 intentional scalar. iterative tile_cache full-dataset materialization is documented MemoryError-guarded design (#1118). All 56 tests pass incl GPU."
 curvature,2026-03-31T18:00:00Z,SAFE,compute-bound,0,,
 dasymetric,2026-03-31T18:00:00Z,SAFE,memory-bound,0,1126,Memory guard added to validate_disaggregation. Core disaggregate uses map_blocks.
 diffusion,2026-03-31T18:00:00Z,WILL OOM,memory-bound,2,1116,Scalar diffusivity now passed as float to chunks. DataArray diffusivity passed as dask array via map_overlap.

--- a/benchmarks/benchmarks/cost_distance.py
+++ b/benchmarks/benchmarks/cost_distance.py
@@ -21,5 +21,16 @@ class CostDistance:
             friction.data = np.abs(friction.data) + 0.1
         self.friction = friction
 
+        # Pick a finite max_cost whose pixel radius stays well inside one
+        # chunk (chunks are ny//2 x nx//2), so the dask path exercises the
+        # bounded map_overlap branch rather than the unbounded iterative
+        # one. radius_px = max_cost / (f_min * cellsize); friction >= 0.1
+        # so using 0.1 keeps the true radius at or below the target.
+        cellsize = min(360.0 / (nx - 1), 180.0 / (ny - 1))
+        self.max_cost = 10 * 0.1 * cellsize
+
     def time_cost_distance(self, nx, type):
         cost_distance(self.agg, self.friction)
+
+    def time_cost_distance_bounded(self, nx, type):
+        cost_distance(self.agg, self.friction, max_cost=self.max_cost)

--- a/xrspatial/cost_distance.py
+++ b/xrspatial/cost_distance.py
@@ -1160,7 +1160,15 @@ def _cost_distance_dask(source_da, friction_da, cellsize_x, cellsize_y,
 
     pad = int(max_radius + 1) if np.isfinite(max_radius) else max_dim
 
-    if not np.isfinite(max_radius) or pad >= height or pad >= width:
+    # map_overlap's depth must not exceed the chunk size; a larger depth makes
+    # dask rechunk toward bigger (eventually single) blocks, defeating
+    # out-of-core processing.  Compare pad against the chunk size, not the full
+    # array dimensions (matches the dask+cupy guard).
+    max_chunk_y = max(source_da.chunks[0])
+    max_chunk_x = max(source_da.chunks[1])
+
+    if (not np.isfinite(max_radius)
+            or pad >= max_chunk_y or pad >= max_chunk_x):
         # Use iterative tile Dijkstra — bounded memory, no single-chunk rechunk
         import warnings
         warnings.warn(

--- a/xrspatial/tests/test_cost_distance.py
+++ b/xrspatial/tests/test_cost_distance.py
@@ -710,6 +710,40 @@ def test_iterative_no_rechunk_to_single():
         "cost_distance rechunked to a single chunk (OOM risk)"
 
 
+@pytest.mark.skipif(da is None, reason="dask not installed")
+def test_bounded_large_radius_no_chunk_collapse():
+    """Finite max_cost with radius > chunk size must not collapse chunks.
+
+    Regression for the #880-class OOM on the bounded path: when the pad
+    radius exceeds the chunk size (but is below the full array dimension),
+    map_overlap would silently rechunk toward a single block. The branch
+    must instead route to the iterative tile Dijkstra.
+    """
+    source = np.zeros((100, 100))
+    source[50, 50] = 1.0
+
+    friction_data = np.ones((100, 100))
+
+    raster_np = _make_raster(source, backend='numpy')
+    friction_np = _make_raster(friction_data, backend='numpy')
+    result_np = cost_distance(raster_np, friction_np, max_cost=95.0)
+
+    raster = _make_raster(source, backend='dask+numpy', chunks=(10, 10))
+    friction = _make_raster(friction_data, backend='dask+numpy', chunks=(10, 10))
+
+    # pad = 96 > chunk size 10 but < full dim 100
+    with pytest.warns(UserWarning, match="iterative tile Dijkstra"):
+        result = cost_distance(raster, friction, max_cost=95.0)
+
+    # The result must keep more than one chunk per axis (no collapse).
+    assert result.data.npartitions > 1, \
+        "bounded large-radius path collapsed to a single chunk (OOM risk)"
+
+    np.testing.assert_allclose(
+        _compute(result), result_np.data, equal_nan=True, atol=1e-4,
+    )
+
+
 # -----------------------------------------------------------------------
 # Memory guard on numpy path (Issue #1252)
 # -----------------------------------------------------------------------


### PR DESCRIPTION
Closes #3342.

## Problem

`cost_distance` on a dask+numpy raster with a finite `max_cost` could rechunk
the input toward a single monolithic chunk and OOM. `_cost_distance_dask`
gated the `map_overlap` vs iterative-tile-Dijkstra branch on the pad radius
versus the full array dimensions:

```python
if not np.isfinite(max_radius) or pad >= height or pad >= width:
```

`map_overlap`'s `depth` must stay within the chunk size. When
`chunk_size <= pad < full_dim`, this still took the `map_overlap` branch with
`depth > chunk_size`, and dask silently rechunked toward larger blocks. With a
large radius it collapsed to one chunk, the same OOM class as #880 (fixed in
#888 for the unbounded path only).

The dask+cupy path already guarded correctly against chunk size.

## Fix

Compare `pad` against the max chunk dimension and route to the iterative tile
Dijkstra when it would overflow a chunk, matching the dask+cupy guard.

## Verification

- New regression `test_bounded_large_radius_no_chunk_collapse`: chunks (10,10),
  `max_cost=95` (pad 96). Asserts the result keeps >1 partition and matches the
  numpy result. Fails on `main` (collapses to 1 chunk, no iterative warning),
  passes with the fix.
- Full suite: 56 passed, including the GPU and dask+cupy paths (CUDA host).

OOM verdict for the bounded large-radius case: was RISKY, now bounded.
Bottleneck: memory-bound. Affected backend: dask+numpy.
