### PR TITLE
Style: fix E305 and isort import ordering in flood.py

### DIFF
--- a/xrspatial/flood.py
+++ b/xrspatial/flood.py
@@ -28,13 +28,8 @@ try:
 except ImportError:
     da = None
 
-from xrspatial.utils import (
-    _dask_task_name_kwargs,
-    _validate_raster,
-    has_cuda_and_cupy,
-    is_cupy_array,
-    is_dask_cupy,
-)
+from xrspatial.utils import (_dask_task_name_kwargs, _validate_raster, has_cuda_and_cupy,
+                             is_cupy_array, is_dask_cupy)
 
 # Minimum tan(slope) clamp: tan(0.001 deg), same as TWI
 _TAN_MIN = np.tan(np.radians(0.001))
@@ -57,6 +52,7 @@ def _validate_mannings_n_dataarray(mannings_n):
             "mannings_n DataArray must contain finite, strictly positive "
             "values (no zeros, negatives, NaN, or Inf)."
         )
+
 
 # ---------------------------------------------------------------------------
 # NLCD-to-Manning's n lookup (Chow 1959; Arcement & Schneider 1989)


### PR DESCRIPTION
Style sweep cleanup for `xrspatial/flood.py`. Two findings, both reported by the project's configured tooling (`setup.cfg`: flake8 `max-line-length=100`, isort `line_length=100`).

Categories addressed:
- Cat 1 (flake8 E305): added the missing second blank line between `_validate_mannings_n_dataarray` and the `NLCD_MANNINGS_N` module-level assignment.
- Cat 4 (isort): collapsed the `from xrspatial.utils import (...)` block to the configured `line_length=100` form, matching the style other modules were brought to in earlier style sweeps.

No behavioural change. Both fixes are pure formatting.

Test plan:
- [x] `flake8 xrspatial/flood.py` clean
- [x] `isort --check-only --diff xrspatial/flood.py` clean
- [x] `pytest xrspatial/tests/test_flood.py` (88 passed)