### PR TITLE
Guard the datashader import in the rasterizer benchmark

### DIFF
--- a/benchmarks/rasterizer_benchmarks.py
+++ b/benchmarks/rasterizer_benchmarks.py
@@ -21,7 +21,6 @@ from datetime import datetime, timezone
 
 import numpy as np
 import geopandas as gpd
-import spatialpandas
 from rasterio.features import rasterize as rio_rasterize
 from rasterio.transform import from_bounds
 from shapely.geometry import (
@@ -29,9 +28,19 @@ from shapely.geometry import (
     box,
 )
 
-import datashader as ds
 from geocube.api.core import make_geocube
 from xrspatial.rasterize import rasterize as xrs_rasterize
+
+# datashader is a deliberate A/B comparison here but is no longer a default
+# dependency. Guard the import (and spatialpandas, which only feeds the
+# datashader path) so the benchmark still runs when it is absent; the
+# datashader column is skipped in that case.
+try:
+    import datashader as ds
+    import spatialpandas
+    HAS_DATASHADER = True
+except ImportError:
+    HAS_DATASHADER = False
 
 
 # ---------------------------------------------------------------------------
@@ -598,7 +607,7 @@ def main():
     for gen_name, gen_cfg in GENERATORS.items():
         gen_fn = gen_cfg["fn"]
         kind = gen_cfg["kind"]
-        use_datashader = kind == "polygon"
+        use_datashader = kind == "polygon" and HAS_DATASHADER
 
         for n in feature_counts:
             geoms, vals = gen_fn(n, rng)


### PR DESCRIPTION
Closes #3452.

`benchmarks/rasterizer_benchmarks.py` keeps datashader as a deliberate A/B comparison, so it stays referenced. But once datashader is no longer installed by default, the unconditional `import datashader as ds` made the whole script fail to run. This wraps that import (plus spatialpandas, which only feeds the datashader path) in a try/except.

- With datashader present, `HAS_DATASHADER` is True and the full comparison runs unchanged.
- With it absent, `HAS_DATASHADER` is False, the polygon path skips the datashader timing run, and the datashader cells show `--` (same as how the cupy column already handles a missing backend).

Backend coverage: not applicable, this is a benchmark script rather than a spatial op.

Test plan:
- With datashader installed: confirmed `HAS_DATASHADER` is True and datashader takes part in both the timing and consistency runs.
- With datashader and spatialpandas blocked at import: confirmed `HAS_DATASHADER` is False, the script imports, the xrspatial/geocube/rasterio runners and consistency checks still work, and the markdown report builds.
- `py_compile` passes.
- No packaged unit test: the standalone benchmark scripts have no pytest coverage, and importing this one pulls in benchmark-only deps (geocube, spatialpandas) that the CI test env does not have.

https://claude.ai/code/session_01TF3CsJ7nee9agjajEWLw5d