### PR TITLE
Fix stale perlin coords test left red by #3470

### DIFF
--- a/xrspatial/tests/test_perlin.py
+++ b/xrspatial/tests/test_perlin.py
@@ -319,17 +319,17 @@ def test_perlin_preserves_dims_and_attrs():
     assert out.attrs == src.attrs
 
 
-def test_perlin_drops_input_coords():
-    # Pins current behavior: perlin() rebuilds the output from dims + attrs but
-    # not coords, so input coordinate variables are dropped.  This is a known
-    # bug -- see the perlin "drops input coordinates from output" issue.  Flip
-    # this to assert the coords ARE preserved once that is fixed.
+def test_perlin_preserves_input_coords():
+    # perlin() now carries the input coordinate variables through to the output
+    # (see #3470).  The output keeps the same lat/lon coords as the input.
     src = xr.DataArray(np.zeros((10, 12), dtype=np.float32), dims=['lat', 'lon'])
     src['lat'] = np.arange(10)
     src['lon'] = np.arange(12)
     out = perlin(src)
-    assert 'lat' not in out.coords
-    assert 'lon' not in out.coords
+    assert 'lat' in out.coords
+    assert 'lon' in out.coords
+    np.testing.assert_array_equal(out['lat'].values, src['lat'].values)
+    np.testing.assert_array_equal(out['lon'].values, src['lon'].values)
 
 
 def test_perlin_docstring_documents_name():


### PR DESCRIPTION
## Problem

`main` is red. `test_perlin_drops_input_coords` asserts perlin drops input coordinates:

```python
assert 'lat' not in out.coords
assert 'lon' not in out.coords
```

But #3470 ("perlin: preserve input x/y coordinates on the output") changed `perlin()` to keep them (`coords=agg.coords` in `perlin.py`). The behavior changed without the test being flipped, so the test now fails on every PR that merges main. The test's own comment already anticipated this: "Flip this to assert the coords ARE preserved once that is fixed."

## Fix

Rename the test to `test_perlin_preserves_input_coords` and assert the coords are present and unchanged, matching the behavior #3470 shipped. No production code changes.

## Test plan
- [x] `pytest xrspatial/tests/test_perlin.py` -> 31 passed
- [x] flake8 clean

Surfaced while merging main into the `from_template` branch (#3487); this is the only check blocking that PR.