### PR TITLE
contour: test coverage for all-equal auto-levels and empty explicit levels

### DIFF
--- a/xrspatial/tests/test_contour.py
+++ b/xrspatial/tests/test_contour.py
@@ -1504,7 +1504,7 @@ class TestNaNBackendParity:
 # Coverage gaps: all-equal auto-levels and empty explicit levels (#3352)
 # ---------------------------------------------------------------------------
 
-class TestIssue3352Coverage:
+class TestFlatAutoLevelsAndEmptyLevels:
 
     def test_contours_flat_auto_levels(self):
         """An all-equal raster with auto-levels (levels=None) returns empty.
@@ -1512,11 +1512,12 @@ class TestIssue3352Coverage:
         When vmin == vmax, np.linspace produces identical levels and no
         contours are generated.  Regression guard for the auto-level branch.
         """
-        raster = xr.DataArray(
-            np.ones((10, 10), dtype=np.float64), dims=["y", "x"]
+        raster = create_test_raster(
+            np.ones((10, 10), dtype=np.float64), backend='numpy'
         )
         result = contours(raster, levels=None, n_levels=10)
-        assert result == []
+        assert isinstance(result, list)
+        assert len(result) == 0
 
     def test_contours_empty_explicit_levels_numpy(self):
         """Passing an empty list as levels with numpy return_type returns [].
@@ -1524,19 +1525,22 @@ class TestIssue3352Coverage:
         No crossing can exist with zero levels, so the function returns an
         empty list without raising.
         """
-        raster = xr.DataArray(
-            np.random.rand(10, 10), dims=["y", "x"]
+        raster = create_test_raster(
+            np.random.rand(10, 10), backend='numpy'
         )
-        result = contours(raster, levels=[], return_type="numpy")
+        result = contours(raster, levels=[], return_type='numpy')
+        assert isinstance(result, list)
         assert result == []
 
     def test_contours_empty_explicit_levels_geopandas(self):
         """Passing an empty list as levels with geopandas returns empty gdf."""
-        pytest.importorskip("geopandas")
+        pytest.importorskip('geopandas')
         import geopandas as gpd
-        raster = xr.DataArray(
-            np.random.rand(10, 10), dims=["y", "x"]
+        raster = create_test_raster(
+            np.random.rand(10, 10), backend='numpy'
         )
-        result_gdf = contours(raster, levels=[], return_type="geopandas")
+        result_gdf = contours(raster, levels=[], return_type='geopandas')
         assert isinstance(result_gdf, gpd.GeoDataFrame)
         assert len(result_gdf) == 0
+        assert 'level' in result_gdf.columns
+        assert 'geometry' in result_gdf.columns

--- a/xrspatial/tests/test_contour.py
+++ b/xrspatial/tests/test_contour.py
@@ -1498,3 +1498,45 @@ class TestNaNBackendParity:
         for lvl in np_segs:
             assert np_segs[lvl] == dc_segs[lvl], (
                 f"NaN-input dask+cupy result diverges from numpy at level {lvl}")
+
+
+# ---------------------------------------------------------------------------
+# Coverage gaps: all-equal auto-levels and empty explicit levels (#3352)
+# ---------------------------------------------------------------------------
+
+class TestIssue3352Coverage:
+
+    def test_contours_flat_auto_levels(self):
+        """An all-equal raster with auto-levels (levels=None) returns empty.
+
+        When vmin == vmax, np.linspace produces identical levels and no
+        contours are generated.  Regression guard for the auto-level branch.
+        """
+        raster = xr.DataArray(
+            np.ones((10, 10), dtype=np.float64), dims=["y", "x"]
+        )
+        result = contours(raster, levels=None, n_levels=10)
+        assert result == []
+
+    def test_contours_empty_explicit_levels_numpy(self):
+        """Passing an empty list as levels with numpy return_type returns [].
+
+        No crossing can exist with zero levels, so the function returns an
+        empty list without raising.
+        """
+        raster = xr.DataArray(
+            np.random.rand(10, 10), dims=["y", "x"]
+        )
+        result = contours(raster, levels=[], return_type="numpy")
+        assert result == []
+
+    def test_contours_empty_explicit_levels_geopandas(self):
+        """Passing an empty list as levels with geopandas returns empty gdf."""
+        pytest.importorskip("geopandas")
+        import geopandas as gpd
+        raster = xr.DataArray(
+            np.random.rand(10, 10), dims=["y", "x"]
+        )
+        result_gdf = contours(raster, levels=[], return_type="geopandas")
+        assert isinstance(result_gdf, gpd.GeoDataFrame)
+        assert len(result_gdf) == 0

--- a/xrspatial/tests/test_contour.py
+++ b/xrspatial/tests/test_contour.py
@@ -1530,7 +1530,7 @@ class TestFlatAutoLevelsAndEmptyLevels:
         )
         result = contours(raster, levels=[], return_type='numpy')
         assert isinstance(result, list)
-        assert result == []
+        assert len(result) == 0
 
     def test_contours_empty_explicit_levels_geopandas(self):
         """Passing an empty list as levels with geopandas returns empty gdf."""


### PR DESCRIPTION
Closes #3352

## Summary
- Add `test_contours_flat_auto_levels` — asserts an all-equal raster with `levels=None` returns `[]` (covers the `vmin == vmax` branch in auto-level generation)
- Add `test_contours_empty_explicit_levels_numpy` — asserts `levels=[]` with numpy return type returns `[]`
- Add `test_contours_empty_explicit_levels_geopandas` — asserts `levels=[]` with geopandas return type returns an empty GeoDataFrame

## Backend coverage
Numpy only (both edge cases hit the early-return path before backend dispatch).
