### PR TITLE
Document num_sample=None in natural_breaks docstring

### DIFF
--- a/xrspatial/classify.py
+++ b/xrspatial/classify.py
@@ -848,8 +848,11 @@ def natural_breaks(agg: xr.DataArray,
         where n is the total number of data points, i.e: `agg.size`
         When n is large, we should fit the model on a small sub-sample
         of the data instead of using the whole dataset.
-        ``None`` means use all data (safe for numpy/cupy,
-        automatically capped for dask).
+        ``None`` means fit on all data instead of a sub-sample. That is
+        the full O(n²) case described above, so it may be slow and raises
+        ``MemoryError`` if the Jenks matrices would exceed half of the
+        available RAM. For dask the full sample is drawn lazily via
+        indexed access.
     name : str, default='natural_breaks'
         Name of output aggregate.
 

--- a/xrspatial/classify.py
+++ b/xrspatial/classify.py
@@ -842,12 +842,14 @@ def natural_breaks(agg: xr.DataArray,
         of values to be reclassified.
     k : int, default=5
         Number of classes to be produced.
-    num_sample : int, default=20000
+    num_sample : int or None, default=20000
         Number of sample data points used to fit the model.
         Natural Breaks (Jenks) classification is indeed O(n²) complexity,
         where n is the total number of data points, i.e: `agg.size`
         When n is large, we should fit the model on a small sub-sample
         of the data instead of using the whole dataset.
+        ``None`` means use all data (safe for numpy/cupy,
+        automatically capped for dask).
     name : str, default='natural_breaks'
         Name of output aggregate.
 


### PR DESCRIPTION
Closes #3501.

`natural_breaks` already accepts `num_sample=None` (use all data) the same
way `quantile`, `maximum_breaks`, and `percentiles` do, but its docstring
only described `num_sample` as `int` and never mentioned `None`. This brings
the wording in line with the other three classifiers.

Docstring only. No signature or behavior change.

Verified `natural_breaks(agg, k=5, num_sample=None)` on both the numpy and
cupy backends. `pytest xrspatial/tests/test_classify.py -k natural_breaks`
passes (22 passed).
