### PR TITLE
Fix stale perlin test that pins dropped-coords behavior (main is red)

### DIFF
--- a/xrspatial/tests/test_perlin.py
+++ b/xrspatial/tests/test_perlin.py
@@ -319,17 +319,16 @@ def test_perlin_preserves_dims_and_attrs():
     assert out.attrs == src.attrs
 
 
-def test_perlin_drops_input_coords():
-    # Pins current behavior: perlin() rebuilds the output from dims + attrs but
-    # not coords, so input coordinate variables are dropped.  This is a known
-    # bug -- see the perlin "drops input coordinates from output" issue.  Flip
-    # this to assert the coords ARE preserved once that is fixed.
+def test_perlin_preserves_input_coords():
+    # perlin() preserves the caller's x/y coordinates on the output (#3470).
     src = xr.DataArray(np.zeros((10, 12), dtype=np.float32), dims=['lat', 'lon'])
     src['lat'] = np.arange(10)
     src['lon'] = np.arange(12)
     out = perlin(src)
-    assert 'lat' not in out.coords
-    assert 'lon' not in out.coords
+    assert 'lat' in out.coords
+    assert 'lon' in out.coords
+    np.testing.assert_array_equal(out['lat'].values, src['lat'].values)
+    np.testing.assert_array_equal(out['lon'].values, src['lon'].values)
 
 
 def test_perlin_docstring_documents_name():


### PR DESCRIPTION
`main` is currently red on the `run (..., 3.14)` checks. The matrix runs fail-fast, so when the ubuntu 3.14 job fails the macOS/Windows/3.14t jobs report as canceled, but there is only one real failure:

```
FAILED xrspatial/tests/test_perlin.py::test_perlin_drops_input_coords
AssertionError: assert 'lat' not in Coordinates: ...
```

This is a merge race between two perlin PRs:

- #3472 added `test_perlin_drops_input_coords`, pinning the old behavior where `perlin()` dropped input coordinates. Its comment says to "Flip this to assert the coords ARE preserved once that is fixed."
- #3470 then changed `perlin()` to preserve the caller's x/y coordinates, but did not update the pinning test.

They merged in an order that left the test asserting behavior the code no longer has.

This flips the test to match the shipped behavior: it now asserts the coordinates are preserved and equal to the input, and is renamed `test_perlin_preserves_input_coords`. No source changes; `perlin()` already does the right thing.

Test plan:
- [x] `pytest xrspatial/tests/test_perlin.py` — 31 passed