### PR TITLE
Scope 'performance' labeler to benchmarked modules

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,8 +3,12 @@
 # source file, so the benchmarks ran on nearly every PR. Limit the label to
 # the modules the PR-time benchmarks actually measure (the asv `continuous`
 # filter in benchmarks.yml: Slope, Proximity, Zonal, CostDistance, Focal,
-# Rescale/Standardize, Diffusion, Dasymetric). Add a module here when it
-# gains a benchmark in that filter.
+# Rescale/Standardize, Diffusion, Dasymetric), plus the hot compute kernels
+# those benchmarks run through (convolution.py drives Focal; geodesic.py
+# drives Slope). utils.py is deliberately left out: it is shared infra
+# touched by almost every PR, so including it would re-broaden the label
+# back toward the original problem. Add a module here when it gains a
+# benchmark in that filter or becomes a kernel the benchmarks exercise.
 performance:
   - changed-files:
     - any-glob-to-any-file:
@@ -16,3 +20,5 @@ performance:
       - 'xrspatial/normalize.py'
       - 'xrspatial/diffusion.py'
       - 'xrspatial/dasymetric.py'
+      - 'xrspatial/convolution.py'
+      - 'xrspatial/geodesic.py'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,18 @@
+# Applying the `performance` label triggers the ASV benchmark job in
+# benchmarks.yml. The old `xrspatial/**/*.py` glob matched almost every
+# source file, so the benchmarks ran on nearly every PR. Limit the label to
+# the modules the PR-time benchmarks actually measure (the asv `continuous`
+# filter in benchmarks.yml: Slope, Proximity, Zonal, CostDistance, Focal,
+# Rescale/Standardize, Diffusion, Dasymetric). Add a module here when it
+# gains a benchmark in that filter.
 performance:
   - changed-files:
     - any-glob-to-any-file:
-      - 'xrspatial/*.py'
-      - 'xrspatial/**/*.py'
-      - '!xrspatial/tests/**'
+      - 'xrspatial/slope.py'
+      - 'xrspatial/proximity.py'
+      - 'xrspatial/zonal.py'
+      - 'xrspatial/cost_distance.py'
+      - 'xrspatial/focal.py'
+      - 'xrspatial/normalize.py'
+      - 'xrspatial/diffusion.py'
+      - 'xrspatial/dasymetric.py'


### PR DESCRIPTION
Closes #3356

`.github/labeler.yml` matched `xrspatial/*.py` and `xrspatial/**/*.py`, so nearly every code PR picked up the `performance` label. That label is a trigger: `benchmarks.yml` runs the ASV suite whenever a PR carries it, so the benchmark job ran on almost every PR.

- Scope the `performance` rule to the eight modules the PR-time benchmark filter actually measures: `slope.py`, `proximity.py`, `zonal.py`, `cost_distance.py`, `focal.py`, `normalize.py` (Rescale/Standardize), `diffusion.py`, `dasymetric.py`.
- Add a comment tying the label to the asv `continuous` filter in `benchmarks.yml` so the list stays in sync as benchmarks are added.

Keeping the label (rather than removing it) preserves the on-demand benchmark trigger for the PRs that can move the numbers.

Not a code change, so no backend work (numpy / cupy / dask) applies.

Test plan:
- [x] `yaml.safe_load` parses the file and the structure matches the `actions/labeler@v5` schema
- [x] all eight globbed paths exist in the tree