### PR TITLE
Sort templates.py imports to match the project isort config

### DIFF
--- a/xrspatial/templates.py
+++ b/xrspatial/templates.py
@@ -14,8 +14,7 @@ import xarray as xr
 
 from xrspatial._template_data import (_CITIES, _CITY_DEFAULT_RESOLUTION, _COUNTRY_BBOXES,
                                       _COUNTRY_DEFAULT_RESOLUTION, _EQUAL_AREA_FALLBACK_EPSG,
-                                      _REGION_ALIASES, _REGIONS, _UPS_NORTH_EPSG,
-                                      _UPS_SOUTH_EPSG)
+                                      _REGION_ALIASES, _REGIONS, _UPS_NORTH_EPSG, _UPS_SOUTH_EPSG)
 from xrspatial.reproject._crs_utils import _require_pyproj, _resolve_crs
 from xrspatial.reproject._grid import _edge_samples, _make_output_coords, _transform_boundary
 


### PR DESCRIPTION
Closes #3577.

Runs isort over `xrspatial/templates.py` so the `_template_data` import block matches the project's `line_length = 100` config. flake8 was already clean; this is the only style finding in the module.

- Collapses the `_UPS_NORTH_EPSG` / `_UPS_SOUTH_EPSG` import onto one line (98 chars, within the limit)
- Imports only, no runtime behavior change

Test plan:
- [x] `isort --check-only --diff xrspatial/templates.py` passes
- [x] `flake8 xrspatial/templates.py` stays clean