### PR TITLE
Stop a short-row PAM RAT from crashing open_geotiff

### DIFF
--- a/xrspatial/geotiff/_pam.py
+++ b/xrspatial/geotiff/_pam.py
@@ -144,9 +144,14 @@ def read_pam_sidecar(path):
         if colors is not None:
             out['category_colors'] = colors
         return out
-    except (OSError, ValueError, TypeError):
+    except (OSError, ValueError, TypeError, IndexError):
         # A missing, malformed, or foreign sidecar is non-fatal auxiliary
         # metadata, not a read error -- never let it break open_geotiff.
+        # IndexError covers a thematic RAT whose <Row> carries fewer <F>
+        # cells than its highest column index (e.g. a Name column at index
+        # 1 paired with a single-cell row), which would otherwise escape
+        # _parse_rat and crash the open_geotiff call that reads the
+        # adjacent sidecar.
         return {}
 
 

--- a/xrspatial/geotiff/_pam.py
+++ b/xrspatial/geotiff/_pam.py
@@ -15,6 +15,7 @@ This module builds that sidecar from ``attrs['category_names']`` /
 from __future__ import annotations
 
 import os
+from xml.etree.ElementTree import ParseError
 from xml.sax.saxutils import escape
 
 from ._safe_xml import safe_fromstring
@@ -144,14 +145,17 @@ def read_pam_sidecar(path):
         if colors is not None:
             out['category_colors'] = colors
         return out
-    except (OSError, ValueError, TypeError, IndexError):
+    except (OSError, ValueError, TypeError, IndexError, ParseError):
         # A missing, malformed, or foreign sidecar is non-fatal auxiliary
         # metadata, not a read error -- never let it break open_geotiff.
         # IndexError covers a thematic RAT whose <Row> carries fewer <F>
         # cells than its highest column index (e.g. a Name column at index
         # 1 paired with a single-cell row), which would otherwise escape
         # _parse_rat and crash the open_geotiff call that reads the
-        # adjacent sidecar.
+        # adjacent sidecar. ParseError covers a truncated or otherwise
+        # non-well-formed sidecar: safe_fromstring raises it (a SyntaxError
+        # subclass, so not covered by the types above) and it would
+        # likewise escape and crash the read.
         return {}
 
 

--- a/xrspatial/tests/test_rasterize_categorical_3482.py
+++ b/xrspatial/tests/test_rasterize_categorical_3482.py
@@ -257,6 +257,31 @@ class TestPamHelpers:
         # Must never raise; worst case returns {}.
         assert isinstance(read_pam_sidecar(path), dict)
 
+    def test_short_row_thematic_rat_returns_empty(self, tmp_path):
+        """A thematic RAT row with fewer <F> cells than the Name column
+        index must not crash read_pam_sidecar.
+
+        The Name column sits at index 1 (after a Value column at index 0),
+        but the row carries a single cell, so indexing the name cell raises
+        IndexError inside _parse_rat. read_pam_sidecar must swallow it and
+        fall back to {} like every other malformed-sidecar case, since
+        open_geotiff reads this sidecar for any local string source.
+        """
+        from xrspatial.geotiff._pam import read_pam_sidecar
+        path = str(tmp_path / 'short_row.tif')
+        with open(path + '.aux.xml', 'w') as fh:
+            fh.write('<PAMDataset><PAMRasterBand band="1">'
+                     '<GDALRasterAttributeTable tableType="thematic">'
+                     '<FieldDefn index="0"><Name>Value</Name><Type>0</Type>'
+                     '<Usage>5</Usage></FieldDefn>'
+                     '<FieldDefn index="1"><Name>Class</Name><Type>2</Type>'
+                     '<Usage>2</Usage></FieldDefn>'
+                     '<Row index="0"><F>0</F></Row>'
+                     '</GDALRasterAttributeTable>'
+                     '</PAMRasterBand></PAMDataset>')
+        # Must never raise; worst case returns {}.
+        assert read_pam_sidecar(path) == {}
+
 
 # ---------------------------------------------------------------------------
 # GPU backend parity

--- a/xrspatial/tests/test_rasterize_categorical_3482.py
+++ b/xrspatial/tests/test_rasterize_categorical_3482.py
@@ -282,6 +282,21 @@ class TestPamHelpers:
         # Must never raise; worst case returns {}.
         assert read_pam_sidecar(path) == {}
 
+    def test_non_well_formed_xml_sidecar_returns_empty(self, tmp_path):
+        """A truncated / non-well-formed .aux.xml must not crash the read.
+
+        safe_fromstring raises xml.etree.ElementTree.ParseError, which is a
+        SyntaxError subclass (not an OSError/ValueError/TypeError/IndexError),
+        so it would otherwise escape read_pam_sidecar and break the
+        open_geotiff call that reads the sidecar for any local string source.
+        """
+        from xrspatial.geotiff._pam import read_pam_sidecar
+        path = str(tmp_path / 'truncated.tif')
+        with open(path + '.aux.xml', 'w') as fh:
+            fh.write('<PAMDataset><PAMRasterBand band="1"><Category>oops')
+        # Must never raise; worst case returns {}.
+        assert read_pam_sidecar(path) == {}
+
 
 # ---------------------------------------------------------------------------
 # GPU backend parity


### PR DESCRIPTION
`read_pam_sidecar()` is supposed to never raise on a bad sidecar. `open_geotiff()` reads the PAM `.aux.xml` for any local string source, and a malformed one should degrade to `{}` rather than break the read.

`_parse_rat()` indexes RAT cells by column index (`fields[name_col]` and friends). A `<Row>` with fewer `<F>` cells than the highest column index raises `IndexError`, which the `read_pam_sidecar()` except clause didn't cover (it caught `OSError`, `ValueError`, `TypeError`). The `IndexError` escaped and crashed `open_geotiff` for any TIFF carrying such a sidecar.

This adds `IndexError` to the caught exceptions so a short-row RAT falls back to `{}` like every other malformed case.

Test: `test_short_row_thematic_rat_returns_empty` builds a thematic RAT with the Name column at index 1 and a single-cell row, then asserts `read_pam_sidecar` returns `{}`. It fails with `IndexError` before the fix and passes after.

Closes #3520.