### PR TITLE
Make test_chunks_is_lazy counter thread-safe for the free-threaded CI lane

### DIFF
--- a/xrspatial/geotiff/tests/vrt/test_window.py
+++ b/xrspatial/geotiff/tests/vrt/test_window.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import glob
 import os
 import tempfile
+import threading
 import uuid
 import warnings
 from pathlib import Path
@@ -872,10 +873,17 @@ def test_chunks_is_lazy_does_not_call_internal_reader(monkeypatch, lazy_chunks_t
     vrt_path, _ = lazy_chunks_two_by_two_vrt
     from xrspatial.geotiff import _vrt as vrt_module
     counter = {'calls': 0}
+    # ``compute()`` runs the 16 per-chunk reads through dask's threaded
+    # scheduler, so the counter is incremented from multiple worker threads
+    # concurrently. Guard the read-modify-write with a lock: a bare
+    # ``counter['calls'] += 1`` loses updates under the free-threaded
+    # interpreter (PYTHON_GIL=0), undercounting the decodes (issue #3363).
+    counter_lock = threading.Lock()
     real_read = vrt_module.read_vrt
 
     def counting_read(*args, **kwargs):
-        counter['calls'] += 1
+        with counter_lock:
+            counter['calls'] += 1
         return real_read(*args, **kwargs)
     monkeypatch.setattr(vrt_module, 'read_vrt', counting_read)
     result = _read_vrt(vrt_path, chunks=(64, 64))


### PR DESCRIPTION
Closes #3363

The `3.14t` full-suite job on `main` fails on one test:

```
test_chunks_is_lazy_does_not_call_internal_reader
  AssertionError: expected 16 per-chunk decodes after compute, got 15
```

`result.compute()` runs the 16 per-chunk reads through dask's threaded scheduler. Under `PYTHON_GIL=0` (the `3.14t` pytest step) those run truly in parallel, and the counting wrapper's `counter['calls'] += 1` is a non-atomic read-modify-write that loses an update, so 16 real decodes count as 15.

- Guard the increment with a `threading.Lock` so the count is exact under both the GIL and the free-threaded interpreter.
- Test-instrumentation fix only: the chunked decode already runs 16 times and returns correct data. No product code changes.
- Only this test is affected; the other counter-based tests assert a single non-concurrent call (`== 1`) and can't lose an update.

Surfaced by the `3.14t` lane (#3360). That job is allowed-failure, so `main` still concludes success, but this clears the red.

Test plan:
- [ ] `pytest xrspatial/geotiff/tests/vrt/test_window.py` passes under the GIL (no regression).
- [ ] `3.14t` full lane goes green.
