### PR TITLE
Point README AI-review link to xarray-spatial-skills repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!-- markdownlint-disable MD033 MD041 -->
 > [!IMPORTANT]
-> **xarray-spatial uses AI assistance more aggressively than other open-source projects.** Before opening a PR, read the [AI-Assisted Contribution Policy](AI_POLICY.md) and run your changes through the project's approved AI review workflow (see the slash-command suite in [`.claude/commands/`](.claude/commands)). PRs that ignore the workflow are likely to be rejected.
+> **xarray-spatial uses AI assistance more aggressively than other open-source projects.** Before opening a PR, read the [AI-Assisted Contribution Policy](AI_POLICY.md) and run your changes through the project's approved AI review workflow (see the command suite in the [xarray-spatial-skills](https://github.com/brendancol/xarray-spatial-skills) repo). PRs that ignore the workflow are likely to be rejected.
 >
 > **Feature freeze in effect.** The project is working toward its first major release (1.0.0). Until 1.0.0 ships, only bug fixes, test coverage, performance work, and documentation PRs will be considered. New feature proposals will be triaged but not implemented until after the release.
 > 


### PR DESCRIPTION
Closes #3668

The README's top callout linked the AI review workflow to `.claude/commands/`, which is gitignored (`.gitignore:107`) and never committed, so the link 404s on GitHub. The command suite now lives in `brendancol/xarray-spatial-skills` and is synced locally via `sync.sh`.

- Repoint that link to `https://github.com/brendancol/xarray-spatial-skills`, matching how `AI_POLICY.md` and `CONTRIBUTING.md` already reference it.

Docs-only change, no code paths touched.

Test plan:

- [x] Confirmed `.claude/commands/` is gitignored and absent from the committed tree
- [x] Grepped the README for other `.claude`/`.codex`/`.cursor`/`.kilo` links; this was the only one
