### PR TITLE
Fix _parse_rat to pad category_names to pixel indices for sparse RATs

### DIFF
--- a/xrspatial/geotiff/_pam.py
+++ b/xrspatial/geotiff/_pam.py
@@ -191,13 +191,21 @@ def read_pam_sidecar(path):
         return {}
 
 
+_MAX_CATEGORIES = 1_000_000
+
+
 def _parse_rat(rat):
     """Return (names, colors) from a thematic ``<GDALRasterAttributeTable>``.
 
     Returns ``(None, None)`` when the table has no Name column, i.e. it does
-    not describe categories. ``names`` is ordered by the row's Value column;
-    ``colors`` is the RGBA list when the RAT defines color columns, else
-    ``None``.
+    not describe categories. ``names`` is index-aligned to pixel values
+    (index == pixel value), padded with empty strings for gaps between
+    sparse RAT rows. ``colors`` is the RGBA list when the RAT defines color
+    columns, else ``None``; gaps are padded with ``(0, 0, 0, 0)``.
+
+    Fails closed (returns ``(None, None)``) on negative pixel values or a
+    maximum value exceeding ``_MAX_CATEGORIES``, which would otherwise
+    allocate a list large enough to OOM.
     """
     usage_to_col = {}
     for fd in rat.findall('FieldDefn'):
@@ -230,7 +238,19 @@ def _parse_rat(rat):
     if not rows:
         return None, None
 
-    rows.sort(key=lambda r: r[0])
-    names = [name for _, name, _ in rows]
-    colors = [color for _, _, color in rows] if have_colors else None
+    max_val = max(r[0] for r in rows)
+    min_val = min(r[0] for r in rows)
+    if min_val < 0 or max_val >= _MAX_CATEGORIES:
+        return None, None
+
+    names = [''] * (max_val + 1)
+    if have_colors:
+        colors = [(0, 0, 0, 0)] * (max_val + 1)
+    else:
+        colors = None
+    for value, name, color in rows:
+        names[value] = name
+        if have_colors:
+            colors[value] = color
+
     return names, colors

--- a/xrspatial/geotiff/_pam.py
+++ b/xrspatial/geotiff/_pam.py
@@ -238,8 +238,13 @@ def _parse_rat(rat):
     if not rows:
         return None, None
 
-    max_val = max(r[0] for r in rows)
-    min_val = min(r[0] for r in rows)
+    min_val = max_val = rows[0][0]
+    for r in rows:
+        v = r[0]
+        if v < min_val:
+            min_val = v
+        if v > max_val:
+            max_val = v
     if min_val < 0 or max_val >= _MAX_CATEGORIES:
         return None, None
 

--- a/xrspatial/geotiff/tests/unit/test_pam_reader_edges.py
+++ b/xrspatial/geotiff/tests/unit/test_pam_reader_edges.py
@@ -71,3 +71,120 @@ def test_field_defn_without_usage_is_skipped(tmp_path):
         '<Row index="1"><F>1</F><F>ground</F><F>y</F></Row>'
         '</GDALRasterAttributeTable>')
     assert _pam.read_pam_sidecar(path) == {"category_names": ["sea", "ground"]}
+
+
+def test_sparse_one_based_rat_is_padded_to_pixel_values(tmp_path):
+    """A thematic RAT with 1-based sparse values [1, 2, 5] must pad names so
+    list index equals pixel value (issue #3591)."""
+    path = _write(
+        tmp_path, "sparse.tif",
+        '<GDALRasterAttributeTable tableType="thematic">'
+        '<FieldDefn index="0"><Name>Value</Name><Type>0</Type>'
+        '<Usage>5</Usage></FieldDefn>'
+        '<FieldDefn index="1"><Name>Class</Name><Type>2</Type>'
+        '<Usage>2</Usage></FieldDefn>'
+        '<Row index="0"><F>1</F><F>water</F></Row>'
+        '<Row index="1"><F>2</F><F>forest</F></Row>'
+        '<Row index="2"><F>5</F><F>urban</F></Row>'
+        '</GDALRasterAttributeTable>')
+    names = _pam.read_pam_sidecar(path)["category_names"]
+    assert names == ["", "water", "forest", "", "", "urban"]
+
+
+def test_sparse_rat_with_colors_is_padded(tmp_path):
+    """A thematic RAT with sparse values and RGBA columns pads colors with
+    (0,0,0,0) for gaps."""
+    path = _write(
+        tmp_path, "sparse_colors.tif",
+        '<GDALRasterAttributeTable tableType="thematic">'
+        '<FieldDefn index="0"><Name>Value</Name><Type>0</Type>'
+        '<Usage>5</Usage></FieldDefn>'
+        '<FieldDefn index="1"><Name>Class</Name><Type>2</Type>'
+        '<Usage>2</Usage></FieldDefn>'
+        '<FieldDefn index="2"><Name>Red</Name><Type>0</Type>'
+        '<Usage>6</Usage></FieldDefn>'
+        '<FieldDefn index="3"><Name>Green</Name><Type>0</Type>'
+        '<Usage>7</Usage></FieldDefn>'
+        '<FieldDefn index="4"><Name>Blue</Name><Type>0</Type>'
+        '<Usage>8</Usage></FieldDefn>'
+        '<FieldDefn index="5"><Name>Alpha</Name><Type>0</Type>'
+        '<Usage>9</Usage></FieldDefn>'
+        '<Row index="0"><F>2</F><F>forest</F><F>34</F><F>139</F>'
+        '<F>34</F><F>255</F></Row>'
+        '<Row index="1"><F>5</F><F>urban</F><F>128</F><F>128</F>'
+        '<F>128</F><F>255</F></Row>'
+        '</GDALRasterAttributeTable>')
+    result = _pam.read_pam_sidecar(path)
+    assert result["category_names"] == [
+        "", "", "forest", "", "", "urban",
+    ]
+    assert result["category_colors"] == [
+        (0, 0, 0, 0), (0, 0, 0, 0),
+        (34, 139, 34, 255), (0, 0, 0, 0), (0, 0, 0, 0),
+        (128, 128, 128, 255),
+    ]
+
+
+def test_negative_value_rat_returns_empty(tmp_path):
+    """A RAT with a negative pixel value fails closed: the sidecar is ignored
+    rather than producing misaligned categories."""
+    path = _write(
+        tmp_path, "neg.tif",
+        '<GDALRasterAttributeTable tableType="thematic">'
+        '<FieldDefn index="0"><Name>Value</Name><Type>0</Type>'
+        '<Usage>5</Usage></FieldDefn>'
+        '<FieldDefn index="1"><Name>Class</Name><Type>2</Type>'
+        '<Usage>2</Usage></FieldDefn>'
+        '<Row index="0"><F>-1</F><F>bogus</F></Row>'
+        '<Row index="1"><F>0</F><F>real</F></Row>'
+        '</GDALRasterAttributeTable>')
+    assert _pam.read_pam_sidecar(path) == {}
+
+
+def test_huge_max_value_rat_returns_empty(tmp_path):
+    """A RAT whose maximum pixel value exceeds _MAX_CATEGORIES fails closed
+    rather than allocating an enormous list."""
+    path = _write(
+        tmp_path, "huge.tif",
+        '<GDALRasterAttributeTable tableType="thematic">'
+        '<FieldDefn index="0"><Name>Value</Name><Type>0</Type>'
+        '<Usage>5</Usage></FieldDefn>'
+        '<FieldDefn index="1"><Name>Class</Name><Type>2</Type>'
+        '<Usage>2</Usage></FieldDefn>'
+        '<Row index="0"><F>1000000</F><F>huge</F></Row>'
+        '</GDALRasterAttributeTable>')
+    assert _pam.read_pam_sidecar(path) == {}
+
+
+def test_no_value_column_uses_row_index_and_pads(tmp_path):
+    """When the RAT omits the Value column, row index attributes serve as
+    pixel values, and the result is still padded."""
+    path = _write(
+        tmp_path, "no_value_col.tif",
+        '<GDALRasterAttributeTable tableType="thematic">'
+        '<FieldDefn index="0"><Name>Class</Name><Type>2</Type>'
+        '<Usage>2</Usage></FieldDefn>'
+        '<Row index="1"><F>water</F></Row>'
+        '<Row index="3"><F>land</F></Row>'
+        '</GDALRasterAttributeTable>')
+    names = _pam.read_pam_sidecar(path)["category_names"]
+    assert names == ["", "water", "", "land"]
+
+
+def test_dense_zero_based_rat_still_works(tmp_path):
+    """A standard dense 0-based RAT produces index-aligned names, same as
+    before the sparse fix."""
+    path = _write(
+        tmp_path, "dense.tif",
+        '<GDALRasterAttributeTable tableType="thematic">'
+        '<FieldDefn index="0"><Name>Value</Name><Type>0</Type>'
+        '<Usage>5</Usage></FieldDefn>'
+        '<FieldDefn index="1"><Name>Class</Name><Type>2</Type>'
+        '<Usage>2</Usage></FieldDefn>'
+        '<Row index="0"><F>0</F><F>water</F></Row>'
+        '<Row index="1"><F>1</F><F>land</F></Row>'
+        '<Row index="2"><F>2</F><F>snow</F></Row>'
+        '</GDALRasterAttributeTable>')
+    assert _pam.read_pam_sidecar(path) == {
+        "category_names": ["water", "land", "snow"],
+    }


### PR DESCRIPTION
Closes #3591.

When a PAM sidecar's thematic RAT has sparse or non-zero-based values (e.g. `[1, 2, 5]` from QGIS/GDAL classified rasters), `_parse_rat` was sorting rows and returning a dense list, misaligning category names against their pixel values. The attrs contract promises index == pixel value.

- Pad `category_names` with empty strings and `category_colors` with `(0,0,0,0)` for gaps between sparse RAT rows so list index == pixel value.
- Fail closed on negative pixel values or a max value exceeding 1,000,000 to prevent OOM from pathological RATs.

Backend coverage: backend-agnostic — runs during `open_geotiff` metadata attach on all backends (numpy, dask, cupy, dask+cupy).

## Test plan

- [x] Existing dense 0-based RAT tests pass unchanged.
- [x] Sparse 1-based RAT produces padded, index-aligned names.
- [x] Sparse RAT with RGBA columns pads both names and colors.
- [x] Negative values fail closed (return empty dict from `read_pam_sidecar`).
- [x] Values >= 1M fail closed.
- [x] No Value column uses Row index attributes and pads.
- [x] `test_field_defn_without_usage_is_skipped` still passes.