### PR TITLE
Add datashader to doc extra for RTD builds (#3427)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,8 +52,6 @@ doc =
     sphinx
     sphinx-panels
     sphinx_rtd_theme
-examples =
-    # datashader moved to doc extra; install [doc] for notebook dependencies
 plot =
     # Optional for the .xrs.plot accessor helpers. Every matplotlib
     # import in the package is lazy, so the compute functions work

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ xarray.backends =
 
 [options.extras_require]
 doc =
+    datashader >= 0.15.0
     dask[dataframe]
     geopandas
     Jinja2 >=2.11

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ doc =
     sphinx-panels
     sphinx_rtd_theme
 examples =
-    datashader >= 0.15.0
+    # datashader moved to doc extra; install [doc] for notebook dependencies
 plot =
     # Optional for the .xrs.plot accessor helpers. Every matplotlib
     # import in the package is lazy, so the compute functions work


### PR DESCRIPTION
Closes #3427

- Added `datashader >= 0.15.0` to the `doc` extra in `setup.cfg` so it gets installed during ReadTheDocs builds via `pip install '.[doc,tests]'`
- Fixes `ModuleNotFoundError: No module named 'datashader'` in the `fire.ipynb` and `pathfinding.ipynb` user-guide notebooks

No new functions or backend changes — this is a packaging fix for the docs build environment.