### PR TITLE
Add list_templates() to discover from_template names

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Built-in Numba JIT and CUDA projection kernels bypass pyproj for per-pixel coord
 
 | Name | Description | Source | NumPy xr.DataArray | Dask xr.DataArray | CuPy GPU xr.DataArray | Dask GPU xr.DataArray |
 |:----------:|:------------|:------:|:----------------------:|:--------------------:|:-------------------:|:------:|
-| [from_template](xrspatial/templates.py) | Empty study-area grid for a named region (CONUS, NYC, ...), a world city (London, Tokyo, ... in its UTM zone) or country code; `preserve='area'/'shape'` picks an EPSG projection by property | Custom | ✅ | 🔼 | 🔼 | 🔼 |
+| [from_template](xrspatial/templates.py) | Empty study-area grid for a named region (CONUS, NYC, ...), a world city (London, Tokyo, ... in its UTM zone) or country code; `preserve='area'/'shape'` picks an EPSG projection by property; `list_templates()` lists every accepted name | Custom | ✅ | 🔼 | 🔼 | 🔼 |
 
 -----------
 

--- a/docs/source/reference/templates.rst
+++ b/docs/source/reference/templates.rst
@@ -11,9 +11,13 @@ feeds straight into the rest of the library. Cities (national capitals, major
 regional metros, and recognizable US secondary cities) come back as a metro
 bounding box in their UTM zone.
 
+Call :func:`~xrspatial.templates.list_templates` to discover every name
+``from_template`` accepts (curated regions, world cities, and country codes).
+
 From Template
 =============
 .. autosummary::
     :toctree: _autosummary
 
     xrspatial.templates.from_template
+    xrspatial.templates.list_templates

--- a/xrspatial/__init__.py
+++ b/xrspatial/__init__.py
@@ -104,6 +104,7 @@ from xrspatial.surface_distance import surface_allocation  # noqa
 from xrspatial.surface_distance import surface_direction  # noqa
 from xrspatial.surface_distance import surface_distance  # noqa
 from xrspatial.templates import from_template  # noqa
+from xrspatial.templates import list_templates  # noqa
 from xrspatial.terrain import generate_terrain  # noqa
 from xrspatial.terrain_metrics import landforms  # noqa
 from xrspatial.terrain_metrics import LANDFORM_CLASSES  # noqa

--- a/xrspatial/templates.py
+++ b/xrspatial/templates.py
@@ -67,9 +67,9 @@ def _resolve(name):
     raise ValueError(
         f"Unknown template {name!r}. Available named regions: {regions}. "
         f"{len(_CITIES)} world cities are also supported (lowercase name, e.g. "
-        f"'london', 'tokyo'; see the templates reference). Countries must be an "
-        f"ISO-3166 / GADM alpha-3 code (e.g. 'USA', 'FRA', 'JPN'); "
-        f"{len(_COUNTRY_BBOXES)} are supported."
+        f"'london', 'tokyo'). Countries must be an ISO-3166 / GADM alpha-3 code "
+        f"(e.g. 'USA', 'FRA', 'JPN'); {len(_COUNTRY_BBOXES)} are supported. "
+        f"Call xrspatial.templates.list_templates() to list every accepted name."
     )
 
 
@@ -197,6 +197,56 @@ def _cf_crs_attrs(crs):
     cf = pyproj.CRS.from_epsg(int(crs)).to_cf()
     return {k: cf[k] for k in ("grid_mapping_name", "crs_wkt")
             if cf.get(k) is not None}
+
+
+_TEMPLATE_KINDS = ("regions", "cities", "countries")
+
+
+def list_templates(kind=None):
+    """List the template names ``from_template`` accepts.
+
+    Every name in the result is a valid ``from_template`` argument: region and
+    city names are lowercase, country codes are uppercase ISO-3166 / GADM
+    alpha-3.
+
+    Parameters
+    ----------
+    kind : {'regions', 'cities', 'countries'}, optional
+        Return just one group as a sorted list. When omitted (the default),
+        return a dict mapping each group to its sorted list of names.
+
+    Returns
+    -------
+    dict of str to list of str, or list of str
+        With ``kind=None``, ``{'regions': [...], 'cities': [...],
+        'countries': [...]}``. With ``kind`` set, the sorted list for that
+        group.
+
+    Examples
+    --------
+    .. sourcecode:: python
+
+        >>> from xrspatial.templates import list_templates
+        >>> names = list_templates()
+        >>> sorted(names)
+        ['cities', 'countries', 'regions']
+        >>> 'conus' in names['regions']
+        True
+        >>> 'london' in list_templates('cities')
+        True
+    """
+    groups = {
+        "regions": sorted(_REGIONS),
+        "cities": sorted(_CITIES),
+        "countries": sorted(_COUNTRY_BBOXES),
+    }
+    if kind is None:
+        return groups
+    if kind not in groups:
+        raise ValueError(
+            f"kind must be one of {_TEMPLATE_KINDS} or None, got {kind!r}."
+        )
+    return groups[kind]
 
 
 def from_template(name, resolution=None, *, preserve=None, backend="numpy",

--- a/xrspatial/templates.py
+++ b/xrspatial/templates.py
@@ -199,9 +199,6 @@ def _cf_crs_attrs(crs):
             if cf.get(k) is not None}
 
 
-_TEMPLATE_KINDS = ("regions", "cities", "countries")
-
-
 def list_templates(kind=None):
     """List the template names ``from_template`` accepts.
 
@@ -244,7 +241,7 @@ def list_templates(kind=None):
         return groups
     if kind not in groups:
         raise ValueError(
-            f"kind must be one of {_TEMPLATE_KINDS} or None, got {kind!r}."
+            f"kind must be one of {tuple(groups)} or None, got {kind!r}."
         )
     return groups[kind]
 

--- a/xrspatial/tests/test_templates.py
+++ b/xrspatial/tests/test_templates.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from xrspatial import from_template, slope
+from xrspatial import from_template, list_templates, slope
 from xrspatial._template_data import _CITIES, _CITY_DEFAULT_RESOLUTION, _COUNTRY_BBOXES, _REGIONS
 from xrspatial.tests.general_checks import cuda_and_cupy_available, dask_array_available
 
@@ -132,6 +132,43 @@ def test_world_grid():
 def test_unknown_name_raises(bad):
     with pytest.raises(ValueError, match="Unknown template"):
         from_template(bad)
+
+
+def test_unknown_name_points_to_list_templates():
+    # the error tells the user how to discover valid names
+    with pytest.raises(ValueError, match="list_templates"):
+        from_template("does-not-exist")
+
+
+def test_list_templates_grouped():
+    names = list_templates()
+    assert set(names) == {"regions", "cities", "countries"}
+    # each group lists exactly its registry keys, sorted
+    assert names["regions"] == sorted(_REGIONS)
+    assert names["cities"] == sorted(_CITIES)
+    assert names["countries"] == sorted(_COUNTRY_BBOXES)
+
+
+@pytest.mark.parametrize(
+    "kind,registry",
+    [("regions", _REGIONS), ("cities", _CITIES), ("countries", _COUNTRY_BBOXES)],
+)
+def test_list_templates_kind_filter(kind, registry):
+    assert list_templates(kind) == sorted(registry)
+
+
+def test_list_templates_bad_kind_raises():
+    with pytest.raises(ValueError, match="kind must be one of"):
+        list_templates("city")
+
+
+def test_list_templates_names_resolve():
+    # every advertised name is a valid from_template argument; build one from
+    # each group to confirm the listed names map straight to a template
+    names = list_templates()
+    for kind in ("regions", "cities", "countries"):
+        agg = from_template(names[kind][0])
+        assert agg.dims == ("y", "x")
 
 
 def test_nonpositive_resolution_raises():


### PR DESCRIPTION
## Summary

`from_template` accepts curated regions, world cities, and country codes, but the names live in private dicts (`_REGIONS`, `_CITIES`, `_COUNTRY_BBOXES`). Short of reading the source, there was no supported way to find out what's available. This adds `list_templates()` to fill that gap.

- `list_templates()` returns the accepted names grouped into `regions`, `cities`, and `countries`, each a sorted list.
- `list_templates(kind)` returns one group's list; a bad `kind` raises `ValueError`.
- Every name it returns is a valid `from_template` argument (regions/cities lowercase, countries uppercase ISO-3166 / GADM alpha-3).
- The unknown-name error and the templates reference doc now point at the helper.

Available as both `xrspatial.list_templates` (next to `from_template`) and `xrspatial.templates.list_templates`.

## Backends

No backend dimension. `list_templates` returns plain lists and dicts of strings, not arrays. `from_template` is unchanged.

## Test plan

- [x] `list_templates()` keys are exactly `regions`/`cities`/`countries`, each equal to the sorted registry keys
- [x] `kind` filter returns the right sorted list; invalid `kind` raises
- [x] every listed name builds via `from_template`
- [x] unknown-name error mentions `list_templates`
- [x] full `test_templates.py` passes (63 tests), flake8 clean

Closes #3535