### PR TITLE
ci: pin libjxl to 0.11.* in geotiff-corpus and cog-validator envs

### DIFF
--- a/.github/workflows/test-cog-validator.yml
+++ b/.github/workflows/test-cog-validator.yml
@@ -70,6 +70,12 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up micromamba env (conda-forge rio-cogeo + GDAL)
+      # libjxl is pinned to 0.11.* because conda-forge published libjxl
+      # 0.12.0 (2026-07-03) before rebuilding libgdal-core / rasterio
+      # against it, so an unpinned solve pairs a GDAL linked to
+      # libjxl.so.0.11 with only 0.12 installed and rasterio fails to
+      # import. Drop the pin once conda-forge ships libgdal-core /
+      # rasterio builds linked against libjxl 0.12.
       uses: mamba-org/setup-micromamba@v1
       with:
         environment-name: xrspatial-cog-validator
@@ -80,6 +86,7 @@ jobs:
           rio-cogeo
           pyyaml
           tifffile
+          libjxl=0.11.*
         condarc: |
           channels:
             - conda-forge

--- a/.github/workflows/test-geotiff-corpus.yml
+++ b/.github/workflows/test-geotiff-corpus.yml
@@ -41,6 +41,12 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up micromamba env (conda-forge rasterio + GDAL)
+      # libjxl is pinned to 0.11.* because conda-forge published libjxl
+      # 0.12.0 (2026-07-03) before rebuilding libgdal-core / rasterio
+      # against it, so an unpinned solve pairs a GDAL linked to
+      # libjxl.so.0.11 with only 0.12 installed and rasterio fails to
+      # import. Drop the pin once conda-forge ships libgdal-core /
+      # rasterio builds linked against libjxl 0.12.
       uses: mamba-org/setup-micromamba@v1
       with:
         environment-name: xrspatial-geotiff
@@ -50,6 +56,7 @@ jobs:
           gdal
           pyyaml
           tifffile
+          libjxl=0.11.*
         condarc: |
           channels:
             - conda-forge


### PR DESCRIPTION
pytest-geotiff-corpus and pytest-cog-validator have been red on main since 2026-07-03. Both die at the rasterio import check:

```
ImportError: libjxl.so.0.11: cannot open shared object file: No such file or directory
```

conda-forge published libjxl 0.12.0 on 2026-07-03. The libgdal-core 3.12.3 and rasterio 1.5.0 builds we get are still linked against libjxl 0.11, and nothing in their metadata caps libjxl below 0.12, so a fresh solve installs 0.12.0 next to binaries that want `libjxl.so.0.11` (`libjxl.0.11.dylib` on macOS, where the loader error names `libgdal.38.3.12.3.dylib` as the culprit). The last green run (2026-07-03 04:43 UTC) solved libjxl 0.11.2 with the exact same libgdal-core and rasterio builds, so this is purely an upstream packaging gap, not a repo change.

Fix: add `libjxl=0.11.*` to the micromamba create-args in both workflows. A local dry-run solve with the pin reproduces the last green combination (libjxl 0.11.2, libgdal-core 3.12.3 he63569f_3, rasterio 1.5.0). Once conda-forge rebuilds the GDAL stack against libjxl 0.12 the pin should come back out; there's a comment in both workflow files saying so.